### PR TITLE
fix(meshservice): skip gen when no tags

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -22,6 +22,10 @@ func Setup(rt runtime.Runtime) error {
 		logger.Info("MeshService is not enabled. Skip starting generator for MeshService.")
 		return nil
 	}
+	if rt.Config().Experimental.InboundTagsDisabled {
+		logger.Info("Inbound tags are disabled. Skip starting generator for MeshService. Users should create MeshService manually.")
+		return nil
+	}
 	generator, err := New(
 		logger,
 		rt.Config().MeshService.GenerationInterval.Duration,


### PR DESCRIPTION
## Motivation

Fixes #16015

Universal MeshService generator relies on dataplane inbound tags to create MeshServices with `DataplaneTags` selector. When `InboundTagsDisabled` is true, dataplanes have no tags, producing broken MeshServices. Users should create MeshServices manually in this mode.

## Implementation information

Skip the Universal MeshService generator entirely in `component.go` when `InboundTagsDisabled` is true, with a log message informing users to create MeshServices manually. This mirrors how K8s handles it differently (using `DataplaneLabels` instead), but Universal has no equivalent mechanism.

> Changelog: feat(kuma-cp): support running without inbound tags
