### PR TITLE
fix(config): K8s EnableReloadableTokens defaulting

### DIFF
--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -211,7 +211,7 @@ func (c *Config) Sanitize() {
 }
 
 func (c *Config) PostProcess() error {
-	return multierr.Combine(
+	if err := multierr.Combine(
 		c.General.PostProcess(),
 		c.Store.PostProcess(),
 		c.BootstrapServer.PostProcess(),
@@ -225,7 +225,14 @@ func (c *Config) PostProcess() error {
 		c.Multizone.PostProcess(),
 		c.Diagnostics.PostProcess(),
 		c.Policies.PostProcess(),
-	)
+		c.DpServer.PostProcess(),
+	); err != nil {
+		return err
+	}
+	if c.Store.Type == store.KubernetesStore {
+		c.DpServer.Authn.EnableReloadableTokens = true
+	}
+	return nil
 }
 
 var DefaultConfig = func() Config {

--- a/pkg/xds/bootstrap/components.go
+++ b/pkg/xds/bootstrap/components.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/v2/pkg/config/core/resources/store"
 	dp_server "github.com/kumahq/kuma/v2/pkg/config/dp-server"
 	core_runtime "github.com/kumahq/kuma/v2/pkg/core/runtime"
 )
@@ -18,7 +17,7 @@ func RegisterBootstrap(rt core_runtime.Runtime) error {
 			string(mesh_proto.IngressProxyType):   rt.Config().DpServer.Authn.ZoneProxy.Type != dp_server.DpServerAuthNone,
 			string(mesh_proto.EgressProxyType):    rt.Config().DpServer.Authn.ZoneProxy.Type != dp_server.DpServerAuthNone,
 		},
-		rt.Config().DpServer.Authn.EnableReloadableTokens || rt.Config().Store.Type == store.KubernetesStore,
+		rt.Config().DpServer.Authn.EnableReloadableTokens,
 		rt.Config().DpServer.Hds.Enabled,
 		rt.Config().GetEnvoyAdminPort(),
 		rt.Config().Experimental.DeltaXds,


### PR DESCRIPTION
## Motivation

On Kubernetes, `DpServer.Authn.EnableReloadableTokens` is always effectively `true` at runtime, but the config dump logged at startup shows `false`. This confuses operators inspecting the config.

## Implementation information

Move the K8s defaulting logic from `components.go` into `Config.PostProcess()` in `kuma-cp/config.go`. `PostProcess` runs after config is fully loaded (env vars, files) but before the config is logged, so the dump now reflects the actual value.

Also adds the missing `c.DpServer.PostProcess()` call to the top-level `PostProcess` chain.

The redundant `|| rt.Config().Store.Type == store.KubernetesStore` in `components.go` is removed since `PostProcess` now sets the field correctly.

## Supporting documentation

Fixes #12786

> Changelog: fix(config): K8s EnableReloadableTokens defaulting