### PR TITLE
feat(log): per-component log level control via API

### DIFF
--- a/pkg/api-server/logging_endpoint.go
+++ b/pkg/api-server/logging_endpoint.go
@@ -1,0 +1,123 @@
+package api_server
+
+import (
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+
+	"github.com/kumahq/kuma/v2/pkg/core/access"
+	rest_errors "github.com/kumahq/kuma/v2/pkg/core/rest/errors"
+	"github.com/kumahq/kuma/v2/pkg/core/user"
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+type loggingEndpoint struct {
+	access   access.ControlPlaneMetadataAccess
+	registry *kuma_log.ComponentLevelRegistry
+}
+
+type loggingResponse struct {
+	Global     string            `json:"global"`
+	Components map[string]string `json:"components"`
+}
+
+type setLevelRequest struct {
+	Component string `json:"component"`
+	Level     string `json:"level"`
+}
+
+func addLoggingEndpoints(ws *restful.WebService, accessControl access.ControlPlaneMetadataAccess) {
+	e := &loggingEndpoint{
+		access:   accessControl,
+		registry: kuma_log.GlobalComponentLevelRegistry(),
+	}
+
+	ws.Route(ws.GET("/logging").To(e.list).
+		Doc("List current log levels"))
+
+	ws.Route(ws.PUT("/logging").To(e.setLevel).
+		Doc("Set log level for a component or global"))
+
+	ws.Route(ws.DELETE("/logging/{component}").To(e.resetLevel).
+		Doc("Reset log level override for a component").
+		Param(ws.PathParameter("component", "component name")))
+
+	ws.Route(ws.DELETE("/logging").To(e.resetAll).
+		Doc("Reset all log level overrides"))
+}
+
+func (e *loggingEndpoint) list(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
+	if err := e.access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
+		rest_errors.HandleError(ctx, resp, err, "Access denied")
+		return
+	}
+
+	overrides := e.registry.ListOverrides()
+	components := make(map[string]string, len(overrides))
+	for name, level := range overrides {
+		components[name] = level.String()
+	}
+
+	if err := resp.WriteAsJson(loggingResponse{
+		Global:     kuma_log.GetGlobalLogLevel().String(),
+		Components: components,
+	}); err != nil {
+		log.Error(err, "Could not write logging response")
+	}
+}
+
+func (e *loggingEndpoint) setLevel(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
+	if err := e.access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
+		rest_errors.HandleError(ctx, resp, err, "Access denied")
+		return
+	}
+
+	var r setLevelRequest
+	if err := req.ReadEntity(&r); err != nil {
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	level, err := kuma_log.ParseLogLevel(r.Level)
+	if err != nil {
+		if writeErr := resp.WriteHeaderAndJson(http.StatusBadRequest, map[string]string{
+			"error": err.Error(),
+		}, "application/json"); writeErr != nil {
+			log.Error(writeErr, "Could not write error response")
+		}
+		return
+	}
+
+	if r.Component == "" {
+		kuma_log.SetGlobalLogLevel(level)
+	} else {
+		e.registry.SetLevel(r.Component, level)
+	}
+
+	resp.WriteHeader(http.StatusOK)
+}
+
+func (e *loggingEndpoint) resetLevel(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
+	if err := e.access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
+		rest_errors.HandleError(ctx, resp, err, "Access denied")
+		return
+	}
+
+	component := req.PathParameter("component")
+	e.registry.ResetLevel(component)
+	resp.WriteHeader(http.StatusOK)
+}
+
+func (e *loggingEndpoint) resetAll(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
+	if err := e.access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
+		rest_errors.HandleError(ctx, resp, err, "Access denied")
+		return
+	}
+
+	e.registry.ResetAll()
+	resp.WriteHeader(http.StatusOK)
+}

--- a/pkg/api-server/logging_endpoint_test.go
+++ b/pkg/api-server/logging_endpoint_test.go
@@ -1,0 +1,107 @@
+package api_server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	api_server "github.com/kumahq/kuma/v2/pkg/api-server"
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+var _ = Describe("Logging Endpoint", func() {
+	var apiServer *api_server.ApiServer
+	var stop func()
+	var baseURL string
+
+	BeforeEach(func() {
+		kuma_log.GlobalComponentLevelRegistry().ResetAll()
+		apiServer, _, stop = StartApiServer(NewTestApiServerConfigurer())
+		baseURL = fmt.Sprintf("http://%s", apiServer.Address())
+	})
+	AfterEach(func() {
+		stop()
+		kuma_log.GlobalComponentLevelRegistry().ResetAll()
+	})
+
+	It("should return current log levels", func() {
+		resp, err := http.Get(baseURL + "/logging")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		var result map[string]any
+		Expect(json.Unmarshal(body, &result)).To(Succeed())
+		Expect(result).To(HaveKey("global"))
+		Expect(result).To(HaveKey("components"))
+	})
+
+	It("should set component log level", func() {
+		// set xds to debug
+		reqBody, _ := json.Marshal(map[string]string{
+			"component": "xds",
+			"level":     "debug",
+		})
+		req, _ := http.NewRequest(http.MethodPut, baseURL+"/logging", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		// verify it shows up in GET
+		resp, err = http.Get(baseURL + "/logging")
+		Expect(err).ToNot(HaveOccurred())
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		var result map[string]any
+		Expect(json.Unmarshal(body, &result)).To(Succeed())
+		components := result["components"].(map[string]any)
+		Expect(components["xds"]).To(Equal("debug"))
+	})
+
+	It("should reject invalid log level", func() {
+		reqBody, _ := json.Marshal(map[string]string{
+			"component": "xds",
+			"level":     "invalid",
+		})
+		req, _ := http.NewRequest(http.MethodPut, baseURL+"/logging", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should reset single component level", func() {
+		kuma_log.GlobalComponentLevelRegistry().SetLevel("xds", kuma_log.DebugLevel)
+
+		req, _ := http.NewRequest(http.MethodDelete, baseURL+"/logging/xds", nil)
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		overrides := kuma_log.GlobalComponentLevelRegistry().ListOverrides()
+		Expect(overrides).To(BeEmpty())
+	})
+
+	It("should reset all component levels", func() {
+		kuma_log.GlobalComponentLevelRegistry().SetLevel("xds", kuma_log.DebugLevel)
+		kuma_log.GlobalComponentLevelRegistry().SetLevel("kds", kuma_log.InfoLevel)
+
+		req, _ := http.NewRequest(http.MethodDelete, baseURL+"/logging", nil)
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		overrides := kuma_log.GlobalComponentLevelRegistry().ListOverrides()
+		Expect(overrides).To(BeEmpty())
+	})
+})

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -180,6 +180,7 @@ func NewApiServer(
 		return nil, errors.Wrap(err, "could not create index webservice")
 	}
 	addWhoamiEndpoints(ws)
+	addLoggingEndpoints(ws, rt.Access().ControlPlaneMetadataAccess)
 
 	ws.SetDynamicRoutes(true)
 	if err := rt.APIWebServiceCustomize()(ws); err != nil {

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -1,0 +1,91 @@
+package log
+
+import (
+	"maps"
+	"strings"
+	"sync"
+)
+
+var globalRegistry = &ComponentLevelRegistry{
+	overrides: make(map[string]LogLevel),
+}
+
+// GlobalComponentLevelRegistry returns the singleton registry used to manage
+// per-component log level overrides.
+func GlobalComponentLevelRegistry() *ComponentLevelRegistry {
+	return globalRegistry
+}
+
+// NewComponentLevelRegistry creates a new empty registry, mainly for testing.
+func NewComponentLevelRegistry() *ComponentLevelRegistry {
+	return &ComponentLevelRegistry{
+		overrides: make(map[string]LogLevel),
+	}
+}
+
+// ComponentLevelRegistry holds per-component log level overrides.
+// Components are identified by dot-separated names matching the hierarchy
+// built by logr.Logger.WithName() calls (e.g. "xds.server").
+type ComponentLevelRegistry struct {
+	mu        sync.RWMutex
+	overrides map[string]LogLevel
+}
+
+// SetLevel sets a log level override for the given component.
+func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) {
+	r.mu.Lock()
+	r.overrides[component] = level
+	r.mu.Unlock()
+}
+
+// ResetLevel removes the log level override for the given component.
+func (r *ComponentLevelRegistry) ResetLevel(component string) {
+	r.mu.Lock()
+	delete(r.overrides, component)
+	r.mu.Unlock()
+}
+
+// ResetAll removes all component log level overrides.
+func (r *ComponentLevelRegistry) ResetAll() {
+	r.mu.Lock()
+	r.overrides = make(map[string]LogLevel)
+	r.mu.Unlock()
+}
+
+// GetEffectiveLevel returns the effective log level for a component.
+// It checks for an exact match first, then walks up the hierarchy
+// (e.g. "xds.server" → "xds"). Returns the level and true if an
+// override was found, or zero value and false otherwise.
+func (r *ComponentLevelRegistry) GetEffectiveLevel(component string) (LogLevel, bool) {
+	if component == "" {
+		return 0, false
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// Walk from most specific to least specific
+	name := component
+	for {
+		if level, ok := r.overrides[name]; ok {
+			return level, true
+		}
+		idx := strings.LastIndex(name, ".")
+		if idx < 0 {
+			break
+		}
+		name = name[:idx]
+	}
+
+	return 0, false
+}
+
+// ListOverrides returns a snapshot of all current component level overrides.
+func (r *ComponentLevelRegistry) ListOverrides() map[string]LogLevel {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]LogLevel, len(r.overrides))
+	maps.Copy(result, r.overrides)
+	return result
+}

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -1,0 +1,97 @@
+package log_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+var _ = Describe("ComponentLevelRegistry", func() {
+	var registry *kuma_log.ComponentLevelRegistry
+
+	BeforeEach(func() {
+		registry = kuma_log.NewComponentLevelRegistry()
+	})
+
+	It("should return false when no overrides set", func() {
+		_, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should return exact match", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		level, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.DebugLevel))
+	})
+
+	It("should walk up hierarchy", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		level, ok := registry.GetEffectiveLevel("xds.server")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.DebugLevel))
+	})
+
+	It("should prefer exact match over ancestor", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("xds.server", kuma_log.InfoLevel)
+
+		level, ok := registry.GetEffectiveLevel("xds.server")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.InfoLevel))
+	})
+
+	It("should not match unrelated components", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		_, ok := registry.GetEffectiveLevel("kds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should handle deep hierarchy", func() {
+		registry.SetLevel("plugins", kuma_log.DebugLevel)
+
+		level, ok := registry.GetEffectiveLevel("plugins.authn.api-server.tokens")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.DebugLevel))
+	})
+
+	It("should reset single level", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.ResetLevel("xds")
+
+		_, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should reset all levels", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("kds", kuma_log.InfoLevel)
+		registry.ResetAll()
+
+		_, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeFalse())
+		_, ok = registry.GetEffectiveLevel("kds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should list overrides", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("kds", kuma_log.InfoLevel)
+
+		overrides := registry.ListOverrides()
+		Expect(overrides).To(HaveLen(2))
+		Expect(overrides["xds"]).To(Equal(kuma_log.DebugLevel))
+		Expect(overrides["kds"]).To(Equal(kuma_log.InfoLevel))
+	})
+
+	It("should return false for empty component name", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		_, ok := registry.GetEffectiveLevel("")
+		Expect(ok).To(BeFalse())
+	})
+})

--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -1,0 +1,84 @@
+package log
+
+import (
+	"github.com/go-logr/logr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// componentAwareSink wraps a logr.LogSink to add per-component log level
+// control. It intercepts WithName calls to track the hierarchical component
+// name (dot-separated) and checks the ComponentLevelRegistry on each
+// Enabled call to apply per-component level overrides.
+//
+// The inner sink must be created at maximum verbosity (-10) so that Info()
+// never filters — all filtering is done by this sink's Enabled() method.
+type componentAwareSink struct {
+	inner     logr.LogSink
+	name      string
+	registry  *ComponentLevelRegistry
+	baseLevel *zap.AtomicLevel // base level for fallback when no override
+}
+
+// NewComponentAwareSink wraps an existing LogSink with per-component level
+// awareness. The inner sink should be created at max verbosity. baseLevel
+// is used as fallback when no per-component override is set.
+func NewComponentAwareSink(inner logr.LogSink, registry *ComponentLevelRegistry, baseLevel *zap.AtomicLevel) logr.LogSink {
+	return &componentAwareSink{
+		inner:     inner,
+		registry:  registry,
+		baseLevel: baseLevel,
+	}
+}
+
+func (s *componentAwareSink) Init(info logr.RuntimeInfo) {
+	s.inner.Init(info)
+}
+
+func (s *componentAwareSink) Enabled(level int) bool {
+	if s.name != "" {
+		if override, ok := s.registry.GetEffectiveLevel(s.name); ok {
+			switch override {
+			case OffLevel:
+				return false
+			case DebugLevel:
+				return true
+			case InfoLevel:
+				return level <= 0
+			}
+		}
+	}
+	// No override — check base level
+	// logr V-level N maps to zap level (InfoLevel - N)
+	return s.baseLevel.Enabled(zapcore.InfoLevel - zapcore.Level(level))
+}
+
+func (s *componentAwareSink) Info(level int, msg string, keysAndValues ...any) {
+	s.inner.Info(level, msg, keysAndValues...)
+}
+
+func (s *componentAwareSink) Error(err error, msg string, keysAndValues ...any) {
+	s.inner.Error(err, msg, keysAndValues...)
+}
+
+func (s *componentAwareSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return &componentAwareSink{
+		inner:     s.inner.WithValues(keysAndValues...),
+		name:      s.name,
+		registry:  s.registry,
+		baseLevel: s.baseLevel,
+	}
+}
+
+func (s *componentAwareSink) WithName(name string) logr.LogSink {
+	fullName := name
+	if s.name != "" {
+		fullName = s.name + "." + name
+	}
+	return &componentAwareSink{
+		inner:     s.inner.WithName(name),
+		name:      fullName,
+		registry:  s.registry,
+		baseLevel: s.baseLevel,
+	}
+}

--- a/pkg/log/component_sink_test.go
+++ b/pkg/log/component_sink_test.go
@@ -1,0 +1,87 @@
+package log_test
+
+import (
+	"bytes"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+var _ = Describe("ComponentAwareSink", func() {
+	var (
+		registry *kuma_log.ComponentLevelRegistry
+		buf      *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		registry = kuma_log.NewComponentLevelRegistry()
+		buf = &bytes.Buffer{}
+	})
+
+	newLogger := func() logr.Logger {
+		return kuma_log.NewLoggerToWithRegistry(buf, kuma_log.InfoLevel, registry)
+	}
+
+	It("should accumulate dot-separated names", func() {
+		logger := newLogger()
+		named := logger.WithName("xds").WithName("server")
+
+		// Without override, info level should work
+		named.Info("test")
+		Expect(buf.String()).To(ContainSubstring("test"))
+	})
+
+	It("should allow debug logs when component override is debug", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.V(1).Info("debug message")
+		Expect(buf.String()).To(ContainSubstring("debug message"))
+	})
+
+	It("should block debug logs when component override is info", func() {
+		registry.SetLevel("xds", kuma_log.InfoLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.V(1).Info("debug message")
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("should block all logs when component override is off", func() {
+		registry.SetLevel("xds", kuma_log.OffLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.Info("info message")
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("should apply parent override to child component", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		logger := newLogger().WithName("xds").WithName("server")
+
+		logger.V(1).Info("debug from child")
+		Expect(buf.String()).To(ContainSubstring("debug from child"))
+	})
+
+	It("should fall back to global level when no override", func() {
+		// No override set — global level is info
+		logger := newLogger().WithName("xds")
+
+		logger.V(1).Info("debug message")
+		Expect(buf.String()).To(BeEmpty())
+
+		logger.Info("info message")
+		Expect(buf.String()).To(ContainSubstring("info message"))
+	})
+
+	It("should not affect unnamed logger with overrides", func() {
+		registry.SetLevel("xds", kuma_log.OffLevel)
+		logger := newLogger()
+
+		logger.Info("root message")
+		Expect(buf.String()).To(ContainSubstring("root message"))
+	})
+})

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -71,7 +71,18 @@ func NewLoggerWithRotation(level LogLevel, outputPath string, maxSize int, maxBa
 }
 
 func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {
-	return zapr.NewLogger(newZapLoggerTo(destWriter, level))
+	return NewLoggerToWithRegistry(destWriter, level, GlobalComponentLevelRegistry())
+}
+
+// NewLoggerToWithRegistry creates a logger writing to destWriter using the
+// given registry for per-component level overrides. The inner zap logger is
+// created at max verbosity — all level filtering is done by the sink.
+func NewLoggerToWithRegistry(destWriter io.Writer, level LogLevel, registry *ComponentLevelRegistry) logr.Logger {
+	baseLevel := newAtomicLogLevel(level)
+	// Inner logger at max verbosity so Info() never filters
+	innerZap := buildZapLogger(destWriter, zap.NewAtomicLevelAt(-10), level == DebugLevel)
+	base := zapr.NewLogger(innerZap)
+	return logr.New(NewComponentAwareSink(base.GetSink(), registry, &baseLevel))
 }
 
 // NewLoggerWithGlobalLevel creates a logger that uses the global atomic level.
@@ -79,7 +90,10 @@ func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {
 // replacing the logger instance. This is useful for early initialization
 // (e.g., in init() functions) where the final log level is not yet known.
 func NewLoggerWithGlobalLevel() logr.Logger {
-	return zapr.NewLogger(newZapLoggerWithGlobalLevel(os.Stderr))
+	verbose := defaultAtomicLevel.Level() <= zapcore.Level(-10)
+	innerZap := buildZapLogger(os.Stderr, zap.NewAtomicLevelAt(-10), verbose)
+	base := zapr.NewLogger(innerZap)
+	return logr.New(NewComponentAwareSink(base.GetSink(), GlobalComponentLevelRegistry(), &defaultAtomicLevel))
 }
 
 // SetGlobalLogLevel updates the global atomic log level used by loggers
@@ -101,43 +115,31 @@ func SetGlobalLogLevel(level LogLevel) {
 	}
 }
 
-func newZapLoggerTo(destWriter io.Writer, level LogLevel, opts ...zap.Option) *zap.Logger {
-	if level == OffLevel {
-		return zap.NewNop()
-	}
-
-	// Create a new AtomicLevel for this logger
-	var lvl zap.AtomicLevel
-	var verbose bool
-
-	switch level {
-	case DebugLevel:
-		// The value we pass here is the most verbose level that
-		// will end up being emitted through the `V(level int)`
-		// accessor. Passing -10 ensures that levels up to `V(10)`
-		// will work, which seems like plenty.
-		lvl = zap.NewAtomicLevelAt(-10)
-		verbose = true
+// GetGlobalLogLevel returns the current global log level by reading the
+// atomic level used by loggers created with NewLoggerWithGlobalLevel.
+func GetGlobalLogLevel() LogLevel {
+	lvl := defaultAtomicLevel.Level()
+	switch {
+	case lvl >= zapcore.Level(100):
+		return OffLevel
+	case lvl <= zapcore.Level(-10):
+		return DebugLevel
 	default:
-		lvl = zap.NewAtomicLevelAt(zap.InfoLevel)
-		verbose = false
+		return InfoLevel
 	}
-
-	return buildZapLogger(destWriter, lvl, verbose, opts...)
 }
 
-func newZapLoggerWithGlobalLevel(destWriter io.Writer, opts ...zap.Option) *zap.Logger {
-	// defaultAtomicLevel starts at InfoLevel (zap.NewAtomicLevel() default).
-	// The level can be changed via SetGlobalLogLevel() before or after this call.
-
-	// Note: verbose is determined at creation time based on the current level.
-	// If the level changes later via SetGlobalLogLevel(), the verbose flag
-	// (affecting KubeAwareEncoder.Verbose and stacktrace behavior) will NOT
-	// update. For kumactl's use case, this is acceptable since we only call
-	// SetGlobalLogLevel() once during flag parsing, before any logging occurs.
-	verbose := defaultAtomicLevel.Level() <= zapcore.Level(-10)
-
-	return buildZapLogger(destWriter, defaultAtomicLevel, verbose, opts...)
+func newAtomicLogLevel(level LogLevel) zap.AtomicLevel {
+	al := zap.NewAtomicLevel()
+	switch level {
+	case OffLevel:
+		al.SetLevel(zapcore.Level(100))
+	case DebugLevel:
+		al.SetLevel(zapcore.Level(-10))
+	case InfoLevel:
+		al.SetLevel(zapcore.InfoLevel)
+	}
+	return al
 }
 
 // buildZapLogger is the common implementation for creating zap loggers.


### PR DESCRIPTION
## Motivation

When debugging issues in production, the only option is setting the global log level to `debug`, flooding logs from all 188+ components. This makes it hard to find relevant info and impacts performance. Operators need targeted debugging for specific components (e.g. only KDS or XDS) without the noise.

Resolves #16095

## Implementation information

**Registry-aware LogSink wrapper** — zero changes to existing `core.Log.WithName()` call sites.

- `ComponentLevelRegistry` (`pkg/log/component_level.go`) — thread-safe map of component name → log level with hierarchical lookup (setting `xds` to debug also applies to `xds.server`, `xds.secrets`, etc.)
- `componentAwareSink` (`pkg/log/component_sink.go`) — custom `logr.LogSink` wrapping zapr. Intercepts `WithName()` to track dot-separated component names, `Enabled()` to check registry overrides. Inner zap logger runs at max verbosity; all level filtering happens in the sink
- HTTP API (`pkg/api-server/logging_endpoint.go`):
  - `GET /logging` — list global level + all component overrides
  - `PUT /logging` — set component or global level
  - `DELETE /logging/{component}` — reset one override
  - `DELETE /logging` — reset all overrides
- Overrides are in-memory only (lost on restart) — this is a runtime debugging tool

> Changelog: feat(log): per-component log level control via CP API