### PR TITLE
fix(xds): pass namespace in reachable backends

### DIFF
--- a/pkg/xds/context/destination_index.go
+++ b/pkg/xds/context/destination_index.go
@@ -49,16 +49,17 @@ func (di *DestinationIndex) GetReachableBackends(dataplane *core_mesh.DataplaneR
 
 	networking := dataplane.Spec.GetNetworking()
 
-	processRef := func(kind string, name string, port *uint32, labels map[string]string) {
+	processRef := func(kind string, name string, namespace string, port *uint32, labels map[string]string) {
 		ids := di.resolveResourceIdentifiersForLabels(core_model.ResourceType(kind), labels)
 		if len(ids) == 0 {
 			ids = []kri.Identifier{
 				resolve.TargetRefToKRI(
 					kri.From(dataplane),
 					common_api.TargetRef{
-						Kind:   common_api.TargetRefKind(kind),
-						Name:   &name,
-						Labels: &labels,
+						Kind:      common_api.TargetRefKind(kind),
+						Name:      &name,
+						Namespace: &namespace,
+						Labels:    &labels,
 					},
 				),
 			}
@@ -87,7 +88,7 @@ func (di *DestinationIndex) GetReachableBackends(dataplane *core_mesh.DataplaneR
 
 	// Handle user defined outbound without a transparent proxy
 	for _, o := range networking.GetOutbounds(mesh_proto.BackendRefFilter) {
-		processRef(o.BackendRef.Kind, o.BackendRef.Name, &o.BackendRef.Port, o.BackendRef.Labels)
+		processRef(o.BackendRef.Kind, o.BackendRef.Name, "", &o.BackendRef.Port, o.BackendRef.Labels)
 	}
 
 	if len(outbounds) > 0 {
@@ -111,7 +112,7 @@ func (di *DestinationIndex) GetReachableBackends(dataplane *core_mesh.DataplaneR
 			port = pointer.To(ref.Port.GetValue())
 		}
 
-		processRef(ref.Kind, ref.Name, port, ref.Labels)
+		processRef(ref.Kind, ref.Name, ref.Namespace, port, ref.Labels)
 	}
 
 	return outbounds, true

--- a/pkg/xds/context/destination_index_test.go
+++ b/pkg/xds/context/destination_index_test.go
@@ -1,0 +1,141 @@
+package context_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	"github.com/kumahq/kuma/v2/pkg/core/metadata"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
+	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+)
+
+var _ = Describe("DestinationIndex", func() {
+	Describe("GetReachableBackends", func() {
+		It("should resolve name/namespace format to correct MeshService", func() {
+			ms := builders.MeshService().
+				WithName("backend-svc-hash123").
+				WithLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-svc",
+					mesh_proto.KubeNamespaceTag: "other-ns",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				AddIntPort(8080, 8080, metadata.ProtocolHTTP).
+				Build()
+
+			dp := builders.Dataplane().
+				WithName("dp-1").
+				WithLabels(map[string]string{
+					mesh_proto.KubeNamespaceTag: "default",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				WithAddress("127.0.0.1").
+				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
+				WithTransparentProxying(15001, 15006, "").
+				Build()
+
+			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
+				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
+					{
+						Kind:      "MeshService",
+						Name:      "backend-svc",
+						Namespace: "other-ns",
+						Port:      wrapperspb.UInt32(8080),
+					},
+				},
+			}
+
+			index := xds_context.NewDestinationIndex([]core_model.Resource{ms})
+			outbounds, matched := index.GetReachableBackends(dp)
+
+			Expect(matched).To(BeTrue())
+			Expect(outbounds).To(HaveLen(1))
+
+			expectedKRI := kri.WithSectionName(kri.From(ms), "8080")
+			Expect(outbounds).To(HaveKey(expectedKRI))
+		})
+
+		It("should fallback to dataplane namespace when namespace not specified", func() {
+			ms := builders.MeshService().
+				WithName("backend-svc-hash456").
+				WithLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-svc",
+					mesh_proto.KubeNamespaceTag: "default",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				AddIntPort(9000, 9000, metadata.ProtocolHTTP).
+				Build()
+
+			dp := builders.Dataplane().
+				WithName("dp-1").
+				WithLabels(map[string]string{
+					mesh_proto.KubeNamespaceTag: "default",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				WithAddress("127.0.0.1").
+				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
+				WithTransparentProxying(15001, 15006, "").
+				Build()
+
+			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
+				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
+					{
+						Kind: "MeshService",
+						Name: "backend-svc",
+					},
+				},
+			}
+
+			index := xds_context.NewDestinationIndex([]core_model.Resource{ms})
+			outbounds, matched := index.GetReachableBackends(dp)
+
+			Expect(matched).To(BeTrue())
+			Expect(outbounds).To(HaveLen(1))
+
+			expectedKRI := kri.WithSectionName(kri.From(ms), "9000")
+			Expect(outbounds).To(HaveKey(expectedKRI))
+		})
+
+		It("should not resolve when namespace does not match", func() {
+			ms := builders.MeshService().
+				WithName("backend-svc-hash789").
+				WithLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-svc",
+					mesh_proto.KubeNamespaceTag: "other-ns",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				AddIntPort(8080, 8080, metadata.ProtocolHTTP).
+				Build()
+
+			dp := builders.Dataplane().
+				WithName("dp-1").
+				WithLabels(map[string]string{
+					mesh_proto.KubeNamespaceTag: "default",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				WithAddress("127.0.0.1").
+				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
+				WithTransparentProxying(15001, 15006, "").
+				Build()
+
+			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
+				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
+					{
+						Kind:      "MeshService",
+						Name:      "backend-svc",
+						Namespace: "wrong-ns",
+					},
+				},
+			}
+
+			index := xds_context.NewDestinationIndex([]core_model.Resource{ms})
+			outbounds, matched := index.GetReachableBackends(dp)
+
+			Expect(matched).To(BeTrue())
+			Expect(outbounds).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
## Motivation

The `kuma.io/reachable-backends` annotation with `name/namespace/port` format is broken since the `DestinationIndex` refactor (da963de). `processRef` ignored `ref.Namespace` from the proto, so `TargetRefToKRI` always fell back to the dataplane's namespace instead of the explicitly specified one. The labels format was unaffected because it bypasses KRI name matching.

Closes #15812

## Implementation information

Added `namespace` parameter to `processRef` in `destination_index.go` so `ref.Namespace` is passed through to `TargetRefToKRI()`. For outbounds (which don't have a namespace field), empty string is passed so the existing fallback to origin namespace still applies.

Added unit tests covering:
- name/namespace resolves cross-namespace MeshService
- name-only falls back to dataplane namespace
- mismatched namespace returns empty results

> Changelog: fix(xds): pass namespace in reachable backends ref lookup