### PR TITLE
chore(build): migrate to use oidc token

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: cloudsmith-io/cloudsmith-cli-action@18665afcce9f859312b61989671af9af7402e4fb # v2.0.2
         with:
           oidc-namespace: kong
-          oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_ACCOUNT }}
+          oidc-service-slug: ${{ contains(inputs.VERSION_NAME, 'preview') && vars.CLOUDSMITH_PREVIEW_SERVICE_ACCOUNT || vars.CLOUDSMITH_PROD_SERVICE_ACCOUNT }}
           oidc-auth-only: true
       - name: publish binaries
         env:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -233,7 +233,7 @@ jobs:
         uses: cloudsmith-io/cloudsmith-cli-action@18665afcce9f859312b61989671af9af7402e4fb # v2.0.2
         with:
           oidc-namespace: kong
-          oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_ACCOUNT }}
+          oidc-service-slug: ${{ contains(needs.check.outputs.VERSION_NAME, 'preview') && vars.CLOUDSMITH_PREVIEW_SERVICE_ACCOUNT || vars.CLOUDSMITH_PROD_SERVICE_ACCOUNT }}
           oidc-auth-only: true
       - name: Push security assets to cloudsmith
         id: push_security_assets


### PR DESCRIPTION
## Motivation

We want to switch to using OIDC instead of token

## Implementation information

Switch workflow to use OIDC instead of token
* created 2 envs one for preview and one for release

