### PR TITLE
fix(e2e): use stable metric in MeshMetric profile test

### DIFF
--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -440,8 +440,8 @@ func MeshMetric() {
 			g.Expect(stdout).ToNot(BeNil())
 			// metric from envoy
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_circuit_breakers_default_remaining_cx")) // from basic
-			g.Expect(stdout).To(ContainSubstring("envoy_cluster_default_total_match_count")) // from include
-			g.Expect(stdout).To(Not(ContainSubstring("envoy_cluster_lb_healthy_panic")))     // from exclude
+			g.Expect(stdout).To(ContainSubstring("envoy_cluster_default_total_match_count"))             // from include
+			g.Expect(stdout).To(Not(ContainSubstring("envoy_cluster_lb_healthy_panic")))                 // from exclude
 		}).Should(Succeed())
 	})
 


### PR DESCRIPTION
## Motivation

`envoy_cluster_upstream_cx_active` only appears after connection pools are created (after traffic flows). In sidecar containers mode, timing differs, causing consistent 30s timeouts on the 'Basic MeshMetric policy with profiles exposes correct Envoy metrics' test.

Discovered while bumping kuma in Kong Mesh after #15795 (admin UDS support).

## Implementation information

Replace `envoy_cluster_upstream_cx_active` with `envoy_cluster_circuit_breakers_default_remaining_cx` — this metric is present for every cluster immediately, regardless of traffic, making it a stable signal for the "basic profile metrics are exposed" assertion.

> Changelog: skip