### PR TITLE
feat(motb): deprecate inline OTel endpoint

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"slices"
+
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
@@ -10,5 +12,30 @@ func (t *MeshAccessLogResource) Deprecations() []string {
 	if len(pointer.Deref(t.Spec.From)) > 0 {
 		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
 	}
+	if hasInlineOtelEndpoint(t.Spec) {
+		deprecations = append(deprecations, "openTelemetry.endpoint is deprecated, use openTelemetry.backendRef with a MeshOpenTelemetryBackend resource instead")
+	}
 	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
+}
+
+func hasInlineOtelEndpoint(spec *MeshAccessLog) bool {
+	inlineEndpoint := func(b Backend) bool {
+		return b.OpenTelemetry != nil && b.OpenTelemetry.Endpoint != "" && b.OpenTelemetry.BackendRef == nil
+	}
+	for _, to := range pointer.Deref(spec.To) {
+		if slices.ContainsFunc(pointer.Deref(to.Default.Backends), inlineEndpoint) {
+			return true
+		}
+	}
+	for _, from := range pointer.Deref(spec.From) {
+		if slices.ContainsFunc(pointer.Deref(from.Default.Backends), inlineEndpoint) {
+			return true
+		}
+	}
+	for _, rule := range pointer.Deref(spec.Rules) {
+		if slices.ContainsFunc(pointer.Deref(rule.Default.Backends), inlineEndpoint) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
@@ -2,8 +2,16 @@ package v1alpha1
 
 import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 func (t *MeshMetricResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+	var deprecations []string
+	for _, backend := range pointer.Deref(t.Spec.Default.Backends) {
+		if backend.OpenTelemetry != nil && backend.OpenTelemetry.Endpoint != "" && backend.OpenTelemetry.BackendRef == nil {
+			deprecations = append(deprecations, "openTelemetry.endpoint is deprecated, use openTelemetry.backendRef with a MeshOpenTelemetryBackend resource instead")
+			break
+		}
+	}
+	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
@@ -2,8 +2,16 @@ package v1alpha1
 
 import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 func (t *MeshTraceResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
+	var deprecations []string
+	for _, backend := range pointer.Deref(t.Spec.Default.Backends) {
+		if backend.OpenTelemetry != nil && backend.OpenTelemetry.Endpoint != "" && backend.OpenTelemetry.BackendRef == nil {
+			deprecations = append(deprecations, "openTelemetry.endpoint is deprecated, use openTelemetry.backendRef with a MeshOpenTelemetryBackend resource instead")
+			break
+		}
+	}
+	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
 }


### PR DESCRIPTION
> [!CAUTION]
> **Do not merge until all other MOTB PRs are merged and 2.14 release branch is cut.**
> This PR adds deprecation warnings that users will see immediately. Merging before the MeshOpenTelemetryBackend replacement is fully available would warn users about a migration path that doesn't exist yet. Keep as draft until ready.

## Motivation

MADR 095 replaces `openTelemetry.endpoint` in MeshAccessLog, MeshTrace, and MeshMetric with `openTelemetry.backendRef` pointing to a `MeshOpenTelemetryBackend` resource. Users need deprecation warnings before the field is removed in 3.0.

## Implementation information

Each policy's `deprecated.go` checks if any backend has a non-empty `openTelemetry.endpoint` without a `backendRef` and emits a warning. MeshAccessLog checks across `to`, `from`, and `rules` sections via an `allBackends()` helper. MeshTrace and MeshMetric check `spec.default.backends[]` directly. All three use the same message: `"openTelemetry.endpoint is deprecated, use openTelemetry.backendRef with a MeshOpenTelemetryBackend resource instead"`

## Supporting documentation

- MADR 095: #15677
- MOTB resource + backendRef: #15863, #15865