### PR TITLE
fix(api): add KRI support for Zone resource

### DIFF
--- a/api/system/v1alpha1/zone.pb.go
+++ b/api/system/v1alpha1/zone.pb.go
@@ -75,11 +75,11 @@ var File_api_system_v1alpha1_zone_proto protoreflect.FileDescriptor
 
 const file_api_system_v1alpha1_zone_proto_rawDesc = "" +
 	"\n" +
-	"\x1eapi/system/v1alpha1/zone.proto\x12\x14kuma.system.v1alpha1\x1a\x16api/mesh/options.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xa4\x01\n" +
+	"\x1eapi/system/v1alpha1/zone.proto\x12\x14kuma.system.v1alpha1\x1a\x16api/mesh/options.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xa8\x01\n" +
 	"\x04Zone\x124\n" +
-	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled:f\xaa\x8c\x89\xa6\x01`\n" +
+	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled:j\xaa\x8c\x89\xa6\x01d\n" +
 	"\fZoneResource\x12\x04Zone\x18\x01\"\x06system:\x06\n" +
-	"\x04zoneR5model.ProvidedByGlobalFlag | model.ProvidedByZoneFlag\x90\x01\x01B/Z-github.com/kumahq/kuma/v2/api/system/v1alpha1b\x06proto3"
+	"\x04zoneR5model.ProvidedByGlobalFlag | model.ProvidedByZoneFlag\x90\x01\x01\x9a\x01\x01zB/Z-github.com/kumahq/kuma/v2/api/system/v1alpha1b\x06proto3"
 
 var (
 	file_api_system_v1alpha1_zone_proto_rawDescOnce sync.Once

--- a/api/system/v1alpha1/zone.proto
+++ b/api/system/v1alpha1/zone.proto
@@ -19,6 +19,7 @@ message Zone {
   // synced
   option (kuma.mesh.resource).kds = "model.ProvidedByGlobalFlag | model.ProvidedByZoneFlag";
   option (kuma.mesh.resource).has_insights = true;
+  option (kuma.mesh.resource).short_name = "z";
 
   // enable allows to turn the zone on/off and exclude the whole zone from
   // balancing traffic on it

--- a/app/kumactl/cmd/get/testdata/list/get-zones.golden.json
+++ b/app/kumactl/cmd/get/testdata/list/get-zones.golden.json
@@ -5,13 +5,15 @@
       "type": "Zone",
       "name": "zone-1",
       "creationTime": "0001-01-01T00:00:00Z",
-      "modificationTime": "0001-01-01T00:00:00Z"
+      "modificationTime": "0001-01-01T00:00:00Z",
+      "kri": "kri_z____zone-1_"
     },
     {
       "type": "Zone",
       "name": "zone-2",
       "creationTime": "0001-01-01T00:00:00Z",
-      "modificationTime": "0001-01-01T00:00:00Z"
+      "modificationTime": "0001-01-01T00:00:00Z",
+      "kri": "kri_z____zone-2_"
     }
   ],
   "next": null

--- a/app/kumactl/cmd/get/testdata/list/get-zones.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/list/get-zones.golden.yaml
@@ -1,9 +1,11 @@
 items:
 - creationTime: "0001-01-01T00:00:00Z"
+  kri: kri_z____zone-1_
   modificationTime: "0001-01-01T00:00:00Z"
   name: zone-1
   type: Zone
 - creationTime: "0001-01-01T00:00:00Z"
+  kri: kri_z____zone-2_
   modificationTime: "0001-01-01T00:00:00Z"
   name: zone-2
   type: Zone

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -9765,6 +9765,8 @@ spec:
     kind: Zone
     listKind: ZoneList
     plural: zones
+    shortNames:
+    - z
     singular: zone
   scope: Cluster
   versions:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -9765,6 +9765,8 @@ spec:
     kind: Zone
     listKind: ZoneList
     plural: zones
+    shortNames:
+    - z
     singular: zone
   scope: Cluster
   versions:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -9785,6 +9785,8 @@ spec:
     kind: Zone
     listKind: ZoneList
     plural: zones
+    shortNames:
+    - z
     singular: zone
   scope: Cluster
   versions:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -11777,6 +11777,8 @@ spec:
     kind: Zone
     listKind: ZoneList
     plural: zones
+    shortNames:
+    - z
     singular: zone
   scope: Cluster
   versions:

--- a/deployments/charts/kuma/crds/kuma.io_zones.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_zones.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Zone
     listKind: ZoneList
     plural: zones
+    shortNames:
+    - z
     singular: zone
   scope: Cluster
   versions:

--- a/docs/generated/raw/crds/kuma.io_zones.yaml
+++ b/docs/generated/raw/crds/kuma.io_zones.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Zone
     listKind: ZoneList
     plural: zones
+    shortNames:
+    - z
     singular: zone
   scope: Cluster
   versions:

--- a/pkg/api-server/testdata/base_endpoints/_resources.golden.json
+++ b/pkg/api-server/testdata/base_endpoints/_resources.golden.json
@@ -680,7 +680,7 @@
    "pluralDisplayName": "Zones",
    "readOnly": false,
    "scope": "Global",
-   "shortName": "",
+   "shortName": "z",
    "singularDisplayName": "Zone"
   },
   {

--- a/pkg/core/resources/apis/system/zz_generated.resources.go
+++ b/pkg/core/resources/apis/system/zz_generated.resources.go
@@ -360,6 +360,7 @@ var ZoneResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	IsPolicy:            false,
 	SingularDisplayName: "Zone",
 	PluralDisplayName:   "Zones",
+	ShortName:           "z",
 	IsExperimental:      false,
 	IsProxy:             false,
 	Insight:             NewZoneInsightResource(),

--- a/pkg/kds/context/testdata/full_sync/mesh-only/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-only/global.golden.yaml
@@ -10,6 +10,7 @@ type: Mesh
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-1_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-1
 type: Zone
@@ -17,6 +18,7 @@ type: Zone
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-2_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-2
 type: Zone

--- a/pkg/kds/context/testdata/full_sync/mesh-service/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/global.golden.yaml
@@ -85,6 +85,7 @@ type: MeshService
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-1_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-1
 type: Zone
@@ -92,6 +93,7 @@ type: Zone
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-2_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-2
 type: Zone

--- a/pkg/kds/context/testdata/full_sync/policy-simple/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/policy-simple/global.golden.yaml
@@ -49,6 +49,7 @@ type: MeshTimeout
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-1_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-1
 type: Zone
@@ -56,6 +57,7 @@ type: Zone
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-2_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-2
 type: Zone

--- a/pkg/kds/context/testdata/full_sync/policy-with-kds-disabled/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/policy-with-kds-disabled/global.golden.yaml
@@ -30,6 +30,7 @@ type: MeshTimeout
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-1_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-1
 type: Zone
@@ -37,6 +38,7 @@ type: Zone
 ---
 creationTime: "0001-01-01T00:00:00Z"
 enabled: true
+kri: kri_z____zone-2_
 modificationTime: "0001-01-01T00:00:00Z"
 name: zone-2
 type: Zone

--- a/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
+++ b/pkg/plugins/resources/k8s/native/api/v1alpha1/zz_generated.system.go
@@ -18,7 +18,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=kuma,scope=Cluster
+// +kubebuilder:resource:categories=kuma,scope=Cluster,shortName=z
 type Zone struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
## Motivation

Zone resource is missing KRI (Kuma Resource Identifier) support (#16000). The `/_resources` endpoint lists Zone with an empty `shortName`, the `/_kri/{kri}` endpoint returns 400 for Zone KRIs, and zone overview responses omit the `kri` field.

Root cause: the `short_name` proto option was not set on the Zone message.

## Implementation information

Added `short_name = "z"` to `api/system/v1alpha1/zone.proto` and regenerated all dependent files. This follows the existing pattern used by other resources (Mesh=`m`, Dataplane=`dp`, ZoneEgress=`ze`, ZoneIngress=`zi`).

All existing KRI infrastructure (overview endpoints, REST marshaling, KRI parsing) already handles Zone correctly once the short name is present — no code changes beyond the proto option were needed.

## Supporting documentation

Closes #16000

> Changelog: fix(api): add KRI support for Zone resource