### PR TITLE
fix(xds): use listener name as vhost fallback

### DIFF
--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -155,6 +155,12 @@ func FilterChainBuilder(
 	contextualName := naming.MustContextualInboundName(proxy.Dataplane, endpoint.InboundName)
 	routeConfigName := getName(contextualName, envoy_names.GetInboundRouteName(service))
 	virtualHostName := getName(contextualName, service)
+	if virtualHostName == "" {
+		// kuma.io/service tag not set; fall back to the listener address
+		listenerName := envoy_names.GetInboundListenerName(endpoint.DataplaneIP, endpoint.DataplanePort)
+		routeConfigName = listenerName
+		virtualHostName = listenerName
+	}
 
 	cluster := plugins_xds.NewClusterBuilder().WithName(localClusterName).Build()
 

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -288,5 +288,9 @@ var _ = Describe("InboundProxyGenerator", func() {
 				"my-test.domain.com": {xds_context.PEMBytes("123")},
 			},
 		}),
+		Entry("10. transparent_proxying=false, no kuma.io/service tag, http protocol", testCase{
+			dataplaneFile: "10-dataplane.input.yaml",
+			expected:      "10-envoy-config.golden.yaml",
+		}),
 	)
 })

--- a/pkg/xds/generator/testdata/inbound-proxy/10-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/10-dataplane.input.yaml
@@ -1,0 +1,7 @@
+networking:
+  address: 192.168.0.1
+  inbound:
+    - port: 9000
+      servicePort: 9001
+      tags:
+        kuma.io/protocol: http

--- a/pkg/xds/generator/testdata/inbound-proxy/10-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/10-envoy-config.golden.yaml
@@ -1,0 +1,104 @@
+resources:
+- name: localhost:9001
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: localhost_9001
+    connectTimeout: 10s
+    loadAssignment:
+      clusterName: localhost:9001
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 9001
+    name: localhost:9001
+    type: STATIC
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 7200s
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: inbound:192.168.0.1:9000
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 9000
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_192_168_0_1_9000.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            idleTimeout: 7200s
+          forwardClientCertDetails: SANITIZE_SET
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 100.64.0.0
+              prefixLen: 16
+            - addressPrefix: fc00::/7
+              prefixLen: 128
+            - addressPrefix: ::1/128
+              prefixLen: 128
+          routeConfig:
+            name: inbound:192.168.0.1:9000
+            requestHeadersToRemove:
+            - x-kuma-tags
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: inbound:192.168.0.1:9000
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: localhost:9001
+                  timeout: 0s
+          setCurrentClientCertDetails:
+            uri: true
+          statPrefix: localhost_9001
+          streamIdleTimeout: 3600s
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://default/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:default
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/protocol: http
+    name: inbound:192.168.0.1:9000
+    trafficDirection: INBOUND


### PR DESCRIPTION
## Motivation

When deploying on Universal without transparent proxy and without
defining `kuma.io/service` on an HTTP inbound, the control plane
fails with:

```
virtual host name is required, but it was not provided
```

`FilterChainBuilder` derives `virtualHostName` from the service tag.
With no tag present and unified naming disabled, the name is an empty
string, which the virtual host builder rejects.

Fixes #15580

## Implementation information

When `virtualHostName` is empty (service tag absent, unified naming
off), fall back to `inbound:IP:port` — the inbound listener name —
for both `routeConfigName` and `virtualHostName`. This is always
unique and non-empty.

Added test case 10: HTTP inbound without `kuma.io/service` tag,
with golden file confirming the listener is generated correctly.

> Changelog: fix(xds): use listener name as vhost fallback when kuma.io/service absent