### PR TITLE
chore(pkg): use fmt.Errorf instead of errors.Errorf part 6

### DIFF
--- a/pkg/config/core/resources/store/config.go
+++ b/pkg/config/core/resources/store/config.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -78,7 +79,7 @@ func (s *StoreConfig) Validate() error {
 	case MemoryStore:
 		return nil
 	default:
-		return errors.Errorf("Type should be either %s, %s or %s", PostgresStore, KubernetesStore, MemoryStore)
+		return fmt.Errorf("type should be either %s, %s or %s", PostgresStore, KubernetesStore, MemoryStore)
 	}
 	if err := s.Cache.Validate(); err != nil {
 		return errors.Wrap(err, "Cache validation failed")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"reflect"
@@ -67,7 +68,7 @@ func (l *Loader) LoadFile(filename string) error {
 	}
 
 	if _, err := os.Stat(filename); err != nil {
-		return errors.Errorf("unable to access configuration file '%s', please check if the file exists and has the correct permissions", filename)
+		return fmt.Errorf("unable to access configuration file '%s', please check if the file exists and has the correct permissions: %w", filename, err)
 	}
 
 	content, err := os.ReadFile(filename)

--- a/pkg/hds/authn/callbacks_test.go
+++ b/pkg/hds/authn/callbacks_test.go
@@ -2,6 +2,7 @@ package authn_test
 
 import (
 	"context"
+	"fmt"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_health_v3 "github.com/envoyproxy/go-control-plane/envoy/service/health/v3"
@@ -35,7 +36,7 @@ func (t *testAuthenticator) Authenticate(_ context.Context, resource model.Resou
 			return nil
 		}
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 
 	return errors.New("invalid credential")

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"slices"
 
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -46,7 +47,7 @@ func (n *networkFilterModificator) apply(resources *core_xds.ResourceSet) error 
 						return errors.Wrap(err, "could not patch the resource")
 					}
 				default:
-					return errors.Errorf("invalid operation: %s", n.Operation)
+					return fmt.Errorf("invalid operation: %s", n.Operation)
 				}
 			}
 		}

--- a/pkg/xds/auth/callbacks_test.go
+++ b/pkg/xds/auth/callbacks_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -50,7 +51,7 @@ func (t *testAuthenticator) Authenticate(_ context.Context, resource core_model.
 			return nil
 		}
 	default:
-		return errors.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
+		return fmt.Errorf("no matching authenticator for %s resource", resource.Descriptor().Name)
 	}
 
 	return errors.New("invalid credential")

--- a/pkg/xds/generator/tracing_proxy_generator.go
+++ b/pkg/xds/generator/tracing_proxy_generator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"context"
+	"fmt"
 	net_url "net/url"
 	"strconv"
 
@@ -85,7 +86,7 @@ func (t TracingProxyGenerator) endpointForZipkin(cfg *mesh_proto.ZipkinTracingBa
 
 func (t TracingProxyGenerator) endpointForDatadog(cfg *mesh_proto.DatadogTracingBackendConfig) (*core_xds.Endpoint, error) {
 	if cfg.Port > 0xFFFF || cfg.Port < 1 {
-		return nil, errors.Errorf("invalid Datadog port number %d. Must be in range 1-65535", cfg.Port)
+		return nil, fmt.Errorf("invalid Datadog port number %d. Must be in range 1-65535", cfg.Port)
 	}
 	return &core_xds.Endpoint{
 		Target: cfg.Address,

--- a/pkg/xds/secrets/ca_provider.go
+++ b/pkg/xds/secrets/ca_provider.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -54,7 +55,7 @@ func (s *meshCaProvider) Get(ctx context.Context, mesh *core_mesh.MeshResource) 
 
 	caManager, exist := s.caManagers[backend.Type]
 	if !exist {
-		return nil, nil, errors.Errorf("CA manager of type %s not exist", backend.Type)
+		return nil, nil, fmt.Errorf("CA manager of type %s does not exist", backend.Type)
 	}
 
 	var certs [][]byte

--- a/pkg/xds/topology/dataplanes_test.go
+++ b/pkg/xds/topology/dataplanes_test.go
@@ -1,11 +1,11 @@
 package topology_test
 
 import (
+	"fmt"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -32,7 +32,7 @@ var _ = Describe("Resolve Dataplane address", func() {
 		if s == "advertise-2.example.com" {
 			return []net.IP{net.ParseIP("192.0.2.2")}, nil
 		}
-		return nil, errors.Errorf("can't resolve hostname: %s", s)
+		return nil, fmt.Errorf("can't resolve hostname: %s", s)
 	}
 
 	Context("ResolveDataplaneAddress", func() {


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in pkg

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
