### PR TITLE
chore(.github): use fmt.Errorf instead of errors.Errorf part 1

### DIFF
--- a/.github/instructions/api-server.instructions.md
+++ b/.github/instructions/api-server.instructions.md
@@ -63,7 +63,7 @@ func formatResource(resource, format, k8sMapper, namespace) (any, error) {
     switch format {
     case "k8s", "kubernetes": return k8sMapper(resource, namespace), nil  // K8s YAML
     case "universal", "": return rest.From.Resource(resource), nil        // REST JSON
-    default: return nil, errors.Errorf("unknown format: %s", format)
+    default: return nil, fmt.Errorf("unknown format: %s", format)
     }
 }
 ```

--- a/.github/instructions/coding.instructions.md
+++ b/.github/instructions/coding.instructions.md
@@ -34,11 +34,11 @@ func (e *NotFound) Is(err error) bool {
 }
 
 // Wrap with context
-return errors.Errorf("failed to create dataplane: %w", err)
+return fmt.Errorf("failed to create dataplane: %w", err)
 
 // Type assertions with clear messages
 if !ok {
-    return errors.Errorf("invalid type: expected=%T, got=%T", expectedType, actualType)
+    return fmt.Errorf("invalid type: expected=%T, got=%T", expectedType, actualType)
 }
 
 // Multi-error (transactions)


### PR DESCRIPTION
## Motivation

use fmt.Errorf instead of errors.Errorf in .github/instructions

Related to https://github.com/kumahq/kuma/pull/15962#pullrequestreview-3997348533

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
