### PR TITLE
fix(meshaccesslog): skip dangling otel backendRef

### DIFF
--- a/pkg/envoy/builders/listener/listener.go
+++ b/pkg/envoy/builders/listener/listener.go
@@ -18,6 +18,9 @@ func AccessLogs(builders []*Builder[envoy_accesslog.AccessLog]) Configurer[envoy
 	return func(l *envoy_listener.Listener) error {
 		accessLogs := []*envoy_accesslog.AccessLog{}
 		for _, b := range builders {
+			if b == nil {
+				continue
+			}
 			al, err := b.Build()
 			if err != nil {
 				return err

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -428,7 +428,11 @@ func applyToRealResource(
 	})) > 0
 
 	builderForSharedBackend := func(b api.Backend) *Builder[envoy_accesslog.AccessLog] {
-		return BaseAccessLogBuilder(b, defaultFormat, backendsAcc, kumaValues, accessLogSocketPath).
+		base := BaseAccessLogBuilder(b, defaultFormat, backendsAcc, kumaValues, accessLogSocketPath)
+		if base == nil {
+			return nil
+		}
+		return base.
 			Configure(If(core_meta.IsHTTPBased(r.Protocol), bldrs_accesslog.MetadataFilter(true, bldrs_matcher.NewMetadataBuilder().
 				Configure(bldrs_matcher.Key(namespace, routeMetadataKey)).
 				Configure(bldrs_matcher.NullValue())),
@@ -437,7 +441,11 @@ func applyToRealResource(
 
 	builderForRouteBackend := func(routeID kri.Identifier) func(b api.Backend) *Builder[envoy_accesslog.AccessLog] {
 		return func(b api.Backend) *Builder[envoy_accesslog.AccessLog] {
-			return BaseAccessLogBuilder(b, defaultFormat, backendsAcc, kumaValues, accessLogSocketPath).
+			base := BaseAccessLogBuilder(b, defaultFormat, backendsAcc, kumaValues, accessLogSocketPath)
+			if base == nil {
+				return nil
+			}
+			return base.
 				Configure(bldrs_accesslog.MetadataFilter(false, bldrs_matcher.NewMetadataBuilder().
 					Configure(bldrs_matcher.Key(namespace, routeMetadataKey)).
 					Configure(bldrs_matcher.ExactValue(routeID.String()))))

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -991,6 +991,100 @@ var _ = Describe("MeshAccessLog", func() {
 		Expect(backends[0].Logs.Enabled).To(BeTrue())
 	})
 
+	It("should skip access log for dangling opentelemetry backendRef", func() {
+		resourceSet := core_xds.NewResourceSet()
+		outboundListener := outboundServiceTCPListener("other-service-tcp", 37777)
+		resourceSet.Add(&outboundListener)
+
+		// No MOTB resources - the backendRef will be dangling
+		meshResources := xds_context.NewResources()
+		meshResources.MeshLocalResources[motb_api.MeshOpenTelemetryBackendType] = &motb_api.MeshOpenTelemetryBackendResourceList{
+			Items: []*motb_api.MeshOpenTelemetryBackendResource{},
+		}
+
+		xdsCtx := *xds_builders.Context().
+			WithMeshBuilder(samples.MeshDefaultBuilder()).
+			WithResources(meshResources).
+			WithEndpointMap(
+				xds_builders.EndpointMap().
+					AddEndpoint("backend", xds_builders.Endpoint().WithTags("kuma.io/service", "backend")).
+					AddEndpoint("other-service-tcp", xds_builders.Endpoint().WithTags("kuma.io/service", "other-service-tcp")),
+			).
+			AddServiceProtocol("backend", core_meta.ProtocolHTTP).
+			AddServiceProtocol("other-service-tcp", core_meta.ProtocolTCP).
+			Build()
+
+		proxy := xds_builders.Proxy().
+			WithID(*core_xds.BuildProxyId("default", "backend")).
+			WithMetadata(&core_xds.DataplaneMetadata{
+				WorkDir: "/tmp",
+				Features: xds_types.Features{
+					xds_types.FeatureOtelViaKumaDp: true,
+				},
+			}).
+			WithDataplane(
+				builders.Dataplane().
+					WithName("backend").
+					WithMesh("default").
+					AddInbound(builders.Inbound().
+						WithService("backend").
+						WithAddress("127.0.0.1").
+						WithPort(17777).
+						WithTags(map[string]string{
+							mesh_proto.ProtocolTag: "http",
+						}),
+					),
+			).
+			WithOutbounds(xds_types.Outbounds{
+				{
+					LegacyOutbound: builders.Outbound().
+						WithService("other-service-tcp").
+						WithAddress("127.0.0.1").
+						WithPort(37777).Build(),
+				},
+			}).
+			WithPolicies(xds_builders.MatchedPolicies().WithPolicy(api.MeshAccessLogType, core_rules.ToRules{
+				Rules: []*core_rules.Rule{ //nolint:staticcheck // SA1019 Test: backward compat with deprecated Rule
+					{
+						Subset: subsetutils.Subset{{
+							Key:   mesh_proto.ServiceTag,
+							Value: "other-service-tcp",
+						}},
+						Conf: api.Conf{
+							Backends: &[]api.Backend{{
+								OpenTelemetry: &api.OtelBackend{
+									BackendRef: &common_api.BackendResourceRef{
+										Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+										Labels: map[string]string{"kuma.io/display-name": "non-existent-backend"},
+									},
+								},
+							}},
+						},
+					},
+				},
+			}, core_rules.FromRules{})).
+			WithInternalAddresses(core_xds.InternalAddress{AddressPrefix: "172.16.0.0", PrefixLen: 12}, core_xds.InternalAddress{AddressPrefix: "fc00::", PrefixLen: 7}).
+			Build()
+
+		proxy.OtelPipeBackends = &core_xds.OtelPipeBackends{}
+
+		meshAccessLogPlugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
+		Expect(meshAccessLogPlugin.Apply(resourceSet, xdsCtx, proxy)).To(Succeed())
+
+		// No clusters should be created for the dangling backendRef
+		clusterResources, err := util_yaml.GetResourcesToYaml(resourceSet, envoy_resource.ClusterType)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.TrimSpace(string(clusterResources))).To(Equal("{}"))
+
+		// No pipe backends should be accumulated
+		Expect(proxy.OtelPipeBackends.Empty()).To(BeTrue())
+
+		// The listener must still be valid - no partial access_log entries
+		listenerResources, err := util_yaml.GetResourcesToYaml(resourceSet, envoy_resource.ListenerType)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(listenerResources)).ToNot(ContainSubstring("open_telemetry"))
+	})
+
 	type gatewayTestCase struct {
 		routes []*core_mesh.MeshGatewayRouteResource
 		rules  core_rules.GatewayRules

--- a/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go
@@ -48,6 +48,18 @@ func BaseAccessLogBuilder(
 	values listeners_v3.KumaValues,
 	accessLogSocketPath string,
 ) *Builder[envoy_accesslog.AccessLog] {
+	// Pre-resolve OTel endpoint so we can skip the entire access log entry
+	// when the backendRef is dangling. Without this, the builder produces an
+	// empty AccessLog that downstream configurers (MetadataFilter) still
+	// write to, causing Envoy to reject the listener.
+	var otelEndpoint *LoggingEndpoint
+	if backend.OpenTelemetry != nil {
+		otelEndpoint = resolveOtelLoggingEndpoint(backend.OpenTelemetry, backendsAcc)
+		if otelEndpoint == nil && backend.Tcp == nil && backend.File == nil {
+			return nil
+		}
+	}
+
 	return bldrs_accesslog.NewBuilder().
 		Configure(IfNotNil(backend.Tcp, func(tcpBackend api.TCPBackend) Configurer[envoy_accesslog.AccessLog] {
 			return bldrs_accesslog.Config(envoy_wellknown.FileAccessLog, bldrs_accesslog.NewFileBuilder().
@@ -59,18 +71,14 @@ func BaseAccessLogBuilder(
 				Configure(FileBackendSFS(&fileBackend, defaultFormat, values)).
 				Configure(bldrs_accesslog.Path(fileBackend.Path)))
 		})).
-		Configure(IfNotNil(backend.OpenTelemetry, func(otelBackend api.OtelBackend) Configurer[envoy_accesslog.AccessLog] {
-			endpoint := resolveOtelLoggingEndpoint(&otelBackend, backendsAcc)
-			if endpoint == nil {
-				return func(*envoy_accesslog.AccessLog) error { return nil }
-			}
+		Configure(IfNotNil(otelEndpoint, func(endpoint LoggingEndpoint) Configurer[envoy_accesslog.AccessLog] {
 			return bldrs_accesslog.Config("envoy.access_loggers.open_telemetry", bldrs_accesslog.NewOtelBuilder().
-				Configure(OtelBody(&otelBackend, defaultFormat, values)).
-				Configure(OtelAttributes(&otelBackend, values)).
+				Configure(OtelBody(backend.OpenTelemetry, defaultFormat, values)).
+				Configure(OtelAttributes(backend.OpenTelemetry, values)).
 				Configure(OtelResourceAttributes(values)).
 				Configure(bldrs_accesslog.CommonConfig(
 					"MeshAccessLog",
-					string(backendsAcc.ClusterForEndpoint(*endpoint)),
+					string(backendsAcc.ClusterForEndpoint(endpoint)),
 				)))
 		}))
 }


### PR DESCRIPTION
## Motivation

When a MeshAccessLog references a MeshOpenTelemetryBackend backendRef that doesn't exist (not synced, deleted, typo in labels), the OTel endpoint resolves to nil. The old code returned a no-op configurer but left the AccessLog entry in the filter chain. Downstream configurers like MetadataFilter still attached to it, and Envoy NACKed the listener.

## Implementation information

`BaseAccessLogBuilder` returns nil early when the only backend is OTel and the endpoint can't be resolved. Both call sites in `plugin.go` check for nil before chaining configurers, and the `AccessLogs` builder in `listener.go` skips nil entries.

This doesn't remove the backend from the policy or fake an endpoint - just the narrowest fix to keep the listener valid while the backendRef stays unresolvable.