### PR TITLE
fix(kds): add GlobalToZone session logging

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -186,13 +186,8 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 		c.rt.Config().Multizone.Zone.KDS.ResponseBackoff.Duration,
 	)
 
-	if err := syncClient.Receive(); err != nil {
-		if !errors.Is(err, context.Canceled) {
-			log.Error(err, "GlobalToZoneSync finished with an error")
-			errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
-		} else {
-			log.Info("GlobalToZoneSync stopped")
-		}
+	if err := syncClient.Receive(); err != nil && !errors.Is(err, context.Canceled) {
+		errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
 		return
 	}
 

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -91,7 +91,7 @@ func (s *kdsSyncClient) Receive() error {
 			}
 			return errors.Wrap(err, "failed to receive a discovery response")
 		}
-		s.log.V(1).Info("DeltaDiscoveryResponse received", "type", received.Type, "added", len(received.AddedResources.GetItems()), "removed", len(received.RemovedResourcesKey))
+		s.log.V(1).Info("DeltaDiscoveryResponse received", "response", received)
 		validationErrors := received.Validate()
 
 		if s.callbacks == nil {


### PR DESCRIPTION
## Motivation

The GlobalToZone KDS sync has a visibility gap: when the zone CP receives a resource update from global CP, there is no INFO-level log. The only evidence is a V(1) (debug) log that never appears in production.

This makes it impossible to distinguish between two failure modes:
- Zone received the update but failed to store it
- Zone never received the update (stream silently dead)

We hit this in practice when `timeout-global-3` was created on global CP and never appeared on zone CP despite the global CP logging "detected changes, sending". Without additional logging, we cannot tell where the delivery broke down.

## Implementation information

Three targeted changes:

1. `pkg/kds/mux/client.go` — `startGlobalToZoneSync` now logs session start (`GlobalToZoneSync new session created`, mirrors the existing `ZoneToGlobalSync new session created` log) and explicit stop (both error and context.Canceled paths, previously the context.Canceled path exited with zero logging at INFO level).

2. `pkg/kds/v2/client/kds_client.go` — promotes `DeltaDiscoveryResponse received` from `V(1)` to INFO, with type/added/removed counts instead of the full response object. This is the key log that proves whether a specific resource update was delivered to the zone's receive loop.

> Changelog: skip