### PR TITLE
feat(motb): otel env bootstrap plumbing

### DIFF
--- a/api/mesh/v1alpha1/dataplane_insight.pb.go
+++ b/api/mesh/v1alpha1/dataplane_insight.pb.go
@@ -31,8 +31,10 @@ type DataplaneInsight struct {
 	// List of ADS subscriptions created by a given Dataplane.
 	Subscriptions []*DiscoverySubscription `protobuf:"bytes,1,rep,name=subscriptions,proto3" json:"subscriptions,omitempty"`
 	// Insights about mTLS for Dataplane.
-	MTLS          *DataplaneInsight_MTLS `protobuf:"bytes,2,opt,name=mTLS,proto3" json:"mTLS,omitempty"`
-	Metadata      *structpb.Struct       `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	MTLS     *DataplaneInsight_MTLS `protobuf:"bytes,2,opt,name=mTLS,proto3" json:"mTLS,omitempty"`
+	Metadata *structpb.Struct       `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// Insights about OTel runtime resolution for this Dataplane.
+	OpenTelemetry *DataplaneInsight_OpenTelemetry `protobuf:"bytes,4,opt,name=openTelemetry,proto3" json:"openTelemetry,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -84,6 +86,13 @@ func (x *DataplaneInsight) GetMTLS() *DataplaneInsight_MTLS {
 func (x *DataplaneInsight) GetMetadata() *structpb.Struct {
 	if x != nil {
 		return x.Metadata
+	}
+	return nil
+}
+
+func (x *DataplaneInsight) GetOpenTelemetry() *DataplaneInsight_OpenTelemetry {
+	if x != nil {
+		return x.OpenTelemetry
 	}
 	return nil
 }
@@ -645,21 +654,244 @@ func (x *DataplaneInsight_MTLS) GetSupportedBackends() []string {
 	return nil
 }
 
+type DataplaneInsight_OpenTelemetry struct {
+	state         protoimpl.MessageState                    `protogen:"open.v1"`
+	Backends      []*DataplaneInsight_OpenTelemetry_Backend `protobuf:"bytes,1,rep,name=backends,proto3" json:"backends,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DataplaneInsight_OpenTelemetry) Reset() {
+	*x = DataplaneInsight_OpenTelemetry{}
+	mi := &file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DataplaneInsight_OpenTelemetry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DataplaneInsight_OpenTelemetry) ProtoMessage() {}
+
+func (x *DataplaneInsight_OpenTelemetry) ProtoReflect() protoreflect.Message {
+	mi := &file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DataplaneInsight_OpenTelemetry.ProtoReflect.Descriptor instead.
+func (*DataplaneInsight_OpenTelemetry) Descriptor() ([]byte, []int) {
+	return file_api_mesh_v1alpha1_dataplane_insight_proto_rawDescGZIP(), []int{0, 1}
+}
+
+func (x *DataplaneInsight_OpenTelemetry) GetBackends() []*DataplaneInsight_OpenTelemetry_Backend {
+	if x != nil {
+		return x.Backends
+	}
+	return nil
+}
+
+type DataplaneInsight_OpenTelemetry_Backend struct {
+	state         protoimpl.MessageState                 `protogen:"open.v1"`
+	Name          string                                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Traces        *DataplaneInsight_OpenTelemetry_Signal `protobuf:"bytes,2,opt,name=traces,proto3" json:"traces,omitempty"`
+	Logs          *DataplaneInsight_OpenTelemetry_Signal `protobuf:"bytes,3,opt,name=logs,proto3" json:"logs,omitempty"`
+	Metrics       *DataplaneInsight_OpenTelemetry_Signal `protobuf:"bytes,4,opt,name=metrics,proto3" json:"metrics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) Reset() {
+	*x = DataplaneInsight_OpenTelemetry_Backend{}
+	mi := &file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DataplaneInsight_OpenTelemetry_Backend) ProtoMessage() {}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) ProtoReflect() protoreflect.Message {
+	mi := &file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DataplaneInsight_OpenTelemetry_Backend.ProtoReflect.Descriptor instead.
+func (*DataplaneInsight_OpenTelemetry_Backend) Descriptor() ([]byte, []int) {
+	return file_api_mesh_v1alpha1_dataplane_insight_proto_rawDescGZIP(), []int{0, 1, 0}
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) GetTraces() *DataplaneInsight_OpenTelemetry_Signal {
+	if x != nil {
+		return x.Traces
+	}
+	return nil
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) GetLogs() *DataplaneInsight_OpenTelemetry_Signal {
+	if x != nil {
+		return x.Logs
+	}
+	return nil
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Backend) GetMetrics() *DataplaneInsight_OpenTelemetry_Signal {
+	if x != nil {
+		return x.Metrics
+	}
+	return nil
+}
+
+type DataplaneInsight_OpenTelemetry_Signal struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Enabled         bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	EnvAllowed      bool                   `protobuf:"varint,2,opt,name=envAllowed,proto3" json:"envAllowed,omitempty"`
+	EnvInputPresent bool                   `protobuf:"varint,3,opt,name=envInputPresent,proto3" json:"envInputPresent,omitempty"`
+	State           string                 `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
+	OverrideKinds   []string               `protobuf:"bytes,5,rep,name=overrideKinds,proto3" json:"overrideKinds,omitempty"`
+	MissingFields   []string               `protobuf:"bytes,6,rep,name=missingFields,proto3" json:"missingFields,omitempty"`
+	BlockedReasons  []string               `protobuf:"bytes,7,rep,name=blockedReasons,proto3" json:"blockedReasons,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) Reset() {
+	*x = DataplaneInsight_OpenTelemetry_Signal{}
+	mi := &file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DataplaneInsight_OpenTelemetry_Signal) ProtoMessage() {}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) ProtoReflect() protoreflect.Message {
+	mi := &file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DataplaneInsight_OpenTelemetry_Signal.ProtoReflect.Descriptor instead.
+func (*DataplaneInsight_OpenTelemetry_Signal) Descriptor() ([]byte, []int) {
+	return file_api_mesh_v1alpha1_dataplane_insight_proto_rawDescGZIP(), []int{0, 1, 1}
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetEnvAllowed() bool {
+	if x != nil {
+		return x.EnvAllowed
+	}
+	return false
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetEnvInputPresent() bool {
+	if x != nil {
+		return x.EnvInputPresent
+	}
+	return false
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetOverrideKinds() []string {
+	if x != nil {
+		return x.OverrideKinds
+	}
+	return nil
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetMissingFields() []string {
+	if x != nil {
+		return x.MissingFields
+	}
+	return nil
+}
+
+func (x *DataplaneInsight_OpenTelemetry_Signal) GetBlockedReasons() []string {
+	if x != nil {
+		return x.BlockedReasons
+	}
+	return nil
+}
+
 var File_api_mesh_v1alpha1_dataplane_insight_proto protoreflect.FileDescriptor
 
 const file_api_mesh_v1alpha1_dataplane_insight_proto_rawDesc = "" +
 	"\n" +
-	")api/mesh/v1alpha1/dataplane_insight.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\"\x98\x05\n" +
+	")api/mesh/v1alpha1/dataplane_insight.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\"\xec\n" +
+	"\n" +
 	"\x10DataplaneInsight\x12O\n" +
 	"\rsubscriptions\x18\x01 \x03(\v2).kuma.mesh.v1alpha1.DiscoverySubscriptionR\rsubscriptions\x12=\n" +
 	"\x04mTLS\x18\x02 \x01(\v2).kuma.mesh.v1alpha1.DataplaneInsight.MTLSR\x04mTLS\x123\n" +
-	"\bmetadata\x18\x03 \x01(\v2\x17.google.protobuf.StructR\bmetadata\x1a\xd3\x02\n" +
+	"\bmetadata\x18\x03 \x01(\v2\x17.google.protobuf.StructR\bmetadata\x12X\n" +
+	"\ropenTelemetry\x18\x04 \x01(\v22.kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetryR\ropenTelemetry\x1a\xd3\x02\n" +
 	"\x04MTLS\x12Z\n" +
 	"\x1bcertificate_expiration_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x19certificateExpirationTime\x12^\n" +
 	"\x1dlast_certificate_regeneration\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x1blastCertificateRegeneration\x12;\n" +
 	"\x19certificate_regenerations\x18\x03 \x01(\rR\x18certificateRegenerations\x12$\n" +
 	"\rissuedBackend\x18\x04 \x01(\tR\rissuedBackend\x12,\n" +
-	"\x11supportedBackends\x18\x05 \x03(\tR\x11supportedBackends:i\xaa\x8c\x89\xa6\x01c\n" +
+	"\x11supportedBackends\x18\x05 \x03(\tR\x11supportedBackends\x1a\xf7\x04\n" +
+	"\rOpenTelemetry\x12V\n" +
+	"\bbackends\x18\x01 \x03(\v2:.kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.BackendR\bbackends\x1a\x94\x02\n" +
+	"\aBackend\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12Q\n" +
+	"\x06traces\x18\x02 \x01(\v29.kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.SignalR\x06traces\x12M\n" +
+	"\x04logs\x18\x03 \x01(\v29.kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.SignalR\x04logs\x12S\n" +
+	"\ametrics\x18\x04 \x01(\v29.kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.SignalR\ametrics\x1a\xf6\x01\n" +
+	"\x06Signal\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1e\n" +
+	"\n" +
+	"envAllowed\x18\x02 \x01(\bR\n" +
+	"envAllowed\x12(\n" +
+	"\x0fenvInputPresent\x18\x03 \x01(\bR\x0fenvInputPresent\x12\x14\n" +
+	"\x05state\x18\x04 \x01(\tR\x05state\x12$\n" +
+	"\roverrideKinds\x18\x05 \x03(\tR\roverrideKinds\x12$\n" +
+	"\rmissingFields\x18\x06 \x03(\tR\rmissingFields\x12&\n" +
+	"\x0eblockedReasons\x18\a \x03(\tR\x0eblockedReasons:i\xaa\x8c\x89\xa6\x01c\n" +
 	"\x18DataplaneInsightResource\x12\x10DataplaneInsight\"\x04mesh:\x15\n" +
 	"\x11dataplane-insight\x18\x01R\x16model.ZoneToGlobalFlagX\x01\"\xac\x03\n" +
 	"\x15DiscoverySubscription\x12\x17\n" +
@@ -713,44 +945,52 @@ func file_api_mesh_v1alpha1_dataplane_insight_proto_rawDescGZIP() []byte {
 	return file_api_mesh_v1alpha1_dataplane_insight_proto_rawDescData
 }
 
-var file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_api_mesh_v1alpha1_dataplane_insight_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_api_mesh_v1alpha1_dataplane_insight_proto_goTypes = []any{
-	(*DataplaneInsight)(nil),            // 0: kuma.mesh.v1alpha1.DataplaneInsight
-	(*DiscoverySubscription)(nil),       // 1: kuma.mesh.v1alpha1.DiscoverySubscription
-	(*DiscoverySubscriptionStatus)(nil), // 2: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus
-	(*DiscoveryServiceStats)(nil),       // 3: kuma.mesh.v1alpha1.DiscoveryServiceStats
-	(*Version)(nil),                     // 4: kuma.mesh.v1alpha1.Version
-	(*KumaDpVersion)(nil),               // 5: kuma.mesh.v1alpha1.KumaDpVersion
-	(*EnvoyVersion)(nil),                // 6: kuma.mesh.v1alpha1.EnvoyVersion
-	(*DataplaneInsight_MTLS)(nil),       // 7: kuma.mesh.v1alpha1.DataplaneInsight.MTLS
-	nil,                                 // 8: kuma.mesh.v1alpha1.Version.DependenciesEntry
-	(*structpb.Struct)(nil),             // 9: google.protobuf.Struct
-	(*timestamppb.Timestamp)(nil),       // 10: google.protobuf.Timestamp
+	(*DataplaneInsight)(nil),                       // 0: kuma.mesh.v1alpha1.DataplaneInsight
+	(*DiscoverySubscription)(nil),                  // 1: kuma.mesh.v1alpha1.DiscoverySubscription
+	(*DiscoverySubscriptionStatus)(nil),            // 2: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus
+	(*DiscoveryServiceStats)(nil),                  // 3: kuma.mesh.v1alpha1.DiscoveryServiceStats
+	(*Version)(nil),                                // 4: kuma.mesh.v1alpha1.Version
+	(*KumaDpVersion)(nil),                          // 5: kuma.mesh.v1alpha1.KumaDpVersion
+	(*EnvoyVersion)(nil),                           // 6: kuma.mesh.v1alpha1.EnvoyVersion
+	(*DataplaneInsight_MTLS)(nil),                  // 7: kuma.mesh.v1alpha1.DataplaneInsight.MTLS
+	(*DataplaneInsight_OpenTelemetry)(nil),         // 8: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry
+	(*DataplaneInsight_OpenTelemetry_Backend)(nil), // 9: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend
+	(*DataplaneInsight_OpenTelemetry_Signal)(nil),  // 10: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal
+	nil,                           // 11: kuma.mesh.v1alpha1.Version.DependenciesEntry
+	(*structpb.Struct)(nil),       // 12: google.protobuf.Struct
+	(*timestamppb.Timestamp)(nil), // 13: google.protobuf.Timestamp
 }
 var file_api_mesh_v1alpha1_dataplane_insight_proto_depIdxs = []int32{
 	1,  // 0: kuma.mesh.v1alpha1.DataplaneInsight.subscriptions:type_name -> kuma.mesh.v1alpha1.DiscoverySubscription
 	7,  // 1: kuma.mesh.v1alpha1.DataplaneInsight.mTLS:type_name -> kuma.mesh.v1alpha1.DataplaneInsight.MTLS
-	9,  // 2: kuma.mesh.v1alpha1.DataplaneInsight.metadata:type_name -> google.protobuf.Struct
-	10, // 3: kuma.mesh.v1alpha1.DiscoverySubscription.connect_time:type_name -> google.protobuf.Timestamp
-	10, // 4: kuma.mesh.v1alpha1.DiscoverySubscription.disconnect_time:type_name -> google.protobuf.Timestamp
-	2,  // 5: kuma.mesh.v1alpha1.DiscoverySubscription.status:type_name -> kuma.mesh.v1alpha1.DiscoverySubscriptionStatus
-	4,  // 6: kuma.mesh.v1alpha1.DiscoverySubscription.version:type_name -> kuma.mesh.v1alpha1.Version
-	10, // 7: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.last_update_time:type_name -> google.protobuf.Timestamp
-	3,  // 8: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.total:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
-	3,  // 9: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.cds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
-	3,  // 10: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.eds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
-	3,  // 11: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.lds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
-	3,  // 12: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.rds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
-	5,  // 13: kuma.mesh.v1alpha1.Version.kumaDp:type_name -> kuma.mesh.v1alpha1.KumaDpVersion
-	6,  // 14: kuma.mesh.v1alpha1.Version.envoy:type_name -> kuma.mesh.v1alpha1.EnvoyVersion
-	8,  // 15: kuma.mesh.v1alpha1.Version.dependencies:type_name -> kuma.mesh.v1alpha1.Version.DependenciesEntry
-	10, // 16: kuma.mesh.v1alpha1.DataplaneInsight.MTLS.certificate_expiration_time:type_name -> google.protobuf.Timestamp
-	10, // 17: kuma.mesh.v1alpha1.DataplaneInsight.MTLS.last_certificate_regeneration:type_name -> google.protobuf.Timestamp
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	12, // 2: kuma.mesh.v1alpha1.DataplaneInsight.metadata:type_name -> google.protobuf.Struct
+	8,  // 3: kuma.mesh.v1alpha1.DataplaneInsight.openTelemetry:type_name -> kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry
+	13, // 4: kuma.mesh.v1alpha1.DiscoverySubscription.connect_time:type_name -> google.protobuf.Timestamp
+	13, // 5: kuma.mesh.v1alpha1.DiscoverySubscription.disconnect_time:type_name -> google.protobuf.Timestamp
+	2,  // 6: kuma.mesh.v1alpha1.DiscoverySubscription.status:type_name -> kuma.mesh.v1alpha1.DiscoverySubscriptionStatus
+	4,  // 7: kuma.mesh.v1alpha1.DiscoverySubscription.version:type_name -> kuma.mesh.v1alpha1.Version
+	13, // 8: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.last_update_time:type_name -> google.protobuf.Timestamp
+	3,  // 9: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.total:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
+	3,  // 10: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.cds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
+	3,  // 11: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.eds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
+	3,  // 12: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.lds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
+	3,  // 13: kuma.mesh.v1alpha1.DiscoverySubscriptionStatus.rds:type_name -> kuma.mesh.v1alpha1.DiscoveryServiceStats
+	5,  // 14: kuma.mesh.v1alpha1.Version.kumaDp:type_name -> kuma.mesh.v1alpha1.KumaDpVersion
+	6,  // 15: kuma.mesh.v1alpha1.Version.envoy:type_name -> kuma.mesh.v1alpha1.EnvoyVersion
+	11, // 16: kuma.mesh.v1alpha1.Version.dependencies:type_name -> kuma.mesh.v1alpha1.Version.DependenciesEntry
+	13, // 17: kuma.mesh.v1alpha1.DataplaneInsight.MTLS.certificate_expiration_time:type_name -> google.protobuf.Timestamp
+	13, // 18: kuma.mesh.v1alpha1.DataplaneInsight.MTLS.last_certificate_regeneration:type_name -> google.protobuf.Timestamp
+	9,  // 19: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.backends:type_name -> kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend
+	10, // 20: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend.traces:type_name -> kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal
+	10, // 21: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend.logs:type_name -> kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal
+	10, // 22: kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend.metrics:type_name -> kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_api_mesh_v1alpha1_dataplane_insight_proto_init() }
@@ -764,7 +1004,7 @@ func file_api_mesh_v1alpha1_dataplane_insight_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_mesh_v1alpha1_dataplane_insight_proto_rawDesc), len(file_api_mesh_v1alpha1_dataplane_insight_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/mesh/v1alpha1/dataplane_insight.pb.go
+++ b/api/mesh/v1alpha1/dataplane_insight.pb.go
@@ -771,12 +771,14 @@ type DataplaneInsight_OpenTelemetry_Signal struct {
 	Enabled         bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	EnvAllowed      bool                   `protobuf:"varint,2,opt,name=envAllowed,proto3" json:"envAllowed,omitempty"`
 	EnvInputPresent bool                   `protobuf:"varint,3,opt,name=envInputPresent,proto3" json:"envInputPresent,omitempty"`
-	State           string                 `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
-	OverrideKinds   []string               `protobuf:"bytes,5,rep,name=overrideKinds,proto3" json:"overrideKinds,omitempty"`
-	MissingFields   []string               `protobuf:"bytes,6,rep,name=missingFields,proto3" json:"missingFields,omitempty"`
-	BlockedReasons  []string               `protobuf:"bytes,7,rep,name=blockedReasons,proto3" json:"blockedReasons,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Computed state: "ready", "blocked", "missing", or "ambiguous".
+	// String (not enum) for extensibility without proto schema changes.
+	State          string   `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
+	OverrideKinds  []string `protobuf:"bytes,5,rep,name=overrideKinds,proto3" json:"overrideKinds,omitempty"`
+	MissingFields  []string `protobuf:"bytes,6,rep,name=missingFields,proto3" json:"missingFields,omitempty"`
+	BlockedReasons []string `protobuf:"bytes,7,rep,name=blockedReasons,proto3" json:"blockedReasons,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *DataplaneInsight_OpenTelemetry_Signal) Reset() {

--- a/api/mesh/v1alpha1/dataplane_insight.pb.go
+++ b/api/mesh/v1alpha1/dataplane_insight.pb.go
@@ -771,14 +771,12 @@ type DataplaneInsight_OpenTelemetry_Signal struct {
 	Enabled         bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	EnvAllowed      bool                   `protobuf:"varint,2,opt,name=envAllowed,proto3" json:"envAllowed,omitempty"`
 	EnvInputPresent bool                   `protobuf:"varint,3,opt,name=envInputPresent,proto3" json:"envInputPresent,omitempty"`
-	// Computed state: "ready", "blocked", "missing", or "ambiguous".
-	// String (not enum) for extensibility without proto schema changes.
-	State          string   `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
-	OverrideKinds  []string `protobuf:"bytes,5,rep,name=overrideKinds,proto3" json:"overrideKinds,omitempty"`
-	MissingFields  []string `protobuf:"bytes,6,rep,name=missingFields,proto3" json:"missingFields,omitempty"`
-	BlockedReasons []string `protobuf:"bytes,7,rep,name=blockedReasons,proto3" json:"blockedReasons,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	State           string                 `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
+	OverrideKinds   []string               `protobuf:"bytes,5,rep,name=overrideKinds,proto3" json:"overrideKinds,omitempty"`
+	MissingFields   []string               `protobuf:"bytes,6,rep,name=missingFields,proto3" json:"missingFields,omitempty"`
+	BlockedReasons  []string               `protobuf:"bytes,7,rep,name=blockedReasons,proto3" json:"blockedReasons,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DataplaneInsight_OpenTelemetry_Signal) Reset() {

--- a/api/mesh/v1alpha1/dataplane_insight.proto
+++ b/api/mesh/v1alpha1/dataplane_insight.proto
@@ -63,8 +63,6 @@ message DataplaneInsight {
       bool enabled = 1;
       bool envAllowed = 2;
       bool envInputPresent = 3;
-      // Computed state: "ready", "blocked", "missing", or "ambiguous".
-      // String (not enum) for extensibility without proto schema changes.
       string state = 4;
       repeated string overrideKinds = 5;
       repeated string missingFields = 6;

--- a/api/mesh/v1alpha1/dataplane_insight.proto
+++ b/api/mesh/v1alpha1/dataplane_insight.proto
@@ -63,6 +63,8 @@ message DataplaneInsight {
       bool enabled = 1;
       bool envAllowed = 2;
       bool envInputPresent = 3;
+      // Computed state: "ready", "blocked", "missing", or "ambiguous".
+      // String (not enum) for extensibility without proto schema changes.
       string state = 4;
       repeated string overrideKinds = 5;
       repeated string missingFields = 6;

--- a/api/mesh/v1alpha1/dataplane_insight.proto
+++ b/api/mesh/v1alpha1/dataplane_insight.proto
@@ -45,6 +45,30 @@ message DataplaneInsight {
   }
 
   google.protobuf.Struct metadata = 3;
+
+  // Insights about OTel runtime resolution for this Dataplane.
+  OpenTelemetry openTelemetry = 4;
+
+  message OpenTelemetry {
+    repeated Backend backends = 1;
+
+    message Backend {
+      string name = 1;
+      Signal traces = 2;
+      Signal logs = 3;
+      Signal metrics = 4;
+    }
+
+    message Signal {
+      bool enabled = 1;
+      bool envAllowed = 2;
+      bool envInputPresent = 3;
+      string state = 4;
+      repeated string overrideKinds = 5;
+      repeated string missingFields = 6;
+      repeated string blockedReasons = 7;
+    }
+  }
 }
 
 // DiscoverySubscription describes a single ADS subscription

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -458,6 +458,86 @@ components:
             metadata:
               properties: {}
               type: object
+            openTelemetry:
+              description: Insights about OTel runtime resolution for this Dataplane.
+              properties:
+                backends:
+                  items:
+                    properties:
+                      logs:
+                        properties:
+                          blockedReasons:
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            type: boolean
+                          envAllowed:
+                            type: boolean
+                          envInputPresent:
+                            type: boolean
+                          missingFields:
+                            items:
+                              type: string
+                            type: array
+                          overrideKinds:
+                            items:
+                              type: string
+                            type: array
+                          state:
+                            type: string
+                        type: object
+                      metrics:
+                        properties:
+                          blockedReasons:
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            type: boolean
+                          envAllowed:
+                            type: boolean
+                          envInputPresent:
+                            type: boolean
+                          missingFields:
+                            items:
+                              type: string
+                            type: array
+                          overrideKinds:
+                            items:
+                              type: string
+                            type: array
+                          state:
+                            type: string
+                        type: object
+                      name:
+                        type: string
+                      traces:
+                        properties:
+                          blockedReasons:
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            type: boolean
+                          envAllowed:
+                            type: boolean
+                          envInputPresent:
+                            type: boolean
+                          missingFields:
+                            items:
+                              type: string
+                            type: array
+                          overrideKinds:
+                            items:
+                              type: string
+                            type: array
+                          state:
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
             subscriptions:
               description: List of ADS subscriptions created by a given Dataplane.
               items:

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -485,6 +485,9 @@ components:
                               type: string
                             type: array
                           state:
+                            description: |-
+                              Computed state: "ready", "blocked", "missing", or "ambiguous".
+                              String (not enum) for extensibility without proto schema changes.
                             type: string
                         type: object
                       metrics:
@@ -508,6 +511,9 @@ components:
                               type: string
                             type: array
                           state:
+                            description: |-
+                              Computed state: "ready", "blocked", "missing", or "ambiguous".
+                              String (not enum) for extensibility without proto schema changes.
                             type: string
                         type: object
                       name:
@@ -533,6 +539,9 @@ components:
                               type: string
                             type: array
                           state:
+                            description: |-
+                              Computed state: "ready", "blocked", "missing", or "ambiguous".
+                              String (not enum) for extensibility without proto schema changes.
                             type: string
                         type: object
                     type: object

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -485,9 +485,6 @@ components:
                               type: string
                             type: array
                           state:
-                            description: |-
-                              Computed state: "ready", "blocked", "missing", or "ambiguous".
-                              String (not enum) for extensibility without proto schema changes.
                             type: string
                         type: object
                       metrics:
@@ -511,9 +508,6 @@ components:
                               type: string
                             type: array
                           state:
-                            description: |-
-                              Computed state: "ready", "blocked", "missing", or "ambiguous".
-                              String (not enum) for extensibility without proto schema changes.
                             type: string
                         type: object
                       name:
@@ -539,9 +533,6 @@ components:
                               type: string
                             type: array
                           state:
-                            description: |-
-                              Computed state: "ready", "blocked", "missing", or "ambiguous".
-                              String (not enum) for extensibility without proto schema changes.
                             type: string
                         type: object
                     type: object

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -605,7 +605,7 @@ func metricsTargetsForBackends(
 }
 
 func metricsRuntimeUsable(runtime otelenv.SignalRuntime) bool {
-	if !runtime.Enabled {
+	if !runtime.Enabled || runtime.HasHardBlock() {
 		return false
 	}
 	if runtime.Transport.Protocol == "" || runtime.Transport.Endpoint == "" {

--- a/app/kuma-dp/pkg/dataplane/otelenv/runtime.go
+++ b/app/kuma-dp/pkg/dataplane/otelenv/runtime.go
@@ -46,7 +46,7 @@ func (c Config) resolveSignal(
 		return runtime
 	}
 
-	preferEnv := backend.EnvPolicy != nil &&
+	preferEnv := backend.EnvPolicy == nil ||
 		backend.EnvPolicy.Precedence != motb_api.EnvPrecedenceExplicitFirst
 
 	type source struct{ protocol, fields []runtimeOption }
@@ -265,6 +265,8 @@ func (layer Layer) resolveEndpoint(
 			ep.HTTPPath = p
 		case p != "":
 			ep.HTTPPath = path.Join(p, "v1", string(signal))
+		default:
+			ep.HTTPPath = path.Join("/v1", string(signal))
 		}
 	}
 

--- a/app/kuma-dp/pkg/dataplane/otelenv/types.go
+++ b/app/kuma-dp/pkg/dataplane/otelenv/types.go
@@ -37,19 +37,8 @@ type SignalRuntime struct {
 }
 
 // HasHardBlock returns true if any blocked reason prevents actual signal usage.
-// Soft blocks (EnvDisabledByPolicy, SignalOverridesBlocked) are informational -
-// the signal still works via explicit configuration.
 func (r SignalRuntime) HasHardBlock() bool {
-	for _, reason := range r.BlockedReasons {
-		switch reason {
-		case core_xds.OtelBlockedReasonEnvDisabledByPolicy,
-			core_xds.OtelBlockedReasonSignalOverridesBlocked:
-			continue
-		default:
-			return true
-		}
-	}
-	return false
+	return core_xds.HasHardBlockedReason(r.BlockedReasons)
 }
 
 type BackendRuntime struct {

--- a/app/kuma-dp/pkg/dataplane/otelenv/types.go
+++ b/app/kuma-dp/pkg/dataplane/otelenv/types.go
@@ -36,6 +36,22 @@ type SignalRuntime struct {
 	Transport      ExporterTransport
 }
 
+// HasHardBlock returns true if any blocked reason prevents actual signal usage.
+// Soft blocks (EnvDisabledByPolicy, SignalOverridesBlocked) are informational -
+// the signal still works via explicit configuration.
+func (r SignalRuntime) HasHardBlock() bool {
+	for _, reason := range r.BlockedReasons {
+		switch reason {
+		case core_xds.OtelBlockedReasonEnvDisabledByPolicy,
+			core_xds.OtelBlockedReasonSignalOverridesBlocked:
+			continue
+		default:
+			return true
+		}
+	}
+	return false
+}
+
 type BackendRuntime struct {
 	Traces  SignalRuntime
 	Logs    SignalRuntime

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -17933,6 +17933,12 @@ components:
                               type: string
                             type: array
                           state:
+                            description: >-
+                              Computed state: "ready", "blocked", "missing", or
+                              "ambiguous".
+
+                              String (not enum) for extensibility without proto
+                              schema changes.
                             type: string
                         type: object
                       metrics:
@@ -17956,6 +17962,12 @@ components:
                               type: string
                             type: array
                           state:
+                            description: >-
+                              Computed state: "ready", "blocked", "missing", or
+                              "ambiguous".
+
+                              String (not enum) for extensibility without proto
+                              schema changes.
                             type: string
                         type: object
                       name:
@@ -17981,6 +17993,12 @@ components:
                               type: string
                             type: array
                           state:
+                            description: >-
+                              Computed state: "ready", "blocked", "missing", or
+                              "ambiguous".
+
+                              String (not enum) for extensibility without proto
+                              schema changes.
                             type: string
                         type: object
                     type: object

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -17906,6 +17906,86 @@ components:
             metadata:
               properties: {}
               type: object
+            openTelemetry:
+              description: Insights about OTel runtime resolution for this Dataplane.
+              properties:
+                backends:
+                  items:
+                    properties:
+                      logs:
+                        properties:
+                          blockedReasons:
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            type: boolean
+                          envAllowed:
+                            type: boolean
+                          envInputPresent:
+                            type: boolean
+                          missingFields:
+                            items:
+                              type: string
+                            type: array
+                          overrideKinds:
+                            items:
+                              type: string
+                            type: array
+                          state:
+                            type: string
+                        type: object
+                      metrics:
+                        properties:
+                          blockedReasons:
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            type: boolean
+                          envAllowed:
+                            type: boolean
+                          envInputPresent:
+                            type: boolean
+                          missingFields:
+                            items:
+                              type: string
+                            type: array
+                          overrideKinds:
+                            items:
+                              type: string
+                            type: array
+                          state:
+                            type: string
+                        type: object
+                      name:
+                        type: string
+                      traces:
+                        properties:
+                          blockedReasons:
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            type: boolean
+                          envAllowed:
+                            type: boolean
+                          envInputPresent:
+                            type: boolean
+                          missingFields:
+                            items:
+                              type: string
+                            type: array
+                          overrideKinds:
+                            items:
+                              type: string
+                            type: array
+                          state:
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
             subscriptions:
               description: List of ADS subscriptions created by a given Dataplane.
               items:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -17933,12 +17933,6 @@ components:
                               type: string
                             type: array
                           state:
-                            description: >-
-                              Computed state: "ready", "blocked", "missing", or
-                              "ambiguous".
-
-                              String (not enum) for extensibility without proto
-                              schema changes.
                             type: string
                         type: object
                       metrics:
@@ -17962,12 +17956,6 @@ components:
                               type: string
                             type: array
                           state:
-                            description: >-
-                              Computed state: "ready", "blocked", "missing", or
-                              "ambiguous".
-
-                              String (not enum) for extensibility without proto
-                              schema changes.
                             type: string
                         type: object
                       name:
@@ -17993,12 +17981,6 @@ components:
                               type: string
                             type: array
                           state:
-                            description: >-
-                              Computed state: "ready", "blocked", "missing", or
-                              "ambiguous".
-
-                              String (not enum) for extensibility without proto
-                              schema changes.
                             type: string
                         type: object
                     type: object

--- a/docs/generated/raw/protos/DataplaneInsight.json
+++ b/docs/generated/raw/protos/DataplaneInsight.json
@@ -19,6 +19,11 @@
                 "metadata": {
                     "additionalProperties": true,
                     "type": "object"
+                },
+                "openTelemetry": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry",
+                    "additionalProperties": true,
+                    "description": "Insights about OTel runtime resolution for this Dataplane."
                 }
             },
             "additionalProperties": true,
@@ -58,6 +63,78 @@
             "type": "object",
             "title": "MTLS",
             "description": "MTLS defines insights for mTLS"
+        },
+        "kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry": {
+            "properties": {
+                "backends": {
+                    "items": {
+                        "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Open Telemetry"
+        },
+        "kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "traces": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal",
+                    "additionalProperties": true
+                },
+                "logs": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal",
+                    "additionalProperties": true
+                },
+                "metrics": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal",
+                    "additionalProperties": true
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Backend"
+        },
+        "kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "envAllowed": {
+                    "type": "boolean"
+                },
+                "envInputPresent": {
+                    "type": "boolean"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "overrideKinds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "missingFields": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "blockedReasons": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Signal"
         },
         "kuma.mesh.v1alpha1.DiscoveryServiceStats": {
             "properties": {

--- a/docs/generated/raw/protos/DataplaneInsight.json
+++ b/docs/generated/raw/protos/DataplaneInsight.json
@@ -111,7 +111,8 @@
                     "type": "boolean"
                 },
                 "state": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Computed state: \"ready\", \"blocked\", \"missing\", or \"ambiguous\". String (not enum) for extensibility without proto schema changes."
                 },
                 "overrideKinds": {
                     "items": {

--- a/docs/generated/raw/protos/DataplaneInsight.json
+++ b/docs/generated/raw/protos/DataplaneInsight.json
@@ -111,8 +111,7 @@
                     "type": "boolean"
                 },
                 "state": {
-                    "type": "string",
-                    "description": "Computed state: \"ready\", \"blocked\", \"missing\", or \"ambiguous\". String (not enum) for extensibility without proto schema changes."
+                    "type": "string"
                 },
                 "overrideKinds": {
                     "items": {

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -509,6 +509,11 @@
                 "metadata": {
                     "additionalProperties": true,
                     "type": "object"
+                },
+                "openTelemetry": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry",
+                    "additionalProperties": true,
+                    "description": "Insights about OTel runtime resolution for this Dataplane."
                 }
             },
             "additionalProperties": true,
@@ -548,6 +553,78 @@
             "type": "object",
             "title": "MTLS",
             "description": "MTLS defines insights for mTLS"
+        },
+        "kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry": {
+            "properties": {
+                "backends": {
+                    "items": {
+                        "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Open Telemetry"
+        },
+        "kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Backend": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "traces": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal",
+                    "additionalProperties": true
+                },
+                "logs": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal",
+                    "additionalProperties": true
+                },
+                "metrics": {
+                    "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal",
+                    "additionalProperties": true
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Backend"
+        },
+        "kuma.mesh.v1alpha1.DataplaneInsight.OpenTelemetry.Signal": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "envAllowed": {
+                    "type": "boolean"
+                },
+                "envInputPresent": {
+                    "type": "boolean"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "overrideKinds": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "missingFields": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "blockedReasons": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Signal"
         },
         "kuma.mesh.v1alpha1.DiscoveryServiceStats": {
             "properties": {

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -601,7 +601,8 @@
                     "type": "boolean"
                 },
                 "state": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Computed state: \"ready\", \"blocked\", \"missing\", or \"ambiguous\". String (not enum) for extensibility without proto schema changes."
                 },
                 "overrideKinds": {
                     "items": {

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -601,8 +601,7 @@
                     "type": "boolean"
                 },
                 "state": {
-                    "type": "string",
-                    "description": "Computed state: \"ready\", \"blocked\", \"missing\", or \"ambiguous\". String (not enum) for extensibility without proto schema changes."
+                    "type": "string"
                 },
                 "overrideKinds": {
                     "items": {

--- a/pkg/core/xds/otel_pipe.go
+++ b/pkg/core/xds/otel_pipe.go
@@ -31,6 +31,12 @@ type OtelSignalRuntimePlan struct {
 	RefreshInterval string   `json:"refreshInterval,omitempty"`
 }
 
+// IsHardBlocked checks if the plan is missing required resolution inputs.
+// This is narrower than otelenv.SignalRuntime.HasHardBlock() and
+// otelstatus.hasHardBlockedReason(), which treat any non-soft block as hard.
+// The difference is intentional: IsHardBlocked gates whether to attempt
+// resolution at all, while the broader checks gate runtime usability
+// after resolution.
 func (p *OtelSignalRuntimePlan) IsHardBlocked() bool {
 	if p == nil {
 		return false

--- a/pkg/core/xds/otel_pipe.go
+++ b/pkg/core/xds/otel_pipe.go
@@ -32,11 +32,10 @@ type OtelSignalRuntimePlan struct {
 }
 
 // IsHardBlocked checks if the plan is missing required resolution inputs.
-// This is narrower than otelenv.SignalRuntime.HasHardBlock() and
-// otelstatus.hasHardBlockedReason(), which treat any non-soft block as hard.
-// The difference is intentional: IsHardBlocked gates whether to attempt
-// resolution at all, while the broader checks gate runtime usability
-// after resolution.
+// This is narrower than HasHardBlockedReason, which treats any non-soft
+// block as hard. The difference is intentional: IsHardBlocked gates whether
+// to attempt resolution at all, while HasHardBlockedReason gates runtime
+// usability after resolution.
 func (p *OtelSignalRuntimePlan) IsHardBlocked() bool {
 	if p == nil {
 		return false
@@ -47,6 +46,22 @@ func (p *OtelSignalRuntimePlan) IsHardBlocked() bool {
 	}
 
 	return slices.Contains(p.BlockedReasons, OtelBlockedReasonRequiredEnvMissing)
+}
+
+// HasHardBlockedReason returns true if any blocked reason prevents actual
+// signal usage. Soft blocks (EnvDisabledByPolicy, SignalOverridesBlocked)
+// are informational - the signal still works via explicit configuration.
+func HasHardBlockedReason(reasons []string) bool {
+	for _, reason := range reasons {
+		switch reason {
+		case OtelBlockedReasonEnvDisabledByPolicy,
+			OtelBlockedReasonSignalOverridesBlocked:
+			continue
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 func (p *OtelSignalRuntimePlan) SharedEnvAllowed() bool {

--- a/pkg/xds/bootstrap/generator.go
+++ b/pkg/xds/bootstrap/generator.go
@@ -130,6 +130,7 @@ func (b *bootstrapGenerator) Generate(ctx context.Context, request types.Bootstr
 		TransparentProxy:     request.TransparentProxy,
 		IPv6Enabled:          request.IPv6Enabled,
 		SpireSocketPath:      request.SpireResources.SocketPath,
+		OtelEnvInventory:     request.OtelEnv,
 	}
 
 	setAdminPort := func(adminPortFromResource uint32) {

--- a/pkg/xds/bootstrap/parameters.go
+++ b/pkg/xds/bootstrap/parameters.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	tproxy_config "github.com/kumahq/kuma/v2/pkg/transparentproxy/config/dataplane"
 	"github.com/kumahq/kuma/v2/pkg/xds/bootstrap/types"
@@ -91,4 +92,5 @@ type configParameters struct {
 	TransparentProxy     *tproxy_config.DataplaneConfig
 	IPv6Enabled          bool
 	SpireSocketPath      string
+	OtelEnvInventory     *core_xds.OtelBootstrapInventory
 }

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -398,6 +398,14 @@ func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloada
 		}
 	}
 
+	if parameters.OtelEnvInventory != nil {
+		res.Node.Metadata.Fields[core_xds.FieldOtelEnvInventory] = &structpb.Value{
+			Kind: &structpb.Value_StructValue{
+				StructValue: util_proto.MustStructToProtoStruct(parameters.OtelEnvInventory),
+			},
+		}
+	}
+
 	return res, nil
 }
 

--- a/pkg/xds/otel/status/status.go
+++ b/pkg/xds/otel/status/status.go
@@ -100,6 +100,9 @@ func buildSignalStatus(
 	}
 }
 
+// envAllowed checks both the policy mode and the blocked reason. The blocked
+// reason is derived from the mode during resolution, but we check both to
+// guard against inconsistencies between the two resolution stages.
 func envAllowed(backend core_xds.OtelPipeBackend, plan *core_xds.OtelSignalRuntimePlan) bool {
 	if backend.EnvPolicy == nil {
 		return true
@@ -115,24 +118,11 @@ func signalState(plan *core_xds.OtelSignalRuntimePlan) string {
 	case len(plan.MissingFields) > 0,
 		slices.Contains(plan.BlockedReasons, core_xds.OtelBlockedReasonRequiredEnvMissing):
 		return SignalStateMissing
-	case len(plan.BlockedReasons) > 0 && hasHardBlockedReason(plan):
+	case len(plan.BlockedReasons) > 0 && core_xds.HasHardBlockedReason(plan.BlockedReasons):
 		return SignalStateBlocked
 	default:
 		return SignalStateReady
 	}
-}
-
-func hasHardBlockedReason(plan *core_xds.OtelSignalRuntimePlan) bool {
-	for _, reason := range plan.BlockedReasons {
-		switch reason {
-		case core_xds.OtelBlockedReasonEnvDisabledByPolicy,
-			core_xds.OtelBlockedReasonSignalOverridesBlocked:
-			continue
-		default:
-			return true
-		}
-	}
-	return false
 }
 
 func cloneStatus(status *mesh_proto.DataplaneInsight_OpenTelemetry) *mesh_proto.DataplaneInsight_OpenTelemetry {

--- a/pkg/xds/otel/status/status.go
+++ b/pkg/xds/otel/status/status.go
@@ -1,0 +1,143 @@
+package status
+
+import (
+	"slices"
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+)
+
+const (
+	SignalStateReady     = "ready"
+	SignalStateBlocked   = "blocked"
+	SignalStateMissing   = "missing"
+	SignalStateAmbiguous = "ambiguous"
+)
+
+type Cache struct {
+	mu       sync.RWMutex
+	statuses map[core_model.ResourceKey]*mesh_proto.DataplaneInsight_OpenTelemetry
+}
+
+func NewCache() *Cache {
+	return &Cache{
+		statuses: map[core_model.ResourceKey]*mesh_proto.DataplaneInsight_OpenTelemetry{},
+	}
+}
+
+func (c *Cache) Set(key core_model.ResourceKey, status *mesh_proto.DataplaneInsight_OpenTelemetry) {
+	if c == nil {
+		return
+	}
+
+	if status == nil {
+		c.mu.Lock()
+		delete(c.statuses, key)
+		c.mu.Unlock()
+		return
+	}
+
+	cloned := cloneStatus(status)
+
+	c.mu.Lock()
+	c.statuses[key] = cloned
+	c.mu.Unlock()
+}
+
+func (c *Cache) Get(key core_model.ResourceKey) *mesh_proto.DataplaneInsight_OpenTelemetry {
+	if c == nil {
+		return nil
+	}
+
+	c.mu.RLock()
+	status := c.statuses[key]
+	c.mu.RUnlock()
+
+	return cloneStatus(status)
+}
+
+func Build(backends []core_xds.OtelPipeBackend) *mesh_proto.DataplaneInsight_OpenTelemetry {
+	if len(backends) == 0 {
+		return nil
+	}
+
+	result := make([]*mesh_proto.DataplaneInsight_OpenTelemetry_Backend, 0, len(backends))
+	for _, backend := range backends {
+		result = append(result, &mesh_proto.DataplaneInsight_OpenTelemetry_Backend{
+			Name:    backend.Name,
+			Traces:  buildSignalStatus(backend, backend.Traces),
+			Logs:    buildSignalStatus(backend, backend.Logs),
+			Metrics: buildSignalStatus(backend, backend.Metrics),
+		})
+	}
+
+	return &mesh_proto.DataplaneInsight_OpenTelemetry{
+		Backends: result,
+	}
+}
+
+func buildSignalStatus(
+	backend core_xds.OtelPipeBackend,
+	plan *core_xds.OtelSignalRuntimePlan,
+) *mesh_proto.DataplaneInsight_OpenTelemetry_Signal {
+	if plan == nil {
+		return nil
+	}
+
+	return &mesh_proto.DataplaneInsight_OpenTelemetry_Signal{
+		Enabled:         plan.Enabled,
+		EnvAllowed:      envAllowed(backend, plan),
+		EnvInputPresent: plan.EnvInputPresent,
+		State:           signalState(plan),
+		OverrideKinds:   slices.Clone(plan.OverrideKinds),
+		MissingFields:   slices.Clone(plan.MissingFields),
+		BlockedReasons:  slices.Clone(plan.BlockedReasons),
+	}
+}
+
+func envAllowed(backend core_xds.OtelPipeBackend, plan *core_xds.OtelSignalRuntimePlan) bool {
+	if backend.EnvPolicy == nil {
+		return true
+	}
+	return backend.EnvPolicy.Mode != motb_api.EnvModeDisabled &&
+		!slices.Contains(plan.BlockedReasons, core_xds.OtelBlockedReasonEnvDisabledByPolicy)
+}
+
+func signalState(plan *core_xds.OtelSignalRuntimePlan) string {
+	switch {
+	case slices.Contains(plan.BlockedReasons, core_xds.OtelBlockedReasonMultipleBackends):
+		return SignalStateAmbiguous
+	case len(plan.MissingFields) > 0,
+		slices.Contains(plan.BlockedReasons, core_xds.OtelBlockedReasonRequiredEnvMissing):
+		return SignalStateMissing
+	case len(plan.BlockedReasons) > 0 && hasHardBlockedReason(plan):
+		return SignalStateBlocked
+	default:
+		return SignalStateReady
+	}
+}
+
+func hasHardBlockedReason(plan *core_xds.OtelSignalRuntimePlan) bool {
+	for _, reason := range plan.BlockedReasons {
+		switch reason {
+		case core_xds.OtelBlockedReasonEnvDisabledByPolicy,
+			core_xds.OtelBlockedReasonSignalOverridesBlocked:
+			continue
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+func cloneStatus(status *mesh_proto.DataplaneInsight_OpenTelemetry) *mesh_proto.DataplaneInsight_OpenTelemetry {
+	if status == nil {
+		return nil
+	}
+	return proto.CloneOf(status)
+}

--- a/pkg/xds/otel/status/status_suite_test.go
+++ b/pkg/xds/otel/status/status_suite_test.go
@@ -1,0 +1,9 @@
+package status_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestOtelStatus(t *testing.T) { test.RunSpecs(t, "OTel Status Suite") }

--- a/pkg/xds/otel/status/status_test.go
+++ b/pkg/xds/otel/status/status_test.go
@@ -1,0 +1,205 @@
+package status_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	motb_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
+)
+
+var _ = Describe("OTel Status Cache", func() {
+	It("should store and retrieve status", func() {
+		cache := otelstatus.NewCache()
+		key := core_model.ResourceKey{Mesh: "default", Name: "dp-1"}
+
+		status := &mesh_proto.DataplaneInsight_OpenTelemetry{
+			Backends: []*mesh_proto.DataplaneInsight_OpenTelemetry_Backend{
+				{Name: "otel-main"},
+			},
+		}
+
+		cache.Set(key, status)
+		got := cache.Get(key)
+		Expect(got).ToNot(BeNil())
+		Expect(got.Backends).To(HaveLen(1))
+		Expect(got.Backends[0].Name).To(Equal("otel-main"))
+	})
+
+	It("should return nil for missing key", func() {
+		cache := otelstatus.NewCache()
+		got := cache.Get(core_model.ResourceKey{Mesh: "default", Name: "missing"})
+		Expect(got).To(BeNil())
+	})
+
+	It("should delete on nil status", func() {
+		cache := otelstatus.NewCache()
+		key := core_model.ResourceKey{Mesh: "default", Name: "dp-1"}
+
+		cache.Set(key, &mesh_proto.DataplaneInsight_OpenTelemetry{})
+		cache.Set(key, nil)
+		Expect(cache.Get(key)).To(BeNil())
+	})
+
+	It("should isolate cached state from caller mutations", func() {
+		cache := otelstatus.NewCache()
+		key := core_model.ResourceKey{Mesh: "default", Name: "dp-1"}
+		status := &mesh_proto.DataplaneInsight_OpenTelemetry{
+			Backends: []*mesh_proto.DataplaneInsight_OpenTelemetry_Backend{
+				{Name: "otel-main"},
+			},
+		}
+
+		cache.Set(key, status)
+		status.Backends[0].Name = "mutated-input"
+
+		got := cache.Get(key)
+		Expect(got.Backends[0].Name).To(Equal("otel-main"))
+
+		got.Backends[0].Name = "mutated-output"
+		Expect(cache.Get(key).Backends[0].Name).To(Equal("otel-main"))
+	})
+
+	It("should be safe on nil cache", func() {
+		var cache *otelstatus.Cache
+		cache.Set(core_model.ResourceKey{}, nil)
+		Expect(cache.Get(core_model.ResourceKey{})).To(BeNil())
+	})
+})
+
+var _ = Describe("Build", func() {
+	It("should return nil for empty backends", func() {
+		Expect(otelstatus.Build(nil)).To(BeNil())
+	})
+
+	It("should build status from backends", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-main",
+				EnvPolicy: &core_xds.OtelResolvedEnvPolicy{
+					Mode: motb_api.EnvModeOptional,
+				},
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled:         true,
+					EnvInputPresent: true,
+				},
+				Logs: &core_xds.OtelSignalRuntimePlan{
+					Enabled: true,
+				},
+				Metrics: &core_xds.OtelSignalRuntimePlan{
+					Enabled:         true,
+					EnvInputPresent: false,
+				},
+			},
+		}
+
+		result := otelstatus.Build(backends)
+		Expect(result).ToNot(BeNil())
+		Expect(result.Backends).To(HaveLen(1))
+
+		b := result.Backends[0]
+		Expect(b.Name).To(Equal("otel-main"))
+		Expect(b.Traces.State).To(Equal(otelstatus.SignalStateReady))
+		Expect(b.Traces.EnvAllowed).To(BeTrue())
+		Expect(b.Traces.EnvInputPresent).To(BeTrue())
+		Expect(b.Logs.State).To(Equal(otelstatus.SignalStateReady))
+		Expect(b.Metrics.State).To(Equal(otelstatus.SignalStateReady))
+		Expect(b.Metrics.EnvInputPresent).To(BeFalse())
+	})
+
+	It("should report ambiguous state for multiple backends", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-1",
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled:        true,
+					BlockedReasons: []string{core_xds.OtelBlockedReasonMultipleBackends},
+				},
+			},
+		}
+		result := otelstatus.Build(backends)
+		Expect(result.Backends[0].Traces.State).To(Equal(otelstatus.SignalStateAmbiguous))
+	})
+
+	It("should report missing state for required env missing", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-1",
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled:        true,
+					BlockedReasons: []string{core_xds.OtelBlockedReasonRequiredEnvMissing},
+					MissingFields:  []string{"endpoint"},
+				},
+			},
+		}
+		result := otelstatus.Build(backends)
+		Expect(result.Backends[0].Traces.State).To(Equal(otelstatus.SignalStateMissing))
+		Expect(result.Backends[0].Traces.MissingFields).To(ContainElement("endpoint"))
+	})
+
+	It("should pick highest-precedence state when multiple blocked reasons coexist", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-1",
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled:        true,
+					BlockedReasons: []string{core_xds.OtelBlockedReasonMultipleBackends, core_xds.OtelBlockedReasonRequiredEnvMissing},
+					MissingFields:  []string{"endpoint"},
+				},
+			},
+		}
+		result := otelstatus.Build(backends)
+		// ambiguous takes precedence over missing
+		Expect(result.Backends[0].Traces.State).To(Equal(otelstatus.SignalStateAmbiguous))
+	})
+
+	It("should report missing when RequiredEnvMissing without MultipleBackends", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-1",
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled:        true,
+					BlockedReasons: []string{core_xds.OtelBlockedReasonRequiredEnvMissing, core_xds.OtelBlockedReasonEnvDisabledByPolicy},
+					MissingFields:  []string{"endpoint"},
+				},
+			},
+		}
+		result := otelstatus.Build(backends)
+		// missing takes precedence over soft blocks
+		Expect(result.Backends[0].Traces.State).To(Equal(otelstatus.SignalStateMissing))
+	})
+
+	It("should report env not allowed when policy disables it", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-1",
+				EnvPolicy: &core_xds.OtelResolvedEnvPolicy{
+					Mode: motb_api.EnvModeDisabled,
+				},
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled:        true,
+					BlockedReasons: []string{core_xds.OtelBlockedReasonEnvDisabledByPolicy},
+				},
+			},
+		}
+		result := otelstatus.Build(backends)
+		Expect(result.Backends[0].Traces.EnvAllowed).To(BeFalse())
+		Expect(result.Backends[0].Traces.State).To(Equal(otelstatus.SignalStateReady))
+	})
+
+	It("should default env allowed when env policy is nil", func() {
+		backends := []core_xds.OtelPipeBackend{
+			{
+				Name: "otel-1",
+				Traces: &core_xds.OtelSignalRuntimePlan{
+					Enabled: true,
+				},
+			},
+		}
+		result := otelstatus.Build(backends)
+		Expect(result.Backends[0].Traces.EnvAllowed).To(BeTrue())
+	})
+})

--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -21,6 +21,7 @@ import (
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	"github.com/kumahq/kuma/v2/pkg/events"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
+	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
 	"github.com/kumahq/kuma/v2/pkg/xds/secrets"
 )
 
@@ -41,6 +42,7 @@ type DataplaneInsightStore interface {
 		dataplaneID core_model.ResourceKey,
 		subscription *mesh_proto.DiscoverySubscription,
 		secretsInfo *secrets.Info,
+		otel *mesh_proto.DataplaneInsight_OpenTelemetry,
 	) error
 }
 
@@ -48,6 +50,7 @@ func NewDataplaneInsightSink(
 	xdsMetadata *structpb.Struct,
 	accessor SubscriptionStatusAccessor,
 	secrets secrets.Secrets,
+	otelStatusCache *otelstatus.Cache,
 	newTicker func() *time.Ticker,
 	generationTicker func() *time.Ticker,
 	flushBackoff time.Duration,
@@ -77,6 +80,7 @@ func NewDataplaneInsightSink(
 		dataplaneType:    dpType,
 		accessor:         accessor,
 		secrets:          secrets,
+		otelStatusCache:  otelStatusCache,
 		flushBackoff:     flushBackoff,
 		store:            store,
 		xdsMetadata:      xdsMetadata,
@@ -94,6 +98,7 @@ type dataplaneInsightSink struct {
 	dataplaneType    core_model.ResourceType
 	accessor         SubscriptionStatusAccessor
 	secrets          secrets.Secrets
+	otelStatusCache  *otelstatus.Cache
 	store            DataplaneInsightStore
 	flushBackoff     time.Duration
 	xdsMetadata      *structpb.Struct
@@ -110,6 +115,7 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 
 	var lastStoredState *mesh_proto.DiscoverySubscription
 	var lastStoredSecretsInfo *secrets.Info
+	var lastStoredOtel *mesh_proto.DataplaneInsight_OpenTelemetry
 	var lastEvent *events.WorkloadIdentityChangedEvent
 	var generation uint32
 
@@ -158,13 +164,20 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 		}
 		currentState.Generation = generation
 
-		if proto.Equal(currentState, lastStoredState) && secretsInfo == lastStoredSecretsInfo {
+		otel := s.otelStatusCache.Get(dataplaneID)
+
+		otelChanged := !proto.Equal(otel, lastStoredOtel)
+		if otelChanged {
+			sinkLog.V(1).Info("OTel status changed", "dataplaneID", dataplaneID)
+		}
+
+		if proto.Equal(currentState, lastStoredState) && secretsInfo == lastStoredSecretsInfo && !otelChanged {
 			// We compare secretsInfo and lastStoredSecretsInfo as pointers. It makes sense to short-circuit if flush() runs
 			// on tick without events and we're picking exactly the same secreetsInfo structure from the cachedCerts cache.
 			return
 		}
 
-		if err := s.store.Upsert(ctx, s.xdsMetadata, s.dataplaneType, dataplaneID, currentState, secretsInfo); err != nil {
+		if err := s.store.Upsert(ctx, s.xdsMetadata, s.dataplaneType, dataplaneID, currentState, secretsInfo, otel); err != nil {
 			switch {
 			case closing:
 				// When XDS stream is closed, Dataplane Status Tracker executes OnStreamClose which closes stop channel
@@ -187,6 +200,7 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 			sinkLog.V(1).Info("DataplaneInsight saved", "dataplaneID", dataplaneID, "subscription", currentState)
 			lastStoredState = currentState
 			lastStoredSecretsInfo = secretsInfo
+			lastStoredOtel = otel
 		}
 	}
 
@@ -207,6 +221,8 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 			flush(false, &workloadIdentity)
 		case <-stop:
 			flush(true, lastEvent)
+			dataplaneID, _ := s.accessor.GetStatus()
+			s.otelStatusCache.Set(dataplaneID, nil)
 			return
 		}
 	}
@@ -250,6 +266,7 @@ func (s *dataplaneInsightStore) Upsert(
 	dataplaneID core_model.ResourceKey,
 	subscription *mesh_proto.DiscoverySubscription,
 	secretsInfo *secrets.Info,
+	otel *mesh_proto.DataplaneInsight_OpenTelemetry,
 ) error {
 	switch dataplaneType {
 	case core_mesh.ZoneIngressType:
@@ -272,6 +289,7 @@ func (s *dataplaneInsightStore) Upsert(
 			}
 
 			insight.Spec.Metadata = xdsMetadata
+			insight.Spec.OpenTelemetry = otel
 			if secretsInfo == nil { // it means mTLS was disabled, we need to clear stats
 				insight.Spec.MTLS = nil
 			} else if insight.Spec.MTLS == nil ||

--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -221,8 +221,6 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 			flush(false, &workloadIdentity)
 		case <-stop:
 			flush(true, lastEvent)
-			dataplaneID, _ := s.accessor.GetStatus()
-			s.otelStatusCache.Set(dataplaneID, nil)
 			return
 		}
 	}

--- a/pkg/xds/server/callbacks/dataplane_status_sink_test.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/test/xds"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
+	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
 	"github.com/kumahq/kuma/v2/pkg/xds/server/callbacks"
 )
 
@@ -87,6 +88,7 @@ var _ = Describe("DataplaneInsightSink", func() {
 				},
 				accessor,
 				&xds.TestSecrets{},
+				nil,
 				func() *time.Ticker { return ticker },
 				func() *time.Ticker { return &time.Ticker{C: make(chan time.Time)} },
 				1*time.Millisecond,
@@ -200,6 +202,7 @@ var _ = Describe("DataplaneInsightSink", func() {
 				},
 				accessor,
 				&xds.TestSecrets{NoSecrets: true}, // let's use events
+				nil,
 				func() *time.Ticker { return ticker },
 				func() *time.Ticker { return &time.Ticker{C: make(chan time.Time)} },
 				1*time.Millisecond,
@@ -296,6 +299,97 @@ var _ = Describe("DataplaneInsightSink", func() {
 			Expect(latestOperation.DataplaneInsight_MTLS.LastCertificateRegeneration).To(BeNil())
 			Expect(latestOperation.DataplaneInsight_MTLS.SupportedBackends).To(BeEmpty())
 		})
+
+		It("should flush OTel status changes and dedup unchanged status", func() {
+			// setup
+			key := core_model.ResourceKey{Mesh: "default", Name: "example-001"}
+			subscription := &mesh_proto.DiscoverySubscription{
+				Id:                     "3287995C-7E11-41FB-9479-7D39337F845D",
+				ControlPlaneInstanceId: "control-plane-01",
+				ConnectTime:            util_proto.MustTimestampProto(t0),
+				Status:                 mesh_proto.NewSubscriptionStatus(t0),
+			}
+			accessor := &SubscriptionStatusHolder{key, subscription}
+			ticks := make(chan time.Time)
+			ticker := &time.Ticker{C: ticks}
+			metrics, err := core_metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
+			eventBus, err := events.NewEventBus(10, metrics)
+			Expect(err).ToNot(HaveOccurred())
+
+			otelCache := otelstatus.NewCache()
+
+			var latestOperation *DataplaneInsightOperation
+
+			// given
+			sink := callbacks.NewDataplaneInsightSink(
+				&structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						core_xds.FieldDataplaneProxyType: {
+							Kind: &structpb.Value_StringValue{
+								StringValue: string(mesh_proto.DataplaneProxyType),
+							},
+						},
+					},
+				},
+				accessor,
+				&xds.TestSecrets{},
+				otelCache,
+				func() *time.Ticker { return ticker },
+				func() *time.Ticker { return &time.Ticker{C: make(chan time.Time)} },
+				1*time.Millisecond,
+				store,
+				eventBus,
+				recorder.ResourceManager,
+			)
+
+			// when
+			go sink.Start(stop)
+
+			// then - initial create without OTel
+			create, ok := <-recorder.Creates
+			Expect(ok).To(BeTrue())
+			latestOperation = &create
+			Expect(latestOperation.OpenTelemetry).To(BeNil())
+
+			// when - OTel status is set in the cache
+			otelCache.Set(key, &mesh_proto.DataplaneInsight_OpenTelemetry{
+				Backends: []*mesh_proto.DataplaneInsight_OpenTelemetry_Backend{
+					{Name: "otel-main", Traces: &mesh_proto.DataplaneInsight_OpenTelemetry_Signal{
+						Enabled: true,
+						State:   "ready",
+					}},
+				},
+			})
+			ticks <- t0.Add(2 * time.Second)
+
+			// then - update with OTel status
+			Eventually(func() bool {
+				select {
+				case update, ok := <-recorder.Updates:
+					latestOperation = &update
+					return ok
+				default:
+					return false
+				}
+			}, "1s", "1ms").Should(BeTrue())
+			Expect(latestOperation.OpenTelemetry).ToNot(BeNil())
+			Expect(latestOperation.OpenTelemetry.Backends).To(HaveLen(1))
+			Expect(latestOperation.OpenTelemetry.Backends[0].Name).To(Equal("otel-main"))
+			Expect(latestOperation.OpenTelemetry.Backends[0].Traces.State).To(Equal("ready"))
+
+			// when - tick without changes (dedup)
+			ticks <- t0.Add(3 * time.Second)
+			// then - no update
+			select {
+			case <-recorder.Creates:
+				Fail("unchanged OTel status should not trigger update")
+			case <-recorder.Updates:
+				Fail("unchanged OTel status should not trigger update")
+			case <-time.After(100 * time.Millisecond):
+				// no update is good
+			}
+		})
 	})
 
 	Describe("DataplaneInsightStore", func() {
@@ -326,7 +420,7 @@ var _ = Describe("DataplaneInsightSink", func() {
 			statusStore := callbacks.NewDataplaneInsightStore(manager.NewResourceManager(store))
 
 			// when
-			err := statusStore.Upsert(ctx, nil, dataplaneType, key, proto.Clone(subscription).(*mesh_proto.DiscoverySubscription), nil)
+			err := statusStore.Upsert(ctx, nil, dataplaneType, key, proto.Clone(subscription).(*mesh_proto.DiscoverySubscription), nil, nil)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
@@ -361,7 +455,7 @@ var _ = Describe("DataplaneInsightSink", func() {
 			subscription.Status.Lds.ResponsesSent += 1
 			subscription.Status.Total.ResponsesSent += 1
 			// and
-			err = statusStore.Upsert(ctx, nil, dataplaneType, key, proto.Clone(subscription).(*mesh_proto.DiscoverySubscription), nil)
+			err = statusStore.Upsert(ctx, nil, dataplaneType, key, proto.Clone(subscription).(*mesh_proto.DiscoverySubscription), nil, nil)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			// and
@@ -412,6 +506,7 @@ var _ manager.ResourceManager = &DataplaneInsightStoreRecorder{}
 type DataplaneInsightOperation struct {
 	core_model.ResourceKey
 	*mesh_proto.DataplaneInsight_MTLS
+	OpenTelemetry *mesh_proto.DataplaneInsight_OpenTelemetry
 	Subscriptions []*mesh_proto.DiscoverySubscription
 }
 
@@ -430,6 +525,7 @@ func (d *DataplaneInsightStoreRecorder) Create(ctx context.Context, resource cor
 		ResourceKey:           core_model.ResourceKey{Mesh: opts.Mesh, Name: opts.Name},
 		Subscriptions:         resource.GetSpec().(*mesh_proto.DataplaneInsight).Subscriptions,
 		DataplaneInsight_MTLS: resource.GetSpec().(*mesh_proto.DataplaneInsight).MTLS,
+		OpenTelemetry:         resource.GetSpec().(*mesh_proto.DataplaneInsight).OpenTelemetry,
 	}
 	return nil
 }
@@ -442,6 +538,7 @@ func (d *DataplaneInsightStoreRecorder) Update(ctx context.Context, resource cor
 		ResourceKey:           core_model.ResourceKey{Mesh: resource.GetMeta().GetMesh(), Name: resource.GetMeta().GetName()},
 		Subscriptions:         resource.GetSpec().(*mesh_proto.DataplaneInsight).Subscriptions,
 		DataplaneInsight_MTLS: resource.GetSpec().(*mesh_proto.DataplaneInsight).MTLS,
+		OpenTelemetry:         resource.GetSpec().(*mesh_proto.DataplaneInsight).OpenTelemetry,
 	}
 	return nil
 }

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/xds/generator"
 	generator_meta "github.com/kumahq/kuma/v2/pkg/xds/generator/metadata"
 	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
+	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
 	"github.com/kumahq/kuma/v2/pkg/xds/secrets"
 	xds_callbacks "github.com/kumahq/kuma/v2/pkg/xds/server/callbacks"
 	xds_sync "github.com/kumahq/kuma/v2/pkg/xds/sync"
@@ -48,13 +49,14 @@ func RegisterXDS(
 	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks)
 	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks)
 	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks)
-	watchdogFactory, err := xds_sync.DefaultDataplaneWatchdogFactory(rt, reconciler, ingressReconciler, egressReconciler, xdsMetrics, envoyCpCtx, envoy_common.APIV3)
+	otelStatusCache := otelstatus.NewCache()
+	watchdogFactory, err := xds_sync.DefaultDataplaneWatchdogFactory(rt, reconciler, ingressReconciler, egressReconciler, xdsMetrics, envoyCpCtx, otelStatusCache, envoy_common.APIV3)
 	if err != nil {
 		return err
 	}
 
 	syncTracker := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory))
-	dpStatusTracker := DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets)
+	dpStatusTracker := DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets, otelStatusCache)
 
 	callbacks := util_xds_v3.CallbacksChain{
 		util_xds_v3.NewControlPlaneIdCallbacks(rt.GetInstanceId()),
@@ -170,13 +172,14 @@ func DefaultEgressReconciler(
 	}
 }
 
-func DefaultDataplaneStatusTracker(rt core_runtime.Runtime, secrets secrets.Secrets) xds_callbacks.DataplaneStatusTracker {
+func DefaultDataplaneStatusTracker(rt core_runtime.Runtime, secrets secrets.Secrets, otelStatusCache *otelstatus.Cache) xds_callbacks.DataplaneStatusTracker {
 	return xds_callbacks.NewDataplaneStatusTracker(rt,
 		func(xdsMetadata *structpb.Struct, accessor xds_callbacks.SubscriptionStatusAccessor) xds_callbacks.DataplaneInsightSink {
 			return xds_callbacks.NewDataplaneInsightSink(
 				xdsMetadata,
 				accessor,
 				secrets,
+				otelStatusCache,
 				func() *time.Ticker {
 					return time.NewTicker(rt.Config().XdsServer.DataplaneStatusFlushInterval.Duration)
 				},

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -7,6 +7,7 @@ import (
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
 	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
+	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
 )
 
 var xdsServerLog = core.Log.WithName("xds").WithName("server")
@@ -52,6 +53,7 @@ func DefaultDataplaneWatchdogFactory(
 	egressReconciler SnapshotReconciler,
 	xdsMetrics *xds_metrics.Metrics,
 	envoyCpCtx *xds_context.ControlPlaneContext,
+	otelStatusCache *otelstatus.Cache,
 	apiVersion core_xds.APIVersion,
 ) (DataplaneWatchdogFactory, error) {
 	config := rt.Config()
@@ -78,6 +80,7 @@ func DefaultDataplaneWatchdogFactory(
 		EnvoyCpCtx:            envoyCpCtx,
 		MeshCache:             rt.MeshCache(),
 		ResManager:            rt.ReadOnlyResourceManager(),
+		OtelStatusCache:       otelStatusCache,
 	}
 	return NewDataplaneWatchdogFactory(
 		xdsMetrics,

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -20,6 +20,7 @@ import (
 	util_tls "github.com/kumahq/kuma/v2/pkg/tls"
 	"github.com/kumahq/kuma/v2/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
 )
 
 type DataplaneWatchdogDependencies struct {
@@ -32,6 +33,7 @@ type DataplaneWatchdogDependencies struct {
 	EnvoyCpCtx            *xds_context.ControlPlaneContext
 	MeshCache             *mesh.Cache
 	ResManager            core_manager.ReadOnlyResourceManager
+	OtelStatusCache       *otelstatus.Cache
 }
 
 type Status string
@@ -96,6 +98,7 @@ func (d *DataplaneWatchdog) Cleanup() error {
 	switch d.dpType {
 	case mesh_proto.DataplaneProxyType:
 		d.EnvoyCpCtx.Secrets.Cleanup(mesh_proto.DataplaneProxyType, d.key)
+		d.OtelStatusCache.Set(d.key, nil)
 		return d.DataplaneReconciler.Clear(&proxyID)
 	case mesh_proto.IngressProxyType:
 		return d.IngressReconciler.Clear(&proxyID)
@@ -199,6 +202,14 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context) (SyncResult, erro
 	}
 	d.lastHash = meshCtx.Hash
 	d.lastIdentityHash = identityHash
+
+	if d.OtelStatusCache != nil {
+		if proxy.OtelPipeBackends == nil || proxy.OtelPipeBackends.Empty() {
+			d.OtelStatusCache.Set(d.key, nil)
+		} else {
+			d.OtelStatusCache.Set(d.key, otelstatus.Build(proxy.OtelPipeBackends.All()))
+		}
+	}
 
 	if changed {
 		result.Status = ChangedStatus


### PR DESCRIPTION
## Motivation

The CP needs to know what OTel env vars kuma-dp discovered at startup and report per-signal runtime status on DataplaneInsight. Without this, operators can't see whether env-based OTel config was detected or why a signal is blocked.

## Implementation information

- Add `OpenTelemetry` proto to `DataplaneInsight` (field 4) with Backend/Signal sub-messages
- Create `pkg/xds/otel/status/` cache bridging xDS watchdog and status sink
- Wire `OtelEnvInventory` through bootstrap into Envoy node metadata
- Thread `OtelStatusCache` through watchdog, sync, sink, and server registration
- Fix 3 bugs: nil EnvPolicy precedence, shared endpoint HTTPPath, blocked metrics gating

## Supporting documentation

Builds on #15898. Design: MADR 095 (#15677) and MADR 100 (#15807).

> Changelog: feat(kuma-cp): add MeshOpenTelemetryBackend for shared policy-based OpenTelemetry backends
