### PR TITLE
fix(upgrade): fix UPGRADE.md 2.9.x MeshTiemout format

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -514,6 +514,8 @@ The default inbound request timeout is now 15s instead of being unbounded.
 If you need longer inbound timeouts make sure to create a policy to override it.
 
 For example:
+
+```yaml
 type: MeshTimeout
 name: mt-higher-inbound
 mesh: mesh-1


### PR DESCRIPTION

## Motivation

UPGRADE.md not rendering properly due to missing format in MeshTimeout added in 2.9.x

