### PR TITLE
fix(zoneingress): no public address causes DPP reconciliation failure

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -197,6 +197,13 @@ func fillRemoteMeshServices(
 			continue
 		}
 
+		if !zi.HasPublicAddress() {
+			// Zone Ingress is not reachable yet from other clusters.
+			// This may happen when Ingress Service is pending waiting on
+			// External IP on Kubernetes.
+			continue
+		}
+
 		ziAddress := zi.Spec.GetNetworking().GetAdvertisedAddress()
 		ziPort := zi.Spec.GetNetworking().GetAdvertisedPort()
 		ziCoordinates := buildCoordinates(ziAddress, ziPort)

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -1602,6 +1602,20 @@ var _ = Describe("TrafficRoute", func() {
 					},
 				},
 			}),
+			Entry("remote MeshService without Zone Ingress public address is not included", testCase{
+				zoneIngresses: []*core_mesh.ZoneIngressResource{
+					builders.ZoneIngress().
+						WithZone("east").
+						// No AdvertisedAddress/AdvertisedPort - simulates pending external IP
+						Build(),
+				},
+				meshServices: []*meshservice_api.MeshServiceResource{
+					samples.MeshServiceSyncedBackend(), // remote MeshService from "east" zone
+				},
+				mesh: defaultMeshWithMTLS,
+				// No endpoints should be generated because Zone Ingress has no public address
+				expected: core_xds.EndpointMap{},
+			}),
 		)
 		Describe("BuildEgressEndpointMap()", func() {
 			type testCase struct {


### PR DESCRIPTION
## Motivation

When service external address is pending ZoneIngress is missing `advertisedAddress` and `advertisedPort`. Old flow has `!zi.HasPublicAddress()` check however new MeshService flow was missing the check.

Another question, do we even need to sync ZoneIngresses from Global to Zone if they're missing public addresses? Since this fix is going to be backported I'm keeping it as simple as possible. 

## Implementation information

Check if remote zone ingress has a public address before configuring cluster endpoints.

## Supporting documentation

None
