### PR TITLE
chore(pkg): use fmt.Errorf instead of errors.Errorf part 2

### DIFF
--- a/pkg/config/mads/config.go
+++ b/pkg/config/mads/config.go
@@ -1,6 +1,7 @@
 package mads
 
 import (
+	"fmt"
 	"slices"
 	"time"
 
@@ -62,16 +63,16 @@ func (c *MonitoringAssignmentServerConfig) Validate() error {
 	}
 	var errs error
 	if 65535 < c.Port {
-		errs = multierr.Append(errs, errors.Errorf(".Port must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".Port must be in the range [0, 65535]"))
 	}
 
 	if len(c.ApiVersions) == 0 {
-		errs = multierr.Append(errs, errors.Errorf(".ApiVersions must contain at least one version"))
+		errs = multierr.Append(errs, errors.New(".ApiVersions must contain at least one version"))
 	}
 
 	for _, apiVersion := range c.ApiVersions {
 		if apiVersion != mads.API_V1 {
-			errs = multierr.Append(errs, errors.Errorf(".ApiVersions contains invalid version %s", apiVersion))
+			errs = multierr.Append(errs, fmt.Errorf(".ApiVersions contains invalid version %s", apiVersion))
 		}
 	}
 
@@ -85,13 +86,13 @@ func (c *MonitoringAssignmentServerConfig) Validate() error {
 		errs = multierr.Append(errs, errors.New(".TlsKeyFile cannot be empty if TlsCertFile has been set"))
 	}
 	if _, err := config_types.TLSVersion(c.TlsMinVersion); err != nil {
-		errs = multierr.Append(errs, errors.New(".TlsMinVersion"+err.Error()))
+		errs = multierr.Append(errs, fmt.Errorf(".TlsMinVersion: %w", err))
 	}
 	if _, err := config_types.TLSVersion(c.TlsMaxVersion); err != nil {
-		errs = multierr.Append(errs, errors.New(".TlsMaxVersion"+err.Error()))
+		errs = multierr.Append(errs, fmt.Errorf(".TlsMaxVersion: %w", err))
 	}
 	if _, err := config_types.TLSCiphers(c.TlsCipherSuites); err != nil {
-		errs = multierr.Append(errs, errors.New(".TlsCipherSuites"+err.Error()))
+		errs = multierr.Append(errs, fmt.Errorf(".TlsCipherSuites: %w", err))
 	}
 	return errs
 }

--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -2,6 +2,7 @@ package multizone
 
 import (
 	"crypto/x509"
+	"fmt"
 	"net/url"
 	"os"
 	"time"
@@ -80,10 +81,10 @@ func (r *ZoneConfig) PostProcess() error {
 
 func (r *ZoneConfig) Validate() error {
 	if r.Name == "" {
-		return errors.Errorf("Name is mandatory")
+		return errors.New("Name is mandatory")
 	}
 	if !govalidator.IsDNSName(r.Name) {
-		return errors.Errorf("Zone name %s has to be a valid DNS name", r.Name)
+		return fmt.Errorf("zone name %s has to be a valid DNS name", r.Name)
 	}
 	if len(r.Name) > 63 {
 		return errors.New("Zone name cannot be longer than 63 characters")
@@ -109,7 +110,7 @@ func (r *ZoneConfig) Validate() error {
 				}
 			}
 		default:
-			return errors.Errorf("unsupported scheme %q in zone GlobalAddress. Use one of %s", u.Scheme, []string{"grpc", "grpcs"})
+			return fmt.Errorf("unsupported scheme %q in zone GlobalAddress. Use one of %s", u.Scheme, []string{"grpc", "grpcs"})
 		}
 		if err := r.KDS.Validate(); err != nil {
 			return errors.Wrap(err, ".KDS validation error")

--- a/pkg/config/plugins/runtime/universal/config.go
+++ b/pkg/config/plugins/runtime/universal/config.go
@@ -1,9 +1,9 @@
 package universal
 
 import (
+	"errors"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	"github.com/kumahq/kuma/v2/pkg/config"
@@ -61,13 +61,13 @@ func (i WorkloadConfig) Validate() error {
 func (u *UniversalRuntimeConfig) Validate() error {
 	var errs error
 	if u.DataplaneCleanupAge.Duration <= 0 {
-		errs = multierr.Append(errs, errors.Errorf(".DataplaneCleanupAge must be positive"))
+		errs = multierr.Append(errs, errors.New(".DataplaneCleanupAge must be positive"))
 	}
 	if u.ZoneResourceCleanupAge.Duration <= 0 {
-		errs = multierr.Append(errs, errors.Errorf(".ZoneResourceCleanupAge must be positive"))
+		errs = multierr.Append(errs, errors.New(".ZoneResourceCleanupAge must be positive"))
 	}
 	if u.VIPRefreshInterval.Duration <= 0 {
-		errs = multierr.Append(errs, errors.Errorf(".VIPRefreshInterval must be positive"))
+		errs = multierr.Append(errs, errors.New(".VIPRefreshInterval must be positive"))
 	}
 	return errs
 }

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 
@@ -275,7 +276,7 @@ func initializeResourceStore(cfg kuma_cp.Config, builder *core_runtime.Builder) 
 		pluginName = core_plugins.Postgres
 		pluginConfig = cfg.Store.Postgres
 	default:
-		return errors.Errorf("unknown store type %s", cfg.Store.Type)
+		return fmt.Errorf("unknown store type %s", cfg.Store.Type)
 	}
 	plugin, err := core_plugins.Plugins().ResourceStore(pluginName)
 	if err != nil {
@@ -316,7 +317,7 @@ func initializeSecretStore(cfg kuma_cp.Config, builder *core_runtime.Builder) er
 	case store.MemoryStore, store.PostgresStore:
 		pluginName = core_plugins.Universal
 	default:
-		return errors.Errorf("unknown store type %s", cfg.Store.Type)
+		return fmt.Errorf("unknown store type %s", cfg.Store.Type)
 	}
 	plugin, err := core_plugins.Plugins().SecretStore(pluginName)
 	if err != nil {
@@ -339,7 +340,7 @@ func initializeConfigStore(cfg kuma_cp.Config, builder *core_runtime.Builder) er
 	case store.MemoryStore, store.PostgresStore:
 		pluginName = core_plugins.Universal
 	default:
-		return errors.Errorf("unknown store type %s", cfg.Store.Type)
+		return fmt.Errorf("unknown store type %s", cfg.Store.Type)
 	}
 	plugin, err := core_plugins.Plugins().ConfigStore(pluginName)
 	if err != nil {
@@ -392,7 +393,7 @@ func initializeAPIServerAuthenticator(builder *core_runtime.Builder) error {
 	authnType := builder.Config().ApiServer.Authn.Type
 	plugin, ok := core_plugins.Plugins().AuthnAPIServer()[core_plugins.PluginName(authnType)]
 	if !ok {
-		return errors.Errorf("there is not implementation of authn named %s", authnType)
+		return fmt.Errorf("there is not implementation of authn named %s", authnType)
 	}
 	authenticator, err := plugin.NewAuthenticator(builder)
 	if err != nil {
@@ -479,7 +480,7 @@ func initializeResourceManager(cfg kuma_cp.Config, builder *core_runtime.Builder
 	case store.MemoryStore, store.PostgresStore:
 		cipher = secret_cipher.TODO() // get back to encryption in universal case
 	default:
-		return errors.Errorf("unknown store type %s", cfg.Store.Type)
+		return fmt.Errorf("unknown store type %s", cfg.Store.Type)
 	}
 	var secretValidator secret_manager.SecretValidator
 	if cfg.IsFederatedZoneCP() {

--- a/pkg/core/kri/kri.go
+++ b/pkg/core/kri/kri.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/exp/constraints"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
@@ -88,16 +87,16 @@ func FromResourceMetaE[T ~string](rm core_model.ResourceMeta, resourceType T) (I
 func FromString(s string) (Identifier, error) {
 	parts := strings.Split(s, "_")
 	if len(parts) < 7 {
-		return Identifier{}, errors.Errorf("invalid identifier string: %q", s)
+		return Identifier{}, fmt.Errorf("invalid identifier string: %q", s)
 	}
 	if parts[0] != "kri" {
-		return Identifier{}, errors.Errorf("identifier must start with 'kri': %q", s)
+		return Identifier{}, fmt.Errorf("identifier must start with 'kri': %q", s)
 	}
 	ds := registry.Global().ObjectDescriptors(core_model.TypeFilterFn(func(d core_model.ResourceTypeDescriptor) bool {
 		return d.ShortName == parts[1] && d.ShortName != ""
 	}))
 	if len(ds) == 0 {
-		return Identifier{}, errors.Errorf("unknown short name of resource type: %q", parts[1])
+		return Identifier{}, fmt.Errorf("unknown short name of resource type: %q", parts[1])
 	}
 	return Identifier{
 		ResourceType: ds[0].Name,

--- a/pkg/core/managers/apis/external_service/external_service_manager.go
+++ b/pkg/core/managers/apis/external_service/external_service_manager.go
@@ -2,9 +2,8 @@ package externalservice
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/v2/pkg/core/resources/manager"
@@ -109,7 +108,7 @@ func (m *externalServiceManager) Update(ctx context.Context, resource core_model
 func (m *externalServiceManager) externalService(resource core_model.Resource) (*core_mesh.ExternalServiceResource, error) {
 	externalService, ok := resource.(*core_mesh.ExternalServiceResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResource)(nil), resource)
 	}
 	return externalService, nil
 }
@@ -117,7 +116,7 @@ func (m *externalServiceManager) externalService(resource core_model.Resource) (
 func (m *externalServiceManager) externalServices(list core_model.ResourceList) (*core_mesh.ExternalServiceResourceList, error) {
 	externalServices, ok := list.(*core_mesh.ExternalServiceResourceList)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResourceList)(nil), list)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.ExternalServiceResourceList)(nil), list)
 	}
 	return externalServices, nil
 }

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -2,9 +2,8 @@ package mesh
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	config_store "github.com/kumahq/kuma/v2/pkg/config/core/resources/store"
@@ -172,7 +171,7 @@ func (m *meshManager) Update(ctx context.Context, resource core_model.Resource, 
 func (m *meshManager) mesh(resource core_model.Resource) (*core_mesh.MeshResource, error) {
 	mesh, ok := resource.(*core_mesh.MeshResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResource)(nil), resource)
 	}
 	return mesh, nil
 }
@@ -180,7 +179,7 @@ func (m *meshManager) mesh(resource core_model.Resource) (*core_mesh.MeshResourc
 func (m *meshManager) meshes(list core_model.ResourceList) (*core_mesh.MeshResourceList, error) {
 	meshes, ok := list.(*core_mesh.MeshResourceList)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResourceList)(nil), list)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.MeshResourceList)(nil), list)
 	}
 	return meshes, nil
 }

--- a/pkg/core/managers/apis/ratelimit/ratelimit_manager.go
+++ b/pkg/core/managers/apis/ratelimit/ratelimit_manager.go
@@ -2,9 +2,8 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/v2/pkg/core/resources/manager"
@@ -109,7 +108,7 @@ func (m *rateLimitManager) Update(ctx context.Context, resource core_model.Resou
 func (m *rateLimitManager) rateLimit(resource core_model.Resource) (*core_mesh.RateLimitResource, error) {
 	rateLimit, ok := resource.(*core_mesh.RateLimitResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResource)(nil), resource)
 	}
 	return rateLimit, nil
 }
@@ -117,7 +116,7 @@ func (m *rateLimitManager) rateLimit(resource core_model.Resource) (*core_mesh.R
 func (m *rateLimitManager) rateLimits(list core_model.ResourceList) (*core_mesh.RateLimitResourceList, error) {
 	rateLimits, ok := list.(*core_mesh.RateLimitResourceList)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResourceList)(nil), list)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.RateLimitResourceList)(nil), list)
 	}
 	return rateLimits, nil
 }

--- a/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshexternalservice/hostname/generator.go
@@ -2,6 +2,7 @@ package hostname
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -38,7 +39,7 @@ func (g *MeshExternalServiceHostnameGenerator) GetResources(ctx context.Context)
 func (g *MeshExternalServiceHostnameGenerator) UpdateResourceStatus(ctx context.Context, resource model.Resource, statuses []hostnamegenerator_api.HostnameGeneratorStatus, addresses []hostnamegenerator_api.Address) error {
 	externalService, ok := resource.(*meshexternalservice_api.MeshExternalServiceResource)
 	if !ok {
-		return errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
+		return fmt.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
 	}
 	externalService.Status.Addresses = addresses
 	externalService.Status.HostnameGenerators = statuses
@@ -51,7 +52,7 @@ func (g *MeshExternalServiceHostnameGenerator) UpdateResourceStatus(ctx context.
 func (g *MeshExternalServiceHostnameGenerator) HasStatusChanged(resource model.Resource, generatorStatuses []hostnamegenerator_api.HostnameGeneratorStatus, addresses []hostnamegenerator_api.Address) (bool, error) {
 	es, ok := resource.(*meshexternalservice_api.MeshExternalServiceResource)
 	if !ok {
-		return false, errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
+		return false, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
 	}
 	return !reflect.DeepEqual(addresses, es.Status.Addresses) || !reflect.DeepEqual(generatorStatuses, es.Status.HostnameGenerators), nil
 }
@@ -59,7 +60,7 @@ func (g *MeshExternalServiceHostnameGenerator) HasStatusChanged(resource model.R
 func (g *MeshExternalServiceHostnameGenerator) GenerateHostname(localZone string, generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
 	es, ok := resource.(*meshexternalservice_api.MeshExternalServiceResource)
 	if !ok {
-		return "", errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
+		return "", fmt.Errorf("invalid resource type: expected=%T, got=%T", (*meshexternalservice_api.MeshExternalServiceResource)(nil), resource)
 	}
 	if generator.Spec.Selector.MeshExternalService == nil {
 		return "", nil

--- a/pkg/core/resources/apis/meshservice/hostname/generator.go
+++ b/pkg/core/resources/apis/meshservice/hostname/generator.go
@@ -2,6 +2,7 @@ package hostname
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -38,7 +39,7 @@ func (g *MeshServiceHostnameGenerator) GetResources(ctx context.Context) (model.
 func (g *MeshServiceHostnameGenerator) UpdateResourceStatus(ctx context.Context, resource model.Resource, statuses []hostnamegenerator_api.HostnameGeneratorStatus, addresses []hostnamegenerator_api.Address) error {
 	service, ok := resource.(*meshservice_api.MeshServiceResource)
 	if !ok {
-		return errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
+		return fmt.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
 	}
 	service.Status.Addresses = addresses
 	service.Status.HostnameGenerators = statuses
@@ -51,7 +52,7 @@ func (g *MeshServiceHostnameGenerator) UpdateResourceStatus(ctx context.Context,
 func (g *MeshServiceHostnameGenerator) HasStatusChanged(resource model.Resource, generatorStatuses []hostnamegenerator_api.HostnameGeneratorStatus, addresses []hostnamegenerator_api.Address) (bool, error) {
 	service, ok := resource.(*meshservice_api.MeshServiceResource)
 	if !ok {
-		return false, errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
+		return false, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
 	}
 
 	return !reflect.DeepEqual(addresses, service.Status.Addresses) || !reflect.DeepEqual(generatorStatuses, service.Status.HostnameGenerators), nil
@@ -60,7 +61,7 @@ func (g *MeshServiceHostnameGenerator) HasStatusChanged(resource model.Resource,
 func (g *MeshServiceHostnameGenerator) GenerateHostname(localZone string, generator *hostnamegenerator_api.HostnameGeneratorResource, resource model.Resource) (string, error) {
 	service, ok := resource.(*meshservice_api.MeshServiceResource)
 	if !ok {
-		return "", errors.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
+		return "", fmt.Errorf("invalid resource type: expected=%T, got=%T", (*meshservice_api.MeshServiceResource)(nil), resource)
 	}
 	if generator.Spec.Selector.MeshService == nil {
 		return "", nil

--- a/pkg/plugins/runtime/k8s/controllers/ingress_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/ingress_converter.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
@@ -25,14 +26,14 @@ func (p *PodConverter) IngressFor(
 	ctx context.Context, zoneIngress *mesh_proto.ZoneIngress, pod *kube_core.Pod, services []*kube_core.Service,
 ) error {
 	if len(services) != 1 {
-		return errors.Errorf("ingress should be matched by exactly one service. Matched %d services", len(services))
+		return fmt.Errorf("ingress should be matched by exactly one service. Matched %d services", len(services))
 	}
 	ifaces, err := p.InboundConverter.InboundInterfacesFor(ctx, p.Zone, pod, services)
 	if err != nil {
 		return errors.Wrap(err, "could not generate inbound interfaces")
 	}
 	if len(ifaces) != 1 {
-		return errors.Errorf("generated %d inbound interfaces, expected 1. Interfaces: %v", len(ifaces), ifaces)
+		return fmt.Errorf("generated %d inbound interfaces, expected 1. Interfaces: %v", len(ifaces), ifaces)
 	}
 
 	if zoneIngress.Networking == nil {
@@ -82,7 +83,7 @@ func (p *PodConverter) coordinatesFromAnnotations(annotations metadata.Annotatio
 		return nil, errors.Wrapf(err, "failed to parse annotation %s", metadata.KumaIngressPublicPortAnnotation)
 	}
 	if addressExist != portExist {
-		return nil, errors.Errorf("both %s and %s has to be defined", metadata.KumaIngressPublicAddressAnnotation, metadata.KumaIngressPublicPortAnnotation)
+		return nil, fmt.Errorf("both %s and %s has to be defined", metadata.KumaIngressPublicAddressAnnotation, metadata.KumaIngressPublicPortAnnotation)
 	}
 	if addressExist && portExist {
 		return &coordinates{

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Annotations that can be used by the end users.
@@ -285,7 +283,7 @@ func (a Annotations) GetBooleanWithDefault(def bool, supportEnabled bool, keys .
 					return false, nil
 				}
 			}
-			return false, errors.Errorf("annotation \"%s\" has wrong value \"%s\"", key, value)
+			return false, fmt.Errorf("annotation \"%s\" has wrong value \"%s\"", key, value)
 		}
 	}, keys...)
 	if err != nil {
@@ -302,7 +300,7 @@ func (a Annotations) GetUint32WithDefault(def uint32, keys ...string) (uint32, b
 	v, exists, err := a.getWithDefault(def, func(key string, value string) (any, error) {
 		u, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
-			return 0, errors.Errorf("failed to parse annotation %q: %s", key, err.Error())
+			return 0, fmt.Errorf("failed to parse annotation %q: %s", key, err.Error())
 		}
 		return uint32(u), nil
 	}, keys...)
@@ -368,7 +366,7 @@ func (a Annotations) GetMapWithDefault(def map[string]string, keys ...string) (m
 		for pair := range pairs {
 			kvSplit := strings.Split(pair, "=")
 			if len(kvSplit) != 2 {
-				return nil, errors.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value1;key2=value2", key)
+				return nil, fmt.Errorf("invalid format. Map in %q has to be provided in the following format: key1=value1;key2=value2", key)
 			}
 			result[kvSplit[0]] = kvSplit[1]
 		}

--- a/pkg/transparentproxy/config/config_executables_functionality.go
+++ b/pkg/transparentproxy/config/config_executables_functionality.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	std_errors "errors"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -75,15 +76,15 @@ func verifyMinimalRequirements(functionality Functionality) error {
 	var errs []error
 
 	if !functionality.Tables.Nat {
-		errs = append(errs, errors.Errorf("missing table: %q", "nat"))
+		errs = append(errs, fmt.Errorf("missing table: %q", "nat"))
 	}
 
 	if !functionality.Modules.Tcp {
-		errs = append(errs, errors.Errorf("missing module: %q", "tcp"))
+		errs = append(errs, fmt.Errorf("missing module: %q", "tcp"))
 	}
 
 	if !functionality.Modules.Owner {
-		errs = append(errs, errors.Errorf("missing module: %q", "owner"))
+		errs = append(errs, fmt.Errorf("missing module: %q", "owner"))
 	}
 
 	if len(errs) > 0 {

--- a/pkg/util/rsa/pem.go
+++ b/pkg/util/rsa/pem.go
@@ -5,8 +5,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 )
 
 const (
@@ -51,7 +51,7 @@ func FromPrivateKeyPEMBytesToPublicKeyPEMBytes(b []byte) ([]byte, error) {
 func FromPEMBytesToPrivateKey(b []byte) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(b)
 	if block.Type != rsaPrivateBlockType {
-		return nil, errors.Errorf("invalid key encoding %q", block.Type)
+		return nil, fmt.Errorf("invalid key encoding %q", block.Type)
 	}
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
@@ -65,7 +65,7 @@ func FromPEMBytesToPublicKey(b []byte) (*rsa.PublicKey, error) {
 	case publicBlockType:
 		return rsaKeyFromPKIX(block.Bytes)
 	default:
-		return nil, errors.Errorf("invalid key encoding %q", block.Type)
+		return nil, fmt.Errorf("invalid key encoding %q", block.Type)
 	}
 }
 
@@ -97,7 +97,7 @@ func rsaKeyFromPKIX(bytes []byte) (*rsa.PublicKey, error) {
 
 	rsaKey, ok := key.(*rsa.PublicKey)
 	if !ok {
-		return nil, errors.Errorf("encoded key is not a RSA key")
+		return nil, errors.New("encoded key is not a RSA key")
 	}
 
 	return rsaKey, nil

--- a/pkg/xds/auth/components/components.go
+++ b/pkg/xds/auth/components/components.go
@@ -2,8 +2,8 @@ package components
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	dp_server "github.com/kumahq/kuma/v2/pkg/config/dp-server"
@@ -26,7 +26,7 @@ type Deps struct {
 func NewKubeAuthenticator(deps Deps) (auth.Authenticator, error) {
 	mgr, ok := k8s_extensions.FromManagerContext(deps.Extensions)
 	if !ok {
-		return nil, errors.Errorf("k8s controller runtime Manager hasn't been configured")
+		return nil, errors.New("k8s controller runtime Manager hasn't been configured")
 	}
 	return k8s_auth.New(mgr.GetClient(), deps.XdsMetrics), nil
 }
@@ -55,6 +55,6 @@ func DefaultAuthenticator(deps Deps, typ string) (auth.Authenticator, error) {
 	case dp_server.DpServerAuthNone:
 		return universal_auth.NewNoopAuthenticator(), nil
 	default:
-		return nil, errors.Errorf("unable to choose authenticator of %q", typ)
+		return nil, fmt.Errorf("unable to choose authenticator of %q", typ)
 	}
 }


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in pkg

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
