### PR TITLE
feat(universal): allow disabling Workload and MeshService generators

### DIFF
--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -564,8 +564,8 @@ func (i MeshMultiZoneServiceIPAM) Validate() error {
 }
 
 type MeshServiceConfig struct {
-	// How often we check whether MeshServices need to be generated from
-	// Dataplanes
+	// How often we check whether MeshServices need to be
+	// generated from Dataplanes set to 0 to disable automatic workload management (only applies to universal)
 	GenerationInterval config_types.Duration `json:"generationInterval" envconfig:"KUMA_MESH_SERVICE_GENERATION_INTERVAL"`
 	// How long we wait before deleting a MeshService if all Dataplanes are gone
 	DeletionGracePeriod config_types.Duration `json:"deletionGracePeriod" envconfig:"KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD"`

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -565,7 +565,7 @@ func (i MeshMultiZoneServiceIPAM) Validate() error {
 
 type MeshServiceConfig struct {
 	// How often we check whether MeshServices need to be
-	// generated from Dataplanes set to 0 to disable automatic workload management (only applies to universal)
+	// generated from Dataplanes set to 0 to disable automatic meshservice management (only applies to universal)
 	GenerationInterval config_types.Duration `json:"generationInterval" envconfig:"KUMA_MESH_SERVICE_GENERATION_INTERVAL"`
 	// How long we wait before deleting a MeshService if all Dataplanes are gone
 	DeletionGracePeriod config_types.Duration `json:"deletionGracePeriod" envconfig:"KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD"`

--- a/pkg/config/plugins/runtime/universal/config.go
+++ b/pkg/config/plugins/runtime/universal/config.go
@@ -50,7 +50,7 @@ type UniversalRuntimeConfig struct {
 // WorkloadConfig holds configuration for Workload generation from Dataplanes.
 type WorkloadConfig struct {
 	// GenerationInterval is how often we check whether Workloads need to be
-	// generated from Dataplanes
+	// generated from Dataplanes set to 0 to disable automatic workload management
 	GenerationInterval config_types.Duration `json:"generationInterval" envconfig:"KUMA_RUNTIME_UNIVERSAL_WORKLOAD_GENERATION_INTERVAL"`
 }
 

--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -18,6 +18,10 @@ func Setup(rt runtime.Runtime) error {
 		return nil
 	}
 	logger := core.Log.WithName("meshservice").WithName("generator")
+	if rt.Config().MeshService.GenerationInterval.Duration == 0 {
+		logger.Info("MeshService generator is disabled, MeshService must be managed manually")
+		return nil
+	}
 	if !slices.Contains(rt.Config().CoreResources.Enabled, "meshservices") {
 		logger.Info("MeshService is not enabled. Skip starting generator for MeshService.")
 		return nil

--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -19,11 +19,11 @@ func Setup(rt runtime.Runtime) error {
 	}
 	logger := core.Log.WithName("meshservice").WithName("generator")
 	if rt.Config().MeshService.GenerationInterval.Duration == 0 {
-		logger.Info("MeshService generator is disabled, MeshService must be managed manually")
+		logger.Info("MeshService generator is disabled, MeshServices must be managed manually")
 		return nil
 	}
 	if !slices.Contains(rt.Config().CoreResources.Enabled, "meshservices") {
-		logger.Info("MeshService is not enabled. Skip starting generator for MeshService.")
+		logger.Info("MeshServices are not enabled. Skip starting generator for MeshServices.")
 		return nil
 	}
 	generator, err := New(

--- a/pkg/core/resources/apis/workload/generate/component.go
+++ b/pkg/core/resources/apis/workload/generate/component.go
@@ -18,6 +18,10 @@ func Setup(rt runtime.Runtime) error {
 		return nil
 	}
 	logger := core.Log.WithName("workload").WithName("generator")
+	if rt.Config().Runtime.Universal.Workload.GenerationInterval.Duration == 0 {
+		logger.Info("Workload generator is disabled, Workloads must be managed manually")
+		return nil
+	}
 	if !slices.Contains(rt.Config().CoreResources.Enabled, "workloads") {
 		logger.Info("Workload is not enabled. Skip starting generator for Workload.")
 		return nil


### PR DESCRIPTION
## Motivation

Users may want to manage them manually. This wasn't possible. You can now set `KUMA_MESH_SERVICE_GENERATION_INTERVAL=0` or `KUMA_RUNTIME_UNIVERSAL_WORKLOAD_GENERATION_INTERVAL=0` which turns these off.

## Implementation information

Log that these are manually manage and simply don't start the component.
Not starting the component is the behaviour we follow when running global or Kubernetes so it's the best suited way to do this

> Changelog: feat(kuma-cp): support running without inbound tags
