### PR TITLE
chore(gen): use 'r' as receiver name in resource templates

### DIFF
--- a/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
@@ -89,46 +89,46 @@ func NewDoNothingResourceResource() *DoNothingResourceResource {
 	}
 }
 
-func (t *DoNothingResourceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *DoNothingResourceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *DoNothingResourceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *DoNothingResourceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *DoNothingResourceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *DoNothingResourceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *DoNothingResourceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *DoNothingResourceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*DoNothingResource)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &DoNothingResource{}
+			r.Spec = &DoNothingResource{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *DoNothingResourceResource) GetStatus() model.ResourceStatus {
+func (*DoNothingResourceResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *DoNothingResourceResource) SetStatus(model.ResourceStatus) error {
+func (*DoNothingResourceResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *DoNothingResourceResource) Descriptor() model.ResourceTypeDescriptor {
+func (*DoNothingResourceResource) Descriptor() model.ResourceTypeDescriptor {
 	return DoNothingResourceResourceTypeDescriptor
 }
 
-func (t *DoNothingResourceResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *DoNothingResourceResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewHostnameGeneratorResource() *HostnameGeneratorResource {
 	}
 }
 
-func (t *HostnameGeneratorResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *HostnameGeneratorResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *HostnameGeneratorResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *HostnameGeneratorResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *HostnameGeneratorResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *HostnameGeneratorResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *HostnameGeneratorResource) SetSpec(spec model.ResourceSpec) error {
+func (r *HostnameGeneratorResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*HostnameGenerator)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &HostnameGenerator{}
+			r.Spec = &HostnameGenerator{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *HostnameGeneratorResource) GetStatus() model.ResourceStatus {
+func (*HostnameGeneratorResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *HostnameGeneratorResource) SetStatus(model.ResourceStatus) error {
+func (*HostnameGeneratorResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *HostnameGeneratorResource) Descriptor() model.ResourceTypeDescriptor {
+func (*HostnameGeneratorResource) Descriptor() model.ResourceTypeDescriptor {
 	return HostnameGeneratorResourceTypeDescriptor
 }
 
-func (t *HostnameGeneratorResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *HostnameGeneratorResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/mesh/zz_generated.resources.go
+++ b/pkg/core/resources/apis/mesh/zz_generated.resources.go
@@ -29,49 +29,49 @@ func NewCircuitBreakerResource() *CircuitBreakerResource {
 	}
 }
 
-func (t *CircuitBreakerResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *CircuitBreakerResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *CircuitBreakerResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *CircuitBreakerResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *CircuitBreakerResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *CircuitBreakerResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *CircuitBreakerResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *CircuitBreakerResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *CircuitBreakerResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *CircuitBreakerResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *CircuitBreakerResource) SetSpec(spec model.ResourceSpec) error {
+func (r *CircuitBreakerResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.CircuitBreaker)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.CircuitBreaker{}
+			r.Spec = &mesh_proto.CircuitBreaker{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *CircuitBreakerResource) GetStatus() model.ResourceStatus {
+func (r *CircuitBreakerResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *CircuitBreakerResource) SetStatus(_ model.ResourceStatus) error {
+func (r *CircuitBreakerResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *CircuitBreakerResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *CircuitBreakerResource) Descriptor() model.ResourceTypeDescriptor {
 	return CircuitBreakerResourceTypeDescriptor
 }
 
@@ -155,41 +155,41 @@ func NewDataplaneResource() *DataplaneResource {
 	}
 }
 
-func (t *DataplaneResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *DataplaneResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *DataplaneResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *DataplaneResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *DataplaneResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *DataplaneResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *DataplaneResource) SetSpec(spec model.ResourceSpec) error {
+func (r *DataplaneResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.Dataplane)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.Dataplane{}
+			r.Spec = &mesh_proto.Dataplane{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *DataplaneResource) GetStatus() model.ResourceStatus {
+func (r *DataplaneResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *DataplaneResource) SetStatus(_ model.ResourceStatus) error {
+func (r *DataplaneResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *DataplaneResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *DataplaneResource) Descriptor() model.ResourceTypeDescriptor {
 	return DataplaneResourceTypeDescriptor
 }
 
@@ -276,41 +276,41 @@ func NewDataplaneInsightResource() *DataplaneInsightResource {
 	}
 }
 
-func (t *DataplaneInsightResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *DataplaneInsightResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *DataplaneInsightResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *DataplaneInsightResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *DataplaneInsightResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *DataplaneInsightResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *DataplaneInsightResource) SetSpec(spec model.ResourceSpec) error {
+func (r *DataplaneInsightResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.DataplaneInsight)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.DataplaneInsight{}
+			r.Spec = &mesh_proto.DataplaneInsight{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *DataplaneInsightResource) GetStatus() model.ResourceStatus {
+func (r *DataplaneInsightResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *DataplaneInsightResource) SetStatus(_ model.ResourceStatus) error {
+func (r *DataplaneInsightResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *DataplaneInsightResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *DataplaneInsightResource) Descriptor() model.ResourceTypeDescriptor {
 	return DataplaneInsightResourceTypeDescriptor
 }
 
@@ -394,46 +394,46 @@ func NewDataplaneOverviewResource() *DataplaneOverviewResource {
 	}
 }
 
-func (t *DataplaneOverviewResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *DataplaneOverviewResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *DataplaneOverviewResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *DataplaneOverviewResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *DataplaneOverviewResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *DataplaneOverviewResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *DataplaneOverviewResource) SetSpec(spec model.ResourceSpec) error {
+func (r *DataplaneOverviewResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.DataplaneOverview)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.DataplaneOverview{}
+			r.Spec = &mesh_proto.DataplaneOverview{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *DataplaneOverviewResource) GetStatus() model.ResourceStatus {
+func (r *DataplaneOverviewResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *DataplaneOverviewResource) SetStatus(_ model.ResourceStatus) error {
+func (r *DataplaneOverviewResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *DataplaneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *DataplaneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return DataplaneOverviewResourceTypeDescriptor
 }
 
-func (t *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
-	t.SetMeta(resource.GetMeta())
+func (r *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
+	r.SetMeta(resource.GetMeta())
 	overview := &mesh_proto.DataplaneOverview{
 		Dataplane: resource.GetSpec().(*mesh_proto.Dataplane),
 	}
@@ -444,7 +444,7 @@ func (t *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, ins
 		}
 		overview.DataplaneInsight = ins
 	}
-	return t.SetSpec(overview)
+	return r.SetSpec(overview)
 }
 
 var _ model.ResourceList = &DataplaneOverviewResourceList{}
@@ -522,41 +522,41 @@ func NewExternalServiceResource() *ExternalServiceResource {
 	}
 }
 
-func (t *ExternalServiceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ExternalServiceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ExternalServiceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ExternalServiceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ExternalServiceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ExternalServiceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ExternalServiceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ExternalServiceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ExternalService)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ExternalService{}
+			r.Spec = &mesh_proto.ExternalService{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ExternalServiceResource) GetStatus() model.ResourceStatus {
+func (r *ExternalServiceResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ExternalServiceResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ExternalServiceResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ExternalServiceResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ExternalServiceResource) Descriptor() model.ResourceTypeDescriptor {
 	return ExternalServiceResourceTypeDescriptor
 }
 
@@ -640,49 +640,49 @@ func NewFaultInjectionResource() *FaultInjectionResource {
 	}
 }
 
-func (t *FaultInjectionResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *FaultInjectionResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *FaultInjectionResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *FaultInjectionResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *FaultInjectionResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *FaultInjectionResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *FaultInjectionResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *FaultInjectionResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *FaultInjectionResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *FaultInjectionResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *FaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
+func (r *FaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.FaultInjection)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.FaultInjection{}
+			r.Spec = &mesh_proto.FaultInjection{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *FaultInjectionResource) GetStatus() model.ResourceStatus {
+func (r *FaultInjectionResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *FaultInjectionResource) SetStatus(_ model.ResourceStatus) error {
+func (r *FaultInjectionResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *FaultInjectionResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *FaultInjectionResource) Descriptor() model.ResourceTypeDescriptor {
 	return FaultInjectionResourceTypeDescriptor
 }
 
@@ -766,49 +766,49 @@ func NewHealthCheckResource() *HealthCheckResource {
 	}
 }
 
-func (t *HealthCheckResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *HealthCheckResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *HealthCheckResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *HealthCheckResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *HealthCheckResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *HealthCheckResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *HealthCheckResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *HealthCheckResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *HealthCheckResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *HealthCheckResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *HealthCheckResource) SetSpec(spec model.ResourceSpec) error {
+func (r *HealthCheckResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.HealthCheck)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.HealthCheck{}
+			r.Spec = &mesh_proto.HealthCheck{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *HealthCheckResource) GetStatus() model.ResourceStatus {
+func (r *HealthCheckResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *HealthCheckResource) SetStatus(_ model.ResourceStatus) error {
+func (r *HealthCheckResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *HealthCheckResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *HealthCheckResource) Descriptor() model.ResourceTypeDescriptor {
 	return HealthCheckResourceTypeDescriptor
 }
 
@@ -892,41 +892,41 @@ func NewMeshResource() *MeshResource {
 	}
 }
 
-func (t *MeshResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.Mesh)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.Mesh{}
+			r.Spec = &mesh_proto.Mesh{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshResource) GetStatus() model.ResourceStatus {
+func (r *MeshResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshResource) SetStatus(_ model.ResourceStatus) error {
+func (r *MeshResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *MeshResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshResourceTypeDescriptor
 }
 
@@ -1012,45 +1012,45 @@ func NewMeshGatewayResource() *MeshGatewayResource {
 	}
 }
 
-func (t *MeshGatewayResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshGatewayResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshGatewayResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshGatewayResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshGatewayResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshGatewayResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshGatewayResource) Selectors() []*mesh_proto.Selector {
-	return t.Spec.GetSelectors()
+func (r *MeshGatewayResource) Selectors() []*mesh_proto.Selector {
+	return r.Spec.GetSelectors()
 }
 
-func (t *MeshGatewayResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshGatewayResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.MeshGateway)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.MeshGateway{}
+			r.Spec = &mesh_proto.MeshGateway{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshGatewayResource) GetStatus() model.ResourceStatus {
+func (r *MeshGatewayResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshGatewayResource) SetStatus(_ model.ResourceStatus) error {
+func (r *MeshGatewayResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshGatewayResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *MeshGatewayResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshGatewayResourceTypeDescriptor
 }
 
@@ -1135,45 +1135,45 @@ func NewMeshGatewayRouteResource() *MeshGatewayRouteResource {
 	}
 }
 
-func (t *MeshGatewayRouteResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshGatewayRouteResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshGatewayRouteResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshGatewayRouteResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshGatewayRouteResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshGatewayRouteResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshGatewayRouteResource) Selectors() []*mesh_proto.Selector {
-	return t.Spec.GetSelectors()
+func (r *MeshGatewayRouteResource) Selectors() []*mesh_proto.Selector {
+	return r.Spec.GetSelectors()
 }
 
-func (t *MeshGatewayRouteResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshGatewayRouteResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.MeshGatewayRoute)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.MeshGatewayRoute{}
+			r.Spec = &mesh_proto.MeshGatewayRoute{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshGatewayRouteResource) GetStatus() model.ResourceStatus {
+func (r *MeshGatewayRouteResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshGatewayRouteResource) SetStatus(_ model.ResourceStatus) error {
+func (r *MeshGatewayRouteResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshGatewayRouteResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *MeshGatewayRouteResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshGatewayRouteResourceTypeDescriptor
 }
 
@@ -1257,41 +1257,41 @@ func NewMeshInsightResource() *MeshInsightResource {
 	}
 }
 
-func (t *MeshInsightResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshInsightResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshInsightResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshInsightResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshInsightResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshInsightResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshInsightResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshInsightResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.MeshInsight)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.MeshInsight{}
+			r.Spec = &mesh_proto.MeshInsight{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshInsightResource) GetStatus() model.ResourceStatus {
+func (r *MeshInsightResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshInsightResource) SetStatus(_ model.ResourceStatus) error {
+func (r *MeshInsightResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshInsightResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *MeshInsightResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshInsightResourceTypeDescriptor
 }
 
@@ -1375,45 +1375,45 @@ func NewProxyTemplateResource() *ProxyTemplateResource {
 	}
 }
 
-func (t *ProxyTemplateResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ProxyTemplateResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ProxyTemplateResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ProxyTemplateResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ProxyTemplateResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ProxyTemplateResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ProxyTemplateResource) Selectors() []*mesh_proto.Selector {
-	return t.Spec.GetSelectors()
+func (r *ProxyTemplateResource) Selectors() []*mesh_proto.Selector {
+	return r.Spec.GetSelectors()
 }
 
-func (t *ProxyTemplateResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ProxyTemplateResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ProxyTemplate)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ProxyTemplate{}
+			r.Spec = &mesh_proto.ProxyTemplate{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ProxyTemplateResource) GetStatus() model.ResourceStatus {
+func (r *ProxyTemplateResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ProxyTemplateResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ProxyTemplateResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ProxyTemplateResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ProxyTemplateResource) Descriptor() model.ResourceTypeDescriptor {
 	return ProxyTemplateResourceTypeDescriptor
 }
 
@@ -1497,49 +1497,49 @@ func NewRateLimitResource() *RateLimitResource {
 	}
 }
 
-func (t *RateLimitResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *RateLimitResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *RateLimitResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *RateLimitResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *RateLimitResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *RateLimitResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *RateLimitResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *RateLimitResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *RateLimitResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *RateLimitResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *RateLimitResource) SetSpec(spec model.ResourceSpec) error {
+func (r *RateLimitResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.RateLimit)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.RateLimit{}
+			r.Spec = &mesh_proto.RateLimit{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *RateLimitResource) GetStatus() model.ResourceStatus {
+func (r *RateLimitResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *RateLimitResource) SetStatus(_ model.ResourceStatus) error {
+func (r *RateLimitResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *RateLimitResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *RateLimitResource) Descriptor() model.ResourceTypeDescriptor {
 	return RateLimitResourceTypeDescriptor
 }
 
@@ -1623,49 +1623,49 @@ func NewRetryResource() *RetryResource {
 	}
 }
 
-func (t *RetryResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *RetryResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *RetryResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *RetryResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *RetryResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *RetryResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *RetryResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *RetryResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *RetryResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *RetryResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *RetryResource) SetSpec(spec model.ResourceSpec) error {
+func (r *RetryResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.Retry)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.Retry{}
+			r.Spec = &mesh_proto.Retry{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *RetryResource) GetStatus() model.ResourceStatus {
+func (r *RetryResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *RetryResource) SetStatus(_ model.ResourceStatus) error {
+func (r *RetryResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *RetryResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *RetryResource) Descriptor() model.ResourceTypeDescriptor {
 	return RetryResourceTypeDescriptor
 }
 
@@ -1749,41 +1749,41 @@ func NewServiceInsightResource() *ServiceInsightResource {
 	}
 }
 
-func (t *ServiceInsightResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ServiceInsightResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ServiceInsightResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ServiceInsightResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ServiceInsightResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ServiceInsightResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ServiceInsightResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ServiceInsightResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ServiceInsight)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ServiceInsight{}
+			r.Spec = &mesh_proto.ServiceInsight{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ServiceInsightResource) GetStatus() model.ResourceStatus {
+func (r *ServiceInsightResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ServiceInsightResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ServiceInsightResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ServiceInsightResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ServiceInsightResource) Descriptor() model.ResourceTypeDescriptor {
 	return ServiceInsightResourceTypeDescriptor
 }
 
@@ -1867,41 +1867,41 @@ func NewServiceOverviewResource() *ServiceOverviewResource {
 	}
 }
 
-func (t *ServiceOverviewResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ServiceOverviewResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ServiceOverviewResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ServiceOverviewResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ServiceOverviewResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ServiceOverviewResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ServiceOverviewResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ServiceOverviewResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ServiceInsight_Service)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ServiceInsight_Service{}
+			r.Spec = &mesh_proto.ServiceInsight_Service{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ServiceOverviewResource) GetStatus() model.ResourceStatus {
+func (r *ServiceOverviewResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ServiceOverviewResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ServiceOverviewResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ServiceOverviewResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ServiceOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return ServiceOverviewResourceTypeDescriptor
 }
 
@@ -1980,49 +1980,49 @@ func NewTimeoutResource() *TimeoutResource {
 	}
 }
 
-func (t *TimeoutResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *TimeoutResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *TimeoutResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *TimeoutResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *TimeoutResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *TimeoutResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *TimeoutResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *TimeoutResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *TimeoutResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *TimeoutResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *TimeoutResource) SetSpec(spec model.ResourceSpec) error {
+func (r *TimeoutResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.Timeout)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.Timeout{}
+			r.Spec = &mesh_proto.Timeout{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *TimeoutResource) GetStatus() model.ResourceStatus {
+func (r *TimeoutResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *TimeoutResource) SetStatus(_ model.ResourceStatus) error {
+func (r *TimeoutResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *TimeoutResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *TimeoutResource) Descriptor() model.ResourceTypeDescriptor {
 	return TimeoutResourceTypeDescriptor
 }
 
@@ -2106,49 +2106,49 @@ func NewTrafficLogResource() *TrafficLogResource {
 	}
 }
 
-func (t *TrafficLogResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *TrafficLogResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *TrafficLogResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *TrafficLogResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *TrafficLogResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *TrafficLogResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *TrafficLogResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *TrafficLogResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *TrafficLogResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *TrafficLogResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *TrafficLogResource) SetSpec(spec model.ResourceSpec) error {
+func (r *TrafficLogResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.TrafficLog)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.TrafficLog{}
+			r.Spec = &mesh_proto.TrafficLog{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *TrafficLogResource) GetStatus() model.ResourceStatus {
+func (r *TrafficLogResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *TrafficLogResource) SetStatus(_ model.ResourceStatus) error {
+func (r *TrafficLogResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *TrafficLogResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *TrafficLogResource) Descriptor() model.ResourceTypeDescriptor {
 	return TrafficLogResourceTypeDescriptor
 }
 
@@ -2232,49 +2232,49 @@ func NewTrafficPermissionResource() *TrafficPermissionResource {
 	}
 }
 
-func (t *TrafficPermissionResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *TrafficPermissionResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *TrafficPermissionResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *TrafficPermissionResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *TrafficPermissionResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *TrafficPermissionResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *TrafficPermissionResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *TrafficPermissionResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *TrafficPermissionResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *TrafficPermissionResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *TrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
+func (r *TrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.TrafficPermission)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.TrafficPermission{}
+			r.Spec = &mesh_proto.TrafficPermission{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *TrafficPermissionResource) GetStatus() model.ResourceStatus {
+func (r *TrafficPermissionResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *TrafficPermissionResource) SetStatus(_ model.ResourceStatus) error {
+func (r *TrafficPermissionResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *TrafficPermissionResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *TrafficPermissionResource) Descriptor() model.ResourceTypeDescriptor {
 	return TrafficPermissionResourceTypeDescriptor
 }
 
@@ -2358,49 +2358,49 @@ func NewTrafficRouteResource() *TrafficRouteResource {
 	}
 }
 
-func (t *TrafficRouteResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *TrafficRouteResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *TrafficRouteResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *TrafficRouteResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *TrafficRouteResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *TrafficRouteResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *TrafficRouteResource) Sources() []*mesh_proto.Selector {
-	return t.Spec.GetSources()
+func (r *TrafficRouteResource) Sources() []*mesh_proto.Selector {
+	return r.Spec.GetSources()
 }
 
-func (t *TrafficRouteResource) Destinations() []*mesh_proto.Selector {
-	return t.Spec.GetDestinations()
+func (r *TrafficRouteResource) Destinations() []*mesh_proto.Selector {
+	return r.Spec.GetDestinations()
 }
 
-func (t *TrafficRouteResource) SetSpec(spec model.ResourceSpec) error {
+func (r *TrafficRouteResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.TrafficRoute)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.TrafficRoute{}
+			r.Spec = &mesh_proto.TrafficRoute{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *TrafficRouteResource) GetStatus() model.ResourceStatus {
+func (r *TrafficRouteResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *TrafficRouteResource) SetStatus(_ model.ResourceStatus) error {
+func (r *TrafficRouteResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *TrafficRouteResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *TrafficRouteResource) Descriptor() model.ResourceTypeDescriptor {
 	return TrafficRouteResourceTypeDescriptor
 }
 
@@ -2484,45 +2484,45 @@ func NewTrafficTraceResource() *TrafficTraceResource {
 	}
 }
 
-func (t *TrafficTraceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *TrafficTraceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *TrafficTraceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *TrafficTraceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *TrafficTraceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *TrafficTraceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *TrafficTraceResource) Selectors() []*mesh_proto.Selector {
-	return t.Spec.GetSelectors()
+func (r *TrafficTraceResource) Selectors() []*mesh_proto.Selector {
+	return r.Spec.GetSelectors()
 }
 
-func (t *TrafficTraceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *TrafficTraceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.TrafficTrace)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.TrafficTrace{}
+			r.Spec = &mesh_proto.TrafficTrace{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *TrafficTraceResource) GetStatus() model.ResourceStatus {
+func (r *TrafficTraceResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *TrafficTraceResource) SetStatus(_ model.ResourceStatus) error {
+func (r *TrafficTraceResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *TrafficTraceResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *TrafficTraceResource) Descriptor() model.ResourceTypeDescriptor {
 	return TrafficTraceResourceTypeDescriptor
 }
 
@@ -2606,45 +2606,45 @@ func NewVirtualOutboundResource() *VirtualOutboundResource {
 	}
 }
 
-func (t *VirtualOutboundResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *VirtualOutboundResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *VirtualOutboundResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *VirtualOutboundResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *VirtualOutboundResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *VirtualOutboundResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *VirtualOutboundResource) Selectors() []*mesh_proto.Selector {
-	return t.Spec.GetSelectors()
+func (r *VirtualOutboundResource) Selectors() []*mesh_proto.Selector {
+	return r.Spec.GetSelectors()
 }
 
-func (t *VirtualOutboundResource) SetSpec(spec model.ResourceSpec) error {
+func (r *VirtualOutboundResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.VirtualOutbound)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.VirtualOutbound{}
+			r.Spec = &mesh_proto.VirtualOutbound{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *VirtualOutboundResource) GetStatus() model.ResourceStatus {
+func (r *VirtualOutboundResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *VirtualOutboundResource) SetStatus(_ model.ResourceStatus) error {
+func (r *VirtualOutboundResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *VirtualOutboundResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *VirtualOutboundResource) Descriptor() model.ResourceTypeDescriptor {
 	return VirtualOutboundResourceTypeDescriptor
 }
 
@@ -2728,41 +2728,41 @@ func NewZoneEgressResource() *ZoneEgressResource {
 	}
 }
 
-func (t *ZoneEgressResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneEgressResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneEgressResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneEgressResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneEgressResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneEgressResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneEgressResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneEgressResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ZoneEgress)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ZoneEgress{}
+			r.Spec = &mesh_proto.ZoneEgress{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneEgressResource) GetStatus() model.ResourceStatus {
+func (r *ZoneEgressResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneEgressResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneEgressResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneEgressResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneEgressResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneEgressResourceTypeDescriptor
 }
 
@@ -2849,41 +2849,41 @@ func NewZoneEgressInsightResource() *ZoneEgressInsightResource {
 	}
 }
 
-func (t *ZoneEgressInsightResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneEgressInsightResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneEgressInsightResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneEgressInsightResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneEgressInsightResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneEgressInsightResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneEgressInsightResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneEgressInsightResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ZoneEgressInsight)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ZoneEgressInsight{}
+			r.Spec = &mesh_proto.ZoneEgressInsight{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneEgressInsightResource) GetStatus() model.ResourceStatus {
+func (r *ZoneEgressInsightResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneEgressInsightResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneEgressInsightResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneEgressInsightResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneEgressInsightResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneEgressInsightResourceTypeDescriptor
 }
 
@@ -2967,46 +2967,46 @@ func NewZoneEgressOverviewResource() *ZoneEgressOverviewResource {
 	}
 }
 
-func (t *ZoneEgressOverviewResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneEgressOverviewResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneEgressOverviewResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneEgressOverviewResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneEgressOverviewResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneEgressOverviewResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneEgressOverviewResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneEgressOverviewResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ZoneEgressOverview)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ZoneEgressOverview{}
+			r.Spec = &mesh_proto.ZoneEgressOverview{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneEgressOverviewResource) GetStatus() model.ResourceStatus {
+func (r *ZoneEgressOverviewResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneEgressOverviewResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneEgressOverviewResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneEgressOverviewResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneEgressOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneEgressOverviewResourceTypeDescriptor
 }
 
-func (t *ZoneEgressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
-	t.SetMeta(resource.GetMeta())
+func (r *ZoneEgressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
+	r.SetMeta(resource.GetMeta())
 	overview := &mesh_proto.ZoneEgressOverview{
 		ZoneEgress: resource.GetSpec().(*mesh_proto.ZoneEgress),
 	}
@@ -3017,7 +3017,7 @@ func (t *ZoneEgressOverviewResource) SetOverviewSpec(resource model.Resource, in
 		}
 		overview.ZoneEgressInsight = ins
 	}
-	return t.SetSpec(overview)
+	return r.SetSpec(overview)
 }
 
 var _ model.ResourceList = &ZoneEgressOverviewResourceList{}
@@ -3095,41 +3095,41 @@ func NewZoneIngressResource() *ZoneIngressResource {
 	}
 }
 
-func (t *ZoneIngressResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneIngressResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneIngressResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneIngressResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneIngressResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneIngressResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneIngressResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneIngressResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ZoneIngress)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ZoneIngress{}
+			r.Spec = &mesh_proto.ZoneIngress{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneIngressResource) GetStatus() model.ResourceStatus {
+func (r *ZoneIngressResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneIngressResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneIngressResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneIngressResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneIngressResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneIngressResourceTypeDescriptor
 }
 
@@ -3219,41 +3219,41 @@ func NewZoneIngressInsightResource() *ZoneIngressInsightResource {
 	}
 }
 
-func (t *ZoneIngressInsightResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneIngressInsightResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneIngressInsightResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneIngressInsightResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneIngressInsightResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneIngressInsightResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneIngressInsightResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneIngressInsightResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ZoneIngressInsight)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ZoneIngressInsight{}
+			r.Spec = &mesh_proto.ZoneIngressInsight{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneIngressInsightResource) GetStatus() model.ResourceStatus {
+func (r *ZoneIngressInsightResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneIngressInsightResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneIngressInsightResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneIngressInsightResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneIngressInsightResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneIngressInsightResourceTypeDescriptor
 }
 
@@ -3337,46 +3337,46 @@ func NewZoneIngressOverviewResource() *ZoneIngressOverviewResource {
 	}
 }
 
-func (t *ZoneIngressOverviewResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneIngressOverviewResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneIngressOverviewResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneIngressOverviewResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneIngressOverviewResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneIngressOverviewResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneIngressOverviewResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneIngressOverviewResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*mesh_proto.ZoneIngressOverview)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &mesh_proto.ZoneIngressOverview{}
+			r.Spec = &mesh_proto.ZoneIngressOverview{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneIngressOverviewResource) GetStatus() model.ResourceStatus {
+func (r *ZoneIngressOverviewResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneIngressOverviewResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneIngressOverviewResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneIngressOverviewResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneIngressOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneIngressOverviewResourceTypeDescriptor
 }
 
-func (t *ZoneIngressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
-	t.SetMeta(resource.GetMeta())
+func (r *ZoneIngressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
+	r.SetMeta(resource.GetMeta())
 	overview := &mesh_proto.ZoneIngressOverview{
 		ZoneIngress: resource.GetSpec().(*mesh_proto.ZoneIngress),
 	}
@@ -3387,7 +3387,7 @@ func (t *ZoneIngressOverviewResource) SetOverviewSpec(resource model.Resource, i
 		}
 		overview.ZoneIngressInsight = ins
 	}
-	return t.SetSpec(overview)
+	return r.SetSpec(overview)
 }
 
 var _ model.ResourceList = &ZoneIngressOverviewResourceList{}

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
@@ -92,56 +92,56 @@ func NewMeshExternalServiceResource() *MeshExternalServiceResource {
 	}
 }
 
-func (t *MeshExternalServiceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshExternalServiceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshExternalServiceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshExternalServiceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshExternalServiceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshExternalServiceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshExternalServiceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshExternalServiceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshExternalService)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshExternalService{}
+			r.Spec = &MeshExternalService{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshExternalServiceResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshExternalServiceResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshExternalServiceResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshExternalServiceResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshExternalServiceStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshExternalServiceStatus{}
+			r.Status = &MeshExternalServiceStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshExternalServiceResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshExternalServiceResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshExternalServiceResourceTypeDescriptor
 }
 
-func (t *MeshExternalServiceResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshExternalServiceResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewMeshIdentityResource() *MeshIdentityResource {
 	}
 }
 
-func (t *MeshIdentityResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshIdentityResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshIdentityResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshIdentityResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshIdentityResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshIdentityResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshIdentityResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshIdentityResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshIdentity)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshIdentity{}
+			r.Spec = &MeshIdentity{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshIdentityResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshIdentityResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshIdentityResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshIdentityResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshIdentityStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshIdentityStatus{}
+			r.Status = &MeshIdentityStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshIdentityResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshIdentityResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshIdentityResourceTypeDescriptor
 }
 
-func (t *MeshIdentityResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshIdentityResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
@@ -92,56 +92,56 @@ func NewMeshMultiZoneServiceResource() *MeshMultiZoneServiceResource {
 	}
 }
 
-func (t *MeshMultiZoneServiceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshMultiZoneServiceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshMultiZoneServiceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshMultiZoneServiceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshMultiZoneServiceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshMultiZoneServiceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshMultiZoneServiceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshMultiZoneServiceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshMultiZoneService)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshMultiZoneService{}
+			r.Spec = &MeshMultiZoneService{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshMultiZoneServiceResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshMultiZoneServiceResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshMultiZoneServiceResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshMultiZoneServiceResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshMultiZoneServiceStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshMultiZoneServiceStatus{}
+			r.Status = &MeshMultiZoneServiceStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshMultiZoneServiceResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshMultiZoneServiceResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshMultiZoneServiceResourceTypeDescriptor
 }
 
-func (t *MeshMultiZoneServiceResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshMultiZoneServiceResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewMeshOpenTelemetryBackendResource() *MeshOpenTelemetryBackendResource {
 	}
 }
 
-func (t *MeshOpenTelemetryBackendResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshOpenTelemetryBackendResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshOpenTelemetryBackendResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshOpenTelemetryBackendResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshOpenTelemetryBackendResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshOpenTelemetryBackendResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshOpenTelemetryBackendResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshOpenTelemetryBackendResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshOpenTelemetryBackend)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshOpenTelemetryBackend{}
+			r.Spec = &MeshOpenTelemetryBackend{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshOpenTelemetryBackendResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshOpenTelemetryBackendResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshOpenTelemetryBackendResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshOpenTelemetryBackendResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshOpenTelemetryBackendStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshOpenTelemetryBackendStatus{}
+			r.Status = &MeshOpenTelemetryBackendStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshOpenTelemetryBackendResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshOpenTelemetryBackendResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshOpenTelemetryBackendResourceTypeDescriptor
 }
 
-func (t *MeshOpenTelemetryBackendResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshOpenTelemetryBackendResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
@@ -92,56 +92,56 @@ func NewMeshServiceResource() *MeshServiceResource {
 	}
 }
 
-func (t *MeshServiceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshServiceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshServiceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshServiceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshServiceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshServiceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshServiceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshServiceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshService)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshService{}
+			r.Spec = &MeshService{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshServiceResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshServiceResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshServiceResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshServiceResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshServiceStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshServiceStatus{}
+			r.Status = &MeshServiceStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshServiceResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshServiceResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshServiceResourceTypeDescriptor
 }
 
-func (t *MeshServiceResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshServiceResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/meshtrust/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshtrust/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewMeshTrustResource() *MeshTrustResource {
 	}
 }
 
-func (t *MeshTrustResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshTrustResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshTrustResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshTrustResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshTrustResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshTrustResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshTrustResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshTrustResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshTrust)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshTrust{}
+			r.Spec = &MeshTrust{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTrustResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshTrustResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshTrustResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshTrustResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshTrustStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshTrustStatus{}
+			r.Status = &MeshTrustStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTrustResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshTrustResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshTrustResourceTypeDescriptor
 }
 
-func (t *MeshTrustResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshTrustResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshZoneAddressResource() *MeshZoneAddressResource {
 	}
 }
 
-func (t *MeshZoneAddressResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshZoneAddressResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshZoneAddressResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshZoneAddressResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshZoneAddressResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshZoneAddressResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshZoneAddressResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshZoneAddressResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshZoneAddress)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshZoneAddress{}
+			r.Spec = &MeshZoneAddress{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshZoneAddressResource) GetStatus() model.ResourceStatus {
+func (*MeshZoneAddressResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshZoneAddressResource) SetStatus(model.ResourceStatus) error {
+func (*MeshZoneAddressResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshZoneAddressResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshZoneAddressResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshZoneAddressResourceTypeDescriptor
 }
 
-func (t *MeshZoneAddressResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshZoneAddressResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/core/resources/apis/system/zz_generated.resources.go
+++ b/pkg/core/resources/apis/system/zz_generated.resources.go
@@ -29,41 +29,41 @@ func NewConfigResource() *ConfigResource {
 	}
 }
 
-func (t *ConfigResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ConfigResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ConfigResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ConfigResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ConfigResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ConfigResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ConfigResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ConfigResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*system_proto.Config)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &system_proto.Config{}
+			r.Spec = &system_proto.Config{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ConfigResource) GetStatus() model.ResourceStatus {
+func (r *ConfigResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ConfigResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ConfigResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ConfigResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ConfigResource) Descriptor() model.ResourceTypeDescriptor {
 	return ConfigResourceTypeDescriptor
 }
 
@@ -148,41 +148,41 @@ func NewSecretResource() *SecretResource {
 	}
 }
 
-func (t *SecretResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *SecretResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *SecretResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *SecretResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *SecretResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *SecretResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *SecretResource) SetSpec(spec model.ResourceSpec) error {
+func (r *SecretResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*system_proto.Secret)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &system_proto.Secret{}
+			r.Spec = &system_proto.Secret{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *SecretResource) GetStatus() model.ResourceStatus {
+func (r *SecretResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *SecretResource) SetStatus(_ model.ResourceStatus) error {
+func (r *SecretResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *SecretResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *SecretResource) Descriptor() model.ResourceTypeDescriptor {
 	return SecretResourceTypeDescriptor
 }
 
@@ -267,41 +267,41 @@ func NewZoneResource() *ZoneResource {
 	}
 }
 
-func (t *ZoneResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*system_proto.Zone)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &system_proto.Zone{}
+			r.Spec = &system_proto.Zone{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneResource) GetStatus() model.ResourceStatus {
+func (r *ZoneResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneResourceTypeDescriptor
 }
 
@@ -387,41 +387,41 @@ func NewZoneInsightResource() *ZoneInsightResource {
 	}
 }
 
-func (t *ZoneInsightResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneInsightResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneInsightResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneInsightResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneInsightResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneInsightResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneInsightResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneInsightResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*system_proto.ZoneInsight)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &system_proto.ZoneInsight{}
+			r.Spec = &system_proto.ZoneInsight{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneInsightResource) GetStatus() model.ResourceStatus {
+func (r *ZoneInsightResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneInsightResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneInsightResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneInsightResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneInsightResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneInsightResourceTypeDescriptor
 }
 
@@ -505,46 +505,46 @@ func NewZoneOverviewResource() *ZoneOverviewResource {
 	}
 }
 
-func (t *ZoneOverviewResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *ZoneOverviewResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *ZoneOverviewResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *ZoneOverviewResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *ZoneOverviewResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *ZoneOverviewResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *ZoneOverviewResource) SetSpec(spec model.ResourceSpec) error {
+func (r *ZoneOverviewResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*system_proto.ZoneOverview)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &system_proto.ZoneOverview{}
+			r.Spec = &system_proto.ZoneOverview{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *ZoneOverviewResource) GetStatus() model.ResourceStatus {
+func (r *ZoneOverviewResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *ZoneOverviewResource) SetStatus(_ model.ResourceStatus) error {
+func (r *ZoneOverviewResource) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *ZoneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
+func (r *ZoneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneOverviewResourceTypeDescriptor
 }
 
-func (t *ZoneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
-	t.SetMeta(resource.GetMeta())
+func (r *ZoneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
+	r.SetMeta(resource.GetMeta())
 	overview := &system_proto.ZoneOverview{
 		Zone: resource.GetSpec().(*system_proto.Zone),
 	}
@@ -555,7 +555,7 @@ func (t *ZoneOverviewResource) SetOverviewSpec(resource model.Resource, insight 
 		}
 		overview.ZoneInsight = ins
 	}
-	return t.SetSpec(overview)
+	return r.SetSpec(overview)
 }
 
 var _ model.ResourceList = &ZoneOverviewResourceList{}

--- a/pkg/core/resources/apis/workload/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewWorkloadResource() *WorkloadResource {
 	}
 }
 
-func (t *WorkloadResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *WorkloadResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *WorkloadResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *WorkloadResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *WorkloadResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *WorkloadResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *WorkloadResource) SetSpec(spec model.ResourceSpec) error {
+func (r *WorkloadResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*Workload)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &Workload{}
+			r.Spec = &Workload{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *WorkloadResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *WorkloadResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *WorkloadResource) SetStatus(status model.ResourceStatus) error {
+func (r *WorkloadResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*WorkloadStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &WorkloadStatus{}
+			r.Status = &WorkloadStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *WorkloadResource) Descriptor() model.ResourceTypeDescriptor {
+func (*WorkloadResource) Descriptor() model.ResourceTypeDescriptor {
 	return WorkloadResourceTypeDescriptor
 }
 
-func (t *WorkloadResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *WorkloadResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
@@ -89,46 +89,46 @@ func NewDoNothingPolicyResource() *DoNothingPolicyResource {
 	}
 }
 
-func (t *DoNothingPolicyResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *DoNothingPolicyResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *DoNothingPolicyResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *DoNothingPolicyResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *DoNothingPolicyResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *DoNothingPolicyResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *DoNothingPolicyResource) SetSpec(spec model.ResourceSpec) error {
+func (r *DoNothingPolicyResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*DoNothingPolicy)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &DoNothingPolicy{}
+			r.Spec = &DoNothingPolicy{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *DoNothingPolicyResource) GetStatus() model.ResourceStatus {
+func (*DoNothingPolicyResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *DoNothingPolicyResource) SetStatus(model.ResourceStatus) error {
+func (*DoNothingPolicyResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *DoNothingPolicyResource) Descriptor() model.ResourceTypeDescriptor {
+func (*DoNothingPolicyResource) Descriptor() model.ResourceTypeDescriptor {
 	return DoNothingPolicyResourceTypeDescriptor
 }
 
-func (t *DoNothingPolicyResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *DoNothingPolicyResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewMeshAccessLogResource() *MeshAccessLogResource {
 	}
 }
 
-func (t *MeshAccessLogResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshAccessLogResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshAccessLogResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshAccessLogResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshAccessLogResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshAccessLogResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshAccessLogResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshAccessLogResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshAccessLog)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshAccessLog{}
+			r.Spec = &MeshAccessLog{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshAccessLogResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshAccessLogResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshAccessLogResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshAccessLogResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshAccessLogStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshAccessLogStatus{}
+			r.Status = &MeshAccessLogStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshAccessLogResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshAccessLogResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshAccessLogResourceTypeDescriptor
 }
 
-func (t *MeshAccessLogResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshAccessLogResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshCircuitBreakerResource() *MeshCircuitBreakerResource {
 	}
 }
 
-func (t *MeshCircuitBreakerResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshCircuitBreakerResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshCircuitBreakerResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshCircuitBreakerResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshCircuitBreakerResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshCircuitBreakerResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshCircuitBreakerResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshCircuitBreakerResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshCircuitBreaker)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshCircuitBreaker{}
+			r.Spec = &MeshCircuitBreaker{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshCircuitBreakerResource) GetStatus() model.ResourceStatus {
+func (*MeshCircuitBreakerResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshCircuitBreakerResource) SetStatus(model.ResourceStatus) error {
+func (*MeshCircuitBreakerResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshCircuitBreakerResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshCircuitBreakerResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshCircuitBreakerResourceTypeDescriptor
 }
 
-func (t *MeshCircuitBreakerResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshCircuitBreakerResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshFaultInjectionResource() *MeshFaultInjectionResource {
 	}
 }
 
-func (t *MeshFaultInjectionResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshFaultInjectionResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshFaultInjectionResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshFaultInjectionResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshFaultInjectionResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshFaultInjectionResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshFaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshFaultInjectionResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshFaultInjection)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshFaultInjection{}
+			r.Spec = &MeshFaultInjection{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshFaultInjectionResource) GetStatus() model.ResourceStatus {
+func (*MeshFaultInjectionResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshFaultInjectionResource) SetStatus(model.ResourceStatus) error {
+func (*MeshFaultInjectionResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshFaultInjectionResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshFaultInjectionResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshFaultInjectionResourceTypeDescriptor
 }
 
-func (t *MeshFaultInjectionResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshFaultInjectionResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshHealthCheckResource() *MeshHealthCheckResource {
 	}
 }
 
-func (t *MeshHealthCheckResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshHealthCheckResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshHealthCheckResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshHealthCheckResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshHealthCheckResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshHealthCheckResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshHealthCheckResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshHealthCheckResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshHealthCheck)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshHealthCheck{}
+			r.Spec = &MeshHealthCheck{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshHealthCheckResource) GetStatus() model.ResourceStatus {
+func (*MeshHealthCheckResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshHealthCheckResource) SetStatus(model.ResourceStatus) error {
+func (*MeshHealthCheckResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshHealthCheckResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshHealthCheckResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshHealthCheckResourceTypeDescriptor
 }
 
-func (t *MeshHealthCheckResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshHealthCheckResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshHTTPRouteResource() *MeshHTTPRouteResource {
 	}
 }
 
-func (t *MeshHTTPRouteResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshHTTPRouteResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshHTTPRouteResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshHTTPRouteResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshHTTPRouteResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshHTTPRouteResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshHTTPRouteResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshHTTPRouteResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshHTTPRoute)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshHTTPRoute{}
+			r.Spec = &MeshHTTPRoute{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshHTTPRouteResource) GetStatus() model.ResourceStatus {
+func (*MeshHTTPRouteResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshHTTPRouteResource) SetStatus(model.ResourceStatus) error {
+func (*MeshHTTPRouteResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshHTTPRouteResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshHTTPRouteResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshHTTPRouteResourceTypeDescriptor
 }
 
-func (t *MeshHTTPRouteResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshHTTPRouteResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshLoadBalancingStrategyResource() *MeshLoadBalancingStrategyResource {
 	}
 }
 
-func (t *MeshLoadBalancingStrategyResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshLoadBalancingStrategyResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshLoadBalancingStrategyResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshLoadBalancingStrategyResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshLoadBalancingStrategyResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshLoadBalancingStrategyResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshLoadBalancingStrategyResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshLoadBalancingStrategyResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshLoadBalancingStrategy)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshLoadBalancingStrategy{}
+			r.Spec = &MeshLoadBalancingStrategy{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshLoadBalancingStrategyResource) GetStatus() model.ResourceStatus {
+func (*MeshLoadBalancingStrategyResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshLoadBalancingStrategyResource) SetStatus(model.ResourceStatus) error {
+func (*MeshLoadBalancingStrategyResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshLoadBalancingStrategyResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshLoadBalancingStrategyResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshLoadBalancingStrategyResourceTypeDescriptor
 }
 
-func (t *MeshLoadBalancingStrategyResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshLoadBalancingStrategyResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewMeshMetricResource() *MeshMetricResource {
 	}
 }
 
-func (t *MeshMetricResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshMetricResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshMetricResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshMetricResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshMetricResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshMetricResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshMetricResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshMetricResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshMetric)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshMetric{}
+			r.Spec = &MeshMetric{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshMetricResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshMetricResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshMetricResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshMetricResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshMetricStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshMetricStatus{}
+			r.Status = &MeshMetricStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshMetricResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshMetricResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshMetricResourceTypeDescriptor
 }
 
-func (t *MeshMetricResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshMetricResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshPassthroughResource() *MeshPassthroughResource {
 	}
 }
 
-func (t *MeshPassthroughResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshPassthroughResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshPassthroughResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshPassthroughResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshPassthroughResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshPassthroughResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshPassthroughResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshPassthroughResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshPassthrough)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshPassthrough{}
+			r.Spec = &MeshPassthrough{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshPassthroughResource) GetStatus() model.ResourceStatus {
+func (*MeshPassthroughResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshPassthroughResource) SetStatus(model.ResourceStatus) error {
+func (*MeshPassthroughResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshPassthroughResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshPassthroughResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshPassthroughResourceTypeDescriptor
 }
 
-func (t *MeshPassthroughResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshPassthroughResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshProxyPatchResource() *MeshProxyPatchResource {
 	}
 }
 
-func (t *MeshProxyPatchResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshProxyPatchResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshProxyPatchResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshProxyPatchResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshProxyPatchResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshProxyPatchResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshProxyPatchResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshProxyPatchResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshProxyPatch)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshProxyPatch{}
+			r.Spec = &MeshProxyPatch{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshProxyPatchResource) GetStatus() model.ResourceStatus {
+func (*MeshProxyPatchResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshProxyPatchResource) SetStatus(model.ResourceStatus) error {
+func (*MeshProxyPatchResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshProxyPatchResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshProxyPatchResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshProxyPatchResourceTypeDescriptor
 }
 
-func (t *MeshProxyPatchResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshProxyPatchResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshRateLimitResource() *MeshRateLimitResource {
 	}
 }
 
-func (t *MeshRateLimitResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshRateLimitResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshRateLimitResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshRateLimitResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshRateLimitResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshRateLimitResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshRateLimitResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshRateLimitResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshRateLimit)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshRateLimit{}
+			r.Spec = &MeshRateLimit{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshRateLimitResource) GetStatus() model.ResourceStatus {
+func (*MeshRateLimitResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshRateLimitResource) SetStatus(model.ResourceStatus) error {
+func (*MeshRateLimitResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshRateLimitResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshRateLimitResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshRateLimitResourceTypeDescriptor
 }
 
-func (t *MeshRateLimitResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshRateLimitResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshRetryResource() *MeshRetryResource {
 	}
 }
 
-func (t *MeshRetryResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshRetryResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshRetryResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshRetryResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshRetryResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshRetryResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshRetryResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshRetryResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshRetry)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshRetry{}
+			r.Spec = &MeshRetry{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshRetryResource) GetStatus() model.ResourceStatus {
+func (*MeshRetryResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshRetryResource) SetStatus(model.ResourceStatus) error {
+func (*MeshRetryResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshRetryResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshRetryResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshRetryResourceTypeDescriptor
 }
 
-func (t *MeshRetryResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshRetryResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshTCPRouteResource() *MeshTCPRouteResource {
 	}
 }
 
-func (t *MeshTCPRouteResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshTCPRouteResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshTCPRouteResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshTCPRouteResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshTCPRouteResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshTCPRouteResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshTCPRouteResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshTCPRouteResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshTCPRoute)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshTCPRoute{}
+			r.Spec = &MeshTCPRoute{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTCPRouteResource) GetStatus() model.ResourceStatus {
+func (*MeshTCPRouteResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshTCPRouteResource) SetStatus(model.ResourceStatus) error {
+func (*MeshTCPRouteResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshTCPRouteResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshTCPRouteResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshTCPRouteResourceTypeDescriptor
 }
 
-func (t *MeshTCPRouteResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshTCPRouteResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshTimeoutResource() *MeshTimeoutResource {
 	}
 }
 
-func (t *MeshTimeoutResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshTimeoutResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshTimeoutResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshTimeoutResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshTimeoutResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshTimeoutResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshTimeoutResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshTimeoutResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshTimeout)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshTimeout{}
+			r.Spec = &MeshTimeout{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTimeoutResource) GetStatus() model.ResourceStatus {
+func (*MeshTimeoutResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshTimeoutResource) SetStatus(model.ResourceStatus) error {
+func (*MeshTimeoutResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshTimeoutResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshTimeoutResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshTimeoutResourceTypeDescriptor
 }
 
-func (t *MeshTimeoutResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshTimeoutResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshTLSResource() *MeshTLSResource {
 	}
 }
 
-func (t *MeshTLSResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshTLSResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshTLSResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshTLSResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshTLSResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshTLSResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshTLSResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshTLSResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshTLS)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshTLS{}
+			r.Spec = &MeshTLS{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTLSResource) GetStatus() model.ResourceStatus {
+func (*MeshTLSResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshTLSResource) SetStatus(model.ResourceStatus) error {
+func (*MeshTLSResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshTLSResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshTLSResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshTLSResourceTypeDescriptor
 }
 
-func (t *MeshTLSResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshTLSResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
@@ -91,56 +91,56 @@ func NewMeshTraceResource() *MeshTraceResource {
 	}
 }
 
-func (t *MeshTraceResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshTraceResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshTraceResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshTraceResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshTraceResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshTraceResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshTraceResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshTraceResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshTrace)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshTrace{}
+			r.Spec = &MeshTrace{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTraceResource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *MeshTraceResource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *MeshTraceResource) SetStatus(status model.ResourceStatus) error {
+func (r *MeshTraceResource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*MeshTraceStatus)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &MeshTraceStatus{}
+			r.Status = &MeshTraceStatus{}
 		} else {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTraceResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshTraceResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshTraceResourceTypeDescriptor
 }
 
-func (t *MeshTraceResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshTraceResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
@@ -90,46 +90,46 @@ func NewMeshTrafficPermissionResource() *MeshTrafficPermissionResource {
 	}
 }
 
-func (t *MeshTrafficPermissionResource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *MeshTrafficPermissionResource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *MeshTrafficPermissionResource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *MeshTrafficPermissionResource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *MeshTrafficPermissionResource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *MeshTrafficPermissionResource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *MeshTrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
+func (r *MeshTrafficPermissionResource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*MeshTrafficPermission)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &MeshTrafficPermission{}
+			r.Spec = &MeshTrafficPermission{}
 		} else {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *MeshTrafficPermissionResource) GetStatus() model.ResourceStatus {
+func (*MeshTrafficPermissionResource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *MeshTrafficPermissionResource) SetStatus(model.ResourceStatus) error {
+func (*MeshTrafficPermissionResource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *MeshTrafficPermissionResource) Descriptor() model.ResourceTypeDescriptor {
+func (*MeshTrafficPermissionResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshTrafficPermissionResourceTypeDescriptor
 }
 
-func (t *MeshTrafficPermissionResource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *MeshTrafficPermissionResource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -148,66 +148,66 @@ func New{{.Name}}Resource() *{{.Name}}Resource {
 	}
 }
 
-func (t *{{.Name}}Resource) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *{{.Name}}Resource) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *{{.Name}}Resource) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *{{.Name}}Resource) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *{{.Name}}Resource) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *{{.Name}}Resource) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
-func (t *{{.Name}}Resource) SetSpec(spec model.ResourceSpec) error {
+func (r *{{.Name}}Resource) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*{{.Name}})
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &{{.Name}}{}
+			r.Spec = &{{.Name}}{}
 		} else  {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
 {{ if .HasStatus }}
-func (t *{{.Name}}Resource) GetStatus() model.ResourceStatus {
-	return t.Status
+func (r *{{.Name}}Resource) GetStatus() model.ResourceStatus {
+	return r.Status
 }
 
-func (t *{{.Name}}Resource) SetStatus(status model.ResourceStatus) error {
+func (r *{{.Name}}Resource) SetStatus(status model.ResourceStatus) error {
 	protoType, ok := status.(*{{.Name}}Status)
 	if !ok {
 		return fmt.Errorf("invalid type %T for Status", status)
 	} else {
 		if protoType == nil {
-			t.Status = &{{.Name}}Status{}
+			r.Status = &{{.Name}}Status{}
 		} else  {
-			t.Status = protoType
+			r.Status = protoType
 		}
 		return nil
 	}
 }
 {{ else }}
-func (t *{{.Name}}Resource) GetStatus() model.ResourceStatus {
+func (*{{.Name}}Resource) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *{{.Name}}Resource) SetStatus(model.ResourceStatus) error {
+func (*{{.Name}}Resource) SetStatus(model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 {{ end }}
 
-func (t *{{.Name}}Resource) Descriptor() model.ResourceTypeDescriptor {
+func (*{{.Name}}Resource) Descriptor() model.ResourceTypeDescriptor {
 	return {{.Name}}ResourceTypeDescriptor 
 }
 
-func (t *{{.Name}}Resource) Validate() error {
-	if v, ok := interface{}(t).(interface{ validate() error }); !ok {
+func (r *{{.Name}}Resource) Validate() error {
+	if v, ok := interface{}(r).(interface{ validate() error }); !ok {
 		return nil
 	} else {
 		return v.validate()

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -246,55 +246,55 @@ func New{{.ResourceName}}() *{{.ResourceName}} {
 	}
 }
 
-func (t *{{.ResourceName}}) GetMeta() model.ResourceMeta {
-	return t.Meta
+func (r *{{.ResourceName}}) GetMeta() model.ResourceMeta {
+	return r.Meta
 }
 
-func (t *{{.ResourceName}}) SetMeta(m model.ResourceMeta) {
-	t.Meta = m
+func (r *{{.ResourceName}}) SetMeta(m model.ResourceMeta) {
+	r.Meta = m
 }
 
-func (t *{{.ResourceName}}) GetSpec() model.ResourceSpec {
-	return t.Spec
+func (r *{{.ResourceName}}) GetSpec() model.ResourceSpec {
+	return r.Spec
 }
 
 {{with $in := .}}
 {{range .Selectors}}
-func (t *{{$in.ResourceName}}) {{.}}() []*{{$pkg}}.Selector {
-	return t.Spec.Get{{.}}()
+func (r *{{$in.ResourceName}}) {{.}}() []*{{$pkg}}.Selector {
+	return r.Spec.Get{{.}}()
 }
 {{end}}
 {{end}}
 
-func (t *{{.ResourceName}}) SetSpec(spec model.ResourceSpec) error {
+func (r *{{.ResourceName}}) SetSpec(spec model.ResourceSpec) error {
 	protoType, ok := spec.(*{{$pkg}}.{{.ProtoType}})
 	if !ok {
 		return fmt.Errorf("invalid type %T for Spec", spec)
 	} else {
 		if protoType == nil {
-			t.Spec = &{{$pkg}}.{{.ProtoType}}{}
+			r.Spec = &{{$pkg}}.{{.ProtoType}}{}
 		} else  {
-			t.Spec = protoType
+			r.Spec = protoType
 		}
 		return nil
 	}
 }
 
-func (t *{{.ResourceName}}) GetStatus() model.ResourceStatus {
+func (r *{{.ResourceName}}) GetStatus() model.ResourceStatus {
 	return nil
 }
 
-func (t *{{.ResourceName}}) SetStatus(_ model.ResourceStatus) error {
+func (r *{{.ResourceName}}) SetStatus(_ model.ResourceStatus) error {
 	return errors.New("status not supported")
 }
 
-func (t *{{.ResourceName}}) Descriptor() model.ResourceTypeDescriptor {
+func (r *{{.ResourceName}}) Descriptor() model.ResourceTypeDescriptor {
 	return {{.ResourceName}}TypeDescriptor 
 }
 {{- if and (hasSuffix .ResourceType "Overview") (ne $baseType "Service") }}
 
-func (t *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
-	t.SetMeta(resource.GetMeta())
+func (r *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
+	r.SetMeta(resource.GetMeta())
 	overview := &{{$pkg}}.{{.ProtoType}}{
 		{{$baseType}}: resource.GetSpec().(*{{$pkg}}.{{$baseType}}),
 	}
@@ -305,7 +305,7 @@ func (t *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight mod
 		}
 		overview.{{$baseType}}Insight = ins
 	}
-	return t.SetSpec(overview)
+	return r.SetSpec(overview)
 }
 {{- end }}
 


### PR DESCRIPTION
## Motivation

This ensures consistency with manually written methods (Deprecations, validate) that already use 'r' as receiver name, fixing ST1016 linter warnings.

## Implementation information

- Modified tools/resource-gen/pkg/generator/main.go template
- Modified tools/policy-gen/generator/cmd/core_resource.go template
- Regenerated all zz_generated.resource(s).go files


## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
