### PR TITLE
test(helm): update meshZoneProxy golden file

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -651,6 +651,8 @@ spec:
               value: "false"
             - name: KUMA_API_SERVER_READ_ONLY
               value: "true"
+            - name: KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET
+              value: "true"
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
               value: "false"
             - name: KUMA_DP_SERVER_HDS_ENABLED


### PR DESCRIPTION
## Motivation

The golden file `meshZoneProxyMultipleMeshes.golden.yaml` was missing the `KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET` env var added in https://github.com/kumahq/kuma/pull/15795, causing unit tests to fail on master.

## Implementation information

Added the missing env var to the golden file.

## Supporting documentation

Broken by https://github.com/kumahq/kuma/pull/15795

> Changelog: skip