### PR TITLE
fix(xds): eliminate TOCTOU race in OnProxyDisconnected

### DIFF
--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -66,16 +66,14 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 }
 
 func (t *dataplaneSyncTracker) OnProxyDisconnected(_ context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey) {
-	t.RLock()
+	t.Lock()
 	dpData := t.watchdogs[dpKey]
-	t.RUnlock()
+	delete(t.watchdogs, dpKey)
+	t.Unlock()
 
 	if dpData != nil {
 		dpData.cancelFunc()
 		<-dpData.stopped
 		dataplaneSyncTrackerLog.V(1).Info("watchdog for a Dataplane stopped", "dpKey", dpKey, "streamID", streamID)
-		t.Lock()
-		defer t.Unlock()
-		delete(t.watchdogs, dpKey)
 	}
 }

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -192,6 +192,71 @@ var _ = Describe("Sync", func() {
 			Expect(activeWatchdogs.Load()).To(Equal(int32(0)))
 		})
 
+		It("should not delete new watchdog when old disconnect races with new connect (TOCTOU)", test.Within(10*time.Second, func() {
+			// afterCancel is signalled when a watchdog's ctx is cancelled but before it finishes.
+			// barrier controls when the watchdog goroutine is actually allowed to complete.
+			// This lets us force the interleaving: OnProxyConnected for stream 2 runs while
+			// stream 1's OnProxyDisconnected has already released the lock (delete done) but
+			// is still blocking on <-dpData.stopped — exactly the original TOCTOU window.
+			//
+			// Note: this test calls the tracker directly (not through xdsCallbacks) because
+			// xdsCallbacks.activeStreams serialises connect/disconnect and would prevent the
+			// concurrent calls needed to reproduce the race.
+			afterCancel := make(chan struct{}, 1)
+			barrier := make(chan struct{})
+			var activeWatchdogs atomic.Int32
+
+			tracker := NewDataplaneSyncTracker(sync.DataplaneWatchdogFactoryFunc(func(key core_model.ResourceKey, _ *core_xds.DataplaneMetadata) util_xds_v3.Watchdog {
+				return util_xds_v3.WatchdogFunc(func(ctx context.Context) {
+					activeWatchdogs.Add(1)
+					<-ctx.Done()
+					select {
+					case afterCancel <- struct{}{}:
+					default:
+					}
+					<-barrier
+					activeWatchdogs.Add(-1)
+				})
+			}))
+
+			dpKey := core_model.ResourceKey{Mesh: "default", Name: "backend-01"}
+			streamCtx := context.Background()
+			meta := core_xds.DataplaneMetadata{}
+
+			// Connect stream 1 and wait for its watchdog to start.
+			Expect(tracker.OnProxyConnected(1, dpKey, streamCtx, meta)).To(Succeed())
+			Eventually(activeWatchdogs.Load, "5s", "10ms").Should(Equal(int32(1)))
+
+			// Start disconnect in background; it blocks on <-dpData.stopped until we release barrier.
+			disconnectDone := make(chan struct{})
+			go func() {
+				defer close(disconnectDone)
+				tracker.OnProxyDisconnected(streamCtx, 1, dpKey)
+			}()
+
+			// Wait until watchdog 1 is past ctx.Done() and blocked on barrier.
+			// At this point OnProxyDisconnected has released the lock (delete already performed).
+			Eventually(afterCancel, "5s", "10ms").Should(Receive())
+
+			// Connect stream 2 for the same dpKey while the old disconnect is still in flight.
+			// Pre-fix code read the entry under RLock then deleted under a separate Lock, so
+			// OnProxyConnected could insert state2 in the gap and OnProxyDisconnected would
+			// then delete it. The fix atomically captures-and-deletes under a single Lock, so
+			// OnProxyConnected's state2 is safe.
+			Expect(tracker.OnProxyConnected(2, dpKey, streamCtx, meta)).To(Succeed())
+
+			// Unblock watchdog 1 so the first disconnect can complete.
+			close(barrier)
+			Eventually(disconnectDone, "5s", "10ms").Should(BeClosed())
+
+			// Stream 2's watchdog must still be running; it must not have been leaked or deleted.
+			Eventually(activeWatchdogs.Load, "5s", "10ms").Should(Equal(int32(1)))
+
+			// Disconnect stream 2 — must properly cancel watchdog 2 with no goroutine leak.
+			tracker.OnProxyDisconnected(streamCtx, 2, dpKey)
+			Eventually(activeWatchdogs.Load, "5s", "10ms").Should(Equal(int32(0)))
+		}))
+
 		It("should pass stream context to watchdog factory when supported", test.Within(5*time.Second, func() {
 			streamCtxCh := make(chan context.Context, 1)
 			watchdogDone := make(chan struct{})

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -193,14 +193,14 @@ var _ = Describe("Sync", func() {
 		})
 
 		It("should not delete new watchdog when old disconnect races with new connect (TOCTOU)", test.Within(10*time.Second, func() {
-			// afterCancel is signalled when a watchdog's ctx is cancelled but before it finishes.
+			// afterCancel is signaled when a watchdog's ctx is cancelled but before it finishes.
 			// barrier controls when the watchdog goroutine is actually allowed to complete.
 			// This lets us force the interleaving: OnProxyConnected for stream 2 runs while
 			// stream 1's OnProxyDisconnected has already released the lock (delete done) but
 			// is still blocking on <-dpData.stopped — exactly the original TOCTOU window.
 			//
 			// Note: this test calls the tracker directly (not through xdsCallbacks) because
-			// xdsCallbacks.activeStreams serialises connect/disconnect and would prevent the
+			// xdsCallbacks.activeStreams serializes connect/disconnect and would prevent the
 			// concurrent calls needed to reproduce the race.
 			afterCancel := make(chan struct{}, 1)
 			barrier := make(chan struct{})


### PR DESCRIPTION
## Motivation

`OnProxyDisconnected` in `pkg/xds/server/callbacks/dataplane_sync_tracker.go` had a TOCTOU race. It read the watchdog entry under `RLock`, released the lock, then acquired `Lock` to delete. In the gap, `OnProxyConnected` could replace the entry for the same `dpKey`. The subsequent `delete` then removed the **new** watchdog, leaking its goroutine.

Under high DP churn (rapid connect/disconnect), this leaks goroutines and causes CP instability. The race is a logical race (not data race), so `-race` won't catch it.

## Implementation information

Hold the write lock for the entire read+delete operation instead of upgrading from RLock to Lock:

```go
t.Lock()
dpData := t.watchdogs[dpKey]
delete(t.watchdogs, dpKey)
t.Unlock()
// blocking wait happens outside the lock
```

The `<-dpData.stopped` wait is intentionally outside the lock to avoid stalling other callbacks.

Added a regression test that directly calls `OnProxyConnected`/`OnProxyDisconnected` on the tracker (bypassing `xdsCallbacks`, which serialises connect/disconnect via `activeStreams` and would prevent reproducing the race).

## Supporting documentation

Fix #16162

> Changelog: fix(xds): eliminate TOCTOU race in OnProxyDisconnected