### PR TITLE
fix(helm): extract top-level Chart.yaml

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -106,7 +106,7 @@ function release {
   local CHART_TAR
   CHART_TAR=$(find "${CHARTS_PACKAGE_PATH}" -name "*.tgz" -type f | head -n 1)
   local CHART_FILE
-  CHART_FILE=$(tar -tf "${CHART_TAR}" | grep -E '^[^/]+/Chart\.yaml$')
+  CHART_FILE=$(tar -tf "${CHART_TAR}" | grep -E '^[^/]+/Chart\.yaml$' | head -n 1)
   local CHART_VERSION
   CHART_VERSION=$(tar -zxOf "${CHART_TAR}" "${CHART_FILE}" | yq .version)
 


### PR DESCRIPTION
## Motivation

When a chart bundles dependencies (kong-mesh bundles kuma), the archive contains multiple `Chart.yaml` files:

```
kong-mesh/Chart.yaml
kong-mesh/charts/kuma/Chart.yaml
```

`grep 'Chart.yaml'` matches both. The multi-line result gets passed as a single argument to `tar -zxOf`, which interprets it as one filename with a literal `\n` in it. tar can't find that, so `CHART_VERSION` resolves as `null`.

You can see this in every recent kong-mesh release commit: `ci(helm): publish chart version null`.

The release still works because `cr upload` and `cr index` operate on the tgz directly and don't use `CHART_VERSION` for anything besides the commit message. But it's wrong and confusing.

## Implementation information

Replace `grep 'Chart.yaml'` with `grep -E '^[^/]+/Chart\.yaml$' | head -n 1`.

The regex matches exactly one path component before `/Chart.yaml`, so it picks the top-level chart and ignores subcharts. `head -n 1` is a safety guard in case there are multiple top-level charts in the package path.

Tested on both macOS BSD grep (`/usr/bin/grep`) and GNU grep:

```
$ echo -e "kong-mesh/Chart.yaml\nkong-mesh/charts/kuma/Chart.yaml" | /usr/bin/grep -E '^[^/]+/Chart\.yaml$'
kong-mesh/Chart.yaml

$ tar -tf kong-mesh-2.11.11.tgz | grep -E '^[^/]+/Chart\.yaml$'
kong-mesh/Chart.yaml

$ tar -tf kuma-2.13.3.tgz | grep -E '^[^/]+/Chart\.yaml$'
kuma/Chart.yaml
```

The pattern uses POSIX Extended Regular Expressions (`-E`), supported by both BSD and GNU grep.

> Changelog: skip