### PR TITLE
fix(xds): deduplicate filter in inbound:passthrough filter chain

### DIFF
--- a/pkg/xds/generator/testdata/transparent-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/10.envoy.golden.yaml
@@ -1,0 +1,122 @@
+resources:
+- name: self_transparentproxy_no_destination_inbound
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: self_transparentproxy_no_destination_inbound
+    connectTimeout: 5s
+    name: self_transparentproxy_no_destination_inbound
+    type: STATIC
+- name: self_transparentproxy_passthrough_inbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_inbound_ipv4
+    type: ORIGINAL_DST
+    upstreamBindConfig:
+      sourceAddress:
+        address: 127.0.0.6
+        portValue: 0
+- name: self_transparentproxy_passthrough_inbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_inbound_ipv6
+    type: ORIGINAL_DST
+    upstreamBindConfig:
+      sourceAddress:
+        address: ::6
+        portValue: 0
+- name: self_transparentproxy_passthrough_outbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_outbound_ipv4
+    type: ORIGINAL_DST
+- name: self_transparentproxy_passthrough_outbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 5s
+    lbPolicy: CLUSTER_PROVIDED
+    name: self_transparentproxy_passthrough_outbound_ipv6
+    type: ORIGINAL_DST
+- name: self_transparentproxy_passthrough_inbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15006
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        destinationPort: 8080
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_inbound_ipv4
+          statPrefix: self_transparentproxy_passthrough_inbound_ipv4
+    name: self_transparentproxy_passthrough_inbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv4
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: self_transparentproxy_passthrough_inbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15006
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        destinationPort: 8080
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_inbound_ipv6
+          statPrefix: self_transparentproxy_passthrough_inbound_ipv6
+    name: self_transparentproxy_passthrough_inbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_inbound_ipv6
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: self_transparentproxy_passthrough_outbound_ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_outbound_ipv4
+          statPrefix: self_transparentproxy_passthrough_outbound_ipv4
+    name: self_transparentproxy_passthrough_outbound_ipv4
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv4
+    trafficDirection: OUTBOUND
+    useOriginalDst: true
+- name: self_transparentproxy_passthrough_outbound_ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15001
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: self_transparentproxy_passthrough_outbound_ipv6
+          statPrefix: self_transparentproxy_passthrough_outbound_ipv6
+    name: self_transparentproxy_passthrough_outbound_ipv6
+    statPrefix: self_transparentproxy_passthrough_outbound_ipv6
+    trafficDirection: OUTBOUND
+    useOriginalDst: true

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -139,7 +139,12 @@ func CreateInboundPassthroughListener(
 		Configure(envoy_listeners.OriginalDstForwarder())
 
 	if useStrictInboundPorts && len(proxy.Dataplane.Spec.Networking.Inbound) > 0 {
+		seenPorts := map[uint32]bool{}
 		for _, inbound := range proxy.Dataplane.Spec.Networking.Inbound {
+			if seenPorts[inbound.Port] {
+				continue
+			}
+			seenPorts[inbound.Port] = true
 			// if service doesn't have any port we don't need to expose listener
 			if inbound.Port == mesh_proto.TCPPortReserved {
 				inboundListenerBuilder.Configure(envoy_listeners.FilterChain(envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -274,6 +274,12 @@ var _ = Describe("TransparentProxyGenerator", func() {
 			tlsMode:          mesh_proto.CertificateAuthorityBackend_PERMISSIVE.Enum(),
 			expected:         "08.envoy.golden.yaml",
 		}),
+		Entry("transparent_proxying=true,unified_naming=true,inbound_filter,strict,duplicate_ports", testCase{
+			proxy:            strictInboundPortsProxy([]uint32{8080, 8080}),
+			meshServicesMode: mesh_proto.Mesh_MeshServices_Exclusive,
+			tlsMode:          mesh_proto.CertificateAuthorityBackend_STRICT.Enum(),
+			expected:         "10.envoy.golden.yaml",
+		}),
 		Entry("transparent_proxying=true,unified_naming=true,inbound_filter,strict,gateway", testCase{
 			proxy: &model.Proxy{
 				Metadata: &model.DataplaneMetadata{Features: map[string]bool{


### PR DESCRIPTION
## Motivation

Once a user have 2 services with the same port we were creating duplicate filter chain matches which caused envoy to reject configuration.

## Implementation information

* track `seenPorts` map and skip any port already added as a filter chain
