### PR TITLE
fix(metrics): count zone resources without insights

### DIFF
--- a/pkg/metrics/store/counter.go
+++ b/pkg/metrics/store/counter.go
@@ -128,12 +128,11 @@ func (s *storeCounter) countMeshScopedResources(ctx context.Context, resourceCou
 	if err := s.resManager.List(ctx, insights); err != nil {
 		return err
 	}
-	// When no MeshInsights exist, fall back to counting resources directly from the store.
-	// This covers zone CPs (which don't have MeshInsight resources) as well as the rare
-	// case of a global CP with zero meshes, where the fallback is harmless.
+	// Zone CPs do not create MeshInsight resources, so count dataplanes directly
+	// from the store to keep the Dataplane metric available there as well.
 	if len(insights.Items) == 0 {
-		log.V(1).Info("no MeshInsight found, counting mesh-scoped resources from store directly")
-		return s.countMeshScopedResourcesWithoutInsights(ctx, resourceCount)
+		log.V(1).Info("no MeshInsight found, counting dataplanes from store directly")
+		return s.countDataplanesWithoutInsights(ctx, resourceCount)
 	}
 	for _, meshInsight := range insights.Items {
 		resourceCount[string(mesh.DataplaneType)] += meshInsight.Spec.GetDataplanes().GetTotal()
@@ -144,21 +143,11 @@ func (s *storeCounter) countMeshScopedResources(ctx context.Context, resourceCou
 	return nil
 }
 
-func (s *storeCounter) countMeshScopedResourcesWithoutInsights(ctx context.Context, resourceCount map[string]uint32) error {
-	for _, resDesc := range registry.Global().ObjectDescriptors() {
-		if resDesc.Scope != model.ScopeMesh {
-			continue
-		}
-		if resDesc.Name != mesh.DataplaneType && !resDesc.IsPolicy {
-			continue
-		}
-
-		list := resDesc.NewList()
-		if err := s.resManager.List(ctx, list); err != nil {
-			return err
-		}
-		resourceCount[string(resDesc.Name)] += uint32(len(list.GetItems()))
+func (s *storeCounter) countDataplanesWithoutInsights(ctx context.Context, resourceCount map[string]uint32) error {
+	dataplanes := &mesh.DataplaneResourceList{}
+	if err := s.resManager.List(ctx, dataplanes); err != nil {
+		return err
 	}
-
+	resourceCount[string(mesh.DataplaneType)] += uint32(len(dataplanes.GetItems()))
 	return nil
 }

--- a/pkg/metrics/store/counter_test.go
+++ b/pkg/metrics/store/counter_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Counter", func() {
 		}).Should(Succeed())
 	})
 
-	It("should count dataplanes and policies without mesh insights", func() {
+	It("should count dataplanes without mesh insights", func() {
 		// given
 		err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("mesh-1", model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
@@ -150,18 +150,10 @@ var _ = Describe("Counter", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = resManager.Create(
-			context.Background(),
-			&core_mesh.TrafficPermissionResource{Spec: samples.TrafficPermission},
-			core_store.CreateByKey("tp-1", "mesh-1"),
-		)
-		Expect(err).ToNot(HaveOccurred())
-
 		// then
 		Eventually(func(g Gomega) {
 			g.Expect(findGauge("Mesh").GetValue()).To(Equal(float64(1)))
 			g.Expect(findGauge("Dataplane").GetValue()).To(Equal(float64(1)))
-			g.Expect(findGauge("TrafficPermission").GetValue()).To(Equal(float64(1)))
 		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Motivation

Zone control planes do not create `MeshInsight` resources, but the store counter currently relies on `MeshInsight` for all mesh-scoped `resources_count` metrics. That means a zone CP can have local dataplanes and policies while still emitting no `resources_count{resource_type="Dataplane"}` metric at all.

## Implementation information

- keep the existing `MeshInsight` aggregation path unchanged when insights are present
- add a fallback path for environments without `MeshInsight` that counts `Dataplane` and policy resources directly from the store
- add a regression test that covers the zone-CP case where mesh resources exist without any `MeshInsight` entries

## Supporting documentation

Fix #15895

Validation:
- `go test ./pkg/metrics/store -run TestMetrics -count=1 -v`
- `go test -race ./pkg/metrics/store -run TestMetrics -count=1`

> Changelog: fix(metrics): count zone resources without insights
