### PR TITLE
feat(meshmetric): extend Basic profile metrics

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -152,6 +152,22 @@ var basicProfile = []selectorFunction{
 		Type:  v1alpha1.ExactSelectorType,
 		Match: "envoy_cluster_membership_total",
 	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ContainsSelectorType,
+		Match: "circuit_breakers",
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ContainsSelectorType,
+		Match: "cx_total",
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ContainsSelectorType,
+		Match: "ssl_handshake",
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.ContainsSelectorType,
+		Match: "ssl_context_update_by_sds",
+	}),
 	// end of dashboards
 	// start of dns stats
 	selectorToFilterFunction(v1alpha1.Selector{
@@ -161,6 +177,10 @@ var basicProfile = []selectorFunction{
 	selectorToFilterFunction(v1alpha1.Selector{
 		Type:  v1alpha1.PrefixSelectorType,
 		Match: "envoy_dns_cares",
+	}),
+	selectorToFilterFunction(v1alpha1.Selector{
+		Type:  v1alpha1.PrefixSelectorType,
+		Match: "kuma_dp_dns",
 	}),
 	// end of dns stats
 }

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic.golden
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic.golden
@@ -106,3 +106,30 @@ envoy_server_memory_heap_size{envoy_cluster_name="example"} 1
 # TYPE envoy_server_uptime counter
 envoy_server_uptime{envoy_cluster_name="example"} 1
 
+# TYPE envoy_cluster_circuit_breakers_default_cx_open counter
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="example"} 1
+
+# TYPE envoy_cluster_circuit_breakers_default_remaining_cx counter
+envoy_cluster_circuit_breakers_default_remaining_cx{envoy_cluster_name="example"} 99
+
+# TYPE envoy_cluster_circuit_breakers_default_remaining_pending counter
+envoy_cluster_circuit_breakers_default_remaining_pending{envoy_cluster_name="example"} 50
+
+# TYPE envoy_cluster_upstream_cx_total counter
+envoy_cluster_upstream_cx_total{envoy_cluster_name="example"} 5
+
+# TYPE envoy_listener_downstream_cx_total counter
+envoy_listener_downstream_cx_total{envoy_listener_address="example"} 5
+
+# TYPE envoy_listener_ssl_handshake counter
+envoy_listener_ssl_handshake{envoy_listener_address="example"} 3
+
+# TYPE envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds counter
+envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{envoy_listener_address="example"} 2
+
+# TYPE kuma_dp_dns_request_duration_seconds_bucket counter
+kuma_dp_dns_request_duration_seconds_bucket{le="0.005"} 10
+
+# TYPE kuma_dp_dns_upstream_request_duration_seconds_bucket counter
+kuma_dp_dns_upstream_request_duration_seconds_bucket{le="0.005"} 8
+

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic.in
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic.in
@@ -115,3 +115,33 @@ envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="system_envoy_adm
 
 # TYPE envoy_listener_sock_downstream_pre_cx_active counter
 envoy_listener_sock_downstream_pre_cx_active{envoy_listener_address="system_meshmetric_foo_bar_baz"} 233
+
+# TYPE envoy_cluster_circuit_breakers_default_cx_open counter
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="example"} 1
+
+# TYPE envoy_cluster_circuit_breakers_default_remaining_cx counter
+envoy_cluster_circuit_breakers_default_remaining_cx{envoy_cluster_name="example"} 99
+
+# TYPE envoy_cluster_circuit_breakers_default_remaining_pending counter
+envoy_cluster_circuit_breakers_default_remaining_pending{envoy_cluster_name="example"} 50
+
+# TYPE envoy_cluster_upstream_cx_total counter
+envoy_cluster_upstream_cx_total{envoy_cluster_name="example"} 5
+
+# TYPE envoy_listener_downstream_cx_total counter
+envoy_listener_downstream_cx_total{envoy_listener_address="example"} 5
+
+# TYPE envoy_listener_ssl_handshake counter
+envoy_listener_ssl_handshake{envoy_listener_address="example"} 3
+
+# TYPE envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds counter
+envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{envoy_listener_address="example"} 2
+
+# TYPE kuma_dp_dns_request_duration_seconds_bucket counter
+kuma_dp_dns_request_duration_seconds_bucket{le="0.005"} 10
+
+# TYPE kuma_dp_dns_upstream_request_duration_seconds_bucket counter
+kuma_dp_dns_upstream_request_duration_seconds_bucket{le="0.005"} 8
+
+# TYPE envoy_some_irrelevant_metric counter
+envoy_some_irrelevant_metric{envoy_cluster_name="example"} 1


### PR DESCRIPTION
## Motivation

The Basic MeshMetric profile was missing several metrics used by the
Kuma Grafana dashboards. Users running with the Basic profile (the
default) would see empty panels for circuit breakers, connection
totals, SSL handshakes, SDS cert rotations, and DNS latency.

## Implementation information

Added the following selectors to `basicProfile` in
`app/kuma-dp/pkg/dataplane/metrics/profiles.go`:

- `contains: circuit_breakers` — CB open/remaining metrics
- `contains: cx_total` — listener and cluster connection totals
- `contains: ssl_handshake` — listener SSL handshake counter
- `contains: ssl_context_update_by_sds` — SDS cert rotation counter
- `prefix: kuma_dp_dns` — kuma-dp DNS request duration metrics

Updated `testdata/profiles/basic.in` and `basic.golden` with the
new metrics to verify they pass through the filter, plus one
irrelevant metric to confirm it is still excluded.

> Changelog: feat(meshmetric): extend Basic profile metrics