### PR TITLE
feat(log): per-component log level control via API

### DIFF
--- a/pkg/diagnostics/components.go
+++ b/pkg/diagnostics/components.go
@@ -2,14 +2,16 @@ package diagnostics
 
 import (
 	core_runtime "github.com/kumahq/kuma/v2/pkg/core/runtime"
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
 )
 
 func SetupServer(rt core_runtime.Runtime) error {
 	return rt.Add(
 		&diagnosticsServer{
-			isReady: rt.Ready,
-			config:  rt.Config().Diagnostics,
-			metrics: rt.Metrics(),
+			isReady:  rt.Ready,
+			config:   rt.Config().Diagnostics,
+			metrics:  rt.Metrics(),
+			registry: kuma_log.GlobalComponentLevelRegistry(),
 		},
 	)
 }

--- a/pkg/diagnostics/components.go
+++ b/pkg/diagnostics/components.go
@@ -8,10 +8,10 @@ import (
 func SetupServer(rt core_runtime.Runtime) error {
 	return rt.Add(
 		&diagnosticsServer{
-			isReady:  rt.Ready,
-			config:   rt.Config().Diagnostics,
-			metrics:  rt.Metrics(),
-			registry: kuma_log.GlobalComponentLevelRegistry(),
+			isReady:     rt.Ready,
+			config:      rt.Config().Diagnostics,
+			metrics:     rt.Metrics(),
+			logRegistry: kuma_log.GlobalComponentLevelRegistry(),
 		},
 	)
 }

--- a/pkg/diagnostics/diagnostics_suite_test.go
+++ b/pkg/diagnostics/diagnostics_suite_test.go
@@ -1,0 +1,11 @@
+package diagnostics_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestDiagnostics(t *testing.T) {
+	test.RunSpecs(t, "Diagnostics")
+}

--- a/pkg/diagnostics/logging_test.go
+++ b/pkg/diagnostics/logging_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 var _ = Describe("Logging handlers", func() {
-	var registry *kuma_log.ComponentLevelRegistry
-	var mux *http.ServeMux
+	var (
+		registry *kuma_log.ComponentLevelRegistry
+		mux      *http.ServeMux
+	)
 
 	BeforeEach(func() {
 		registry = kuma_log.NewComponentLevelRegistry()
@@ -52,23 +54,18 @@ var _ = Describe("Logging handlers", func() {
 		Expect(components["xds"]).To(Equal("debug"))
 	})
 
-	It("should reject invalid log level", func() {
-		body, err := json.Marshal(map[string]string{"component": "xds", "level": "invalid"})
-		Expect(err).ToNot(HaveOccurred())
-		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusBadRequest))
-	})
-
-	It("should reject empty component", func() {
-		body, err := json.Marshal(map[string]string{"level": "debug"})
-		Expect(err).ToNot(HaveOccurred())
-		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusBadRequest))
-	})
+	DescribeTable("should reject invalid PUT requests",
+		func(body string, expectedCode int) {
+			req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader([]byte(body)))
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(expectedCode))
+		},
+		Entry("invalid log level", `{"component":"xds","level":"invalid"}`, http.StatusBadRequest),
+		Entry("empty component", `{"level":"debug"}`, http.StatusBadRequest),
+		Entry("malformed JSON", `{invalid`, http.StatusBadRequest),
+		Entry("invalid component name", `{"component":"../../etc","level":"debug"}`, http.StatusBadRequest),
+	)
 
 	It("should reset single component level", func() {
 		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
@@ -98,33 +95,14 @@ var _ = Describe("Logging handlers", func() {
 		Expect(registry.ListOverrides()).To(BeEmpty())
 	})
 
-	It("should reject malformed JSON body", func() {
-		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader([]byte("{invalid")))
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusBadRequest))
-	})
-
-	It("should reject invalid component name", func() {
-		body, err := json.Marshal(map[string]string{"component": "../../etc", "level": "debug"})
-		Expect(err).ToNot(HaveOccurred())
-		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusBadRequest))
-	})
-
-	It("should return method not allowed for GET on /logging/{component}", func() {
-		req := httptest.NewRequest(http.MethodGet, "/logging/xds", http.NoBody)
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusMethodNotAllowed))
-	})
-
-	It("should reject invalid component name on DELETE", func() {
-		req := httptest.NewRequest(http.MethodDelete, "/logging/invalid!name", http.NoBody)
-		w := httptest.NewRecorder()
-		mux.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusBadRequest))
-	})
+	DescribeTable("should reject invalid requests on /logging/{component}",
+		func(method string, path string, expectedCode int) {
+			req := httptest.NewRequest(method, path, http.NoBody)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(expectedCode))
+		},
+		Entry("GET not allowed", http.MethodGet, "/logging/xds", http.StatusMethodNotAllowed),
+		Entry("invalid component name on DELETE", http.MethodDelete, "/logging/invalid!name", http.StatusBadRequest),
+	)
 })

--- a/pkg/diagnostics/logging_test.go
+++ b/pkg/diagnostics/logging_test.go
@@ -1,0 +1,133 @@
+package diagnostics_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v2/pkg/diagnostics"
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+var _ = Describe("Logging handlers", func() {
+	var registry *kuma_log.ComponentLevelRegistry
+	var mux *http.ServeMux
+
+	BeforeEach(func() {
+		registry = kuma_log.NewComponentLevelRegistry()
+		mux = http.NewServeMux()
+		diagnostics.AddLoggingHandlers(mux, registry)
+	})
+
+	It("should return current log levels", func() {
+		req := httptest.NewRequest(http.MethodGet, "/logging", http.NoBody)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var result map[string]any
+		Expect(json.Unmarshal(w.Body.Bytes(), &result)).To(Succeed())
+		Expect(result).To(HaveKey("components"))
+	})
+
+	It("should set component log level", func() {
+		body, err := json.Marshal(map[string]string{"component": "xds", "level": "debug"})
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		req = httptest.NewRequest(http.MethodGet, "/logging", http.NoBody)
+		w = httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		var result map[string]any
+		Expect(json.Unmarshal(w.Body.Bytes(), &result)).To(Succeed())
+		components := result["components"].(map[string]any)
+		Expect(components["xds"]).To(Equal("debug"))
+	})
+
+	It("should reject invalid log level", func() {
+		body, err := json.Marshal(map[string]string{"component": "xds", "level": "invalid"})
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should reject empty component", func() {
+		body, err := json.Marshal(map[string]string{"level": "debug"})
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should reset single component level", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		req := httptest.NewRequest(http.MethodDelete, "/logging/xds", http.NoBody)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		Expect(registry.ListOverrides()).To(BeEmpty())
+	})
+
+	It("should reset all component levels and return removed overrides", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("kds", kuma_log.InfoLevel)
+
+		req := httptest.NewRequest(http.MethodDelete, "/logging", http.NoBody)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		var result map[string]any
+		Expect(json.Unmarshal(w.Body.Bytes(), &result)).To(Succeed())
+		components := result["components"].(map[string]any)
+		Expect(components).To(HaveLen(2))
+
+		Expect(registry.ListOverrides()).To(BeEmpty())
+	})
+
+	It("should reject malformed JSON body", func() {
+		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader([]byte("{invalid")))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should reject invalid component name", func() {
+		body, err := json.Marshal(map[string]string{"component": "../../etc", "level": "debug"})
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(http.MethodPut, "/logging", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("should return method not allowed for GET on /logging/{component}", func() {
+		req := httptest.NewRequest(http.MethodGet, "/logging/xds", http.NoBody)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusMethodNotAllowed))
+	})
+
+	It("should include baseLevel in GET response", func() {
+		req := httptest.NewRequest(http.MethodGet, "/logging", http.NoBody)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		var result map[string]any
+		Expect(json.Unmarshal(w.Body.Bytes(), &result)).To(Succeed())
+		Expect(result).To(HaveKey("baseLevel"))
+	})
+})

--- a/pkg/diagnostics/logging_test.go
+++ b/pkg/diagnostics/logging_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Logging handlers", func() {
 	})
 
 	It("should reset single component level", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 
 		req := httptest.NewRequest(http.MethodDelete, "/logging/xds", http.NoBody)
 		w := httptest.NewRecorder()
@@ -82,8 +82,8 @@ var _ = Describe("Logging handlers", func() {
 	})
 
 	It("should reset all component levels and return removed overrides", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
-		registry.SetLevel("kds", kuma_log.InfoLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
+		Expect(registry.SetLevel("kds", kuma_log.InfoLevel)).To(Succeed())
 
 		req := httptest.NewRequest(http.MethodDelete, "/logging", http.NoBody)
 		w := httptest.NewRecorder()
@@ -121,13 +121,10 @@ var _ = Describe("Logging handlers", func() {
 		Expect(w.Code).To(Equal(http.StatusMethodNotAllowed))
 	})
 
-	It("should include baseLevel in GET response", func() {
-		req := httptest.NewRequest(http.MethodGet, "/logging", http.NoBody)
+	It("should reject invalid component name on DELETE", func() {
+		req := httptest.NewRequest(http.MethodDelete, "/logging/invalid!name", http.NoBody)
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
-
-		var result map[string]any
-		Expect(json.Unmarshal(w.Body.Bytes(), &result)).To(Succeed())
-		Expect(result).To(HaveKey("baseLevel"))
+		Expect(w.Code).To(Equal(http.StatusBadRequest))
 	})
 })

--- a/pkg/diagnostics/server.go
+++ b/pkg/diagnostics/server.go
@@ -3,6 +3,7 @@ package diagnostics
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -17,6 +18,7 @@ import (
 	config_types "github.com/kumahq/kuma/v2/pkg/config/types"
 	"github.com/kumahq/kuma/v2/pkg/core"
 	"github.com/kumahq/kuma/v2/pkg/core/runtime/component"
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
 	"github.com/kumahq/kuma/v2/pkg/metrics"
 	kuma_srv "github.com/kumahq/kuma/v2/pkg/util/http/server"
 )
@@ -24,10 +26,11 @@ import (
 var diagnosticsServerLog = core.Log.WithName("xds-server").WithName("diagnostics")
 
 type diagnosticsServer struct {
-	isReady func() bool
-	config  *diagnostics_config.DiagnosticsConfig
-	metrics metrics.Metrics
-	ready   atomic.Bool
+	isReady  func() bool
+	config   *diagnostics_config.DiagnosticsConfig
+	metrics  metrics.Metrics
+	registry *kuma_log.ComponentLevelRegistry
+	ready    atomic.Bool
 }
 
 func (s *diagnosticsServer) NeedLeaderElection() bool {
@@ -59,6 +62,7 @@ func (s *diagnosticsServer) Start(stop <-chan struct{}) error {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
+	AddLoggingHandlers(mux, s.registry)
 	var tlsConfig *tls.Config
 	if s.config.TlsEnabled {
 		cert, err := tls.LoadX509KeyPair(s.config.TlsCertFile, s.config.TlsKeyFile)
@@ -101,4 +105,95 @@ func (s *diagnosticsServer) Start(stop <-chan struct{}) error {
 		s.ready.Store(false)
 		return err
 	}
+}
+
+type loggingResponse struct {
+	BaseLevel  string            `json:"baseLevel,omitempty"`
+	Components map[string]string `json:"components"`
+}
+
+type setLevelRequest struct {
+	Component string `json:"component"`
+	Level     string `json:"level"`
+}
+
+// AddLoggingHandlers registers GET/PUT/DELETE /logging routes on mux.
+func AddLoggingHandlers(mux *http.ServeMux, registry *kuma_log.ComponentLevelRegistry) {
+	mux.HandleFunc("/logging", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handleLoggingGet(w, registry)
+		case http.MethodPut:
+			handleLoggingPut(w, r, registry)
+		case http.MethodDelete:
+			overrides := registry.ResetAll()
+			diagnosticsServerLog.Info("all component log level overrides reset", "count", len(overrides))
+			writeOverridesResponse(w, overrides)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+	})
+	mux.HandleFunc("/logging/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		component := r.URL.Path[len("/logging/"):]
+		if component == "" {
+			http.Error(w, "component required", http.StatusBadRequest)
+			return
+		}
+		registry.ResetLevel(component)
+		diagnosticsServerLog.Info("component log level override reset", "component", component)
+	})
+}
+
+func writeOverridesResponse(w http.ResponseWriter, overrides map[string]kuma_log.LogLevel) {
+	components := make(map[string]string, len(overrides))
+	for name, level := range overrides {
+		components[name] = level.String()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(loggingResponse{Components: components}); err != nil {
+		diagnosticsServerLog.Error(err, "could not write logging response")
+	}
+}
+
+func handleLoggingGet(w http.ResponseWriter, registry *kuma_log.ComponentLevelRegistry) {
+	overrides := registry.ListOverrides()
+	components := make(map[string]string, len(overrides))
+	for name, level := range overrides {
+		components[name] = level.String()
+	}
+	resp := loggingResponse{
+		BaseLevel:  kuma_log.GetGlobalLogLevel().String(),
+		Components: components,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		diagnosticsServerLog.Error(err, "could not write logging response")
+	}
+}
+
+func handleLoggingPut(w http.ResponseWriter, r *http.Request, registry *kuma_log.ComponentLevelRegistry) {
+	const maxBodySize = 4096 // generous for {"component":"...","level":"..."}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+	var req setLevelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if err := kuma_log.ValidateComponentName(req.Component); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	level, err := kuma_log.ParseLogLevel(req.Level)
+	if err != nil {
+		http.Error(w, "invalid log level: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	registry.SetLevel(req.Component, level)
+	diagnosticsServerLog.Info("component log level override set", "component", req.Component, "level", req.Level)
+	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/diagnostics/server.go
+++ b/pkg/diagnostics/server.go
@@ -108,7 +108,6 @@ func (s *diagnosticsServer) Start(stop <-chan struct{}) error {
 }
 
 type loggingResponse struct {
-	BaseLevel  string            `json:"baseLevel,omitempty"`
 	Components map[string]string `json:"components"`
 }
 
@@ -140,8 +139,8 @@ func AddLoggingHandlers(mux *http.ServeMux, registry *kuma_log.ComponentLevelReg
 			return
 		}
 		component := r.URL.Path[len("/logging/"):]
-		if component == "" {
-			http.Error(w, "component required", http.StatusBadRequest)
+		if err := kuma_log.ValidateComponentName(component); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		registry.ResetLevel(component)
@@ -166,12 +165,8 @@ func handleLoggingGet(w http.ResponseWriter, registry *kuma_log.ComponentLevelRe
 	for name, level := range overrides {
 		components[name] = level.String()
 	}
-	resp := loggingResponse{
-		BaseLevel:  kuma_log.GetGlobalLogLevel().String(),
-		Components: components,
-	}
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
+	if err := json.NewEncoder(w).Encode(loggingResponse{Components: components}); err != nil {
 		diagnosticsServerLog.Error(err, "could not write logging response")
 	}
 }
@@ -193,7 +188,10 @@ func handleLoggingPut(w http.ResponseWriter, r *http.Request, registry *kuma_log
 		http.Error(w, "invalid log level: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	registry.SetLevel(req.Component, level)
+	if err := registry.SetLevel(req.Component, level); err != nil {
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+		return
+	}
 	diagnosticsServerLog.Info("component log level override set", "component", req.Component, "level", req.Level)
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/diagnostics/server.go
+++ b/pkg/diagnostics/server.go
@@ -26,11 +26,11 @@ import (
 var diagnosticsServerLog = core.Log.WithName("xds-server").WithName("diagnostics")
 
 type diagnosticsServer struct {
-	isReady  func() bool
-	config   *diagnostics_config.DiagnosticsConfig
-	metrics  metrics.Metrics
-	registry *kuma_log.ComponentLevelRegistry
-	ready    atomic.Bool
+	isReady     func() bool
+	config      *diagnostics_config.DiagnosticsConfig
+	metrics     metrics.Metrics
+	logRegistry *kuma_log.ComponentLevelRegistry
+	ready       atomic.Bool
 }
 
 func (s *diagnosticsServer) NeedLeaderElection() bool {
@@ -62,7 +62,7 @@ func (s *diagnosticsServer) Start(stop <-chan struct{}) error {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
-	AddLoggingHandlers(mux, s.registry)
+	AddLoggingHandlers(mux, s.logRegistry)
 	var tlsConfig *tls.Config
 	if s.config.TlsEnabled {
 		cert, err := tls.LoadX509KeyPair(s.config.TlsCertFile, s.config.TlsKeyFile)
@@ -133,12 +133,8 @@ func AddLoggingHandlers(mux *http.ServeMux, registry *kuma_log.ComponentLevelReg
 			return
 		}
 	})
-	mux.HandleFunc("/logging/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		component := r.URL.Path[len("/logging/"):]
+	mux.HandleFunc("DELETE /logging/{component}", func(w http.ResponseWriter, r *http.Request) {
+		component := r.PathValue("component")
 		if err := kuma_log.ValidateComponentName(component); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -63,9 +63,13 @@ func ValidateComponentName(name string) error {
 // SetLevel sets a log level override for the given component.
 // Returns an error if the maximum number of overrides would be exceeded.
 func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) error {
+	current := *r.snapshot.Load()
+	if existing, ok := current[component]; ok && existing == level {
+		return nil
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	current := *r.snapshot.Load()
+	current = *r.snapshot.Load()
 	if _, exists := current[component]; !exists && len(current) >= MaxOverrides {
 		return fmt.Errorf("maximum number of component overrides (%d) reached", MaxOverrides)
 	}
@@ -78,9 +82,16 @@ func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) erro
 
 // ResetLevel removes the log level override for the given component.
 func (r *ComponentLevelRegistry) ResetLevel(component string) {
+	current := *r.snapshot.Load()
+	if _, exists := current[component]; !exists {
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	current := *r.snapshot.Load()
+	current = *r.snapshot.Load()
+	if _, exists := current[component]; !exists {
+		return
+	}
 	next := make(map[string]LogLevel, len(current))
 	maps.Copy(next, current)
 	delete(next, component)
@@ -90,9 +101,16 @@ func (r *ComponentLevelRegistry) ResetLevel(component string) {
 // ResetAll removes all component log level overrides and returns
 // the overrides that were active before the reset.
 func (r *ComponentLevelRegistry) ResetAll() map[string]LogLevel {
+	current := *r.snapshot.Load()
+	if len(current) == 0 {
+		return map[string]LogLevel{}
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	prev := *r.snapshot.Load()
+	if len(prev) == 0 {
+		return map[string]LogLevel{}
+	}
 	m := make(map[string]LogLevel)
 	r.snapshot.Store(&m)
 	result := make(map[string]LogLevel, len(prev))

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -100,17 +100,6 @@ func (r *ComponentLevelRegistry) ResetAll() map[string]LogLevel {
 	return result
 }
 
-// GetEffectiveLevel returns the effective log level for a component.
-// It checks for an exact match first, then walks up the hierarchy
-// (e.g. "xds.server" → "xds"). Returns the level and true if an
-// override was found, or zero value and false otherwise.
-func (r *ComponentLevelRegistry) GetEffectiveLevel(component string) (LogLevel, bool) {
-	if component == "" {
-		return 0, false
-	}
-	return r.GetEffectiveLevelForNames(splitHierarchy(component))
-}
-
 // GetEffectiveLevelForNames returns the effective log level given a
 // pre-computed name hierarchy (most-specific first). This avoids string
 // splitting on the hot path when called from componentAwareSink.Enabled.
@@ -132,9 +121,9 @@ func (r *ComponentLevelRegistry) ListOverrides() map[string]LogLevel {
 	return result
 }
 
-// splitHierarchy returns the name and all its ancestors, most-specific first.
+// SplitHierarchy returns the name and all its ancestors, most-specific first.
 // e.g. "xds.server" → ["xds.server", "xds"]
-func splitHierarchy(name string) []string {
+func SplitHierarchy(name string) []string {
 	var names []string
 	for {
 		names = append(names, name)

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -11,6 +11,11 @@ import (
 
 const maxComponentNameLen = 256
 
+// MaxOverrides is the maximum number of per-component level overrides
+// allowed in a single registry. This prevents unbounded memory growth
+// from misconfigured or malicious API clients.
+const MaxOverrides = 200
+
 var validComponentName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 var globalRegistry = NewComponentLevelRegistry()
@@ -56,14 +61,19 @@ func ValidateComponentName(name string) error {
 }
 
 // SetLevel sets a log level override for the given component.
-func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) {
+// Returns an error if the maximum number of overrides would be exceeded.
+func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	current := *r.snapshot.Load()
+	if _, exists := current[component]; !exists && len(current) >= MaxOverrides {
+		return fmt.Errorf("maximum number of component overrides (%d) reached", MaxOverrides)
+	}
 	next := make(map[string]LogLevel, len(current)+1)
 	maps.Copy(next, current)
 	next[component] = level
 	r.snapshot.Store(&next)
+	return nil
 }
 
 // ResetLevel removes the log level override for the given component.

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -1,0 +1,138 @@
+package log
+
+import (
+	"fmt"
+	"maps"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+const maxComponentNameLen = 256
+
+var validComponentName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+var globalRegistry = NewComponentLevelRegistry()
+
+// GlobalComponentLevelRegistry returns the singleton registry used to manage
+// per-component log level overrides.
+func GlobalComponentLevelRegistry() *ComponentLevelRegistry {
+	return globalRegistry
+}
+
+// NewComponentLevelRegistry creates a new empty registry, mainly for testing.
+func NewComponentLevelRegistry() *ComponentLevelRegistry {
+	r := &ComponentLevelRegistry{}
+	m := make(map[string]LogLevel)
+	r.snapshot.Store(&m)
+	return r
+}
+
+// ComponentLevelRegistry holds per-component log level overrides.
+// Components are identified by dot-separated names matching the hierarchy
+// built by logr.Logger.WithName() calls (e.g. "xds.server").
+//
+// Reads are lock-free via an atomic pointer to an immutable snapshot.
+// Writes acquire a mutex and swap in a new copy (copy-on-write).
+type ComponentLevelRegistry struct {
+	mu       sync.Mutex
+	snapshot atomic.Pointer[map[string]LogLevel]
+}
+
+// ValidateComponentName checks that the component name is well-formed:
+// non-empty, at most 256 characters, alphanumeric with dots/dashes/underscores.
+func ValidateComponentName(name string) error {
+	if name == "" {
+		return fmt.Errorf("component name must not be empty")
+	}
+	if len(name) > maxComponentNameLen {
+		return fmt.Errorf("component name exceeds %d characters", maxComponentNameLen)
+	}
+	if !validComponentName.MatchString(name) {
+		return fmt.Errorf("component name %q contains invalid characters", name)
+	}
+	return nil
+}
+
+// SetLevel sets a log level override for the given component.
+func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current := *r.snapshot.Load()
+	next := make(map[string]LogLevel, len(current)+1)
+	maps.Copy(next, current)
+	next[component] = level
+	r.snapshot.Store(&next)
+}
+
+// ResetLevel removes the log level override for the given component.
+func (r *ComponentLevelRegistry) ResetLevel(component string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current := *r.snapshot.Load()
+	next := make(map[string]LogLevel, len(current))
+	maps.Copy(next, current)
+	delete(next, component)
+	r.snapshot.Store(&next)
+}
+
+// ResetAll removes all component log level overrides and returns
+// the overrides that were active before the reset.
+func (r *ComponentLevelRegistry) ResetAll() map[string]LogLevel {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	prev := *r.snapshot.Load()
+	m := make(map[string]LogLevel)
+	r.snapshot.Store(&m)
+	result := make(map[string]LogLevel, len(prev))
+	maps.Copy(result, prev)
+	return result
+}
+
+// GetEffectiveLevel returns the effective log level for a component.
+// It checks for an exact match first, then walks up the hierarchy
+// (e.g. "xds.server" → "xds"). Returns the level and true if an
+// override was found, or zero value and false otherwise.
+func (r *ComponentLevelRegistry) GetEffectiveLevel(component string) (LogLevel, bool) {
+	if component == "" {
+		return 0, false
+	}
+	return r.GetEffectiveLevelForNames(splitHierarchy(component))
+}
+
+// GetEffectiveLevelForNames returns the effective log level given a
+// pre-computed name hierarchy (most-specific first). This avoids string
+// splitting on the hot path when called from componentAwareSink.Enabled.
+func (r *ComponentLevelRegistry) GetEffectiveLevelForNames(names []string) (LogLevel, bool) {
+	m := r.snapshot.Load()
+	for _, name := range names {
+		if level, ok := (*m)[name]; ok {
+			return level, true
+		}
+	}
+	return 0, false
+}
+
+// ListOverrides returns a snapshot of all current component level overrides.
+func (r *ComponentLevelRegistry) ListOverrides() map[string]LogLevel {
+	m := r.snapshot.Load()
+	result := make(map[string]LogLevel, len(*m))
+	maps.Copy(result, *m)
+	return result
+}
+
+// splitHierarchy returns the name and all its ancestors, most-specific first.
+// e.g. "xds.server" → ["xds.server", "xds"]
+func splitHierarchy(name string) []string {
+	var names []string
+	for {
+		names = append(names, name)
+		idx := strings.LastIndex(name, ".")
+		if idx < 0 {
+			break
+		}
+		name = name[:idx]
+	}
+	return names
+}

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -16,50 +16,42 @@ var _ = Describe("ComponentLevelRegistry", func() {
 		registry = kuma_log.NewComponentLevelRegistry()
 	})
 
-	It("should return false when no overrides set", func() {
-		_, ok := registry.GetEffectiveLevel("xds")
-		Expect(ok).To(BeFalse())
-	})
+	type override struct {
+		component string
+		level     kuma_log.LogLevel
+	}
 
-	It("should return exact match", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-
-		level, ok := registry.GetEffectiveLevel("xds")
-		Expect(ok).To(BeTrue())
-		Expect(level).To(Equal(kuma_log.DebugLevel))
-	})
-
-	It("should walk up hierarchy", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-
-		level, ok := registry.GetEffectiveLevel("xds.server")
-		Expect(ok).To(BeTrue())
-		Expect(level).To(Equal(kuma_log.DebugLevel))
-	})
-
-	It("should prefer exact match over ancestor", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-		Expect(registry.SetLevel("xds.server", kuma_log.InfoLevel)).To(Succeed())
-
-		level, ok := registry.GetEffectiveLevel("xds.server")
-		Expect(ok).To(BeTrue())
-		Expect(level).To(Equal(kuma_log.InfoLevel))
-	})
-
-	It("should not match unrelated components", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-
-		_, ok := registry.GetEffectiveLevel("kds")
-		Expect(ok).To(BeFalse())
-	})
-
-	It("should handle deep hierarchy", func() {
-		Expect(registry.SetLevel("plugins", kuma_log.DebugLevel)).To(Succeed())
-
-		level, ok := registry.GetEffectiveLevel("plugins.authn.api-server.tokens")
-		Expect(ok).To(BeTrue())
-		Expect(level).To(Equal(kuma_log.DebugLevel))
-	})
+	DescribeTable("GetEffectiveLevel",
+		func(overrides []override, query string, expectFound bool, expectLevel kuma_log.LogLevel) {
+			for _, o := range overrides {
+				Expect(registry.SetLevel(o.component, o.level)).To(Succeed())
+			}
+			level, ok := registry.GetEffectiveLevel(query)
+			Expect(ok).To(Equal(expectFound))
+			if expectFound {
+				Expect(level).To(Equal(expectLevel))
+			}
+		},
+		Entry("no overrides set", nil, "xds", false, kuma_log.LogLevel(0)),
+		Entry("exact match",
+			[]override{{"xds", kuma_log.DebugLevel}},
+			"xds", true, kuma_log.DebugLevel),
+		Entry("walks up hierarchy",
+			[]override{{"xds", kuma_log.DebugLevel}},
+			"xds.server", true, kuma_log.DebugLevel),
+		Entry("prefers exact match over ancestor",
+			[]override{{"xds", kuma_log.DebugLevel}, {"xds.server", kuma_log.InfoLevel}},
+			"xds.server", true, kuma_log.InfoLevel),
+		Entry("does not match unrelated components",
+			[]override{{"xds", kuma_log.DebugLevel}},
+			"kds", false, kuma_log.LogLevel(0)),
+		Entry("deep hierarchy",
+			[]override{{"plugins", kuma_log.DebugLevel}},
+			"plugins.authn.api-server.tokens", true, kuma_log.DebugLevel),
+		Entry("empty component name",
+			[]override{{"xds", kuma_log.DebugLevel}},
+			"", false, kuma_log.LogLevel(0)),
+	)
 
 	It("should reset single level", func() {
 		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
@@ -88,13 +80,6 @@ var _ = Describe("ComponentLevelRegistry", func() {
 		Expect(overrides).To(HaveLen(2))
 		Expect(overrides["xds"]).To(Equal(kuma_log.DebugLevel))
 		Expect(overrides["kds"]).To(Equal(kuma_log.InfoLevel))
-	})
-
-	It("should return false for empty component name", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-
-		_, ok := registry.GetEffectiveLevel("")
-		Expect(ok).To(BeFalse())
 	})
 
 	It("should handle concurrent reads and writes", func() {
@@ -129,7 +114,6 @@ var _ = Describe("ComponentLevelRegistry", func() {
 		for i := range kuma_log.MaxOverrides {
 			Expect(registry.SetLevel(fmt.Sprintf("component-%d", i), kuma_log.DebugLevel)).To(Succeed())
 		}
-		// Updating existing key should succeed
 		Expect(registry.SetLevel("component-0", kuma_log.InfoLevel)).To(Succeed())
 	})
 })

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -21,12 +21,16 @@ var _ = Describe("ComponentLevelRegistry", func() {
 		level     kuma_log.LogLevel
 	}
 
-	DescribeTable("GetEffectiveLevel",
+	DescribeTable("GetEffectiveLevelForNames",
 		func(overrides []override, query string, expectFound bool, expectLevel kuma_log.LogLevel) {
 			for _, o := range overrides {
 				Expect(registry.SetLevel(o.component, o.level)).To(Succeed())
 			}
-			level, ok := registry.GetEffectiveLevel(query)
+			names := kuma_log.SplitHierarchy(query)
+			if query == "" {
+				names = nil
+			}
+			level, ok := registry.GetEffectiveLevelForNames(names)
 			Expect(ok).To(Equal(expectFound))
 			if expectFound {
 				Expect(level).To(Equal(expectLevel))
@@ -57,7 +61,7 @@ var _ = Describe("ComponentLevelRegistry", func() {
 		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 		registry.ResetLevel("xds")
 
-		_, ok := registry.GetEffectiveLevel("xds")
+		_, ok := registry.GetEffectiveLevelForNames(kuma_log.SplitHierarchy("xds"))
 		Expect(ok).To(BeFalse())
 	})
 
@@ -66,9 +70,9 @@ var _ = Describe("ComponentLevelRegistry", func() {
 		Expect(registry.SetLevel("kds", kuma_log.InfoLevel)).To(Succeed())
 		registry.ResetAll()
 
-		_, ok := registry.GetEffectiveLevel("xds")
+		_, ok := registry.GetEffectiveLevelForNames(kuma_log.SplitHierarchy("xds"))
 		Expect(ok).To(BeFalse())
-		_, ok = registry.GetEffectiveLevel("kds")
+		_, ok = registry.GetEffectiveLevelForNames(kuma_log.SplitHierarchy("kds"))
 		Expect(ok).To(BeFalse())
 	})
 
@@ -95,7 +99,7 @@ var _ = Describe("ComponentLevelRegistry", func() {
 			}
 		}()
 		for range 1000 {
-			registry.GetEffectiveLevel("xds.server")
+			registry.GetEffectiveLevelForNames(kuma_log.SplitHierarchy("xds.server"))
 			registry.ListOverrides()
 		}
 		<-done

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -1,6 +1,8 @@
 package log_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -20,7 +22,7 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should return exact match", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 
 		level, ok := registry.GetEffectiveLevel("xds")
 		Expect(ok).To(BeTrue())
@@ -28,7 +30,7 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should walk up hierarchy", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 
 		level, ok := registry.GetEffectiveLevel("xds.server")
 		Expect(ok).To(BeTrue())
@@ -36,8 +38,8 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should prefer exact match over ancestor", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
-		registry.SetLevel("xds.server", kuma_log.InfoLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
+		Expect(registry.SetLevel("xds.server", kuma_log.InfoLevel)).To(Succeed())
 
 		level, ok := registry.GetEffectiveLevel("xds.server")
 		Expect(ok).To(BeTrue())
@@ -45,14 +47,14 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should not match unrelated components", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 
 		_, ok := registry.GetEffectiveLevel("kds")
 		Expect(ok).To(BeFalse())
 	})
 
 	It("should handle deep hierarchy", func() {
-		registry.SetLevel("plugins", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("plugins", kuma_log.DebugLevel)).To(Succeed())
 
 		level, ok := registry.GetEffectiveLevel("plugins.authn.api-server.tokens")
 		Expect(ok).To(BeTrue())
@@ -60,7 +62,7 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should reset single level", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 		registry.ResetLevel("xds")
 
 		_, ok := registry.GetEffectiveLevel("xds")
@@ -68,8 +70,8 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should reset all levels", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
-		registry.SetLevel("kds", kuma_log.InfoLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
+		Expect(registry.SetLevel("kds", kuma_log.InfoLevel)).To(Succeed())
 		registry.ResetAll()
 
 		_, ok := registry.GetEffectiveLevel("xds")
@@ -79,8 +81,8 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should list overrides", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
-		registry.SetLevel("kds", kuma_log.InfoLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
+		Expect(registry.SetLevel("kds", kuma_log.InfoLevel)).To(Succeed())
 
 		overrides := registry.ListOverrides()
 		Expect(overrides).To(HaveLen(2))
@@ -89,7 +91,7 @@ var _ = Describe("ComponentLevelRegistry", func() {
 	})
 
 	It("should return false for empty component name", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 
 		_, ok := registry.GetEffectiveLevel("")
 		Expect(ok).To(BeFalse())
@@ -101,8 +103,8 @@ var _ = Describe("ComponentLevelRegistry", func() {
 			defer GinkgoRecover()
 			defer close(done)
 			for range 1000 {
-				registry.SetLevel("xds", kuma_log.DebugLevel)
-				registry.SetLevel("kds", kuma_log.InfoLevel)
+				_ = registry.SetLevel("xds", kuma_log.DebugLevel)
+				_ = registry.SetLevel("kds", kuma_log.InfoLevel)
 				registry.ResetLevel("xds")
 				registry.ResetAll()
 			}
@@ -112,5 +114,22 @@ var _ = Describe("ComponentLevelRegistry", func() {
 			registry.ListOverrides()
 		}
 		<-done
+	})
+
+	It("should reject when max overrides exceeded", func() {
+		for i := range kuma_log.MaxOverrides {
+			Expect(registry.SetLevel(fmt.Sprintf("component-%d", i), kuma_log.DebugLevel)).To(Succeed())
+		}
+		err := registry.SetLevel("one-too-many", kuma_log.DebugLevel)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("maximum"))
+	})
+
+	It("should allow updating existing override when at max", func() {
+		for i := range kuma_log.MaxOverrides {
+			Expect(registry.SetLevel(fmt.Sprintf("component-%d", i), kuma_log.DebugLevel)).To(Succeed())
+		}
+		// Updating existing key should succeed
+		Expect(registry.SetLevel("component-0", kuma_log.InfoLevel)).To(Succeed())
 	})
 })

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -1,0 +1,116 @@
+package log_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+var _ = Describe("ComponentLevelRegistry", func() {
+	var registry *kuma_log.ComponentLevelRegistry
+
+	BeforeEach(func() {
+		registry = kuma_log.NewComponentLevelRegistry()
+	})
+
+	It("should return false when no overrides set", func() {
+		_, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should return exact match", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		level, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.DebugLevel))
+	})
+
+	It("should walk up hierarchy", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		level, ok := registry.GetEffectiveLevel("xds.server")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.DebugLevel))
+	})
+
+	It("should prefer exact match over ancestor", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("xds.server", kuma_log.InfoLevel)
+
+		level, ok := registry.GetEffectiveLevel("xds.server")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.InfoLevel))
+	})
+
+	It("should not match unrelated components", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		_, ok := registry.GetEffectiveLevel("kds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should handle deep hierarchy", func() {
+		registry.SetLevel("plugins", kuma_log.DebugLevel)
+
+		level, ok := registry.GetEffectiveLevel("plugins.authn.api-server.tokens")
+		Expect(ok).To(BeTrue())
+		Expect(level).To(Equal(kuma_log.DebugLevel))
+	})
+
+	It("should reset single level", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.ResetLevel("xds")
+
+		_, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should reset all levels", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("kds", kuma_log.InfoLevel)
+		registry.ResetAll()
+
+		_, ok := registry.GetEffectiveLevel("xds")
+		Expect(ok).To(BeFalse())
+		_, ok = registry.GetEffectiveLevel("kds")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should list overrides", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		registry.SetLevel("kds", kuma_log.InfoLevel)
+
+		overrides := registry.ListOverrides()
+		Expect(overrides).To(HaveLen(2))
+		Expect(overrides["xds"]).To(Equal(kuma_log.DebugLevel))
+		Expect(overrides["kds"]).To(Equal(kuma_log.InfoLevel))
+	})
+
+	It("should return false for empty component name", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+
+		_, ok := registry.GetEffectiveLevel("")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should handle concurrent reads and writes", func() {
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			for range 1000 {
+				registry.SetLevel("xds", kuma_log.DebugLevel)
+				registry.SetLevel("kds", kuma_log.InfoLevel)
+				registry.ResetLevel("xds")
+				registry.ResetAll()
+			}
+		}()
+		for range 1000 {
+			registry.GetEffectiveLevel("xds.server")
+			registry.ListOverrides()
+		}
+		<-done
+	})
+})

--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -82,7 +82,7 @@ func (s *componentAwareSink) WithName(name string) logr.LogSink {
 	return &componentAwareSink{
 		inner:     s.inner.WithName(name),
 		name:      fullName,
-		names:     splitHierarchy(fullName),
+		names:     SplitHierarchy(fullName),
 		registry:  s.registry,
 		baseLevel: s.baseLevel,
 	}

--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -61,12 +61,6 @@ func (s *componentAwareSink) Info(level int, msg string, keysAndValues ...any) {
 }
 
 func (s *componentAwareSink) Error(err error, msg string, keysAndValues ...any) {
-	// OffLevel suppresses all output including errors
-	if len(s.names) > 0 {
-		if override, ok := s.registry.GetEffectiveLevelForNames(s.names); ok && override == OffLevel {
-			return
-		}
-	}
 	s.inner.Error(err, msg, keysAndValues...)
 }
 

--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -1,0 +1,95 @@
+package log
+
+import (
+	"github.com/go-logr/logr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// componentAwareSink wraps a logr.LogSink to add per-component log level
+// control. It intercepts WithName calls to track the hierarchical component
+// name (dot-separated) and checks the ComponentLevelRegistry on each
+// Enabled call to apply per-component level overrides.
+//
+// The inner sink must be created at maximum verbosity (-10) so that Info()
+// never filters — all filtering is done by this sink's Enabled() method.
+type componentAwareSink struct {
+	inner     logr.LogSink
+	name      string
+	names     []string // pre-computed hierarchy, most-specific first
+	registry  *ComponentLevelRegistry
+	baseLevel *zap.AtomicLevel // base level for fallback when no override
+}
+
+// NewComponentAwareSink wraps an existing LogSink with per-component level
+// awareness. The inner sink should be created at max verbosity. baseLevel
+// is used as fallback when no per-component override is set.
+func NewComponentAwareSink(inner logr.LogSink, registry *ComponentLevelRegistry, baseLevel *zap.AtomicLevel) logr.LogSink {
+	return &componentAwareSink{
+		inner:     inner,
+		registry:  registry,
+		baseLevel: baseLevel,
+	}
+}
+
+func (s *componentAwareSink) Init(info logr.RuntimeInfo) {
+	s.inner.Init(info)
+}
+
+func (s *componentAwareSink) Enabled(level int) bool {
+	if len(s.names) > 0 {
+		if override, ok := s.registry.GetEffectiveLevelForNames(s.names); ok {
+			switch override {
+			case OffLevel:
+				return false
+			case DebugLevel:
+				return level <= -maxVerbosity
+			case InfoLevel:
+				return level <= 0
+			default:
+				// unknown override — fall back to base level
+			}
+		}
+	}
+	// No override — check base level
+	// logr V-level N maps to zap level (InfoLevel - N)
+	return s.baseLevel.Enabled(zapcore.InfoLevel - zapcore.Level(level))
+}
+
+func (s *componentAwareSink) Info(level int, msg string, keysAndValues ...any) {
+	s.inner.Info(level, msg, keysAndValues...)
+}
+
+func (s *componentAwareSink) Error(err error, msg string, keysAndValues ...any) {
+	// OffLevel suppresses all output including errors
+	if len(s.names) > 0 {
+		if override, ok := s.registry.GetEffectiveLevelForNames(s.names); ok && override == OffLevel {
+			return
+		}
+	}
+	s.inner.Error(err, msg, keysAndValues...)
+}
+
+func (s *componentAwareSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return &componentAwareSink{
+		inner:     s.inner.WithValues(keysAndValues...),
+		name:      s.name,
+		names:     s.names,
+		registry:  s.registry,
+		baseLevel: s.baseLevel,
+	}
+}
+
+func (s *componentAwareSink) WithName(name string) logr.LogSink {
+	fullName := name
+	if s.name != "" {
+		fullName = s.name + "." + name
+	}
+	return &componentAwareSink{
+		inner:     s.inner.WithName(name),
+		name:      fullName,
+		names:     splitHierarchy(fullName),
+		registry:  s.registry,
+		baseLevel: s.baseLevel,
+	}
+}

--- a/pkg/log/component_sink_test.go
+++ b/pkg/log/component_sink_test.go
@@ -1,0 +1,103 @@
+package log_test
+
+import (
+	"bytes"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
+)
+
+var _ = Describe("ComponentAwareSink", func() {
+	var (
+		registry *kuma_log.ComponentLevelRegistry
+		buf      *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		registry = kuma_log.NewComponentLevelRegistry()
+		buf = &bytes.Buffer{}
+	})
+
+	newLogger := func() logr.Logger {
+		return kuma_log.NewLoggerToWithRegistry(buf, kuma_log.InfoLevel, registry)
+	}
+
+	It("should accumulate dot-separated names", func() {
+		logger := newLogger()
+		named := logger.WithName("xds").WithName("server")
+
+		// Without override, info level should work
+		named.Info("test")
+		Expect(buf.String()).To(ContainSubstring("test"))
+	})
+
+	It("should allow debug logs when component override is debug", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.V(1).Info("debug message")
+		Expect(buf.String()).To(ContainSubstring("debug message"))
+	})
+
+	It("should block debug logs when component override is info", func() {
+		registry.SetLevel("xds", kuma_log.InfoLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.V(1).Info("debug message")
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("should block all logs when component override is off", func() {
+		registry.SetLevel("xds", kuma_log.OffLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.Info("info message")
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("should apply parent override to child component", func() {
+		registry.SetLevel("xds", kuma_log.DebugLevel)
+		logger := newLogger().WithName("xds").WithName("server")
+
+		logger.V(1).Info("debug from child")
+		Expect(buf.String()).To(ContainSubstring("debug from child"))
+	})
+
+	It("should fall back to global level when no override", func() {
+		// No override set — global level is info
+		logger := newLogger().WithName("xds")
+
+		logger.V(1).Info("debug message")
+		Expect(buf.String()).To(BeEmpty())
+
+		logger.Info("info message")
+		Expect(buf.String()).To(ContainSubstring("info message"))
+	})
+
+	It("should not affect unnamed logger with overrides", func() {
+		registry.SetLevel("xds", kuma_log.OffLevel)
+		logger := newLogger()
+
+		logger.Info("root message")
+		Expect(buf.String()).To(ContainSubstring("root message"))
+	})
+
+	It("should block error logs when component override is off", func() {
+		registry.SetLevel("xds", kuma_log.OffLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.Error(nil, "error message")
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("should allow error logs when component override is info", func() {
+		registry.SetLevel("xds", kuma_log.InfoLevel)
+		logger := newLogger().WithName("xds")
+
+		logger.Error(nil, "error message")
+		Expect(buf.String()).To(ContainSubstring("error message"))
+	})
+})

--- a/pkg/log/component_sink_test.go
+++ b/pkg/log/component_sink_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ComponentAwareSink", func() {
 	})
 
 	It("should allow debug logs when component override is debug", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 		logger := newLogger().WithName("xds")
 
 		logger.V(1).Info("debug message")
@@ -43,7 +43,7 @@ var _ = Describe("ComponentAwareSink", func() {
 	})
 
 	It("should block debug logs when component override is info", func() {
-		registry.SetLevel("xds", kuma_log.InfoLevel)
+		Expect(registry.SetLevel("xds", kuma_log.InfoLevel)).To(Succeed())
 		logger := newLogger().WithName("xds")
 
 		logger.V(1).Info("debug message")
@@ -51,7 +51,7 @@ var _ = Describe("ComponentAwareSink", func() {
 	})
 
 	It("should block all logs when component override is off", func() {
-		registry.SetLevel("xds", kuma_log.OffLevel)
+		Expect(registry.SetLevel("xds", kuma_log.OffLevel)).To(Succeed())
 		logger := newLogger().WithName("xds")
 
 		logger.Info("info message")
@@ -59,7 +59,7 @@ var _ = Describe("ComponentAwareSink", func() {
 	})
 
 	It("should apply parent override to child component", func() {
-		registry.SetLevel("xds", kuma_log.DebugLevel)
+		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
 		logger := newLogger().WithName("xds").WithName("server")
 
 		logger.V(1).Info("debug from child")
@@ -78,23 +78,23 @@ var _ = Describe("ComponentAwareSink", func() {
 	})
 
 	It("should not affect unnamed logger with overrides", func() {
-		registry.SetLevel("xds", kuma_log.OffLevel)
+		Expect(registry.SetLevel("xds", kuma_log.OffLevel)).To(Succeed())
 		logger := newLogger()
 
 		logger.Info("root message")
 		Expect(buf.String()).To(ContainSubstring("root message"))
 	})
 
-	It("should block error logs when component override is off", func() {
-		registry.SetLevel("xds", kuma_log.OffLevel)
+	It("should still emit error logs when component override is off", func() {
+		Expect(registry.SetLevel("xds", kuma_log.OffLevel)).To(Succeed())
 		logger := newLogger().WithName("xds")
 
 		logger.Error(nil, "error message")
-		Expect(buf.String()).To(BeEmpty())
+		Expect(buf.String()).To(ContainSubstring("error message"))
 	})
 
 	It("should allow error logs when component override is info", func() {
-		registry.SetLevel("xds", kuma_log.InfoLevel)
+		Expect(registry.SetLevel("xds", kuma_log.InfoLevel)).To(Succeed())
 		logger := newLogger().WithName("xds")
 
 		logger.Error(nil, "error message")

--- a/pkg/log/component_sink_test.go
+++ b/pkg/log/component_sink_test.go
@@ -25,49 +25,64 @@ var _ = Describe("ComponentAwareSink", func() {
 		return kuma_log.NewLoggerToWithRegistry(buf, kuma_log.InfoLevel, registry)
 	}
 
-	It("should accumulate dot-separated names", func() {
-		logger := newLogger()
-		named := logger.WithName("xds").WithName("server")
+	type logAction struct {
+		vLevel  int
+		message string
+		isError bool
+	}
 
-		// Without override, info level should work
+	DescribeTable("per-component overrides",
+		func(overrideComponent string, overrideLevel kuma_log.LogLevel, names []string, action logAction, expectOutput bool) {
+			if overrideComponent != "" {
+				Expect(registry.SetLevel(overrideComponent, overrideLevel)).To(Succeed())
+			}
+			logger := newLogger()
+			for _, n := range names {
+				logger = logger.WithName(n)
+			}
+			if action.isError {
+				logger.Error(nil, action.message)
+			} else if action.vLevel > 0 {
+				logger.V(action.vLevel).Info(action.message)
+			} else {
+				logger.Info(action.message)
+			}
+			if expectOutput {
+				Expect(buf.String()).To(ContainSubstring(action.message))
+			} else {
+				Expect(buf.String()).To(BeEmpty())
+			}
+		},
+		Entry("debug override allows V(1) logs",
+			"xds", kuma_log.DebugLevel, []string{"xds"},
+			logAction{vLevel: 1, message: "debug message"}, true),
+		Entry("info override blocks V(1) logs",
+			"xds", kuma_log.InfoLevel, []string{"xds"},
+			logAction{vLevel: 1, message: "debug message"}, false),
+		Entry("off override blocks info logs",
+			"xds", kuma_log.OffLevel, []string{"xds"},
+			logAction{message: "info message"}, false),
+		Entry("parent override applies to child",
+			"xds", kuma_log.DebugLevel, []string{"xds", "server"},
+			logAction{vLevel: 1, message: "debug from child"}, true),
+		Entry("off override does not suppress errors",
+			"xds", kuma_log.OffLevel, []string{"xds"},
+			logAction{isError: true, message: "error message"}, true),
+		Entry("info override allows errors",
+			"xds", kuma_log.InfoLevel, []string{"xds"},
+			logAction{isError: true, message: "error message"}, true),
+		Entry("override on other component does not affect unnamed logger",
+			"xds", kuma_log.OffLevel, nil,
+			logAction{message: "root message"}, true),
+	)
+
+	It("should accumulate dot-separated names", func() {
+		named := newLogger().WithName("xds").WithName("server")
 		named.Info("test")
 		Expect(buf.String()).To(ContainSubstring("test"))
 	})
 
-	It("should allow debug logs when component override is debug", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-		logger := newLogger().WithName("xds")
-
-		logger.V(1).Info("debug message")
-		Expect(buf.String()).To(ContainSubstring("debug message"))
-	})
-
-	It("should block debug logs when component override is info", func() {
-		Expect(registry.SetLevel("xds", kuma_log.InfoLevel)).To(Succeed())
-		logger := newLogger().WithName("xds")
-
-		logger.V(1).Info("debug message")
-		Expect(buf.String()).To(BeEmpty())
-	})
-
-	It("should block all logs when component override is off", func() {
-		Expect(registry.SetLevel("xds", kuma_log.OffLevel)).To(Succeed())
-		logger := newLogger().WithName("xds")
-
-		logger.Info("info message")
-		Expect(buf.String()).To(BeEmpty())
-	})
-
-	It("should apply parent override to child component", func() {
-		Expect(registry.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
-		logger := newLogger().WithName("xds").WithName("server")
-
-		logger.V(1).Info("debug from child")
-		Expect(buf.String()).To(ContainSubstring("debug from child"))
-	})
-
-	It("should fall back to global level when no override", func() {
-		// No override set — global level is info
+	It("should fall back to base level when no override", func() {
 		logger := newLogger().WithName("xds")
 
 		logger.V(1).Info("debug message")
@@ -75,29 +90,5 @@ var _ = Describe("ComponentAwareSink", func() {
 
 		logger.Info("info message")
 		Expect(buf.String()).To(ContainSubstring("info message"))
-	})
-
-	It("should not affect unnamed logger with overrides", func() {
-		Expect(registry.SetLevel("xds", kuma_log.OffLevel)).To(Succeed())
-		logger := newLogger()
-
-		logger.Info("root message")
-		Expect(buf.String()).To(ContainSubstring("root message"))
-	})
-
-	It("should still emit error logs when component override is off", func() {
-		Expect(registry.SetLevel("xds", kuma_log.OffLevel)).To(Succeed())
-		logger := newLogger().WithName("xds")
-
-		logger.Error(nil, "error message")
-		Expect(buf.String()).To(ContainSubstring("error message"))
-	})
-
-	It("should allow error logs when component override is info", func() {
-		Expect(registry.SetLevel("xds", kuma_log.InfoLevel)).To(Succeed())
-		logger := newLogger().WithName("xds")
-
-		logger.Error(nil, "error message")
-		Expect(buf.String()).To(ContainSubstring("error message"))
 	})
 })

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -31,6 +31,11 @@ const (
 	DebugLevel
 )
 
+// maxVerbosity is the most verbose zap level used for inner loggers.
+// Setting zap to this level ensures V(1)..V(10) all pass through;
+// actual filtering happens in componentAwareSink.Enabled().
+const maxVerbosity = -10
+
 func (l LogLevel) String() string {
 	switch l {
 	case OffLevel:
@@ -71,7 +76,18 @@ func NewLoggerWithRotation(level LogLevel, outputPath string, maxSize int, maxBa
 }
 
 func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {
-	return zapr.NewLogger(newZapLoggerTo(destWriter, level))
+	return NewLoggerToWithRegistry(destWriter, level, GlobalComponentLevelRegistry())
+}
+
+// NewLoggerToWithRegistry creates a logger writing to destWriter using the
+// given registry for per-component level overrides. The inner zap logger is
+// created at max verbosity — all level filtering is done by the sink.
+func NewLoggerToWithRegistry(destWriter io.Writer, level LogLevel, registry *ComponentLevelRegistry) logr.Logger {
+	baseLevel := newAtomicLogLevel(level)
+	// Inner logger at max verbosity so Info() never filters
+	innerZap := buildZapLogger(destWriter, zap.NewAtomicLevelAt(maxVerbosity), level == DebugLevel)
+	base := zapr.NewLogger(innerZap)
+	return logr.New(NewComponentAwareSink(base.GetSink(), registry, &baseLevel))
 }
 
 // NewLoggerWithGlobalLevel creates a logger that uses the global atomic level.
@@ -79,7 +95,10 @@ func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {
 // replacing the logger instance. This is useful for early initialization
 // (e.g., in init() functions) where the final log level is not yet known.
 func NewLoggerWithGlobalLevel() logr.Logger {
-	return zapr.NewLogger(newZapLoggerWithGlobalLevel(os.Stderr))
+	verbose := defaultAtomicLevel.Level() <= zapcore.Level(maxVerbosity)
+	innerZap := buildZapLogger(os.Stderr, zap.NewAtomicLevelAt(maxVerbosity), verbose)
+	base := zapr.NewLogger(innerZap)
+	return logr.New(NewComponentAwareSink(base.GetSink(), GlobalComponentLevelRegistry(), &defaultAtomicLevel))
 }
 
 // SetGlobalLogLevel updates the global atomic log level used by loggers
@@ -95,49 +114,37 @@ func SetGlobalLogLevel(level LogLevel) {
 		// will end up being emitted through the `V(level int)`
 		// accessor. Passing -10 ensures that levels up to `V(10)`
 		// will work, which seems like plenty.
-		defaultAtomicLevel.SetLevel(zapcore.Level(-10))
+		defaultAtomicLevel.SetLevel(zapcore.Level(maxVerbosity))
 	case InfoLevel:
 		defaultAtomicLevel.SetLevel(zapcore.InfoLevel)
 	}
 }
 
-func newZapLoggerTo(destWriter io.Writer, level LogLevel, opts ...zap.Option) *zap.Logger {
-	if level == OffLevel {
-		return zap.NewNop()
-	}
-
-	// Create a new AtomicLevel for this logger
-	var lvl zap.AtomicLevel
-	var verbose bool
-
-	switch level {
-	case DebugLevel:
-		// The value we pass here is the most verbose level that
-		// will end up being emitted through the `V(level int)`
-		// accessor. Passing -10 ensures that levels up to `V(10)`
-		// will work, which seems like plenty.
-		lvl = zap.NewAtomicLevelAt(-10)
-		verbose = true
+// GetGlobalLogLevel returns the current global log level by reading the
+// atomic level used by loggers created with NewLoggerWithGlobalLevel.
+func GetGlobalLogLevel() LogLevel {
+	lvl := defaultAtomicLevel.Level()
+	switch {
+	case lvl >= zapcore.Level(100):
+		return OffLevel
+	case lvl <= zapcore.Level(maxVerbosity):
+		return DebugLevel
 	default:
-		lvl = zap.NewAtomicLevelAt(zap.InfoLevel)
-		verbose = false
+		return InfoLevel
 	}
-
-	return buildZapLogger(destWriter, lvl, verbose, opts...)
 }
 
-func newZapLoggerWithGlobalLevel(destWriter io.Writer, opts ...zap.Option) *zap.Logger {
-	// defaultAtomicLevel starts at InfoLevel (zap.NewAtomicLevel() default).
-	// The level can be changed via SetGlobalLogLevel() before or after this call.
-
-	// Note: verbose is determined at creation time based on the current level.
-	// If the level changes later via SetGlobalLogLevel(), the verbose flag
-	// (affecting KubeAwareEncoder.Verbose and stacktrace behavior) will NOT
-	// update. For kumactl's use case, this is acceptable since we only call
-	// SetGlobalLogLevel() once during flag parsing, before any logging occurs.
-	verbose := defaultAtomicLevel.Level() <= zapcore.Level(-10)
-
-	return buildZapLogger(destWriter, defaultAtomicLevel, verbose, opts...)
+func newAtomicLogLevel(level LogLevel) zap.AtomicLevel {
+	al := zap.NewAtomicLevel()
+	switch level {
+	case OffLevel:
+		al.SetLevel(zapcore.Level(100))
+	case DebugLevel:
+		al.SetLevel(zapcore.Level(maxVerbosity))
+	case InfoLevel:
+		al.SetLevel(zapcore.InfoLevel)
+	}
+	return al
 }
 
 // buildZapLogger is the common implementation for creating zap loggers.

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -83,6 +83,9 @@ func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {
 // given registry for per-component level overrides. The inner zap logger is
 // created at max verbosity — all level filtering is done by the sink.
 func NewLoggerToWithRegistry(destWriter io.Writer, level LogLevel, registry *ComponentLevelRegistry) logr.Logger {
+	if level == OffLevel {
+		return logr.Discard()
+	}
 	baseLevel := newAtomicLogLevel(level)
 	// Inner logger at max verbosity so Info() never filters
 	innerZap := buildZapLogger(destWriter, zap.NewAtomicLevelAt(maxVerbosity), level == DebugLevel)
@@ -117,20 +120,6 @@ func SetGlobalLogLevel(level LogLevel) {
 		defaultAtomicLevel.SetLevel(zapcore.Level(maxVerbosity))
 	case InfoLevel:
 		defaultAtomicLevel.SetLevel(zapcore.InfoLevel)
-	}
-}
-
-// GetGlobalLogLevel returns the current global log level by reading the
-// atomic level used by loggers created with NewLoggerWithGlobalLevel.
-func GetGlobalLogLevel() LogLevel {
-	lvl := defaultAtomicLevel.Level()
-	switch {
-	case lvl >= zapcore.Level(100):
-		return OffLevel
-	case lvl <= zapcore.Level(maxVerbosity):
-		return DebugLevel
-	default:
-		return InfoLevel
 	}
 }
 


### PR DESCRIPTION
## Motivation

When debugging issues in production, the only option is setting the global log level to `debug`, flooding logs from all 188+ components. This makes it hard to find relevant info and impacts performance. Operators need targeted debugging for specific components (e.g. only KDS or XDS) without the noise.

Resolves #16095

## Implementation information

**Registry-aware LogSink wrapper** — zero changes to existing `core.Log.WithName()` call sites.

- `ComponentLevelRegistry` (`pkg/log/component_level.go`) — thread-safe map of component name → log level with hierarchical lookup (setting `xds` to debug also applies to `xds.server`, `xds.secrets`, etc.)
- `componentAwareSink` (`pkg/log/component_sink.go`) — custom `logr.LogSink` wrapping zapr. Intercepts `WithName()` to track dot-separated component names, `Enabled()` to check registry overrides. Inner zap logger runs at max verbosity; all level filtering happens in the sink
- HTTP API (`pkg/api-server/logging_endpoint.go`):
  - `GET /logging` — list global level + all component overrides
  - `PUT /logging` — set component or global level
  - `DELETE /logging/{component}` — reset one override
  - `DELETE /logging` — reset all overrides
- Overrides are in-memory only (lost on restart) — this is a runtime debugging tool

> Changelog: feat(kuma-cp): component based logging
