### PR TITLE
chore(pkg): use fmt.Errorf instead of errors.Errorf part 4

### DIFF
--- a/pkg/api-server/types/inspect.go
+++ b/pkg/api-server/types/inspect.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -53,7 +54,7 @@ func (w *PolicyInspectEntry) UnmarshalJSON(data []byte) error {
 	case GatewayDataplane:
 		entry = &PolicyInspectGatewayEntry{}
 	default:
-		return errors.Errorf("invalid PolicyInspectEntry kind %q", i.Kind)
+		return fmt.Errorf("invalid PolicyInspectEntry kind %q", i.Kind)
 	}
 	if err := json.Unmarshal(data, entry); err != nil {
 		return errors.Wrapf(err, "unable to parse PolicyInspectEntry of kind %q", i.Kind)
@@ -187,7 +188,7 @@ func (w *DataplaneInspectResponse) UnmarshalJSON(data []byte) error {
 	case GatewayDataplane:
 		entry = &GatewayDataplaneInspectResult{}
 	default:
-		return errors.Errorf("invalid DataplaneInspectResponse kind %q", i.Kind)
+		return fmt.Errorf("invalid DataplaneInspectResponse kind %q", i.Kind)
 	}
 	if err := json.Unmarshal(data, entry); err != nil {
 		return errors.Wrapf(err, "unable to parse DataplaneInspectResponse of kind %q", i.Kind)

--- a/pkg/config/multizone/kds.go
+++ b/pkg/config/multizone/kds.go
@@ -56,7 +56,7 @@ func (c *KdsServerConfig) PostProcess() error {
 func (c *KdsServerConfig) Validate() error {
 	var errs error
 	if c.GrpcPort > 65535 {
-		errs = multierr.Append(errs, errors.Errorf(".GrpcPort must be in the range [0, 65535]"))
+		errs = multierr.Append(errs, errors.New(".GrpcPort must be in the range [0, 65535]"))
 	}
 	if c.RefreshInterval.Duration <= 0 {
 		errs = multierr.Append(errs, errors.New(".RefreshInterval must be positive"))

--- a/pkg/config/plugins/runtime/config.go
+++ b/pkg/config/plugins/runtime/config.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
@@ -43,7 +45,7 @@ func (c *RuntimeConfig) Validate(env core.EnvironmentType) error {
 		}
 	case core.UniversalEnvironment:
 	default:
-		return errors.Errorf("unknown environment type %q", env)
+		return fmt.Errorf("unknown environment type %q", env)
 	}
 	return nil
 }

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -2,8 +2,7 @@ package dataplane
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core"
@@ -127,7 +126,7 @@ func (m *dataplaneManager) Update(ctx context.Context, resource core_model.Resou
 func (m *dataplaneManager) dataplane(resource core_model.Resource) (*core_mesh.DataplaneResource, error) {
 	dp, ok := resource.(*core_mesh.DataplaneResource)
 	if !ok {
-		return nil, errors.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.DataplaneResource)(nil), resource)
+		return nil, fmt.Errorf("invalid resource type: expected=%T, got=%T", (*core_mesh.DataplaneResource)(nil), resource)
 	}
 	return dp, nil
 }

--- a/pkg/dns/vips_allocator_test.go
+++ b/pkg/dns/vips_allocator_test.go
@@ -2,10 +2,10 @@ package dns_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	config "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
@@ -54,7 +54,7 @@ type errConfigManager struct {
 
 func (e *errConfigManager) Update(ctx context.Context, r *config_model.ConfigResource, opts ...store.UpdateOptionsFunc) error {
 	meshName, _ := vips.MeshFromConfigKey(r.GetMeta().GetName())
-	return errors.Errorf("error during update, mesh = %s", meshName)
+	return fmt.Errorf("error during update, mesh = %s", meshName)
 }
 
 var testConfig = dns_server.Config{

--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	envoy_service_health "github.com/envoyproxy/go-control-plane/envoy/service/health/v3"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	dp_server "github.com/kumahq/kuma/v2/pkg/config/dp-server"
@@ -203,7 +203,7 @@ func (t *tracker) updateDataplane(streamID xds.StreamID, healthMap map[uint32]bo
 	defer t.RUnlock()
 	dataplaneKey, hasAssociation := t.streamsAssociation[streamID]
 	if !hasAssociation {
-		return errors.Errorf("no proxy for streamID = %d", streamID)
+		return fmt.Errorf("no proxy for streamID = %d", streamID)
 	}
 
 	dp := mesh.NewDataplaneResource()

--- a/pkg/intercp/client/client.go
+++ b/pkg/intercp/client/client.go
@@ -3,10 +3,10 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net/url"
 
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/filters"
 	"google.golang.org/grpc"
@@ -49,7 +49,7 @@ func New(serverURL string, tlsCfg *TLSConfig) (Conn, error) {
 		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	default:
-		return nil, errors.Errorf("unsupported scheme %q. Use one of %s", url.Scheme, []string{"grpc", "grpcs"})
+		return nil, fmt.Errorf("unsupported scheme %q. Use one of %v", url.Scheme, []string{"grpc", "grpcs"})
 	}
 	dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler(
 		otelgrpc.WithFilter(filters.Not(filters.ServiceName(system_proto.InterCpPingService_ServiceDesc.ServiceName))),

--- a/pkg/kds/mux/version.go
+++ b/pkg/kds/mux/version.go
@@ -2,12 +2,12 @@ package mux
 
 import (
 	"context"
+	"fmt"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -38,7 +38,7 @@ func KDSVersion(ctx context.Context) string {
 }
 
 func UnsupportedKDSVersion(version string) error {
-	return errors.Errorf("invalid KDS version %s. Supported versions %s %s", version, KDSVersionV2, KDSVersionV3)
+	return fmt.Errorf("invalid KDS version %s. Supported versions %s %s", version, KDSVersionV2, KDSVersionV3)
 }
 
 func DiscoveryRequestV2(request *envoy_sd_v3.DiscoveryRequest) *envoy_api_v2.DiscoveryRequest {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -2,12 +2,12 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -53,7 +53,7 @@ func ParseLogLevel(text string) (LogLevel, error) {
 	case "debug":
 		return DebugLevel, nil
 	default:
-		return OffLevel, errors.Errorf("unknown log level %q", text)
+		return OffLevel, fmt.Errorf("unknown log level %q", text)
 	}
 }
 

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -2,9 +2,9 @@ package tokens
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/v2/pkg/api-server/authn"
 	config_access "github.com/kumahq/kuma/v2/pkg/config/access"
@@ -86,7 +86,7 @@ func (c *plugin) AfterBootstrap(context *plugins.MutablePluginContext, config pl
 
 	accessFn, ok := AccessStrategies[context.Config().Access.Type]
 	if !ok {
-		return errors.Errorf("no Access strategy for type %q", context.Config().Access.Type)
+		return fmt.Errorf("no Access strategy for type %q", context.Config().Access.Type)
 	}
 	signingKeyManager := core_tokens.NewSigningKeyManager(context.ResourceManager(), system.UserTokenSigningKeyPrefix)
 	tokenIssuer := NewUserTokenIssuer(signingKeyManager)

--- a/pkg/plugins/policies/core/rules/resolve/targetref.go
+++ b/pkg/plugins/policies/core/rules/resolve/targetref.go
@@ -1,10 +1,9 @@
 package resolve
 
 import (
+	"errors"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
@@ -153,7 +152,7 @@ func parseService(host string) (string, string, int32, error) {
 		// one here to note that this service is actually
 		port = 0
 	default:
-		return "", "", 0, errors.Errorf("service tag in unexpected format")
+		return "", "", 0, errors.New("service tag in unexpected format")
 	}
 
 	name, namespace := segments[0], segments[1]

--- a/pkg/plugins/policies/meshhttproute/xds/filters/requestmirror.go
+++ b/pkg/plugins/policies/meshhttproute/xds/filters/requestmirror.go
@@ -1,9 +1,10 @@
 package filters
 
 import (
+	"fmt"
+
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/pkg/errors"
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -28,7 +29,7 @@ func (f *RequestMirrorConfigurer) Configure(envoyRoute *envoy_route.Route) error
 		clusterName, found := f.backendRefToClusterName[f.requestMirror.BackendRef.Hash()]
 		if !found {
 			// this should never happen because we create clusters for all backendRefs
-			return errors.Errorf("could not find cluster for backendRef %s", f.requestMirror.BackendRef.Hash())
+			return fmt.Errorf("could not find cluster for backendRef %s", f.requestMirror.BackendRef.Hash())
 		}
 
 		var runtimeFraction *envoy_config_core.RuntimeFractionalPercent

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/plugin.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -10,7 +11,6 @@ import (
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/pkg/errors"
 	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
@@ -571,7 +571,7 @@ func (p plugin) configureRDS(
 			}
 			rs, ok := hcm.RouteSpecifier.(*envoy_hcm.HttpConnectionManager_Rds)
 			if !ok {
-				return errors.Errorf("unexpected RouteSpecifer %T", hcm.RouteSpecifier)
+				return fmt.Errorf("unexpected RouteSpecifier %T", hcm.RouteSpecifier)
 			}
 			routeConfigs = append(routeConfigs, rs.Rds.RouteConfigName)
 		}

--- a/pkg/plugins/policies/meshpassthrough/plugin/xds/order.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/xds/order.go
@@ -1,6 +1,7 @@
 package xds
 
 import (
+	"fmt"
 	"maps"
 	"net"
 	"slices"
@@ -8,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
@@ -203,7 +203,7 @@ func validatePortAndProtocol(portProtocols map[uint32]map[core_meta.Protocol]boo
 			counter++
 		}
 		if counter > 1 {
-			errs = multierr.Append(errs, errors.Errorf("you cannot configure http, http2, grpc on the same port %d", port))
+			errs = multierr.Append(errs, fmt.Errorf("you cannot configure http, http2, grpc on the same port %d", port))
 		}
 	}
 	return errs

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod.go
@@ -1,9 +1,10 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
@@ -32,7 +33,7 @@ func (l *listenerModificator) apply(resources *core_xds.ResourceSet) error {
 	case api.ModOpPatch:
 		return l.patch(resources, listener)
 	default:
-		return errors.Errorf("invalid operation: %s", l.Operation)
+		return fmt.Errorf("invalid operation: %s", l.Operation)
 	}
 	return nil
 }

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_mod.go
@@ -1,13 +1,13 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"slices"
 
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/pkg/errors"
 
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/jsonpatch"
@@ -73,7 +73,7 @@ func (c *virtualHostModificator) applyHCMModification(hcm *envoy_hcm.HttpConnect
 	case api.ModOpPatch:
 		return c.patch(routeCfg, virtualHost)
 	default:
-		return errors.Errorf("invalid operation: %s", c.Operation)
+		return fmt.Errorf("invalid operation: %s", c.Operation)
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/gateway/builder.go
+++ b/pkg/plugins/runtime/gateway/builder.go
@@ -1,7 +1,8 @@
 package gateway
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/kumahq/kuma/v2/pkg/core/xds"
@@ -25,7 +26,7 @@ func BuildResourceSet(b ResourceBuilder) (*xds.ResourceSet, error) {
 	}
 
 	if resource.GetName() == "" {
-		return nil, errors.Errorf("anonymous resource %T", resource)
+		return nil, fmt.Errorf("anonymous resource %T", resource)
 	}
 
 	set := xds.NewResourceSet()

--- a/pkg/plugins/runtime/gateway/route/configurers.go
+++ b/pkg/plugins/runtime/gateway/route/configurers.go
@@ -1,6 +1,8 @@
 package route
 
 import (
+	"fmt"
+
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -105,7 +107,7 @@ func RouteActionRedirect(redirect *Redirection, port uint32) envoy_routes.RouteC
 		case 308:
 			envoyRedirect.ResponseCode = envoy_config_route.RedirectAction_PERMANENT_REDIRECT
 		default:
-			return errors.Errorf("redirect status code %d is not supported", redirect.Status)
+			return fmt.Errorf("redirect status code %d is not supported", redirect.Status)
 		}
 
 		r.Action = &envoy_config_route.Route_Redirect{

--- a/pkg/transparentproxy/iptables/chains/chains.go
+++ b/pkg/transparentproxy/iptables/chains/chains.go
@@ -1,6 +1,8 @@
 package chains
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/v2/pkg/transparentproxy/config"
@@ -61,7 +63,7 @@ func NewChain(table consts.TableName, chain string) (*Chain, error) {
 	case "":
 		return nil, errors.New("table is required and cannot be empty")
 	default:
-		return nil, errors.Errorf(
+		return nil, fmt.Errorf(
 			"unsupported table %q (valid: [%q, %q, %q])",
 			table,
 			consts.TableRaw,

--- a/pkg/util/proto/any.go
+++ b/pkg/util/proto/any.go
@@ -1,9 +1,9 @@
 package proto
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -47,7 +47,7 @@ func MergeAnys(dst *anypb.Any, src *anypb.Any) (*anypb.Any, error) {
 		return src, nil
 	}
 	if src.TypeUrl != dst.TypeUrl {
-		return nil, errors.Errorf("type URL of dst %q is different than src %q", dst.TypeUrl, src.TypeUrl)
+		return nil, fmt.Errorf("type URL of dst %q is different than src %q", dst.TypeUrl, src.TypeUrl)
 	}
 
 	msgType, err := FindMessageType(dst.TypeUrl)

--- a/pkg/xds/envoy/listeners/v3/timeout_configurer.go
+++ b/pkg/xds/envoy/listeners/v3/timeout_configurer.go
@@ -1,11 +1,12 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
@@ -31,7 +32,7 @@ func (c *TimeoutConfigurer) Configure(filterChain *envoy_listener.FilterChain) e
 			return nil
 		})
 	default:
-		return errors.Errorf("unsupported protocol %s", c.Protocol)
+		return fmt.Errorf("unsupported protocol %s", c.Protocol)
 	}
 }
 

--- a/pkg/xds/envoy/names/resource_names.go
+++ b/pkg/xds/envoy/names/resource_names.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Separator is the separator used in resource names.
@@ -37,7 +35,7 @@ func GetInboundClusterName(servicePort uint32, listenerPort uint32) string {
 func GetPortForLocalClusterName(cluster string) (uint32, error) {
 	parts := strings.Split(cluster, Separator)
 	if len(parts) != 2 {
-		return 0, errors.Errorf("failed to  parse local cluster name: %s", cluster)
+		return 0, fmt.Errorf("failed to parse local cluster name: %s", cluster)
 	}
 	port, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {

--- a/pkg/xds/generator/modifications/v3/http_filter.go
+++ b/pkg/xds/generator/modifications/v3/http_filter.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -64,7 +66,7 @@ func (h *httpFilterModificator) applyHCMModification(hcm *envoy_hcm.HttpConnecti
 			return errors.Wrap(err, "could not patch the resource")
 		}
 	default:
-		return errors.Errorf("invalid operation: %s", h.Operation)
+		return fmt.Errorf("invalid operation: %s", h.Operation)
 	}
 	return nil
 }

--- a/pkg/xds/server/callbacks/dataplane_lifecycle.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle.go
@@ -2,6 +2,7 @@ package callbacks
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -116,7 +117,7 @@ func (d *DataplaneLifecycle) register(
 
 	if info.deleted {
 		// we took info object that was deleted from proxyInfo map by other goroutine, return err so DPP retry registration
-		return errors.Errorf("attempt to concurently register deleted DPP resource, needs retry")
+		return errors.New("attempt to concurrently register deleted DPP resource, needs retry")
 	}
 
 	log.Info("register proxy")
@@ -227,7 +228,7 @@ func (d *DataplaneLifecycle) validateUpsert(ctx context.Context, existing core_m
 
 func (d *DataplaneLifecycle) validateProxyKey(proxyKey core_model.ResourceKey, proxyResource core_model.Resource) error {
 	if core_model.MetaToResourceKey(proxyResource.GetMeta()) != proxyKey {
-		return errors.Errorf("proxyId %s does not match proxy resource %s", proxyKey, proxyResource.GetMeta())
+		return fmt.Errorf("proxyId %s does not match proxy resource %s", proxyKey, proxyResource.GetMeta())
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in pkg

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
