### PR TITLE
chore(deps): bump coredns to v1.14.2

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -20,7 +20,7 @@ export PATH := $(BUILD_KUMACTL_DIR):$(PATH)
 
 # An optional extension to the coredns packages
 COREDNS_EXT ?=
-COREDNS_VERSION = v1.13.1
+COREDNS_VERSION = v1.14.2
 
 # List of binaries that we have build/release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl coredns kuma-cni install-cni envoy


### PR DESCRIPTION
Bump coredns-builds from v1.13.1 to v1.14.2.

coredns 1.14.2 is built with Go 1.26.1, fixing critical CVEs in the kuma-dp image:
- CVE-2025-22871 (Go stdlib, fixed in >= 1.24.2)
- CVE-2025-68121 (Go stdlib, fixed in >= 1.24.13/1.25.7/1.26.0-rc.3)
- GHSA-p77j-4mvh-x3m3 (google.golang.org/grpc, fixed in >= 1.79.3)