### PR TITLE
chore(goldenfiles): fix helm-values for testdata input

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,12 +52,12 @@
       " Without this, Renovate updates *.golden.yaml files (via the kubernetes manager, which",
       " detects the full 'image: <ref>' format) but leaves the values input files behind,",
       " causing helm-render test failures because the rendered output no longer matches the",
-      " golden file. The default pattern (^|/)values\\.ya?ml$ is preserved so that existing",
+      " golden file. The default pattern /(^|/)values\\.ya?ml$/ is preserved so that existing",
       " chart values.yaml files continue to be processed"
     ],
     "managerFilePatterns": [
-      "(^|/)values\\.ya?ml$",
-      "app/kumactl/cmd/install/testdata/install-cp-helm/.+\\.values\\.ya?ml$"
+      "/(^|/)values\\.ya?ml$/",
+      "/app/kumactl/cmd/install/testdata/install-cp-helm/.+\\.values\\.ya?ml$/"
     ]
   },
   "customManagers": [


### PR DESCRIPTION
## Motivation

Renovate bumped `registry.k8s.io/pause` in PR #16115 but only updated `*.golden.yaml` files. The `*.values.yaml` input files were left behind with stale tags, causing helm-render test failures.

`*.golden.yaml` files contain full `image: registry.k8s.io/pause:3.10` inline references, detected by the `kubernetes` manager. The `*.values.yaml` files use split helm format (`registry/repository/tag` sub-keys), which only the `helm-values` manager handles - and no manager was configured to cover the testdata values files.

## Implementation information

Extend `helm-values` `managerFilePatterns` to include `app/kumactl/cmd/install/testdata/install-cp-helm/*.values.yaml`. The helm-values manager natively handles split format and correctly applies `pinDigest` without needing `autoReplaceStringTemplate`.

The existing grouping rule already covers these paths, so both files land in the same PR.

> Changelog: skip