### PR TITLE
chore(pkg): use fmt.Errorf instead of errors.Errorf part 5

### DIFF
--- a/pkg/config/core/config.go
+++ b/pkg/config/core/config.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/pkg/errors"
+import "fmt"
 
 type EnvironmentType = string
 
@@ -23,7 +23,7 @@ const (
 // ValidateCpMode to check modes of kuma-cp
 func ValidateCpMode(mode CpMode) error {
 	if mode != Standalone && mode != Zone && mode != Global {
-		return errors.Errorf("invalid mode. Available modes: %s, %s, %s", Standalone, Zone, Global)
+		return fmt.Errorf("invalid mode. Available modes: %s, %s, %s", Standalone, Zone, Global)
 	}
 	return nil
 }

--- a/pkg/core/managers/apis/mesh/mesh_helpers.go
+++ b/pkg/core/managers/apis/mesh/mesh_helpers.go
@@ -2,6 +2,7 @@ package mesh
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -18,7 +19,7 @@ func EnsureCAs(ctx context.Context, caManagers core_ca.Managers, mesh *core_mesh
 	for typ, backends := range backendsForType {
 		caManager, exist := caManagers[typ]
 		if !exist { // this should be caught by validator earlier
-			return errors.Errorf("CA manager for type %s does not exist", typ)
+			return fmt.Errorf("CA manager for type %s does not exist", typ)
 		}
 		if err := caManager.EnsureBackends(ctx, mesh, backends); err != nil {
 			return errors.Wrapf(err, "could not ensure CA backends of type %s", typ)

--- a/pkg/core/resources/apis/mesh/proxy_type.go
+++ b/pkg/core/resources/apis/mesh/proxy_type.go
@@ -1,7 +1,7 @@
 package mesh
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -16,5 +16,5 @@ func ProxyTypeFromResourceType(t core_model.ResourceType) (mesh_proto.ProxyType,
 	case ZoneEgressType:
 		return mesh_proto.EgressProxyType, nil
 	}
-	return "", errors.Errorf("%s does not have a corresponding proxy type", t)
+	return "", fmt.Errorf("%s does not have a corresponding proxy type", t)
 }

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/helpers.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -151,7 +150,7 @@ func renderTemplate(tmplStr string, meta model.ResourceMeta, data any) (string, 
 		"label": func(key string) (string, error) {
 			val, ok := meta.GetLabels()[key]
 			if !ok {
-				return "", errors.Errorf("label %s not found", key)
+				return "", fmt.Errorf("label %s not found", key)
 			}
 			return val, nil
 		},

--- a/pkg/core/resources/model/rest/api.go
+++ b/pkg/core/resources/model/rest/api.go
@@ -3,8 +3,6 @@ package rest
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/kumahq/kuma/v2/pkg/core/resources/model"
 )
 
@@ -61,7 +59,7 @@ type ApiDescriptor struct {
 func (m *ApiDescriptor) GetResourceApi(typ model.ResourceType) (ResourceApi, error) {
 	mapping, ok := m.Resources[typ]
 	if !ok {
-		return nil, errors.Errorf("unknown resource type: %q", typ)
+		return nil, fmt.Errorf("unknown resource type: %q", typ)
 	}
 	return mapping, nil
 }

--- a/pkg/core/resources/model/rest/list.go
+++ b/pkg/core/resources/model/rest/list.go
@@ -2,8 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"errors"
 
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 )
@@ -23,7 +22,7 @@ var _ json.Unmarshaler = &ResourceListReceiver{}
 
 func (rec *ResourceListReceiver) UnmarshalJSON(data []byte) error {
 	if rec.NewResource == nil {
-		return errors.Errorf("NewResource must not be nil")
+		return errors.New("NewResource must not be nil")
 	}
 	type List struct {
 		Total uint32             `json:"total"`

--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -38,7 +39,7 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 					if err, ok := e.(error); ok {
 						errCh <- errors.WithStack(err)
 					} else {
-						errCh <- errors.Errorf("%v", e)
+						errCh <- fmt.Errorf("%v", e)
 					}
 				}
 			}()

--- a/pkg/gc/finalizer.go
+++ b/pkg/gc/finalizer.go
@@ -2,6 +2,7 @@ package gc
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -60,7 +61,7 @@ type subscriptionFinalizer struct {
 func NewSubscriptionFinalizer(rm manager.ResourceManager, tenants multitenant.Tenants, newTicker func() *time.Ticker, metrics core_metrics.Metrics, extensions context.Context, upsert store.UpsertConfig, types ...core_model.ResourceType) (component.Component, error) {
 	for _, typ := range types {
 		if !isInsightType(typ) {
-			return nil, errors.Errorf("%q type is not an Insight", typ)
+			return nil, fmt.Errorf("%q type is not an Insight", typ)
 		}
 	}
 

--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
-
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -190,7 +188,7 @@ func (f *forwardingKdsEnvoyAdminClient) globalInstanceID(ctx context.Context, zo
 			globalInstanceID = zoneInsightRes.Spec.GetEnvoyAdminStreams().GetClustersGlobalInstanceId()
 		}
 	default:
-		return "", errors.Errorf("invalid operation %s", rpcName)
+		return "", fmt.Errorf("invalid operation %s", rpcName)
 	}
 	if globalInstanceID == "" {
 		return "", &StreamNotConnectedError{rpcName: rpcName}

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net/url"
 	"os"
 	"time"
@@ -109,7 +110,7 @@ func (c *client) Start(stop <-chan struct{}) (errs error) {
 		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	default:
-		return errors.Errorf("unsupported scheme %q. Use one of %s", u.Scheme, []string{"grpc", "grpcs"})
+		return fmt.Errorf("unsupported scheme %q. Use one of %v", u.Scheme, []string{"grpc", "grpcs"})
 	}
 	conn, err := grpc.NewClient(u.Host, dialOpts...)
 	if err != nil {

--- a/pkg/plugins/leader/plugin.go
+++ b/pkg/plugins/leader/plugin.go
@@ -1,6 +1,7 @@
 package leader
 
 import (
+	"fmt"
 	"time"
 
 	"cirello.io/pglock"
@@ -37,6 +38,6 @@ func NewLeaderElector(b *core_runtime.Builder) (component.LeaderElector, error) 
 		return leader_memory.NewAlwaysLeaderElector(), nil
 	// In case of Kubernetes, Leader Elector is embedded in a Kubernetes ComponentManager
 	default:
-		return nil, errors.Errorf("no election leader for storage of type %s", b.Config().Store.Type)
+		return nil, fmt.Errorf("no election leader for storage of type %s", b.Config().Store.Type)
 	}
 }

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -1,7 +1,7 @@
 package matchers
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
@@ -41,7 +41,7 @@ func EgressMatchedPolicies(rType core_model.ResourceType, tags map[string]string
 	p := policies.GetItems()[0]
 
 	if _, ok := p.GetSpec().(core_model.Policy); !ok {
-		return core_xds.TypedMatchingPolicies{}, errors.Errorf("resource type %v doesn't support TargetRef matching", p.Descriptor().Name)
+		return core_xds.TypedMatchingPolicies{}, fmt.Errorf("resource type %v doesn't support TargetRef matching", p.Descriptor().Name)
 	}
 
 	_, isFrom := p.GetSpec().(core_model.PolicyWithFromList)

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"slices"
 
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -72,7 +73,7 @@ func (h *httpFilterModificator) applyHCMModification(hcm *envoy_hcm.HttpConnecti
 			return errors.Wrap(err, "could not patch the resource")
 		}
 	default:
-		return errors.Errorf("invalid operation: %s", h.Operation)
+		return fmt.Errorf("invalid operation: %s", h.Operation)
 	}
 	return nil
 }

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -65,7 +65,7 @@ func ApplyMods(resources *core_xds.ResourceSet, modifications []api.Modification
 			mod := virtualHostModificator(*modification.VirtualHost)
 			modificator = &mod
 		default:
-			return errors.Errorf("invalid modification")
+			return errors.New("invalid modification")
 		}
 		if err := modificator.apply(resources); err != nil {
 			return errors.Wrapf(err, "could not apply %d modification", i)

--- a/pkg/plugins/resources/postgres/events/listener.go
+++ b/pkg/plugins/resources/postgres/events/listener.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -34,7 +35,7 @@ func (k *listener) Start(stop <-chan struct{}) error {
 	case postgres.DriverNamePgx:
 		listener, err = common_postgres.NewPgxListener(k.cfg, core.Log.WithName("postgres-event-listener-pgx"))
 	default:
-		return errors.Errorf("unsupported driver name %s", k.cfg.DriverName)
+		return fmt.Errorf("unsupported driver name %s", k.cfg.DriverName)
 	}
 
 	if err != nil {

--- a/pkg/plugins/resources/postgres/migrate.go
+++ b/pkg/plugins/resources/postgres/migrate.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -39,7 +40,7 @@ func MigrateDb(cfg postgres_cfg.PostgresStoreConfig) (core_plugins.DbVersion, er
 			if err != nil {
 				return 0, err
 			}
-			return 0, errors.Errorf("DB is migrated to newer version than Kuma. DB migration version %d. Kuma migration version %d. Run newer version of Kuma", dbVer, appVer)
+			return 0, fmt.Errorf("DB is migrated to newer version than Kuma. DB migration version %d. Kuma migration version %d. Run newer version of Kuma", dbVer, appVer)
 		}
 		return 0, errors.Wrap(err, "error while executing up migration")
 	}

--- a/pkg/plugins/runtime/k8s/controllers/meshzoneaddress_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshzoneaddress_controller.go
@@ -104,7 +104,7 @@ func (r *MeshZoneAddressReconciler) Reconcile(ctx context.Context, req kube_ctrl
 			if owners := mza.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != svc.GetUID() {
 				r.Eventf(svc, nil, kube_core.EventTypeWarning, NoPublicAddressForZoneProxyReason, "Conflict",
 					"MeshZoneAddress %s already exists and is not owned by this Service", req.Name)
-				return errors.Errorf("MeshZoneAddress already exists and is not owned by Service")
+				return errors.New("MeshZoneAddress already exists and is not owned by Service")
 			}
 		}
 		if mza.Labels == nil {

--- a/pkg/plugins/runtime/k8s/controllers/outbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/outbound_converter.go
@@ -145,7 +145,7 @@ func parseService(host string) (string, string, uint32, error) {
 		// one here to note that this service is actually
 		port = mesh_proto.TCPPortReserved
 	default:
-		return "", "", 0, errors.Errorf("service tag in unexpected format")
+		return "", "", 0, errors.New("service tag in unexpected format")
 	}
 
 	name, namespace := segments[0], segments[1]

--- a/pkg/plugins/runtime/k8s/controllers/probes.go
+++ b/pkg/plugins/runtime/k8s/controllers/probes.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -25,7 +27,7 @@ func ProbesFor(pod *kube_core.Pod) (*mesh_proto.Dataplane_Probes, error) {
 		return nil, err
 	}
 	if !exist {
-		return nil, errors.Errorf("%s annotation doesn't exist", metadata.KumaVirtualProbesPortAnnotation)
+		return nil, fmt.Errorf("%s annotation doesn't exist", metadata.KumaVirtualProbesPortAnnotation)
 	}
 
 	probeProxyPort, _, err := metadata.Annotations(pod.Annotations).GetUint32(metadata.KumaApplicationProbeProxyPortAnnotation)

--- a/pkg/test/matchers/golden.go
+++ b/pkg/test/matchers/golden.go
@@ -1,6 +1,7 @@
 package matchers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -115,6 +116,6 @@ func (g *GoldenMatcher) actualString(actual any) (string, error) {
 	case string:
 		return actual, nil
 	default:
-		return "", errors.Errorf("not supported type %T for MatchGolden", actual)
+		return "", fmt.Errorf("not supported type %T for MatchGolden", actual)
 	}
 }

--- a/pkg/tls/cert.go
+++ b/pkg/tls/cert.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"math/big"
 	"net"
 	"time"
@@ -139,7 +140,7 @@ func newCert(issuer *pkix.Name, certType CertType, hosts ...string) (x509.Certif
 	case ClientCertType:
 		csr.ExtKeyUsage = append(csr.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
 	default:
-		return x509.Certificate{}, errors.Errorf("invalid certificate type %q, expected either %q or %q",
+		return x509.Certificate{}, fmt.Errorf("invalid certificate type %q, expected either %q or %q",
 			certType, ServerCertType, ClientCertType)
 	}
 	for _, host := range hosts {

--- a/pkg/tls/keypair.go
+++ b/pkg/tls/keypair.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -43,7 +44,7 @@ func pemEncodeKey(priv crypto.PrivateKey) ([]byte, error) {
 	case *rsa.PrivateKey:
 		block = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
 	default:
-		return nil, errors.Errorf("unsupported private key type %T", priv)
+		return nil, fmt.Errorf("unsupported private key type %T", priv)
 	}
 	var keyBuf bytes.Buffer
 	if err := pem.Encode(&keyBuf, block); err != nil {

--- a/pkg/tokens/client.go
+++ b/pkg/tokens/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -51,7 +52,7 @@ func (tc TokenClient) Generate(tokenReq any) (string, error) {
 				return "", &kumaErr
 			}
 		}
-		return "", errors.Errorf("(%d): %s", resp.StatusCode, body)
+		return "", fmt.Errorf("(%d): %s", resp.StatusCode, body)
 	}
 	return string(body), nil
 }

--- a/pkg/util/watchdog/watchdog.go
+++ b/pkg/util/watchdog/watchdog.go
@@ -2,6 +2,7 @@ package watchdog
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -91,7 +92,7 @@ func (w *SimpleWatchdog) onTick(ctx context.Context) (err error) {
 			case error:
 				err = errors.WithStack(typ)
 			default:
-				err = errors.Errorf("%v", cause)
+				err = fmt.Errorf("%v", cause)
 			}
 		}
 	}()

--- a/pkg/xds/auth/universal/noop_authenticator.go
+++ b/pkg/xds/auth/universal/noop_authenticator.go
@@ -2,8 +2,7 @@ package universal
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -27,6 +26,6 @@ func (u *noopAuthenticator) Authenticate(ctx context.Context, resource model.Res
 	case *core_mesh.ZoneEgressResource:
 		return nil
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 }

--- a/pkg/xds/generator/modifications/modifications.go
+++ b/pkg/xds/generator/modifications/modifications.go
@@ -1,7 +1,7 @@
 package modifications
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
@@ -14,6 +14,6 @@ func Apply(resources *core_xds.ResourceSet, modifications []*mesh_proto.ProxyTem
 	case envoy_common.APIV3:
 		return modifications_v3.Apply(resources, modifications)
 	default:
-		return errors.Errorf("unknown API version %s", apiVersion)
+		return fmt.Errorf("unknown API version %s", apiVersion)
 	}
 }

--- a/pkg/xds/generator/modifications/v3/modifications.go
+++ b/pkg/xds/generator/modifications/v3/modifications.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
@@ -31,7 +33,7 @@ func Apply(resources *core_xds.ResourceSet, modifications []*mesh_proto.ProxyTem
 			mod := virtualHostModificator(*modification.GetVirtualHost())
 			modificator = &mod
 		default:
-			return errors.Errorf("invalid modification type %T", modification.Type)
+			return fmt.Errorf("invalid modification type %T", modification.Type)
 		}
 		if err := modificator.apply(resources); err != nil {
 			return errors.Wrapf(err, "could not apply %d modification", i)

--- a/pkg/xds/generator/modifications/v3/network_filter.go
+++ b/pkg/xds/generator/modifications/v3/network_filter.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"fmt"
+
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/pkg/errors"
@@ -38,7 +40,7 @@ func (n *networkFilterModificator) apply(resources *core_xds.ResourceSet) error 
 						return errors.Wrap(err, "could not patch the resource")
 					}
 				default:
-					return errors.Errorf("invalid operation: %s", n.Operation)
+					return fmt.Errorf("invalid operation: %s", n.Operation)
 				}
 			}
 		}

--- a/pkg/xds/sync/egress_proxy_builder.go
+++ b/pkg/xds/sync/egress_proxy_builder.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -152,7 +153,7 @@ func matchEgressPolicies(tags map[string]string, resources xds_context.Resources
 			return nil, errors.Wrapf(err, "could not apply policy plugin %s", plugin.Name)
 		}
 		if res.Type == "" {
-			return nil, errors.Errorf("matched policy didn't set type for policy plugin %s", plugin.Name)
+			return nil, fmt.Errorf("matched policy didn't set type for policy plugin %s", plugin.Name)
 		}
 		pluginPolicies[res.Type] = res
 	}

--- a/pkg/xds/topology/dataplanes.go
+++ b/pkg/xds/topology/dataplanes.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/pkg/errors"
@@ -69,7 +70,7 @@ func lookupFirstIp(lookupIPFunc lookup.LookupIPFunc, address string) (string, er
 		return "", err
 	}
 	if len(ips) == 0 {
-		return "", errors.Errorf("can't resolve address %v", address)
+		return "", fmt.Errorf("can't resolve address %v", address)
 	}
 	// Pick the first lexicographic order ip (to make resolution deterministic
 	minIp := ""


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in pkg

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
