### PR TITLE
fix(goldenfiles): update helm golden for admin UDS

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -651,6 +651,8 @@ spec:
               value: "false"
             - name: KUMA_API_SERVER_READ_ONLY
               value: "true"
+            - name: KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET
+              value: "true"
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
               value: "false"
             - name: KUMA_DP_SERVER_HDS_ENABLED


### PR DESCRIPTION
## Motivation

The `feat(bootstrap): admin API UDS support` (#15795) added `KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET` env var but missed updating the `meshZoneProxyMultipleMeshes.golden.yaml` helm test golden file, causing `test_unit` CI to fail on master.

## Implementation information

Regenerated golden file with `UPDATE_GOLDEN_FILES=true make test`.

> Changelog: skip