### PR TITLE
chore(api): use fmt.Errorf instead of errors.Errorf part 1

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -124,7 +122,7 @@ func (o ResourceOrigin) IsValid() error {
 	case GlobalResourceOrigin, ZoneResourceOrigin:
 		return nil
 	default:
-		return errors.Errorf("unknown resource origin %q", o)
+		return fmt.Errorf("unknown resource origin %q", o)
 	}
 }
 
@@ -170,7 +168,7 @@ func (t ProxyType) IsValid() error {
 	case DataplaneProxyType, IngressProxyType, EgressProxyType:
 		return nil
 	}
-	return errors.Errorf("%s is not a valid proxy type", t)
+	return fmt.Errorf("%s is not a valid proxy type", t)
 }
 
 type InboundInterface struct {
@@ -271,7 +269,7 @@ func (n *Dataplane_Networking) GetInboundInterface(service string) (*InboundInte
 		iface := n.ToInboundInterface(inbound)
 		return &iface, nil
 	}
-	return nil, errors.Errorf("Dataplane has no Inbound Interface for service %q", service)
+	return nil, fmt.Errorf("Dataplane has no Inbound Interface for service %q", service)
 }
 
 func (n *Dataplane_Networking) GetInboundInterfaces() []InboundInterface {

--- a/api/mesh/v1alpha1/dataplane_insight_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_insight_helpers.go
@@ -1,10 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/v2/api/generic"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
@@ -93,7 +92,7 @@ func (x *DataplaneInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	discoverySubscription, ok := s.(*DiscoverySubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for DataplaneInsight", s)
+		return fmt.Errorf("invalid type %T for DataplaneInsight", s)
 	}
 	for i, sub := range x.GetSubscriptions() {
 		if sub.GetId() == discoverySubscription.Id {

--- a/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
+++ b/api/mesh/v1alpha1/zone_ingress_insight_helpers.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/v2/api/generic"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
@@ -19,7 +19,7 @@ func (x *ZoneIngressInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	discoverySubscription, ok := s.(*DiscoverySubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for ZoneIngressInsight", s)
+		return fmt.Errorf("invalid type %T for ZoneIngressInsight", s)
 	}
 	for i, sub := range x.GetSubscriptions() {
 		if sub.GetId() == discoverySubscription.Id {

--- a/api/mesh/v1alpha1/zoneegressinsight_helpers.go
+++ b/api/mesh/v1alpha1/zoneegressinsight_helpers.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/kumahq/kuma/v2/api/generic"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
@@ -19,7 +19,7 @@ func (x *ZoneEgressInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	discoverySubscription, ok := s.(*DiscoverySubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for ZoneEgressInsight", s)
+		return fmt.Errorf("invalid type %T for ZoneEgressInsight", s)
 	}
 	for i, sub := range x.GetSubscriptions() {
 		if sub.GetId() == discoverySubscription.Id {

--- a/api/system/v1alpha1/zone_insight_helpers.go
+++ b/api/system/v1alpha1/zone_insight_helpers.go
@@ -1,9 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/kumahq/kuma/v2/api/generic"
@@ -82,7 +82,7 @@ func (x *ZoneInsight) UpdateSubscription(s generic.Subscription) error {
 	}
 	kdsSubscription, ok := s.(*KDSSubscription)
 	if !ok {
-		return errors.Errorf("invalid type %T for ZoneInsight", s)
+		return fmt.Errorf("invalid type %T for ZoneInsight", s)
 	}
 	for i, sub := range x.GetSubscriptions() {
 		if sub.GetId() == kdsSubscription.Id {


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in api

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
