### PR TITLE
fix(kri): apply zone/namespace defaults

### DIFF
--- a/pkg/api-server/kri_endpoint.go
+++ b/pkg/api-server/kri_endpoint.go
@@ -67,7 +67,7 @@ func (k *kriEndpoint) findByKriRoute() restful.RouteFunction {
 			return
 		}
 
-		res, err := formatResource(resource, request.QueryParameter("format"), k.k8sMapper, identifier.Namespace)
+		res, err := formatResource(resource, request.QueryParameter("format"), k.k8sMapper, identifier.Namespace, k.cpZone, k.systemNamespace)
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), response, err, "Could not format a resource")
 			return

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -246,7 +246,7 @@ func (r *resourceEndpoints) findResource(withInsight bool) func(request *restful
 		}
 		var res any
 
-		res, err = formatResource(resource, request.QueryParameter("format"), r.k8sMapper, request.QueryParameter("namespace"))
+		res, err = formatResource(resource, request.QueryParameter("format"), r.k8sMapper, request.QueryParameter("namespace"), r.zoneName, r.systemNamespace)
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
 			return
@@ -257,7 +257,7 @@ func (r *resourceEndpoints) findResource(withInsight bool) func(request *restful
 	}
 }
 
-func formatResource(resource core_model.Resource, format string, k8sMapper k8s.ResourceMapperFunc, namespace string) (any, error) {
+func formatResource(resource core_model.Resource, format string, k8sMapper k8s.ResourceMapperFunc, namespace, defaultZone, defaultNamespace string) (any, error) {
 	switch format {
 	case "k8s", "kubernetes":
 		res, err := k8sMapper(resource, namespace)
@@ -266,7 +266,7 @@ func formatResource(resource core_model.Resource, format string, k8sMapper k8s.R
 		}
 		return res, nil
 	case "universal", "":
-		return rest.From.Resource(resource), nil
+		return rest.From.ResourceWithKRIDefaults(resource, defaultZone, defaultNamespace), nil
 	default:
 		err := validators.MakeFieldMustBeOneOfErr("format", "k8s", "kubernetes", "universal")
 		return nil, err.OrNil()
@@ -354,7 +354,7 @@ func (r *resourceEndpoints) listResources(withInsight bool) func(request *restfu
 				return
 			}
 		}
-		restList := rest.From.ResourceList(list)
+		restList := rest.From.ResourceListWithKRIDefaults(list, r.zoneName, r.systemNamespace)
 		restList.Next = nextLink(request, list.GetPagination().NextOffset)
 		if err := response.WriteAsJson(restList); err != nil {
 			rest_errors.HandleError(request.Request.Context(), response, err, "Could not list resources")

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -52,7 +52,7 @@ func (s *serviceInsightEndpoints) findResource(request *restful.Request, respons
 			}
 		}
 		s.fillStaticInfo(service, stat)
-		out := rest.From.Resource(serviceInsight)
+		out := rest.From.ResourceWithKRIDefaults(serviceInsight, s.zoneName, s.systemNamespace)
 		res := out.(*rest_unversioned.Resource)
 		res.Meta.Name = service
 		res.Spec = stat
@@ -145,7 +145,7 @@ func (s *serviceInsightEndpoints) expandInsights(serviceInsightList *mesh.Servic
 				continue
 			}
 			s.fillStaticInfo(serviceName, service)
-			out := rest.From.Resource(insight)
+			out := rest.From.ResourceWithKRIDefaults(insight, s.zoneName, s.systemNamespace)
 			res := out.(*rest_unversioned.Resource)
 			res.Meta.Name = serviceName
 			res.Spec = service

--- a/pkg/api-server/testdata/resources/crud/get_dp_by_kri.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_dp_by_kri.golden.json
@@ -4,7 +4,7 @@
  "name": "dp-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_dp_default___dp-1_",
+ "kri": "kri_dp_default_default_kuma-system_dp-1_",
  "networking": {
   "address": "10.1.2.1",
   "inbound": [

--- a/pkg/api-server/testdata/resources/crud/get_resource.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_resource.golden.json
@@ -4,7 +4,7 @@
  "name": "mtp-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_mtp_default___mtp-1_",
+ "kri": "kri_mtp_default_default_kuma-system_mtp-1_",
  "spec": {
   "targetRef": {
    "kind": "Mesh"

--- a/pkg/api-server/testdata/resources/crud/get_resource_by_kri.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_resource_by_kri.golden.json
@@ -4,7 +4,7 @@
  "name": "mtp-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_mtp_default___mtp-1_",
+ "kri": "kri_mtp_default_default_kuma-system_mtp-1_",
  "spec": {
   "targetRef": {
    "kind": "Mesh"

--- a/pkg/api-server/testdata/resources/crud/get_zone-ingress.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_zone-ingress.golden.json
@@ -3,7 +3,7 @@
  "name": "zone-ingress-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_zi____zone-ingress-1_",
+ "kri": "kri_zi__default_kuma-system_zone-ingress-1_",
  "networking": {
   "address": "10.2.3.4",
   "advertisedAddress": "10.3.4.5",

--- a/pkg/api-server/testdata/resources/crud/get_zone-ingress_by_kri.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_zone-ingress_by_kri.golden.json
@@ -3,7 +3,7 @@
  "name": "zone-ingress-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_zi____zone-ingress-1_",
+ "kri": "kri_zi__default_kuma-system_zone-ingress-1_",
  "networking": {
   "address": "10.2.3.4",
   "advertisedAddress": "10.3.4.5",

--- a/pkg/api-server/testdata/resources/crud/get_zoneingress.golden.json
+++ b/pkg/api-server/testdata/resources/crud/get_zoneingress.golden.json
@@ -3,7 +3,7 @@
  "name": "zone-ingress-1",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_zi____zone-ingress-1_",
+ "kri": "kri_zi__default_kuma-system_zone-ingress-1_",
  "networking": {
   "address": "10.2.3.4",
   "advertisedAddress": "10.3.4.5",

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_filters.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_filters.golden.json
@@ -7,7 +7,7 @@
    "name": "dp-1",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_dp_default___dp-1_",
+   "kri": "kri_dp_default_default_kuma-system_dp-1_",
    "networking": {
     "address": "10.1.2.1",
     "inbound": [
@@ -26,7 +26,7 @@
    "name": "dp-2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_dp_default___dp-2_",
+   "kri": "kri_dp_default_default_kuma-system_dp-2_",
    "networking": {
     "address": "10.1.2.2",
     "inbound": [

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter.golden.json
@@ -10,7 +10,7 @@
    "labels": {
     "k8s.kuma.io/namespace": "ns1"
    },
-   "kri": "kri_dp_default__ns1_dp-1_",
+   "kri": "kri_dp_default_default_ns1_dp-1_",
    "networking": {
     "address": "10.1.2.1",
     "inbound": [

--- a/pkg/api-server/testdata/resources/crud/list_mesh_03.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_mesh_03.golden.json
@@ -6,14 +6,14 @@
    "name": "m2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_m____m2_"
+   "kri": "kri_m__default_kuma-system_m2_"
   },
   {
    "type": "Mesh",
    "name": "m3",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_m____m3_"
+   "kri": "kri_m__default_kuma-system_m3_"
   }
  ],
  "next": null

--- a/pkg/api-server/testdata/resources/crud/list_mesh_04.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_mesh_04.golden.json
@@ -6,14 +6,14 @@
    "name": "m1",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_m____m1_"
+   "kri": "kri_m__default_kuma-system_m1_"
   },
   {
    "type": "Mesh",
    "name": "m2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_m____m2_"
+   "kri": "kri_m__default_kuma-system_m2_"
   }
  ],
  "next": "http://{{address}}/meshes?offset=2&size=2"

--- a/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
@@ -7,7 +7,7 @@
    "name": "redis-1",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_msvc_default___redis-1_",
+   "kri": "kri_msvc_default_default_kuma-system_redis-1_",
    "spec": {
     "state": "Unavailable",
     "selector": {
@@ -39,7 +39,7 @@
    "name": "redis-2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_msvc_default___redis-2_",
+   "kri": "kri_msvc_default_default_kuma-system_redis-2_",
    "spec": {
     "state": "Unavailable",
     "selector": {

--- a/pkg/api-server/testdata/resources/crud/list_workloads.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_workloads.golden.json
@@ -7,7 +7,7 @@
    "name": "workload-1",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_wl_default___workload-1_",
+   "kri": "kri_wl_default_default_kuma-system_workload-1_",
    "spec": {},
    "status": {
     "dataplaneProxies": {
@@ -23,7 +23,7 @@
    "name": "workload-2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_wl_default___workload-2_",
+   "kri": "kri_wl_default_default_kuma-system_workload-2_",
    "spec": {},
    "status": {
     "dataplaneProxies": {

--- a/pkg/api-server/testdata/resources/crud/list_zone-ingresses.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_zone-ingresses.golden.json
@@ -6,7 +6,7 @@
    "name": "zone-ingress-1",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_zi____zone-ingress-1_",
+   "kri": "kri_zi__default_kuma-system_zone-ingress-1_",
    "networking": {
     "address": "10.0.0.0",
     "advertisedAddress": "10.0.0.0",
@@ -19,7 +19,7 @@
    "name": "zone-ingress-2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_zi____zone-ingress-2_",
+   "kri": "kri_zi__default_kuma-system_zone-ingress-2_",
    "networking": {
     "address": "11.0.0.0",
     "advertisedAddress": "11.0.0.0",
@@ -32,7 +32,7 @@
    "name": "zone-ingress-3",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_zi____zone-ingress-3_",
+   "kri": "kri_zi__default_kuma-system_zone-ingress-3_",
    "networking": {
     "address": "12.0.0.0",
     "advertisedAddress": "12.0.0.0",

--- a/pkg/api-server/testdata/resources/crud/list_zoneingresses.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_zoneingresses.golden.json
@@ -6,7 +6,7 @@
    "name": "zone-ingress-1",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_zi____zone-ingress-1_",
+   "kri": "kri_zi__default_kuma-system_zone-ingress-1_",
    "networking": {
     "address": "10.0.0.0",
     "advertisedAddress": "10.0.0.0",
@@ -19,7 +19,7 @@
    "name": "zone-ingress-2",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_zi____zone-ingress-2_",
+   "kri": "kri_zi__default_kuma-system_zone-ingress-2_",
    "networking": {
     "address": "11.0.0.0",
     "advertisedAddress": "11.0.0.0",
@@ -32,7 +32,7 @@
    "name": "zone-ingress-3",
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
-   "kri": "kri_zi____zone-ingress-3_",
+   "kri": "kri_zi__default_kuma-system_zone-ingress-3_",
    "networking": {
     "address": "12.0.0.0",
     "advertisedAddress": "12.0.0.0",

--- a/pkg/api-server/testdata/resources/crud/put_meshaccesslog_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshaccesslog_01.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_mal_default_default__my-access-log_",
+ "kri": "kri_mal_default_default_kuma-system_my-access-log_",
  "spec": {
   "to": [
    {

--- a/pkg/api-server/testdata/resources/crud/put_meshes_00.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshes_00.golden.json
@@ -3,5 +3,5 @@
  "name": "default",
  "creationTime": "0001-01-01T00:00:00Z",
  "modificationTime": "0001-01-01T00:00:00Z",
- "kri": "kri_m____default_"
+ "kri": "kri_m__default_kuma-system_default_"
 }

--- a/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_extsvc_default_default__mes-tcp_",
+ "kri": "kri_extsvc_default_default_kuma-system_mes-tcp_",
  "spec": {
   "match": {
    "type": "HostnameGenerator",

--- a/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
@@ -7,7 +7,7 @@
  "labels": {
   "kuma.io/mesh": "default"
  },
- "kri": "kri_mzsvc_default___redis_",
+ "kri": "kri_mzsvc_default_default_kuma-system_redis_",
  "spec": {
   "selector": {
    "meshService": {

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_msvc_default_default__redis_",
+ "kri": "kri_msvc_default_default_kuma-system_redis_",
  "spec": {
   "state": "Unavailable",
   "selector": {

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_01.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_msvc_default_default__with-status_",
+ "kri": "kri_msvc_default_default_kuma-system_with-status_",
  "spec": {
   "state": "Unavailable",
   "selector": {

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_03.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_03.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_msvc_default_default__with-status_",
+ "kri": "kri_msvc_default_default_kuma-system_with-status_",
  "spec": {
   "state": "Unavailable",
   "selector": {

--- a/pkg/api-server/testdata/resources/crud/put_meshtrust_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshtrust_01.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_mtrust_meshtrust-test_default__trust-1_",
+ "kri": "kri_mtrust_meshtrust-test_default_kuma-system_trust-1_",
  "spec": {
   "origin": {
    "kri": "kri-test-value"

--- a/pkg/api-server/testdata/resources/crud/put_update_dataplanes_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_update_dataplanes_01.golden.json
@@ -11,7 +11,7 @@
   "kuma.io/proxy-type": "sidecar",
   "kuma.io/zone": "default"
  },
- "kri": "kri_dp_default_default__dp-1_",
+ "kri": "kri_dp_default_default_kuma-system_dp-1_",
  "networking": {
   "address": "10.1.2.1",
   "inbound": [

--- a/pkg/api-server/testdata/resources/crud/put_workload_with_status_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_workload_with_status_01.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_wl_default_default__with-status_",
+ "kri": "kri_wl_default_default_kuma-system_with-status_",
  "spec": {},
  "status": {
   "dataplaneProxies": {

--- a/pkg/api-server/testdata/resources/crud/put_workload_with_status_03.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_workload_with_status_03.golden.json
@@ -10,7 +10,7 @@
   "kuma.io/origin": "zone",
   "kuma.io/zone": "default"
  },
- "kri": "kri_wl_default_default__with-status_",
+ "kri": "kri_wl_default_default_kuma-system_with-status_",
  "spec": {},
  "status": {
   "dataplaneProxies": {

--- a/pkg/core/kri/kri.go
+++ b/pkg/core/kri/kri.go
@@ -63,7 +63,25 @@ func FromResourceMeta(rm core_model.ResourceMeta, resourceType core_model.Resour
 	return id
 }
 
-func FromResourceMetaE[T ~string](rm core_model.ResourceMeta, resourceType T) (Identifier, error) {
+type Option func(*Identifier)
+
+func WithDefaultZone(z string) Option {
+	return func(id *Identifier) {
+		if id.Zone == "" {
+			id.Zone = z
+		}
+	}
+}
+
+func WithDefaultNamespace(ns string) Option {
+	return func(id *Identifier) {
+		if id.Namespace == "" {
+			id.Namespace = ns
+		}
+	}
+}
+
+func FromResourceMetaE[T ~string](rm core_model.ResourceMeta, resourceType T, opts ...Option) (Identifier, error) {
 	if rm == nil {
 		return Identifier{}, nil
 	}
@@ -76,13 +94,17 @@ func FromResourceMetaE[T ~string](rm core_model.ResourceMeta, resourceType T) (I
 		return Identifier{}, nil
 	}
 
-	return Identifier{
+	id := Identifier{
 		ResourceType: rType,
 		Mesh:         rm.GetMesh(),
 		Zone:         rm.GetLabels()[mesh_proto.ZoneTag],
 		Namespace:    rm.GetLabels()[mesh_proto.KubeNamespaceTag],
 		Name:         core_model.GetDisplayName(rm),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(&id)
+	}
+	return id, nil
 }
 
 func FromString(s string) (Identifier, error) {

--- a/pkg/core/resources/model/rest/converter.go
+++ b/pkg/core/resources/model/rest/converter.go
@@ -79,6 +79,12 @@ func (f *from) Meta(r core_model.Resource) v1alpha1.ResourceMeta {
 	return meta
 }
 
+func (f *from) ResourceWithKRIDefaults(r core_model.Resource, zone, namespace string) Resource {
+	res := f.Resource(r)
+	setKRIDefaults(res, zone, namespace)
+	return res
+}
+
 func (f *from) ResourceList(rs core_model.ResourceList) *ResourceList {
 	items := make([]Resource, len(rs.GetItems()))
 	for i, r := range rs.GetItems() {
@@ -87,6 +93,26 @@ func (f *from) ResourceList(rs core_model.ResourceList) *ResourceList {
 	return &ResourceList{
 		Total: rs.GetPagination().Total,
 		Items: items,
+	}
+}
+
+func (f *from) ResourceListWithKRIDefaults(rs core_model.ResourceList, zone, namespace string) *ResourceList {
+	items := make([]Resource, len(rs.GetItems()))
+	for i, r := range rs.GetItems() {
+		items[i] = f.ResourceWithKRIDefaults(r, zone, namespace)
+	}
+	return &ResourceList{
+		Total: rs.GetPagination().Total,
+		Items: items,
+	}
+}
+
+func setKRIDefaults(r Resource, zone, namespace string) {
+	switch res := r.(type) {
+	case *v1alpha1.Resource:
+		res.SetKRIDefaults(zone, namespace)
+	case *unversioned.Resource:
+		res.Meta.SetKRIDefaults(zone, namespace)
 	}
 }
 

--- a/pkg/core/resources/model/rest/v1alpha1/meta.go
+++ b/pkg/core/resources/model/rest/v1alpha1/meta.go
@@ -9,12 +9,30 @@ import (
 )
 
 type ResourceMeta struct {
-	Type             string            `json:"type"`
-	Mesh             string            `json:"mesh,omitempty"`
-	Name             string            `json:"name"`
-	CreationTime     time.Time         `json:"creationTime"`
-	ModificationTime time.Time         `json:"modificationTime"`
-	Labels           map[string]string `json:"labels,omitempty"`
+	Type                string            `json:"type"`
+	Mesh                string            `json:"mesh,omitempty"`
+	Name                string            `json:"name"`
+	CreationTime        time.Time         `json:"creationTime"`
+	ModificationTime    time.Time         `json:"modificationTime"`
+	Labels              map[string]string `json:"labels,omitempty"`
+	kriDefaultZone      string
+	kriDefaultNamespace string
+}
+
+func (r *ResourceMeta) SetKRIDefaults(zone, namespace string) {
+	r.kriDefaultZone = zone
+	r.kriDefaultNamespace = namespace
+}
+
+func (r ResourceMeta) kriOptions() []kri.Option {
+	var opts []kri.Option
+	if r.kriDefaultZone != "" {
+		opts = append(opts, kri.WithDefaultZone(r.kriDefaultZone))
+	}
+	if r.kriDefaultNamespace != "" {
+		opts = append(opts, kri.WithDefaultNamespace(r.kriDefaultNamespace))
+	}
+	return opts
 }
 
 func (r ResourceMeta) MarshalJSON() ([]byte, error) {
@@ -26,7 +44,7 @@ func (r ResourceMeta) MarshalJSON() ([]byte, error) {
 		Alias: Alias(r),
 	}
 
-	if id, _ := kri.FromResourceMetaE(r, r.Type); !id.IsEmpty() {
+	if id, _ := kri.FromResourceMetaE(r, r.Type, r.kriOptions()...); !id.IsEmpty() {
 		out.KRI = id.String()
 	}
 

--- a/pkg/core/resources/model/rest/v1alpha1/resource.go
+++ b/pkg/core/resources/model/rest/v1alpha1/resource.go
@@ -36,7 +36,7 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 	}
 
 	var kriStr string
-	if id, _ := kri.FromResourceMetaE(r.ResourceMeta, r.Type); !id.IsEmpty() {
+	if id, _ := kri.FromResourceMetaE(r.ResourceMeta, r.Type, r.kriOptions()...); !id.IsEmpty() {
 		kriStr = id.String()
 	}
 


### PR DESCRIPTION
## Motivation

KRI strings in REST API responses have empty zone/namespace segments when resource labels are missing (e.g., `kri_mtp_default___mtp-1_`). The `/_kri/` endpoint already applies fallbacks in `getCoreName`, but the KRI string shown to users doesn't match what the endpoint expects, breaking roundtrip lookups.

Fixes #15544

## Implementation information

- Add functional options (`WithDefaultZone`, `WithDefaultNamespace`) to `kri.FromResourceMetaE` — applied after constructing the identifier, only filling empty fields
- Add unexported `kriDefaultZone`/`kriDefaultNamespace` fields to REST `ResourceMeta` with a `SetKRIDefaults` setter — used during JSON marshaling
- Thread CP zone name and system namespace through `formatResource` and list endpoints in the API server
- `kri.From(r)` (no options) stays unchanged — internal xDS/policy matching unaffected
- Defaults only applied in REST API responses, not in stored labels

> Changelog: fix(kri): apply default zone and namespace in KRI strings

## Supporting documentation

- #15544