### PR TITLE
build(make): harden target graph

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -92,48 +92,76 @@ endef
 $(foreach target,$(BUILD_RELEASE_BINARIES) $(BUILD_TEST_BINARIES),$(eval $(call LOCAL_BUILD_TARGET,$(target))))
 
 # Build_Go_Application is a build command for the Kuma Go applications.
-Build_Go_Application = GOOS=$(1) GOARCH=$(2) $$(GOENV) $(GO) build -v $$(GOFLAGS) $(call LD_FLAGS,$(1),$(2)) -o $$@/$$(notdir $$@)
+Build_Go_Application = GOOS=$(1) GOARCH=$(2) $$(GOENV) $(GO) build -v $$(GOFLAGS) $(call LD_FLAGS,$(1),$(2)) -o $$@
+
+artifact_dir = build/artifacts-$(1)-$(2)/$(3)
+artifact_dir_ready = $(call artifact_dir,$(1),$(2),$(3))/
+artifact_bin = $(call artifact_dir,$(1),$(2),$(3))/$(3)
 
 # create targets to build binaries for each OS/ARCH combination
 # $(1) - GOOS to build for
 # $(2) - GOARCH to build for
 define BUILD_TARGET
 ENVOY_VERSION_$(1)_$(2)=$(if $(ENVOY_VERSION_$(1)_$(2)),$(ENVOY_VERSION_$(1)_$(2)),$(ENVOY_VERSION))
-.PHONY: build/artifacts-$(1)-$(2)/kuma-cp
-build/artifacts-$(1)-$(2)/kuma-cp:
+$(call artifact_dir_ready,$(1),$(2),kuma-cp) \
+$(call artifact_dir_ready,$(1),$(2),kuma-dp) \
+$(call artifact_dir_ready,$(1),$(2),kumactl) \
+$(call artifact_dir_ready,$(1),$(2),kuma-cni) \
+$(call artifact_dir_ready,$(1),$(2),install-cni) \
+$(call artifact_dir_ready,$(1),$(2),coredns) \
+$(call artifact_dir_ready,$(1),$(2),envoy) \
+$(call artifact_dir_ready,$(1),$(2),test-server):
+	mkdir -p $$@
+
+$(call artifact_bin,$(1),$(2),kuma-cp): | $(call artifact_dir_ready,$(1),$(2),kuma-cp)
 	$(Build_Go_Application) ./app/kuma-cp
 
-.PHONY: build/artifacts-$(1)-$(2)/kuma-dp
-build/artifacts-$(1)-$(2)/kuma-dp:
+$(call artifact_bin,$(1),$(2),kuma-dp): | $(call artifact_dir_ready,$(1),$(2),kuma-dp)
 	$(Build_Go_Application) ./app/kuma-dp
 
-.PHONY: build/artifacts-$(1)-$(2)/kumactl
-build/artifacts-$(1)-$(2)/kumactl: build/ebpf
+$(call artifact_bin,$(1),$(2),kumactl): build/ebpf | $(call artifact_dir_ready,$(1),$(2),kumactl)
 	$(Build_Go_Application) ./app/kumactl
 
-.PHONY: build/artifacts-$(1)-$(2)/kuma-cni
-build/artifacts-$(1)-$(2)/kuma-cni:
+$(call artifact_bin,$(1),$(2),kuma-cni): | $(call artifact_dir_ready,$(1),$(2),kuma-cni)
 	$(Build_Go_Application) -ldflags="-extldflags=-static" ./app/cni/cmd/kuma-cni
 
-.PHONY: build/artifacts-$(1)-$(2)/install-cni
-build/artifacts-$(1)-$(2)/install-cni:
+$(call artifact_bin,$(1),$(2),install-cni): | $(call artifact_dir_ready,$(1),$(2),install-cni)
 	$(Build_Go_Application) -ldflags="-extldflags=-static" ./app/cni/cmd/install
 
-.PHONY: build/artifacts-$(1)-$(2)/coredns
-build/artifacts-$(1)-$(2)/coredns:
-	mkdir -p $$(@) && \
-	[ -f $$(@)/coredns ] || \
-	curl --retry 3 --retry-delay 60 -s --fail --location https://github.com/kumahq/coredns-builds/releases/download/$(COREDNS_VERSION)/coredns_$(COREDNS_VERSION)_$(1)_$(2)$(COREDNS_EXT).tar.gz | tar -C $$(@) -xz
+$(call artifact_bin,$(1),$(2),coredns): | $(call artifact_dir_ready,$(1),$(2),coredns)
+	curl --retry 3 --retry-delay 60 -s --fail --location https://github.com/kumahq/coredns-builds/releases/download/$(COREDNS_VERSION)/coredns_$(COREDNS_VERSION)_$(1)_$(2)$(COREDNS_EXT).tar.gz | tar -C $$(@D) -xz
+	test -f $$@
 
-.PHONY: build/artifacts-$(1)-$(2)/envoy
-build/artifacts-$(1)-$(2)/envoy:
-	mkdir -p $$(@) && \
-	[ -f $$(@)/envoy ] || \
-	curl --retry 3 --retry-delay 60 -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v$$(ENVOY_VERSION_$(1)_$(2))/envoy-$(1)-$(2)-v$$(ENVOY_VERSION_$(1)_$(2))$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@) -xz
+$(call artifact_bin,$(1),$(2),envoy): | $(call artifact_dir_ready,$(1),$(2),envoy)
+	curl --retry 3 --retry-delay 60 -s --fail --location https://github.com/kumahq/envoy-builds/releases/download/v$$(ENVOY_VERSION_$(1)_$(2))/envoy-$(1)-$(2)-v$$(ENVOY_VERSION_$(1)_$(2))$(ENVOY_EXT_$(1)_$(2)).tar.gz | tar -C $$(@D) -xz
+	test -f $$@
 
-.PHONY: build/artifacts-$(1)-$(2)/test-server
-build/artifacts-$(1)-$(2)/test-server:
+$(call artifact_bin,$(1),$(2),test-server): | $(call artifact_dir_ready,$(1),$(2),test-server)
 	$(Build_Go_Application) ./test/server
+
+build/artifacts-$(1)-$(2)/kuma-cp: $(call artifact_bin,$(1),$(2),kuma-cp)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/kuma-dp: $(call artifact_bin,$(1),$(2),kuma-dp)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/kumactl: $(call artifact_bin,$(1),$(2),kumactl)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/kuma-cni: $(call artifact_bin,$(1),$(2),kuma-cni)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/install-cni: $(call artifact_bin,$(1),$(2),install-cni)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/coredns: $(call artifact_bin,$(1),$(2),coredns)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/envoy: $(call artifact_bin,$(1),$(2),envoy)
+	touch $$@
+
+build/artifacts-$(1)-$(2)/test-server: $(call artifact_bin,$(1),$(2),test-server)
+	touch $$@
 
 endef
 $(foreach goos,$(SUPPORTED_GOOSES),$(foreach goarch,$(SUPPORTED_GOARCHES),$(eval $(call BUILD_TARGET,$(goos),$(goarch)))))

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -34,7 +34,8 @@ KUBEBUILDER_ASSETS_VERSION=1.33
 
 GO := $(shell $(MISE) which go)
 JQ := $(shell $(MISE) which jq)
-export GO_VERSION := $(shell $(GO) mod edit -json | $(JQ) -r .Go)
+GO_VERSION = $(shell $(GO) mod edit -json | $(JQ) -r .Go)
+export GO_VERSION
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
 
@@ -53,10 +54,11 @@ BUF=$(shell $(MISE) which buf)
 
 # Proto dependencies via Buf
 BUF_CACHE_DIR := $(CI_TOOLS_DIR)/buf/cache
-PROTO_GOOGLE_APIS := $(shell $(BUF) export buf.build/googleapis/googleapis --output $(BUF_CACHE_DIR)/googleapis && echo $(BUF_CACHE_DIR)/googleapis)
-PROTO_PGV := $(shell $(BUF) export buf.build/envoyproxy/protoc-gen-validate --output $(BUF_CACHE_DIR)/pgv && echo $(BUF_CACHE_DIR)/pgv)
-PROTO_ENVOY := $(shell $(BUF) export buf.build/envoyproxy/envoy --output $(BUF_CACHE_DIR)/envoy && echo $(BUF_CACHE_DIR)/envoy)
-PROTO_XDS := $(shell $(BUF) export buf.build/cncf/xds --output $(BUF_CACHE_DIR)/xds && echo $(BUF_CACHE_DIR)/xds)
+PROTO_GOOGLE_APIS := $(BUF_CACHE_DIR)/googleapis
+PROTO_PGV := $(BUF_CACHE_DIR)/pgv
+PROTO_ENVOY := $(BUF_CACHE_DIR)/envoy
+PROTO_XDS := $(BUF_CACHE_DIR)/xds
+PROTO_DEPS := $(PROTO_GOOGLE_APIS) $(PROTO_PGV) $(PROTO_ENVOY) $(PROTO_XDS)
 YQ=$(shell $(MISE) which yq)
 HELM=$(shell $(MISE) which helm)
 K3D=$(MISE) exec -- k3d
@@ -86,7 +88,7 @@ TOOLS_DEPS_DIRS=$(KUMA_DIR)/mk/dependencies
 TOOLS_DEPS_LOCK_FILE=mk/dependencies/deps.lock
 TOOLS_MAKEFILE=$(KUMA_DIR)/mk/dev.mk
 
-LATEST_RELEASE_BRANCH := $(shell $(YQ) e '.[] | .branch' versions.yml | grep -v dev | sort -V | tail -n 1)
+LATEST_RELEASE_BRANCH = $(shell $(YQ) e '.[] | .branch' versions.yml | grep -v dev | sort -V | tail -n 1)
 
 .PHONY: cmd/check/%
 cmd/check/%:
@@ -103,6 +105,21 @@ install: cmd/check/curl cmd/check/git cmd/check/unzip cmd/check/make cmd/check/g
 
 $(KUBECONFIG_DIR):
 	@mkdir -p $(KUBECONFIG_DIR)
+
+$(BUF_CACHE_DIR):
+	@mkdir -p $@
+
+$(PROTO_GOOGLE_APIS): | $(BUF_CACHE_DIR)
+	$(BUF) export buf.build/googleapis/googleapis --output $@
+
+$(PROTO_PGV): | $(BUF_CACHE_DIR)
+	$(BUF) export buf.build/envoyproxy/protoc-gen-validate --output $@
+
+$(PROTO_ENVOY): | $(BUF_CACHE_DIR)
+	$(BUF) export buf.build/envoyproxy/envoy --output $@
+
+$(PROTO_XDS): | $(BUF_CACHE_DIR)
+	$(BUF) export buf.build/cncf/xds --output $@
 
 # kubectl always writes the current context into the first config file. When
 # debugging, it's common to switch contexts and we don't want to edit the Kind
@@ -131,7 +148,7 @@ dev/merge-release:
 
 # Generate a .envrc that prepends e2e test suite configs to whatever
 # KUBECONFIG currently has, and stores CI tooling in .tools.
-.PHONY: dev/enrc
+.PHONY: dev/envrc
 dev/envrc: $(KUBECONFIG_DIR)/kind-kuma-current ## Generate .envrc
 	@echo 'export CI_TOOLS_DIR=$$(expand_path .tools)' > .envrc
 	@for c in \

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -23,7 +23,12 @@ TAR_EXCLUDES=--exclude=passwd --exclude=group
 # $(3) - coredns extension to use (or `skip` if we shouldn't include COREDNS)
 # $(4) - primary envoy to use in the distribution (the binary that will be called `envoy`)
 define make_distributions_target
-build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-$(2)/kumactl build/artifacts-$(1)-$(2)/kuma-cp build/artifacts-$(1)-$(2)/kuma-dp
+build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): \
+	build/artifacts-$(1)-$(2)/kumactl \
+	build/artifacts-$(1)-$(2)/kuma-cp \
+	build/artifacts-$(1)-$(2)/kuma-dp \
+	$(if $(filter skip,$(3)),,build/artifacts-$(1)-$(2)/coredns) \
+	$(if $(filter skip,$(4)),,build/artifacts-$(1)-$(2)/envoy)
 	rm -rf $$@
 	mkdir -p $$@/bin $$@/conf
 	command cp build/artifacts-$(1)-$(2)/kumactl/kumactl $$@/bin
@@ -34,13 +39,13 @@ build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-
 	command cp -r dashboards $$@/
 # CoreDNS is not included when the value is `skip` otherwise it's used as the COREDNS_EXT (which is most commonly just coredns)
 ifneq ($(3),skip)
-	$(MAKE) build/artifacts-$(1)-$(2)/coredns COREDNS_EXT=$(subst coredns,,$(3))
 	command cp build/artifacts-$(1)-$(2)/coredns/coredns $$@/bin
 endif
 
 # Package envoy
-	$(MAKE) build/artifacts-$(1)-$(2)/envoy ENVOY_EXT_$(1)_$(2)=$(subst envoy,,$(4))
+ifneq ($(4),skip)
 	command cp -r build/artifacts-$(1)-$(2)/envoy/* $$@/bin
+endif
 
 	# Set permissions correctly
 	find $$@ -type f | xargs chmod 555
@@ -103,7 +108,7 @@ endif
 build/distributions/out: $(patsubst %,build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-%.tar.gz,$(ENABLED_DIST_NAMES))
 	cd $@; sha256sum *.tar.gz > $(DISTRIBUTION_TARGET_NAME).sha256
 
-.PHONY: build/info/distribution/repo
+.PHONY: build/info/cloudsmith_repository
 build/info/cloudsmith_repository:
 	@echo $(PULP_PACKAGE_TYPE)-binaries-$(PULP_DIST_VERSION)
 

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -75,14 +75,15 @@ $(foreach goarch,$(SUPPORTED_GOARCHES),$(eval $(call IMAGE_TARGETS_BY_ARCH,$(goa
 # $(2) - GOARCH to build for
 # (TODO): Support image platform in output file names
 define DOCKER_TARGETS_BY_ARCH
-.PHONY: docker/save/$(1)/$(2)
-docker/save/$(1)/$(2):
-	@mkdir -p build/docker
-	docker save --output build/docker/$(1)-$(2).tar $$(call build_image,$(1),$(2))
+build/docker/$(1)-$(2).tar: image/$(1)/$(2) | build/docker/
+	docker save --output $$@ $$(call build_image,$(1),$(2))
 
-.PHONY: docker/$(1)/$(2)
-docker/load/$(1)/$(2):
-	@docker load --quiet --input build/docker/$(1)-$(2).tar
+.PHONY: docker/save/$(1)/$(2)
+docker/save/$(1)/$(2): build/docker/$(1)-$(2).tar
+
+.PHONY: docker/load/$(1)/$(2)
+docker/load/$(1)/$(2): build/docker/$(1)-$(2).tar
+	@docker load --quiet --input $$<
 
 # we only tag the image that has the same arch than the HOST (tag is meant to use the image just after so having the same arch makes sense)
 .PHONY: docker/tag/$(1)/$(2)
@@ -94,6 +95,9 @@ docker/push/$(1)/$(2):
 	$$(call GATE_PUSH,docker push $$(call build_image,$(1),$(2)))
 endef
 $(foreach goarch, $(SUPPORTED_GOARCHES),$(foreach image, $(IMAGES_RELEASE) $(IMAGES_TEST),$(eval $(call DOCKER_TARGETS_BY_ARCH,$(image),$(goarch)))))
+
+build/docker/:
+	@mkdir -p $@
 
 # add targets to generate docker/{save,load,tag,push} for all supported ARCH
 # $(1) - image name

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -19,7 +19,7 @@ helm-docs: ## Dev: Runs helm-docs generator
 	$(HELM_DOCS) -s="file" --chart-search-root=./deployments/charts
 
 .PHONY: docs/generated/raw
-docs/generated/raw: docs/generated/raw/rbac.yaml
+docs/generated/raw: $(PROTO_DEPS) docs/generated/raw/rbac.yaml
 	mkdir -p $@
 	command cp $(DOCS_CP_CONFIG) $@/kuma-cp.yaml
 	command cp $(HELM_VALUES_FILE) $@/helm-values.yaml
@@ -33,7 +33,6 @@ docs/generated/raw: docs/generated/raw/rbac.yaml
 		--plugin=protoc-gen-jsonschema=$(PROTOC_GEN_JSONSCHEMA) \
 		$(DOCS_PROTOS)
 
-.PHONY: docs/generated/raw/rbac.yaml
 docs/generated/raw/rbac.yaml:
 	@mkdir -p docs/generated/raw
 	@$(HELM) template --namespace $(PROJECT_NAME)-system $(PROJECT_NAME) deployments/charts/$(PROJECT_NAME) | \
@@ -53,7 +52,6 @@ API_DIRS     ?= $(TOP)/api/openapi/specs:base
 docs/generated:
 	mkdir -p $@
 
-.PHONY: docs/generated/openapi.yaml
 docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES) | docs/generated docs/generated/openapi/prepare/specs
 	@echo "Rewriting /specs/ paths in all YAML files..."
 	@mkdir -p $(BUILD_DIR)/oapitmp-rewritten

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -64,20 +64,16 @@ endif
 
 define gen-k8sclusters
 .PHONY: test/e2e/k8s/start/cluster/$1
-test/e2e/k8s/start/cluster/$1: CLUSTER = $1
-test/e2e/k8s/start/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/start
+test/e2e/k8s/start/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/start/$1
 
 .PHONY: test/e2e/k8s/wait/$1
-test/e2e/k8s/wait/$1: CLUSTER = $1
-test/e2e/k8s/wait/$1: test/e2e/k8s/start/cluster/$1 $(K8S_CLUSTER_TOOL)/cluster/wait
+test/e2e/k8s/wait/$1: test/e2e/k8s/start/cluster/$1 $(K8S_CLUSTER_TOOL)/cluster/wait/$1
 
 .PHONY: test/e2e/k8s/load/images/$1
-test/e2e/k8s/load/images/$1: CLUSTER = $1
-test/e2e/k8s/load/images/$1: test/e2e/k8s/wait/$1 $(K8S_CLUSTER_TOOL)/cluster/load/images
+test/e2e/k8s/load/images/$1: test/e2e/k8s/wait/$1 $(K8S_CLUSTER_TOOL)/cluster/load/images/$1
 
 .PHONY: test/e2e/k8s/stop/cluster/$1
-test/e2e/k8s/stop/cluster/$1: CLUSTER = $1
-test/e2e/k8s/stop/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/stop
+test/e2e/k8s/stop/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/stop/$1
 endef
 
 $(foreach cluster,$(K8SCLUSTERS),$(eval $(call gen-k8sclusters,$(cluster))))

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -64,23 +64,23 @@ endif
 
 define gen-k8sclusters
 .PHONY: test/e2e/k8s/start/cluster/$1
-test/e2e/k8s/start/cluster/$1:
-	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/start
-
-.PHONY: test/e2e/k8s/load/images/$1
-test/e2e/k8s/load/images/$1:
-	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/load/images
+test/e2e/k8s/start/cluster/$1: CLUSTER = $1
+test/e2e/k8s/start/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/start
 
 .PHONY: test/e2e/k8s/wait/$1
-test/e2e/k8s/wait/$1:
-	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/wait
+test/e2e/k8s/wait/$1: CLUSTER = $1
+test/e2e/k8s/wait/$1: test/e2e/k8s/start/cluster/$1 $(K8S_CLUSTER_TOOL)/cluster/wait
+
+.PHONY: test/e2e/k8s/load/images/$1
+test/e2e/k8s/load/images/$1: CLUSTER = $1
+test/e2e/k8s/load/images/$1: test/e2e/k8s/wait/$1 $(K8S_CLUSTER_TOOL)/cluster/load/images
 
 .PHONY: test/e2e/k8s/stop/cluster/$1
-test/e2e/k8s/stop/cluster/$1:
-	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/stop
+test/e2e/k8s/stop/cluster/$1: CLUSTER = $1
+test/e2e/k8s/stop/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/stop
 endef
 
-$(foreach cluster, $(K8SCLUSTERS), $(eval $(call gen-k8sclusters,$(cluster))))
+$(foreach cluster,$(K8SCLUSTERS),$(eval $(call gen-k8sclusters,$(cluster))))
 
 ifdef K8SCLUSTERS
 E2E_ENV_VARS += K8SCLUSTERS="$(K8SCLUSTERS)"
@@ -92,8 +92,7 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
-	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
+test/e2e/k8s/start: $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)
 
 .PHONY: test/e2e/k8s/stop
 test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -67,7 +67,7 @@ define gen-k8sclusters
 test/e2e/k8s/start/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/start/$1
 
 .PHONY: test/e2e/k8s/wait/$1
-test/e2e/k8s/wait/$1: test/e2e/k8s/start/cluster/$1 $(K8S_CLUSTER_TOOL)/cluster/wait/$1
+test/e2e/k8s/wait/$1: test/e2e/k8s/start/cluster/$1
 
 .PHONY: test/e2e/k8s/load/images/$1
 test/e2e/k8s/load/images/$1: test/e2e/k8s/wait/$1 $(K8S_CLUSTER_TOOL)/cluster/load/images/$1

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -64,16 +64,20 @@ endif
 
 define gen-k8sclusters
 .PHONY: test/e2e/k8s/start/cluster/$1
-test/e2e/k8s/start/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/start/$1
+test/e2e/k8s/start/cluster/$1:
+	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/start
 
 .PHONY: test/e2e/k8s/wait/$1
-test/e2e/k8s/wait/$1: test/e2e/k8s/start/cluster/$1
+test/e2e/k8s/wait/$1:
+	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/wait
 
 .PHONY: test/e2e/k8s/load/images/$1
-test/e2e/k8s/load/images/$1: test/e2e/k8s/wait/$1 $(K8S_CLUSTER_TOOL)/cluster/load/images/$1
+test/e2e/k8s/load/images/$1:
+	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/load/images
 
 .PHONY: test/e2e/k8s/stop/cluster/$1
-test/e2e/k8s/stop/cluster/$1: $(K8S_CLUSTER_TOOL)/cluster/stop/$1
+test/e2e/k8s/stop/cluster/$1:
+	CLUSTER=$1 $(MAKE) $(K8S_CLUSTER_TOOL)/cluster/stop
 endef
 
 $(foreach cluster,$(K8SCLUSTERS),$(eval $(call gen-k8sclusters,$(cluster))))
@@ -88,7 +92,8 @@ test/e2e/list:
 	@echo $(ALL_TESTS)
 
 .PHONY: test/e2e/k8s/start
-test/e2e/k8s/start: $(K8SCLUSTERS_LOAD_IMAGES_TARGETS)
+test/e2e/k8s/start: $(K8SCLUSTERS_START_TARGETS)
+	$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS) # execute after start targets
 
 .PHONY: test/e2e/k8s/stop
 test/e2e/k8s/stop: $(K8SCLUSTERS_STOP_TARGETS)

--- a/mk/ebpf.mk
+++ b/mk/ebpf.mk
@@ -29,26 +29,29 @@ COMPILE_IN_PATH ?= ./pkg/transparentproxy/ebpf/programs
 # if the tag changes, we will re-fetch programs
 
 define make_ebpf_targets
-$(1)/mb_*: | $(1)
-	curl --progress-bar --location $(TARBALL_URL)/all-$(3).tar.gz | tar -C $$(@D) -xz
+$(1)/.fetched: | $(1)/
+	curl --progress-bar --location $(TARBALL_URL)/all-$(3).tar.gz | tar -C $(1) -xz
+	touch $$@
 
-$(2)/mb_*: | $(2) $(1)/mb_*
+$(2)/.copied: $(1)/.fetched | $(2)/
 	command cp $(1)/mb_* $(2)
+	touch $$@
 
 # Make $(2) $(1) directories if they don't
 # exist
-$(1) $(2):
+$(1)/ $(2)/:
 	mkdir -p $$@
 endef
 
-EBF_ARCH:=amd64 arm64
-$(foreach elt,$(EBF_ARCH),$(eval $(call make_ebpf_targets,$(BASE_BUILD_OUTPUT)/$(elt),$(COMPILE_IN_PATH)/$(elt),$(elt))))
+EBPF_ARCH:=amd64 arm64
+$(foreach elt,$(EBPF_ARCH),$(eval $(call make_ebpf_targets,$(BASE_BUILD_OUTPUT)/$(elt),$(COMPILE_IN_PATH)/$(elt),$(elt))))
 
-EBF_TARGETS:=$(foreach elt,$(EBF_ARCH),$(BASE_BUILD_OUTPUT)/$(elt)/mb_* $(COMPILE_IN_PATH)/$(elt)/mb_*)
+EBPF_TARGETS:=$(foreach elt,$(EBPF_ARCH),$(COMPILE_IN_PATH)/$(elt)/.copied)
 .PHONY: build/ebpf
-build/ebpf: $(EBF_TARGETS)
+build/ebpf: $(EBPF_TARGETS)
 
 .PHONY: clean/ebpf
 clean/ebpf :
 	-rm -rf $(BUILD_DIR)/ebpf
+	rm -f $(foreach elt,$(EBPF_ARCH),$(COMPILE_IN_PATH)/$(elt)/.copied)
 	find $(COMPILE_IN_PATH) -type f -name 'mb_*' -exec rm {} \;

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -17,14 +17,14 @@ EXTRA_GENERATE_DEPS_TARGETS ?= generate/envoy-imports
 clean/generated: clean/protos clean/builtin-crds clean/legacy-resources clean/resources clean/policies clean/tools
 
 .PHONY: generate/protos
-generate/protos:
+generate/protos: $(PROTO_DEPS)
 	find $(PROTO_DIRS) -name '*.proto' -exec $(PROTOC_GO) {} \;
 
 .PHONY: clean/tools
 clean/tools:
 	rm -rf $(KUMA_DIR)/build/tools-*
 
-.PHONY: clean/proto
+.PHONY: clean/protos
 clean/protos: ## Dev: Remove auto-generated Protobuf files
 	find $(PROTO_DIRS) -name '*.pb.go' -delete
 	find $(PROTO_DIRS) -name '*.pb.validate.go' -delete
@@ -79,7 +79,7 @@ clean/policies: $(addprefix clean/policy/,$(policies))
 
 # deletes all files in policy directory except *.proto and validator.go
 clean/policy/%:
-	$(shell find $(POLICIES_DIR)/$* \( -name '*.pb.go' -o -name '*.yaml' -o -name 'zz_generated.*'  \) -not -path '*/testdata/*' -type f -delete)
+	find $(POLICIES_DIR)/$* \( -name '*.pb.go' -o -name '*.yaml' -o -name 'zz_generated.*' \) -not -path '*/testdata/*' -type f -delete
 	@rm -fr $(POLICIES_DIR)/$*/k8s
 
 generate/deep-copy/common:

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -108,7 +108,7 @@ endif
 
 # --- k3d-specific context ---
 
-CLUSTER_KUBECONTEXT := k3d-$(CLUSTER_NAME)
+CLUSTER_KUBECONTEXT = k3d-$(CLUSTER_NAME)
 
 # --- Target-specific variables ---
 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -68,7 +68,7 @@ K3D_DISABLE := $(filter-out $(strip $(K3D_ENABLE)),$(K3D_DISABLE_DEFAULT))
 
 K3D_CLUSTER_CREATE_OPTS ?= \
 	--image "$(K3S_IMAGE)" \
-	--volume "$(subst @,\@,$(TOP)/$(KUMA_DIR))/test/framework/deployments:/tmp/deployments@server:0" \
+	--volume "$(subst @,\@,$(abspath $(KUMA_DIR)))/test/framework/deployments:/tmp/deployments@server:0" \
 	--network "$(DOCKER_NETWORK)" \
 	--timeout "120s" \
 	--k3s-arg "--kubelet-arg=image-gc-high-threshold=100@server:0" \
@@ -116,6 +116,19 @@ k3d/%: KUMACTL := $(BUILD_ARTIFACTS_DIR)/kumactl/kumactl
 k3d/cluster/%: export KUBECONFIG  = $(K3D_CLUSTER_KUBECONFIG)
 k3d/cluster/%: export KUBECONTEXT = $(CLUSTER_KUBECONTEXT)
 
+.PHONY: k3d/cluster/start/% k3d/cluster/load/images/% k3d/cluster/wait/% k3d/cluster/stop/%
+k3d/cluster/start/%: CLUSTER = $*
+k3d/cluster/start/%: k3d/cluster/start
+
+k3d/cluster/load/images/%: CLUSTER = $*
+k3d/cluster/load/images/%: k3d/cluster/load/images
+
+k3d/cluster/wait/%: CLUSTER = $*
+k3d/cluster/wait/%: k3d/cluster/wait
+
+k3d/cluster/stop/%: CLUSTER = $*
+k3d/cluster/stop/%: k3d/cluster/stop
+
 # --- Diagnostics ---
 
 .PHONY: k3d/cluster/diagnose
@@ -131,11 +144,11 @@ k3d/cluster/diagnose:
 # which is required because `k3d image import` needs the tagged images to exist.
 
 .PHONY: k3d/cluster/load
-k3d/cluster/load:
 ifndef K3D_DONT_LOAD
-	$(Q)$(MAKE) images
-	$(Q)$(MAKE) docker/tag
-	$(Q)$(MAKE) k3d/cluster/load/images
+k3d/cluster/load: images docker/tag k3d/cluster/load/images
+else
+k3d/cluster/load:
+	@:
 endif
 
 K3D_IMAGE_IMPORT_MODE    ?= direct
@@ -157,7 +170,7 @@ k3d/cluster/load/images:
 # --- CNI setup ---
 
 .PHONY: k3d/cluster/cni/setup
-k3d/cluster/cni/setup: k3d/cluster/cni/setup/$(K3D_CNI) ; @
+k3d/cluster/cni/setup: k3d/cluster/create k3d/cluster/cni/setup/$(K3D_CNI) ; @
 
 .PHONY: k3d/cluster/cni/setup/flannel
 k3d/cluster/cni/setup/flannel: ; @
@@ -179,7 +192,7 @@ k3d/cluster/cni/setup/calico:
 # --- eBPF setup ---
 
 .PHONY: k3d/cluster/ebpf/setup
-k3d/cluster/ebpf/setup:
+k3d/cluster/ebpf/setup: k3d/cluster/cni/setup
 ifeq ($(GOOS),darwin)
 	$(Q)docker exec k3d-$(CLUSTER_NAME)-server-0 mount bpffs /sys/fs/bpf -t bpf && \
 	docker exec k3d-$(CLUSTER_NAME)-server-0 mount --make-shared /sys/fs/bpf
@@ -256,7 +269,6 @@ $(dir $(DOCKER_NETWORK_LOCK)):
 
 DOCKERHUB_PULL_CREDENTIAL ?=
 
-.PHONY: $(K3D_REGISTRY_FILE)
 $(K3D_REGISTRY_FILE):
 	$(Q)mkdir -p $(dir $@)
 ifneq ($(DOCKERHUB_PULL_CREDENTIAL),)
@@ -279,39 +291,33 @@ k3d/docker/credentials/cleanup:
 K3D_CREATE_CLUSTER ?= $(KUMA_DIR)/mk/resources/k3d-create-cluster.sh
 
 .PHONY: k3d/cluster/create
-k3d/cluster/create: $(KUBECONFIG_DIR)
+k3d/cluster/create: $(KUBECONFIG_DIR) k3d/docker/network/create k3d/docker/credentials/setup
 	$(Q)$(K3D_CREATE_CLUSTER) \
 	  "$(DOCKER_NETWORK)" \
 	  "$(K3D_PORT_PREFIX_LOCK_DIR)" \
 	  -- \
 	  $(K3D) cluster create $(CLUSTER_NAME) $(K3D_CLUSTER_CREATE_OPTS)
+	$(Q)$(call k8s_link_legacy_kubeconfig,$(K3D_CLUSTER_KUBECONFIG))
 
 .PHONY: k3d/cluster/stop
 k3d/cluster/stop:
-	$(Q)$(K3D) cluster delete $(CLUSTER_NAME) && rm -f $(K3D_CLUSTER_KUBECONFIG)
+	$(Q)$(K3D) cluster delete $(CLUSTER_NAME) && \
+	  $(call k8s_unlink_legacy_kubeconfig,$(K3D_CLUSTER_KUBECONFIG)) && \
+	  rm -f $(K3D_CLUSTER_KUBECONFIG)
 
-# Orchestrated via sequential $(MAKE) calls to guarantee ordering under -j.
 .PHONY: k3d/cluster/start
-k3d/cluster/start:
-	$(Q)$(MAKE) k3d/docker/network/create
-	$(Q)$(MAKE) k3d/docker/credentials/setup
-	$(Q)$(MAKE) k3d/cluster/create
-	$(Q)$(MAKE) k3d/cluster/cni/setup
-	$(Q)$(MAKE) k3d/cluster/ebpf/setup
-	$(Q)$(MAKE) k3d/cluster/wait
-	$(Q)$(MAKE) k3d/cluster/metallb/setup
+k3d/cluster/start: k3d/cluster/metallb/setup
 
 # --- MetalLB ---
 
 METALLB_RENDER_POOL    ?= $(KUMA_DIR)/mk/resources/render-metallb-pool.sh
 METALLB_RESOURCES      ?= $(TMP_DIR_K8S)/metallb-$(CLUSTER_NAME).yaml
 
-.PHONY: $(METALLB_RESOURCES)
 $(METALLB_RESOURCES): $(METALLB_RENDER_POOL) k3d/docker/network/create
 	$(Q)$(METALLB_RENDER_POOL) $(DOCKER_NETWORK) $(CLUSTER_NUMBER) $@ $(METALLB_NAMESPACE)
 
 .PHONY: k3d/cluster/metallb/setup
-k3d/cluster/metallb/setup: $(METALLB_RESOURCES)
+k3d/cluster/metallb/setup: k3d/cluster/wait $(METALLB_RESOURCES)
 	$(Q)$(KUBECTL) apply \
 	  --filename $(METALLB_MANIFESTS)
 
@@ -330,7 +336,7 @@ k3d/cluster/metallb/setup: $(METALLB_RESOURCES)
 .PHONY: k3d/cluster/wait
 k3d/cluster/wait: NAMESPACE   ?= kube-system
 k3d/cluster/wait: MAX_RETRIES ?= 30
-k3d/cluster/wait:
+k3d/cluster/wait: k3d/cluster/ebpf/setup
 	$(Q)tries=0; \
 	until $(KUBECTL) wait pods --all \
 	  --context $(KUBECONTEXT) \
@@ -353,6 +359,10 @@ k3d/clusters/destroy:
 	@for cluster in $$($(K3D) cluster list --output json | $(JQ) -r '.[].name'); do \
 		echo "Deleting cluster $$cluster"; \
 		$(K3D) cluster delete $$cluster; \
+		legacy="$(KUBECONFIG_DIR)/$$cluster.yaml"; \
+		if [ -L "$$legacy" ] && [ "$$(readlink "$$legacy")" = "$(KUBECONFIG_DIR)/k3d-$$cluster.yaml" ]; then \
+			rm -f "$$legacy"; \
+		fi; \
 		rm -f $(KUBECONFIG_DIR)/k3d-$$cluster.yaml; \
 	done
 
@@ -395,7 +405,7 @@ k3d/cluster/deploy/wait/mesh:
 # --- Deploy: kumactl ---
 
 .PHONY: k3d/cluster/deploy/kumactl/install
-k3d/cluster/deploy/kumactl/install:
+k3d/cluster/deploy/kumactl/install: build/kumactl k3d/cluster/load
 	$(Q)$(KUMACTL) install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) \
 	  | $(KUBECTL) apply --filename - \
 	  | grep --invert-match 'unchanged'
@@ -407,18 +417,19 @@ k3d/cluster/deploy/kumactl/clean:
 		| $(KUBECTL) delete --filename -
 
 .PHONY: k3d/cluster/deploy/kumactl
-k3d/cluster/deploy/kumactl:
-	$(Q)$(MAKE) build/kumactl
-	$(Q)$(MAKE) k3d/cluster/load
-	$(Q)$(MAKE) k3d/cluster/deploy/kumactl/install
-	$(Q)$(MAKE) k3d/cluster/deploy/wait/cp
+k3d/cluster/deploy/kumactl: k3d/cluster/deploy/kumactl/install k3d/cluster/deploy/wait/cp
+
+.PHONY: k3d/cluster/restart/kumactl/stop
+k3d/cluster/restart/kumactl/stop: k3d/cluster/stop
+
+.PHONY: k3d/cluster/restart/kumactl/start
+k3d/cluster/restart/kumactl/start: k3d/cluster/restart/kumactl/stop k3d/cluster/start
+
+.PHONY: k3d/cluster/restart/kumactl/deploy
+k3d/cluster/restart/kumactl/deploy: k3d/cluster/restart/kumactl/start k3d/cluster/deploy/kumactl
 
 .PHONY: k3d/cluster/restart/kumactl
-k3d/cluster/restart/kumactl:
-	$(Q)$(MAKE) k3d/cluster/stop
-	$(Q)$(MAKE) k3d/cluster/start
-	$(Q)$(MAKE) k3d/cluster/deploy/kumactl
-	$(Q)$(MAKE) k3d/cluster/deploy/demo
+k3d/cluster/restart/kumactl: k3d/cluster/restart/kumactl/deploy k3d/cluster/deploy/demo
 
 # --- Deploy: Helm ---
 
@@ -449,12 +460,10 @@ ifeq (,$(or $(K3D_DEPLOY_HELM_DONT_CLEAN),$(K3D_DEPLOY_HELM_DONT_CLEAN_NS)))
 endif
 
 .PHONY: k3d/cluster/deploy/helm/clean
-k3d/cluster/deploy/helm/clean:
-	$(Q)$(MAKE) k3d/cluster/deploy/helm/clean/release
-	$(Q)$(MAKE) k3d/cluster/deploy/helm/clean/ns
+k3d/cluster/deploy/helm/clean: k3d/cluster/deploy/helm/clean/release k3d/cluster/deploy/helm/clean/ns
 
 .PHONY: k3d/cluster/deploy/helm/upgrade
-k3d/cluster/deploy/helm/upgrade:
+k3d/cluster/deploy/helm/upgrade: k3d/cluster/load k3d/cluster/deploy/helm/clean
 	$(Q)echo "Upgrading or installing Helm release '$(PROJECT_NAME)'..."
 	$(Q)$(HELM) upgrade $(PROJECT_NAME) ./deployments/charts/$(PROJECT_NAME) \
 		--install \
@@ -463,11 +472,7 @@ k3d/cluster/deploy/helm/upgrade:
 		$(strip $(K3D_HELM_DEPLOY_OPTS))
 
 .PHONY: k3d/cluster/deploy/helm
-k3d/cluster/deploy/helm:
-	$(Q)$(MAKE) k3d/cluster/load
-	$(Q)$(MAKE) k3d/cluster/deploy/helm/clean
-	$(Q)$(MAKE) k3d/cluster/deploy/helm/upgrade
-	$(Q)$(MAKE) k3d/cluster/deploy/wait/cp
+k3d/cluster/deploy/helm: k3d/cluster/deploy/helm/upgrade k3d/cluster/deploy/wait/cp
 
 # --- Deploy: demo ---
 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -316,11 +316,12 @@ k3d/cluster/start: k3d/cluster/metallb/setup
 METALLB_RENDER_POOL    ?= $(KUMA_DIR)/mk/resources/render-metallb-pool.sh
 METALLB_RESOURCES      ?= $(TMP_DIR_K8S)/metallb-$(CLUSTER_NAME).yaml
 
-$(METALLB_RESOURCES): $(METALLB_RENDER_POOL) k3d/docker/network/create
-	$(Q)$(METALLB_RENDER_POOL) $(DOCKER_NETWORK) $(CLUSTER_NUMBER) $@ $(METALLB_NAMESPACE)
+.PHONY: k3d/cluster/metallb/render
+k3d/cluster/metallb/render: k3d/docker/network/create
+	$(Q)$(METALLB_RENDER_POOL) $(DOCKER_NETWORK) $(CLUSTER_NUMBER) $(METALLB_RESOURCES) $(METALLB_NAMESPACE)
 
 .PHONY: k3d/cluster/metallb/setup
-k3d/cluster/metallb/setup: k3d/cluster/wait $(METALLB_RESOURCES)
+k3d/cluster/metallb/setup: k3d/cluster/wait k3d/cluster/metallb/render
 	$(Q)$(KUBECTL) apply \
 	  --filename $(METALLB_MANIFESTS)
 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -297,6 +297,9 @@ k3d/cluster/create: $(KUBECONFIG_DIR) k3d/docker/network/create k3d/docker/crede
 	  "$(K3D_PORT_PREFIX_LOCK_DIR)" \
 	  -- \
 	  $(K3D) cluster create $(CLUSTER_NAME) $(K3D_CLUSTER_CREATE_OPTS)
+	$(Q)$(K3D) kubeconfig merge $(CLUSTER_NAME) \
+	  --output $(K3D_CLUSTER_KUBECONFIG) \
+	  --overwrite
 	$(Q)$(call k8s_link_legacy_kubeconfig,$(K3D_CLUSTER_KUBECONFIG))
 
 .PHONY: k3d/cluster/stop

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -117,17 +117,17 @@ k3d/cluster/%: export KUBECONFIG  = $(K3D_CLUSTER_KUBECONFIG)
 k3d/cluster/%: export KUBECONTEXT = $(CLUSTER_KUBECONTEXT)
 
 .PHONY: k3d/cluster/start/% k3d/cluster/load/images/% k3d/cluster/wait/% k3d/cluster/stop/%
-k3d/cluster/start/%: CLUSTER = $*
-k3d/cluster/start/%: k3d/cluster/start
+k3d/cluster/start/%:
+	$(Q)$(MAKE) --no-print-directory CLUSTER=$* k3d/cluster/start
 
-k3d/cluster/load/images/%: CLUSTER = $*
-k3d/cluster/load/images/%: k3d/cluster/load/images
+k3d/cluster/load/images/%:
+	$(Q)$(MAKE) --no-print-directory CLUSTER=$* k3d/cluster/load/images
 
-k3d/cluster/wait/%: CLUSTER = $*
-k3d/cluster/wait/%: k3d/cluster/wait
+k3d/cluster/wait/%:
+	$(Q)$(MAKE) --no-print-directory CLUSTER=$* k3d/cluster/wait
 
-k3d/cluster/stop/%: CLUSTER = $*
-k3d/cluster/stop/%: k3d/cluster/stop
+k3d/cluster/stop/%:
+	$(Q)$(MAKE) --no-print-directory CLUSTER=$* k3d/cluster/stop
 
 # --- Diagnostics ---
 

--- a/mk/k8s.mk
+++ b/mk/k8s.mk
@@ -35,29 +35,22 @@ $(if $(_k8s_cluster_valid),,$(error Invalid CLUSTER "$(CLUSTER)". Expected "kuma
 
 # --- Derived variables ---
 
-# Numeric suffix (used for MetalLB subnet offset, port allocation)
-ifeq ($(CLUSTER),kuma)
-  CLUSTER_NUMBER := 0
-else ifneq ($(filter kuma-%,$(CLUSTER)),)
-  CLUSTER_NUMBER := $(patsubst kuma-%,%,$(CLUSTER))
-else
-  CLUSTER_NUMBER := $(CLUSTER)
-endif
+# Numeric suffix (used for MetalLB subnet offset, port allocation).
+# Keep this recursive so target-specific `CLUSTER=...` overrides propagate
+# into per-cluster e2e targets created after parse time.
+k8s_cluster_number = $(if $(filter kuma,$(1)),0,$(if $(filter kuma-%,$(1)),$(patsubst kuma-%,%,$(1)),$(1)))
+CLUSTER_NUMBER = $(call k8s_cluster_number,$(CLUSTER))
 
-# Canonical cluster name: "kuma" stays "kuma"; numbers become "kuma-<N>"
-ifeq ($(CLUSTER_NUMBER),0)
-  CLUSTER_NAME := kuma
-else
-  CLUSTER_NAME := kuma-$(CLUSTER_NUMBER)
-endif
+# Canonical cluster name: "kuma" stays "kuma"; numbers become "kuma-<N>".
+CLUSTER_NAME = $(if $(filter 0,$(CLUSTER_NUMBER)),kuma,kuma-$(CLUSTER_NUMBER))
 
 # Tool-specific kubeconfig paths keep kind and k3d clusters from clobbering
 # each other's files when they share the same cluster name.
 k8s_cluster_kubeconfig = $(KUBECONFIG_DIR)/$(1)-$(2).yaml
 
-KIND_CLUSTER_KUBECONFIG := $(call k8s_cluster_kubeconfig,kind,$(CLUSTER_NAME))
-K3D_CLUSTER_KUBECONFIG := $(call k8s_cluster_kubeconfig,k3d,$(CLUSTER_NAME))
-LEGACY_CLUSTER_KUBECONFIG := $(KUBECONFIG_DIR)/$(CLUSTER_NAME).yaml
+KIND_CLUSTER_KUBECONFIG = $(call k8s_cluster_kubeconfig,kind,$(CLUSTER_NAME))
+K3D_CLUSTER_KUBECONFIG = $(call k8s_cluster_kubeconfig,k3d,$(CLUSTER_NAME))
+LEGACY_CLUSTER_KUBECONFIG = $(KUBECONFIG_DIR)/$(CLUSTER_NAME).yaml
 
 # Compatibility alias: kong-mesh and older workflows reference
 # `KIND_KUBECONFIG` as the active cluster kubeconfig regardless of tool.

--- a/mk/k8s.mk
+++ b/mk/k8s.mk
@@ -57,9 +57,19 @@ k8s_cluster_kubeconfig = $(KUBECONFIG_DIR)/$(1)-$(2).yaml
 
 KIND_CLUSTER_KUBECONFIG := $(call k8s_cluster_kubeconfig,kind,$(CLUSTER_NAME))
 K3D_CLUSTER_KUBECONFIG := $(call k8s_cluster_kubeconfig,k3d,$(CLUSTER_NAME))
+LEGACY_CLUSTER_KUBECONFIG := $(KUBECONFIG_DIR)/$(CLUSTER_NAME).yaml
 
-# Compatibility alias: kong-mesh and older workflows reference KIND_KUBECONFIG
-KIND_KUBECONFIG = $(KIND_CLUSTER_KUBECONFIG)
+# Compatibility alias: kong-mesh and older workflows reference
+# `KIND_KUBECONFIG` as the active cluster kubeconfig regardless of tool.
+KIND_KUBECONFIG = $(LEGACY_CLUSTER_KUBECONFIG)
+
+define k8s_link_legacy_kubeconfig
+ln -snf "$(abspath $(1))" "$(LEGACY_CLUSTER_KUBECONFIG)"
+endef
+
+define k8s_unlink_legacy_kubeconfig
+if [ -L "$(LEGACY_CLUSTER_KUBECONFIG)" ] && [ "$$(readlink "$(LEGACY_CLUSTER_KUBECONFIG)")" = "$(abspath $(1))" ]; then rm -f "$(LEGACY_CLUSTER_KUBECONFIG)"; fi
+endef
 
 # Temp workspace for generated k8s manifests and caches
 TMP_DIR_K8S ?= /tmp/.kuma-dev

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -27,6 +27,19 @@ kind/setup-docker-credentials:
 kind/cleanup-docker-credentials:
 	@rm -f /tmp/.kuma-dev/kind-config.json
 
+.PHONY: kind/cluster/start/% kind/cluster/load/images/% kind/cluster/wait/% kind/cluster/stop/%
+kind/cluster/start/%: CLUSTER = $*
+kind/cluster/start/%: kind/cluster/start
+
+kind/cluster/load/images/%: CLUSTER = $*
+kind/cluster/load/images/%: kind/cluster/load/images
+
+kind/cluster/wait/%: CLUSTER = $*
+kind/cluster/wait/%: kind/cluster/wait
+
+kind/cluster/stop/%: CLUSTER = $*
+kind/cluster/stop/%: kind/cluster/stop
+
 # Create the Docker network before kind so kind uses it as primary via
 # KIND_EXPERIMENTAL_DOCKER_NETWORK. This puts kind nodes directly on the
 # same network as universal test containers - no secondary interface needed.
@@ -42,6 +55,7 @@ kind/cluster/start: $(KUBECONFIG_DIR) kind/setup-docker-credentials k8s/docker/n
 			--quiet --wait 120s && \
 		KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) scale deployment --replicas 1 coredns --namespace kube-system && \
 		$(MAKE) kind/cluster/wait)
+	@$(call k8s_link_legacy_kubeconfig,$(KIND_CLUSTER_KUBECONFIG))
 	@echo
 	@echo '>>> You need to manually run the following command in your shell: >>>'
 	@echo
@@ -71,11 +85,21 @@ kind/cluster/wait:
 .PHONY: kind/cluster/stop
 kind/cluster/stop: kind/cleanup-docker-credentials
 	@$(KIND) delete cluster --kubeconfig $(KIND_CLUSTER_KUBECONFIG) --name $(CLUSTER_NAME)
+	@$(call k8s_unlink_legacy_kubeconfig,$(KIND_CLUSTER_KUBECONFIG))
 	@rm -f $(KIND_CLUSTER_KUBECONFIG)
 
 .PHONY: kind/clusters/stop
 kind/clusters/stop:
 	@$(KIND) delete clusters --all
+	@for kubeconfig in $(KUBECONFIG_DIR)/kind-kuma*.yaml; do \
+		[ -e "$$kubeconfig" ] || continue; \
+		cluster="$${kubeconfig##*/kind-}"; \
+		cluster="$${cluster%.yaml}"; \
+		legacy="$(KUBECONFIG_DIR)/$$cluster.yaml"; \
+		if [ -L "$$legacy" ] && [ "$$(readlink "$$legacy")" = "$$kubeconfig" ]; then \
+			rm -f "$$legacy"; \
+		fi; \
+	done
 	@rm -f $(KUBECONFIG_DIR)/kind-kuma*.yaml
 
 .PHONY: kind/cluster/load/images

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -28,17 +28,17 @@ kind/cleanup-docker-credentials:
 	@rm -f /tmp/.kuma-dev/kind-config.json
 
 .PHONY: kind/cluster/start/% kind/cluster/load/images/% kind/cluster/wait/% kind/cluster/stop/%
-kind/cluster/start/%: CLUSTER = $*
-kind/cluster/start/%: kind/cluster/start
+kind/cluster/start/%:
+	@$(MAKE) --no-print-directory CLUSTER=$* kind/cluster/start
 
-kind/cluster/load/images/%: CLUSTER = $*
-kind/cluster/load/images/%: kind/cluster/load/images
+kind/cluster/load/images/%:
+	@$(MAKE) --no-print-directory CLUSTER=$* kind/cluster/load/images
 
-kind/cluster/wait/%: CLUSTER = $*
-kind/cluster/wait/%: kind/cluster/wait
+kind/cluster/wait/%:
+	@$(MAKE) --no-print-directory CLUSTER=$* kind/cluster/wait
 
-kind/cluster/stop/%: CLUSTER = $*
-kind/cluster/stop/%: kind/cluster/stop
+kind/cluster/stop/%:
+	@$(MAKE) --no-print-directory CLUSTER=$* kind/cluster/stop
 
 # Create the Docker network before kind so kind uses it as primary via
 # KIND_EXPERIMENTAL_DOCKER_NETWORK. This puts kind nodes directly on the

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -3,7 +3,7 @@ TEST_PKG_LIST ?= ./...
 REPORTS_DIR ?= build/reports
 # Path to the kumactl binary for Linux. This binary will be uploaded to Docker
 # containers during transparent proxy tests.
-KUMACTL_LINUX_BIN ?= $(BUILD_DIR)/artifacts-linux-$(GOARCH)/kumactl/kumactl
+KUMACTL_LINUX_BIN ?= build/artifacts-linux-$(GOARCH)/kumactl/kumactl
 
 GINKGO_UNIT_TEST_FLAGS ?= \
 	--skip-package ./test --race
@@ -55,6 +55,5 @@ test/cni: TEST_PKG_LIST=./app/cni/...
 test/cni: test ## Dev: Run `cni` tests only
 
 .PHONY: test/transparentproxy
-test/transparentproxy:
-	GOOS=linux $(MAKE) build/kumactl
+test/transparentproxy: $(KUMACTL_LINUX_BIN)
 	KUMACTL_LINUX_BIN=$(KUMACTL_LINUX_BIN) $(UNIT_TEST_ENV) $(GINKGO_TEST) -v ./test/transparentproxy/...


### PR DESCRIPTION
> [!WARNING]
> WIP

## Motivation

Fix the GNU make issues by making prerequisite edges explicit and by removing parse-time side effects from dev targets

## Implementation information

- move proto exports, Docker save/load, docs generation, e2e startup, and transparent proxy setup onto explicit prerequisites or file targets
- preserve legacy target aliases and the legacy shared kubeconfig path on top of tool-specific kubeconfigs
- normalize the k3d deployment volume path for absolute `KUMA_DIR` callers and keep existing local workflows working