### PR TITLE
chore(deps): bump scan-docker-image to v6.1.0

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -116,7 +116,7 @@ jobs:
           make test/container-structure/${{ matrix.image }}
       - name: scan amd64 image
         id: scan_image-amd64
-        uses: Kong/public-shared-actions/security-actions/scan-docker-image@f558223899ff2ad616f6c6944d3341ad85318055 # v6.0.1
+        uses: Kong/public-shared-actions/security-actions/scan-docker-image@29dd57c7c19389e07390c1c9fe83aef6ff0c424a # v6.1.0
         with:
           asset_prefix: image_${{ matrix.image }}-amd64
           image: ./build/docker/${{ matrix.image }}-amd64.tar
@@ -125,7 +125,7 @@ jobs:
       - name: scan arm64 image
         id: scan_image-arm64
         if: ${{ fromJSON(inputs.FULL_MATRIX) }}
-        uses: Kong/public-shared-actions/security-actions/scan-docker-image@f558223899ff2ad616f6c6944d3341ad85318055 # v6.0.1
+        uses: Kong/public-shared-actions/security-actions/scan-docker-image@29dd57c7c19389e07390c1c9fe83aef6ff0c424a # v6.1.0
         with:
           asset_prefix: image_${{ matrix.image }}-arm64
           image: ./build/docker/${{ matrix.image }}-arm64.tar


### PR DESCRIPTION
## Motivation

Trivy v0.60.0 was deleted from GitHub Releases. Older versions of `scan-docker-image` hardcode that version and fail when the binary can't be downloaded, breaking release branch builds for 2.11, 2.12, and 2.13.

## Implementation information

Bump `Kong/public-shared-actions/security-actions/scan-docker-image` from v6.0.1 to v6.1.0, which uses Trivy v0.69.2.

> Changelog: skip