### PR TITLE
ci(github): use github runners instead of our self-hosted ones

### DIFF
--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
 env:
-  CI_TOOLS_DIR: ${{ contains(inputs.runner, '-kong') && '/work/kuma/kuma/.ci_tools' || '/home/runner/work/kuma/kuma/.ci_tools' }}
+  CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
   E2E_PARAM_K8S_VERSION: ${{ fromJSON(inputs.matrix).k8sVersion }}
   E2E_PARAM_CNI_NETWORK_PLUGIN: ${{ fromJSON(inputs.matrix).cniNetworkPlugin }}
   E2E_PARAM_ARCH: ${{ fromJSON(inputs.matrix).arch }}

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -150,7 +150,7 @@ jobs:
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}' || '{"amd64":"ubuntu-24.04","arm64":""}' }}
+      RUNNERS_BY_ARCH: '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
     secrets: inherit
   build_publish:
     permissions:


### PR DESCRIPTION
## Motivation

The CNCF now offers a pretty generous allowance to github runners with a high number of concurrent runner.

This experiments with always using github runners. If this shows up as stable enough we should be able to just do this and decommision our self-hosted runner infrastructure

## Supporting documentation

https://contribute.cncf.io/resources/services/hosted-tools/#cicd
https://github.com/cncf/automation/blob/main/ci/README.md