### PR TITLE
fix(meshfaultinjection): deprecate spec.from field

### DIFF
--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/deprecated.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/jsonpatch/validators"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
@@ -9,12 +8,7 @@ import (
 func (t *MeshFaultInjectionResource) Deprecations() []string {
 	var deprecations []string
 	if len(pointer.Deref(t.Spec.From)) > 0 {
-		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' instead")
-		for _, f := range pointer.Deref(t.Spec.From) {
-			if f.GetTargetRef().Kind == v1alpha1.MeshService {
-				deprecations = append(deprecations, "MeshService value for 'from[].targetRef.kind' is deprecated, use MeshSubset with 'kuma.io/service' instead")
-			}
-		}
+		deprecations = append(deprecations, "'from' field is deprecated, use 'rules' with SPIFFE-based 'matches' instead")
 	}
 	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
 }


### PR DESCRIPTION
## Motivation

`spec.from` in MeshFaultInjection is superseded by `spec.rules` which provides equivalent functionality. Deprecating `spec.from` steers users toward the preferred API.

## Implementation information

Added `'from' field is deprecated, use 'rules' instead` deprecation warning when `spec.from` is non-empty, consistent with the pattern used in MeshTimeout, MeshRateLimit, and other policies. Existing MeshService-kind deprecation warning is preserved and nested inside the `from` check.

## Supporting documentation

Fix #12380

> Changelog: fix(meshfaultinjection): deprecate spec.from field