### PR TITLE
feat(distribution): extra files in tarball

### DIFF
--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -33,8 +33,8 @@ build/distributions/$(1)-$(2)/$(DISTRIBUTION_TARGET_NAME): build/artifacts-$(1)-
 	command cp build/artifacts-$(1)-$(2)/kuma-dp/kuma-dp $$@/bin
 	command cp $(DISTRIBUTION_LICENSE_PATH)/* $$@
 	command cp $(DISTRIBUTION_CONFIG_PATH) $$@/conf
-	for dir in $(DISTRIBUTION_EXTRA_DIRS); do command cp -r "$$$$dir" "$$@/" || exit 1; done
-	for file in $(DISTRIBUTION_EXTRA_FILES); do command cp "$$$$file" "$$@/" || exit 1; done
+	$(foreach dir,$(DISTRIBUTION_EXTRA_DIRS),command cp -r $(dir) $$@/ &&) true
+	$(foreach file,$(DISTRIBUTION_EXTRA_FILES),command cp $(file) $$@/ &&) true
 # CoreDNS is not included when the value is `skip` otherwise it's used as the COREDNS_EXT (which is most commonly just coredns)
 ifneq ($(3),skip)
 	$(MAKE) build/artifacts-$(1)-$(2)/coredns COREDNS_EXT=$(subst coredns,,$(3))


### PR DESCRIPTION
## Motivation

No formal mechanism existed for including non-binary files in release tarballs. `dashboards/` was hardcoded, making it impossible for downstream forks to add extra files (e.g. cloud provider dashboards) without modifying the core build.

Closes #13694

## Implementation information

Introduces two overridable variables in `mk/distribution.mk`:

- `DISTRIBUTION_EXTRA_DIRS ?= dashboards` — directories copied recursively into the tarball root
- `DISTRIBUTION_EXTRA_FILES ?= UPGRADE.md` — individual files copied into the tarball root

Downstream forks override these to add their own files:
```makefile
DISTRIBUTION_EXTRA_DIRS = dashboards cloud-dashboards
DISTRIBUTION_EXTRA_FILES = UPGRADE.md
```

> Changelog: feat(distribution): extra files in tarball