### PR TITLE
refactor(kds): use core_model.ZoneOfResource in global filter

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -324,9 +324,7 @@ func GlobalProvidedFilter(rm manager.ResourceManager) reconcile_v2.ResourceFilte
 				}
 			}
 
-			// TODO (Icarus9913): replace the function by model.ZoneOfResource(r)
-			// Reference: https://github.com/kumahq/kuma/issues/10952
-			zoneTag := util.ZoneTag(r)
+			zoneTag := core_model.ZoneOfResource(r)
 
 			// don't need to sync resource to the zone where resource is originating from
 			if zoneName == zoneTag {

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -123,7 +123,11 @@ func ZoneTag(r core_model.Resource) string {
 		if res.GetNetworking().GetGateway() != nil {
 			return res.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
 		}
-		return res.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]
+		inbounds := res.GetNetworking().GetInbound()
+		if len(inbounds) == 0 {
+			return ""
+		}
+		return inbounds[0].GetTags()[mesh_proto.ZoneTag]
 	case *mesh_proto.ZoneIngress:
 		return res.GetZone()
 	case *mesh_proto.ZoneEgress:

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -117,27 +117,6 @@ func ResourceNameHasAtLeastOneOfPrefixes(resName string, prefixes ...string) boo
 	return false
 }
 
-func ZoneTag(r core_model.Resource) string {
-	switch res := r.GetSpec().(type) {
-	case *mesh_proto.Dataplane:
-		if res.GetNetworking().GetGateway() != nil {
-			return res.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
-		}
-		inbounds := res.GetNetworking().GetInbound()
-		if len(inbounds) == 0 {
-			return ""
-		}
-		return inbounds[0].GetTags()[mesh_proto.ZoneTag]
-	case *mesh_proto.ZoneIngress:
-		return res.GetZone()
-	case *mesh_proto.ZoneEgress:
-		return res.GetZone()
-	default:
-		// todo(jakubdyszkiewicz): consider replacing this whole function with just core_model.ZoneOfResource(r)
-		return core_model.ZoneOfResource(r)
-	}
-}
-
 func toResources(resourceType core_model.ResourceType, krs []*mesh_proto.KumaResource) (core_model.ResourceList, error) {
 	list, err := registry.Global().NewList(resourceType)
 	if err != nil {


### PR DESCRIPTION
## Motivation

`ZoneTag()` in `pkg/kds/util/resource.go` accesses `GetInbound()[0]` without a bounds check. When a `Dataplane` has no gateway and no inbound listeners (empty slice), this panics with `index out of range [0] with length 0`, crashing the control plane.

A pre-existing TODO at the only call site already suggested replacing the function with `core_model.ZoneOfResource(r)` (see #10952). `ZoneOfResource` reads `kuma.io/zone` from metadata labels (set during KDS sync) and works uniformly across resource types, so it removes the panic without needing a band-aid bounds check.

## Implementation information

- Replace `util.ZoneTag(r)` with `core_model.ZoneOfResource(r)` at the only call site in `pkg/kds/context/context.go`.
- Drop the now-unused `util.ZoneTag` helper.

## Supporting documentation

- #10952

> Changelog: refactor(kds): replace util.ZoneTag with core_model.ZoneOfResource