### PR TITLE
chore(pkg): use fmt.Errorf instead of errors.Errorf part 1

### DIFF
--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -462,7 +462,7 @@ func (c *KubernetesRuntimeConfig) Validate() error {
 		errs = multierr.Append(errs, errors.Wrapf(err, ".Injector is not valid"))
 	}
 	if c.MarshalingCacheExpirationTime.Duration < 0 {
-		errs = multierr.Append(errs, errors.Errorf(".MarshalingCacheExpirationTime must be positive or equal to 0"))
+		errs = multierr.Append(errs, errors.New(".MarshalingCacheExpirationTime must be positive or equal to 0"))
 	}
 	return errs
 }
@@ -472,10 +472,10 @@ var _ config.Config = &AdmissionServerConfig{}
 func (c *AdmissionServerConfig) Validate() error {
 	var errs error
 	if 65535 < c.Port {
-		errs = multierr.Append(errs, errors.Errorf(".Port must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".Port must be in the range [0, 65535]"))
 	}
 	if c.CertDir == "" {
-		errs = multierr.Append(errs, errors.Errorf(".CertDir should not be empty"))
+		errs = multierr.Append(errs, errors.New(".CertDir should not be empty"))
 	}
 	return errs
 }
@@ -524,22 +524,22 @@ func (c *SidecarContainer) PostProcess() error {
 func (c *SidecarContainer) Validate() error {
 	var errs error
 	if c.Image == "" {
-		errs = multierr.Append(errs, errors.Errorf(".Image must be non-empty"))
+		errs = multierr.Append(errs, errors.New(".Image must be non-empty"))
 	}
 	if c.IpFamilyMode != "" && c.IpFamilyMode != "ipv4" && c.IpFamilyMode != "dualstack" {
-		errs = multierr.Append(errs, errors.Errorf(".IpFamilyMode must be either 'ipv4' or 'dualstack'"))
+		errs = multierr.Append(errs, errors.New(".IpFamilyMode must be either 'ipv4' or 'dualstack'"))
 	}
 	if 65535 < c.RedirectPortInbound {
-		errs = multierr.Append(errs, errors.Errorf(".RedirectPortInbound must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".RedirectPortInbound must be in the range [0, 65535]"))
 	}
 	if 65535 < c.RedirectPortOutbound {
-		errs = multierr.Append(errs, errors.Errorf(".RedirectPortOutbound must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".RedirectPortOutbound must be in the range [0, 65535]"))
 	}
 	if 65535 < c.AdminPort {
-		errs = multierr.Append(errs, errors.Errorf(".AdminPort must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".AdminPort must be in the range [0, 65535]"))
 	}
 	if c.DrainTime.Duration <= 0 {
-		errs = multierr.Append(errs, errors.Errorf(".DrainTime must be positive"))
+		errs = multierr.Append(errs, errors.New(".DrainTime must be positive"))
 	}
 	if err := c.ReadinessProbe.Validate(); err != nil {
 		errs = multierr.Append(errs, errors.Wrapf(err, ".ReadinessProbe is not valid"))
@@ -558,7 +558,7 @@ var _ config.Config = &InitContainer{}
 func (c *InitContainer) Validate() error {
 	var errs error
 	if c.Image == "" {
-		errs = multierr.Append(errs, errors.Errorf(".Image must be non-empty"))
+		errs = multierr.Append(errs, errors.New(".Image must be non-empty"))
 	}
 	return errs
 }
@@ -568,19 +568,19 @@ var _ config.Config = &SidecarReadinessProbe{}
 func (c *SidecarReadinessProbe) Validate() error {
 	var errs error
 	if c.InitialDelaySeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".InitialDelaySeconds must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".InitialDelaySeconds must be >= 1"))
 	}
 	if c.TimeoutSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".TimeoutSeconds must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".TimeoutSeconds must be >= 1"))
 	}
 	if c.PeriodSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".PeriodSeconds must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".PeriodSeconds must be >= 1"))
 	}
 	if c.SuccessThreshold < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".SuccessThreshold must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".SuccessThreshold must be >= 1"))
 	}
 	if c.FailureThreshold < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".FailureThreshold must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".FailureThreshold must be >= 1"))
 	}
 	return errs
 }
@@ -590,16 +590,16 @@ var _ config.Config = &SidecarLivenessProbe{}
 func (c *SidecarLivenessProbe) Validate() error {
 	var errs error
 	if c.InitialDelaySeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".InitialDelaySeconds must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".InitialDelaySeconds must be >= 1"))
 	}
 	if c.TimeoutSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".TimeoutSeconds must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".TimeoutSeconds must be >= 1"))
 	}
 	if c.PeriodSeconds < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".PeriodSeconds must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".PeriodSeconds must be >= 1"))
 	}
 	if c.FailureThreshold < 1 {
-		errs = multierr.Append(errs, errors.Errorf(".FailureThreshold must be >= 1"))
+		errs = multierr.Append(errs, errors.New(".FailureThreshold must be >= 1"))
 	}
 	return errs
 }
@@ -660,7 +660,7 @@ var _ config.Config = &BuiltinDNS{}
 func (c *BuiltinDNS) Validate() error {
 	var errs error
 	if 65535 < c.Port {
-		errs = multierr.Append(errs, errors.Errorf(".port must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".port must be in the range [0, 65535]"))
 	}
 	return errs
 }

--- a/pkg/hds/authn/callbacks.go
+++ b/pkg/hds/authn/callbacks.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -67,7 +68,7 @@ func (a *authn) OnStreamOpen(ctx context.Context, streamID int64) error {
 func (a *authn) OnHealthCheckRequest(streamID int64, req *envoy_service_health.HealthCheckRequest) error {
 	if id, alreadyAuthenticated := a.authNodeId(streamID); alreadyAuthenticated {
 		if req.GetNode().GetId() != "" && req.GetNode().GetId() != id {
-			return errors.Errorf("stream was authenticated for ID %s. Received request is for node with ID %s. Node ID cannot be changed after stream is initialized", id, req.GetNode().GetId())
+			return fmt.Errorf("stream was authenticated for ID %s. Received request is for node with ID %s. Node ID cannot be changed after stream is initialized", id, req.GetNode().GetId())
 		}
 		return nil
 	}
@@ -88,7 +89,7 @@ func (a *authn) OnHealthCheckRequest(streamID int64, req *envoy_service_health.H
 
 func (a *authn) OnEndpointHealthResponse(streamID int64, _ *envoy_service_health.EndpointHealthResponse) error {
 	if id, alreadyAuthenticated := a.authNodeId(streamID); !alreadyAuthenticated {
-		return errors.Errorf("stream was not authenticated for ID %s", id)
+		return fmt.Errorf("stream was not authenticated for ID %s", id)
 	}
 	return nil
 }
@@ -113,7 +114,7 @@ func (a *authn) credential(streamID core_xds.StreamID) (xds_auth.Credential, err
 
 	ctx, exists := a.contexts[streamID]
 	if !exists {
-		return "", errors.Errorf("there is no context for stream ID %d", streamID)
+		return "", fmt.Errorf("there is no context for stream ID %d", streamID)
 	}
 	credential, err := extractCredential(ctx)
 	if err != nil {
@@ -125,11 +126,11 @@ func (a *authn) credential(streamID core_xds.StreamID) (xds_auth.Credential, err
 func extractCredential(ctx context.Context) (xds_auth.Credential, error) {
 	metadata, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", errors.Errorf("request has no metadata")
+		return "", errors.New("request has no metadata")
 	}
 	if values, ok := metadata[authorization]; ok {
 		if len(values) != 1 {
-			return "", errors.Errorf("request must have exactly 1 %q header, got %d", authorization, len(values))
+			return "", fmt.Errorf("request must have exactly 1 %q header, got %d", authorization, len(values))
 		}
 		return values[0], nil
 	}

--- a/pkg/plugins/resources/k8s/plugin.go
+++ b/pkg/plugins/resources/k8s/plugin.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
 	core_store "github.com/kumahq/kuma/v2/pkg/core/resources/store"
@@ -21,11 +21,11 @@ func init() {
 func (p *plugin) NewResourceStore(pc core_plugins.PluginContext, _ core_plugins.PluginConfig) (core_store.ResourceStore, core_store.Transactions, error) {
 	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return nil, nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return nil, nil, errors.New("k8s controller runtime Manager hasn't been configured")
 	}
 	converter, ok := k8s_runtime.FromResourceConverterContext(pc.Extensions())
 	if !ok {
-		return nil, nil, errors.Errorf("k8s resource converter hasn't been configured")
+		return nil, nil, errors.New("k8s resource converter hasn't been configured")
 	}
 	store, err := NewStore(mgr.GetClient(), mgr.GetScheme(), converter)
 	return store, core_store.NoTransactions{}, err
@@ -38,7 +38,7 @@ func (p *plugin) Migrate(pc core_plugins.PluginContext, config core_plugins.Plug
 func (p *plugin) EventListener(pc core_plugins.PluginContext, writer events.Emitter) error {
 	mgr, ok := k8s_runtime.FromManagerContext(pc.Extensions())
 	if !ok {
-		return errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return errors.New("k8s controller runtime Manager hasn't been configured")
 	}
 	if err := pc.ComponentManager().Add(k8s_events.NewListener(mgr, writer)); err != nil {
 		return err

--- a/pkg/plugins/resources/remote/store.go
+++ b/pkg/plugins/resources/remote/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"maps"
 	"net/http"
@@ -104,9 +105,9 @@ func (s *remoteStore) upsert(ctx context.Context, res model.Resource, meta rest_
 			ctx.Value(WarningsCallback).(func([]string))(resp.Warnings)
 		}
 	case http.StatusMethodNotAllowed:
-		return errors.Errorf("%s", string(b))
+		return fmt.Errorf("%s", string(b))
 	default:
-		return errors.Errorf("(%d): %s", statusCode, string(b))
+		return fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 
 	res.SetMeta(meta)
@@ -132,9 +133,9 @@ func (s *remoteStore) Delete(ctx context.Context, res model.Resource, fs ...stor
 	}
 	if statusCode != http.StatusOK {
 		if statusCode == http.StatusMethodNotAllowed {
-			return errors.Errorf("%s", string(b))
+			return fmt.Errorf("%s", string(b))
 		} else {
-			return errors.Errorf("(%d): %s", statusCode, string(b))
+			return fmt.Errorf("(%d): %s", statusCode, string(b))
 		}
 	}
 	return nil
@@ -158,7 +159,7 @@ func (s *remoteStore) Get(ctx context.Context, res model.Resource, fs ...store.G
 		return err
 	}
 	if statusCode != 200 {
-		return errors.Errorf("(%d): %s", statusCode, string(b))
+		return fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	restRes, err := rest.JSON.Unmarshal(b, res.Descriptor())
 	if err != nil {
@@ -198,7 +199,7 @@ func (s *remoteStore) List(ctx context.Context, rs model.ResourceList, fs ...sto
 		return err
 	}
 	if statusCode != http.StatusOK {
-		return errors.Errorf("(%d): %s", statusCode, string(b))
+		return fmt.Errorf("(%d): %s", statusCode, string(b))
 	}
 	return rest.JSON.UnmarshalListToCore(b, rs)
 }

--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
@@ -103,7 +102,7 @@ func ServiceToConfigMapsMapper(client kube_client.Reader, l logr.Logger, systemN
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*kube_core.Service)
 		if !ok {
-			l.WithValues("dataplane", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("service", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -140,7 +139,7 @@ func DataplaneToMeshMapper(l logr.Logger, ns string, resourceConverter k8s_commo
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.Dataplane)
 		if !ok {
-			l.WithValues("dataplane", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("dataplane", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -161,7 +160,7 @@ func MeshGatewayToMeshMapper(client kube_client.Reader, l logr.Logger, ns string
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.MeshGateway)
 		if !ok {
-			l.WithValues("meshgateway", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("meshgateway", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -189,7 +188,7 @@ func MeshGatewayRouteToMeshMapper(client kube_client.Reader, l logr.Logger, ns s
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.MeshGatewayRoute)
 		if !ok {
-			l.WithValues("meshgatewayroute", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("meshgatewayroute", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -217,7 +216,7 @@ func ZoneIngressToMeshMapper(l logr.Logger, ns string, resourceConverter k8s_com
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.ZoneIngress)
 		if !ok {
-			l.WithValues("zoneIngress", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("zoneIngress", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 		zoneIngress := core_mesh.NewZoneIngressResource()
@@ -246,7 +245,7 @@ func ExternalServiceToConfigMapsMapper(l logr.Logger, ns string) kube_handler.Ma
 	return func(_ context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.ExternalService)
 		if !ok {
-			l.WithValues("externalService", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("externalService", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 
@@ -261,7 +260,7 @@ func VirtualOutboundToConfigMapsMapper(l logr.Logger, ns string) kube_handler.Ma
 	return func(_ context.Context, obj kube_client.Object) []kube_reconile.Request {
 		cause, ok := obj.(*mesh_k8s.VirtualOutbound)
 		if !ok {
-			l.WithValues("virtualOutbound", obj.GetName()).Error(errors.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
+			l.WithValues("virtualOutbound", obj.GetName()).Error(fmt.Errorf("wrong argument type: expected %T, got %T", cause, obj), "wrong argument type")
 			return nil
 		}
 

--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -158,7 +159,7 @@ func (a *authCallbacks) stream(streamID core_xds.StreamID, req util_xds.Request,
 	}
 
 	if s.nodeID != req.NodeId() {
-		return stream{}, errors.Errorf("stream was authenticated for ID %s. Received request is for node with ID %s. Node ID cannot be changed after stream is initialized", s.nodeID, req.NodeId())
+		return stream{}, fmt.Errorf("stream was authenticated for ID %s. Received request is for node with ID %s. Node ID cannot be changed after stream is initialized", s.nodeID, req.NodeId())
 	}
 
 	if s.resource == nil {
@@ -192,14 +193,14 @@ func (a *authCallbacks) resource(ctx context.Context, md *core_xds.DataplaneMeta
 	case mesh_proto.DataplaneProxyType:
 		resource = core_mesh.NewDataplaneResource()
 	default:
-		return nil, errors.Errorf("unsupported proxy type %q", md.GetProxyType())
+		return nil, fmt.Errorf("unsupported proxy type %q", md.GetProxyType())
 	}
 
 	backoff := retry.WithMaxRetries(uint64(a.dpNotFoundRetry.MaxTimes), retry.NewConstant(a.dpNotFoundRetry.Backoff))
 	err = retry.Do(ctx, backoff, func(ctx context.Context) error {
 		err := a.resManager.Get(ctx, resource, core_store.GetBy(proxyId.ToResourceKey()))
 		if core_store.IsNotFound(err) {
-			return retry.RetryableError(errors.Errorf(
+			return retry.RetryableError(fmt.Errorf(
 				"resource %q not found; create a %s in Kuma CP first or pass it as an argument to kuma-dp",
 				proxyId, resource.Descriptor().Name))
 		}
@@ -211,11 +212,11 @@ func (a *authCallbacks) resource(ctx context.Context, md *core_xds.DataplaneMeta
 func ExtractCredential(ctx context.Context) (Credential, error) {
 	metadata, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", errors.Errorf("request has no metadata")
+		return "", errors.New("request has no metadata")
 	}
 	if values, ok := metadata[authorization]; ok {
 		if len(values) != 1 {
-			return "", errors.Errorf("request must have exactly 1 %q header, got %d", authorization, len(values))
+			return "", fmt.Errorf("request must have exactly 1 %q header, got %d", authorization, len(values))
 		}
 		return values[0], nil
 	}

--- a/pkg/xds/auth/universal/authenticator.go
+++ b/pkg/xds/auth/universal/authenticator.go
@@ -2,8 +2,8 @@ package universal
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -48,7 +48,7 @@ func (u *universalAuthenticator) Authenticate(ctx context.Context, resource mode
 	case *core_mesh.ZoneEgressResource:
 		return u.authZoneEntity(ctx, credential, zone.EgressScope)
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 }
 
@@ -59,10 +59,10 @@ func (u *universalAuthenticator) authDataplane(ctx context.Context, dataplane *c
 	}
 
 	if dpIdentity.Name != "" && dataplane.Meta.GetName() != dpIdentity.Name {
-		return errors.Errorf("proxy name from requestor: %s is different than in token: %s", dataplane.Meta.GetName(), dpIdentity.Name)
+		return fmt.Errorf("proxy name from requestor: %s is different than in token: %s", dataplane.Meta.GetName(), dpIdentity.Name)
 	}
 	if dpIdentity.Mesh != "" && dataplane.Meta.GetMesh() != dpIdentity.Mesh {
-		return errors.Errorf("proxy mesh from requestor: %s is different than in token: %s", dataplane.Meta.GetMesh(), dpIdentity.Mesh)
+		return fmt.Errorf("proxy mesh from requestor: %s is different than in token: %s", dataplane.Meta.GetMesh(), dpIdentity.Mesh)
 	}
 	if err := validateTags(dpIdentity.Tags, dataplane.Spec.TagSet()); err != nil {
 		return err
@@ -84,7 +84,7 @@ func (u *universalAuthenticator) authZoneEntity(
 	}
 
 	if !zone.InScope(identity.Scope, scope) {
-		return errors.Errorf(
+		return fmt.Errorf(
 			"token cannot be used to authenticate zone entity (%s is out of token's scope: %+v)",
 			scope,
 			identity.Scope,
@@ -92,7 +92,7 @@ func (u *universalAuthenticator) authZoneEntity(
 	}
 
 	if identity.Zone != "" && u.zone != identity.Zone {
-		return errors.Errorf("zone from requestor: %s is different than in token: %s", u.zone, identity.Zone)
+		return fmt.Errorf("zone from requestor: %s is different than in token: %s", u.zone, identity.Zone)
 	}
 
 	return nil
@@ -102,11 +102,11 @@ func validateTags(tokenTags mesh_proto.MultiValueTagSet, dpTags mesh_proto.Multi
 	for tagName, allowedValues := range tokenTags {
 		dpValues, exist := dpTags[tagName]
 		if !exist {
-			return errors.Errorf("dataplane has no tag %q required by the token", tagName)
+			return fmt.Errorf("dataplane has no tag %q required by the token", tagName)
 		}
 		for value := range dpValues {
 			if !allowedValues[value] {
-				return errors.Errorf("dataplane contains tag %q with value %q which is not allowed with this token. Allowed values in token are %q", tagName, value, tokenTags.Values(tagName))
+				return fmt.Errorf("dataplane contains tag %q with value %q which is not allowed with this token. Allowed values in token are %q", tagName, value, tokenTags.Values(tagName))
 			}
 		}
 	}
@@ -119,10 +119,10 @@ func validateWorkload(tokenWorkload string, dpLabels map[string]string) error {
 	}
 	dpWorkload, exists := dpLabels[metadata.KumaWorkload]
 	if !exists {
-		return errors.Errorf("dataplane has no workload label required by the token")
+		return errors.New("dataplane has no workload label required by the token")
 	}
 	if dpWorkload != tokenWorkload {
-		return errors.Errorf("dataplane workload %q is not allowed with this token. Allowed workload in token is %q", dpWorkload, tokenWorkload)
+		return fmt.Errorf("dataplane workload %q is not allowed with this token. Allowed workload in token is %q", dpWorkload, tokenWorkload)
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in pkg

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
