### PR TITLE
fix(tokens): better error for future nbf claim

### DIFF
--- a/pkg/core/tokens/issuer_test.go
+++ b/pkg/core/tokens/issuer_test.go
@@ -58,10 +58,11 @@ var _ = Describe("Token issuer", func() {
 	var store core_store.ResourceStore
 	var signingKeyManager tokens.SigningKeyManager
 
-	now := time.Now()
+	var now time.Time
 	var ctx context.Context
 
 	BeforeEach(func() {
+		now = time.Now()
 		ctx = context.Background()
 		core.Now = func() time.Time {
 			return now

--- a/pkg/core/tokens/validator.go
+++ b/pkg/core/tokens/validator.go
@@ -84,7 +84,7 @@ func (j *jwtTokenValidator) ParseWithValidation(ctx context.Context, rawToken To
 			return signingKeyError
 		}
 		if errors2.Is(err, jwt.ErrTokenNotValidYet) {
-			return errors.New("token is not yet valid: 'valid_from' date is in the future." +
+			return errors.Wrap(err, "token is not yet valid: 'valid_from' date is in the future."+
 				" Check if the system clock on the instance that issued the token is set correctly")
 		}
 		if j.storeType == store_config.MemoryStore {


### PR DESCRIPTION
## Motivation

When a token's `valid_from` (`nbf`) date is in the future, the error returned is a generic "could not parse token" message. Users have no indication that the problem is a clock skew issue and how to fix it.

Closes #4407

## Implementation information

Added an `errors.Is(err, jwt.ErrTokenNotValidYet)` check in `jwtTokenValidator.ParseWithValidation` before the generic fallback. When matched, returns an actionable error:

> token is not yet valid: 'valid_from' date is in the future. Check if
> the system clock on the instance that issued the token is set correctly

Added a unit test that moves the clock back an hour after issuing a
token, triggering the nbf check, and asserts the error message contains
`valid_from`.

> Changelog: fix(tokens): better error when valid_from is in the future