### PR TITLE
chore(deps): bump distroless-iptables to v0.8.8

### DIFF
--- a/tools/releases/dockerfiles/kuma-init.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/k8s-staging-build-image/distroless-iptables:v0.8.6@sha256:4e0a77d0973618ce2a76e65fa2dc97694eb690ac8baf69cefe6e20f17957d9dd
+FROM gcr.io/k8s-staging-build-image/distroless-iptables:v0.8.8@sha256:d3586afb735e4e9cb2810ef9bfb5548a7cff8cbc2d53ae555352cdc408ee4f05
 ARG ARCH
 
 COPY /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin


### PR DESCRIPTION
## Motivation

kuma-init image scan fails with 2 critical CVEs from the distroless-iptables v0.8.6 base image (Debian 12.12, go1.25.5).

## Implementation information

Bump distroless-iptables from v0.8.6 to v0.8.8. v0.8.8 ships Debian 12.13 + go1.25.7, fixing:

- CVE-2025-68121 (Go stdlib in go-runner, fixed in >= 1.25.7)
- CVE-2025-15467 (libssl3 OpenSSL RCE, fixed in 3.0.18-1~deb12u2)