### PR TITLE
chore(app): use fmt.Errorf instead of errors.Errorf part 2

### DIFF
--- a/app/cni/pkg/cni/injector_linux.go
+++ b/app/cni/pkg/cni/injector_linux.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -167,7 +168,7 @@ func GetEnabled(value string) (bool, error) {
 	case "disabled", "false":
 		return false, nil
 	default:
-		return false, errors.Errorf(`wrong value "%s", available values are: "enabled", "disabled", "true", "false"`, value)
+		return false, fmt.Errorf(`wrong value "%s", available values are: "enabled", "disabled", "true", "false"`, value)
 	}
 }
 

--- a/app/cni/pkg/cni/kubernetes_linux.go
+++ b/app/cni/pkg/cni/kubernetes_linux.go
@@ -2,6 +2,7 @@ package cni
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/go-logr/logr"
@@ -107,7 +108,7 @@ func getAndValidatePodAnnotations(
 	}
 
 	if pod.Annotations[metadata.KumaSidecarInjectedAnnotation] != "true" {
-		return nil, true, errors.Errorf(
+		return nil, true, fmt.Errorf(
 			"annotation '%s' is missing or is not set to 'true'",
 			metadata.KumaSidecarInjectedAnnotation,
 		)

--- a/app/cni/pkg/install/main.go
+++ b/app/cni/pkg/install/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	std_errors "errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -144,7 +145,7 @@ func setupChainedPlugin(ctx context.Context, mountedCniNetDir, cniConfName, kuma
 			return nil
 		}
 
-		err := errors.Errorf("cni config '%s' not found", cniConfPath)
+		err := fmt.Errorf("cni config '%s' not found", cniConfPath)
 		log.Error(err, "error chaining CNI config, retrying...")
 		return retry.RetryableError(err)
 	})

--- a/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
+++ b/app/kuma-dp/pkg/dataplane/dnsserver/dnsserver.go
@@ -3,6 +3,7 @@ package dnsserver
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 	"regexp"
@@ -67,7 +68,7 @@ func (s *DNSServer) GetVersion() (string, error) {
 
 	match := regexp.MustCompile(`CoreDNS-(.*)`).FindSubmatch(output)
 	if len(match) < 2 {
-		return "", errors.Errorf("unexpected version output format: %s", output)
+		return "", fmt.Errorf("unexpected version output format: %s", output)
 	}
 
 	return string(match[1]), nil

--- a/app/kumactl/pkg/config/io.go
+++ b/app/kumactl/pkg/config/io.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -19,7 +20,7 @@ func Load(file string, cfg *config_proto.Configuration) error {
 		if util_files.FileExists(file) {
 			configFile = file
 		} else {
-			return errors.Errorf("Failed to access configuration file %q", file)
+			return fmt.Errorf("failed to access configuration file %q", file)
 		}
 	}
 	if util_files.FileExists(configFile) {

--- a/app/kumactl/pkg/config/validate.go
+++ b/app/kumactl/pkg/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,7 +24,7 @@ func ValidateCpCoordinates(cp *kumactl_config.ControlPlane, timeout time.Duratio
 		return errors.Wrap(err, "could not connect to the Control Plane API Server")
 	}
 	if response.Product != version.Product && !version.IsPreviewVersion(response.Version) {
-		return errors.Errorf("this CLI is for %s but the control plane you're connected to is %s. Please use the CLI for your control plane", version.Product, response.Product)
+		return fmt.Errorf("this CLI is for %s but the control plane you're connected to is %s. Please use the CLI for your control plane", version.Product, response.Product)
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in app

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
