### PR TITLE
feat(tools): add CP perf testing scripts

### DIFF
--- a/tools/perf-test/.gitignore
+++ b/tools/perf-test/.gitignore
@@ -1,0 +1,1 @@
+profiles/

--- a/tools/perf-test/README.md
+++ b/tools/perf-test/README.md
@@ -1,0 +1,126 @@
+# Perf Test
+
+Scripts for running Kuma control plane performance tests on an existing cluster
+(typically k3d / kind for local runs, GKE / EKS for real scale).
+
+The scripts capture [pprof](https://pkg.go.dev/net/http/pprof) profiles and
+Prometheus metrics so you can compare Kuma CP behaviour across releases, configs,
+or scale points.
+
+## Contents
+
+| Script                 | Purpose                                                           |
+| ---------------------- | ----------------------------------------------------------------- |
+| `deploy-wave.sh`       | Deploy a "wave" of fake-service namespaces (N × services × replicas). |
+| `collect-profiles.sh`  | Grab pprof (cpu, heap, goroutine, mutex, block, trace) + metrics snapshot from one or more CP endpoints. |
+| `run-waves.sh`         | Progressive load ramp: deploys waves 1..5, stabilizes, profiles after each wave. |
+| `policy-scenarios.sh`  | Policy/KDS load scenarios: spread vs. single-DP MeshTimeout targeting, updates, bulk delete. |
+| `dump-prometheus.sh`   | Pull a range of Kuma CP metrics from Prometheus as JSON for offline analysis. |
+
+All scripts are driven by environment variables and take sensible defaults for
+local runs.
+
+## Prerequisites
+
+- `kubectl` context pointing at a cluster with Kuma already deployed
+- CP has `KUMA_DIAGNOSTICS_DEBUG_ENDPOINTS=true` (enables `/debug/pprof`)
+- CP diagnostics port reachable (typically via `kubectl port-forward`)
+- `go` in `$PATH` (for `go tool pprof`)
+- `curl`, `python3` (for `dump-prometheus.sh`)
+
+## Quick start
+
+```bash
+# Port-forward the CP diagnostics port
+kubectl -n kuma-system port-forward svc/kuma-control-plane 5680:5680 &
+
+# Progressive wave test (50 → 2350 DPs), profiles after each wave
+./run-waves.sh
+
+# Phase 4: policy scenarios (requires at least wave1 DPs already deployed)
+./policy-scenarios.sh
+
+# Dump Prometheus metrics for the last 150 minutes
+kubectl -n monitoring port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090 &
+./dump-prometheus.sh
+```
+
+## Multi-zone profiling
+
+Profile zone and global CPs simultaneously by setting `ENDPOINTS`:
+
+```bash
+ENDPOINTS="zone=http://localhost:5680 global=http://34.10.179.32:5680" \
+  ./run-waves.sh
+```
+
+Each collected profile is prefixed with its endpoint name (e.g. `zone-cpu.pb.gz`,
+`global-heap.pb.gz`).
+
+## Wave definitions
+
+`run-waves.sh` defaults to this ramp (override with `WAVES="..."`):
+
+| Wave | Namespaces | Services/ns | Replicas | Total DPs | Cumulative |
+| ---- | ---------- | ----------- | -------- | --------- | ---------- |
+| 1    | 5          | 5           | 2        | 50        | 50         |
+| 2    | 10         | 5           | 2        | 100       | 150        |
+| 3    | 20         | 5           | 3        | 300       | 450        |
+| 4    | 30         | 10          | 3        | 900       | 1350       |
+| 5    | 20         | 10          | 5        | 1000      | 2350       |
+
+## Policy scenarios
+
+`policy-scenarios.sh` runs these against an already-running DP fleet:
+
+1. **baseline** — no user policies, just CPU + heap
+2. **spread** — N `MeshTimeout` policies targeting N different Dataplane label
+   selectors (load distributed)
+3. **single-dp** — N policies all targeting the same selector (load concentrated)
+4. **spread-update** — patch every spread policy
+5. **single-dp-update** — patch every single-dp policy
+6. **delete** — bulk delete
+
+Assumes the mesh has `MeshService.Mode=Exclusive` and the CP runs with
+`KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED=true` so policies target DPs via label
+selectors rather than deprecated service references.
+
+## Output layout
+
+```
+profiles/
+├── wave1/                    — one dir per wave or scenario
+│   ├── cpu.pb.gz
+│   ├── heap.pb.gz
+│   ├── goroutine.pb.gz
+│   ├── mutex.pb.gz
+│   ├── block.pb.gz
+│   ├── trace.out
+│   └── metrics.txt
+├── p4-baseline/              — policy scenario output (one dir per scenario)
+│   ├── zone-cpu.pb.gz        — prefix matches the ENDPOINTS name
+│   ├── zone-heap.pb.gz
+│   ├── zone-metrics.txt
+│   ├── global-cpu.pb.gz
+│   └── global-metrics.txt
+└── prometheus/               — JSON range-query dumps
+    ├── go_goroutines.json
+    ├── xds_generation_count.json
+    └── ...
+```
+
+`profiles/` is ignored by git (`.gitignore`) — results stay local.
+
+## Analysis hints
+
+```bash
+# Compare CPU profiles across waves
+go tool pprof -http=:8080 profiles/wave1/cpu.pb.gz
+go tool pprof -base profiles/wave1/cpu.pb.gz profiles/wave3/cpu.pb.gz
+
+# Heap growth
+go tool pprof -diff_base profiles/wave1/heap.pb.gz profiles/wave3/heap.pb.gz
+
+# Trace analysis
+go tool trace profiles/wave3/trace.out
+```

--- a/tools/perf-test/collect-profiles.sh
+++ b/tools/perf-test/collect-profiles.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# collect-profiles.sh — collect pprof profiles and a metrics snapshot from Kuma CP(s)
+#
+# Usage: collect-profiles.sh <label> [endpoint_url]
+#
+# Env:
+#   OUT_DIR     — base directory for profiles (default: ./profiles)
+#   ENDPOINTS   — space-separated list of "<name>=<url>" pairs.
+#                 If set, overrides the positional endpoint argument and
+#                 collects from every endpoint in parallel. Each profile is
+#                 prefixed with its name (e.g. zone-cpu.pb.gz, global-cpu.pb.gz).
+#   CPU_SECS    — CPU profile duration (default: 30)
+#   TRACE_SECS  — execution trace duration (default: 5)
+#
+# Examples:
+#   # single endpoint
+#   collect-profiles.sh wave1 http://localhost:5680
+#
+#   # multi-CP (zone + global)
+#   ENDPOINTS="zone=http://localhost:5680 global=http://34.10.179.32:5680" \
+#     collect-profiles.sh wave1
+set -e
+
+LABEL=${1:-manual}
+SINGLE_EP=${2:-http://localhost:5680}
+OUT_DIR=${OUT_DIR:-./profiles}
+CPU_SECS=${CPU_SECS:-30}
+TRACE_SECS=${TRACE_SECS:-5}
+
+OUT="$OUT_DIR/$LABEL"
+mkdir -p "$OUT"
+
+collect_one() {
+  local name=$1 ep=$2 prefix=$3
+  echo "  [$name] metrics snapshot..."
+  curl -sf "$ep/metrics" \
+    | grep -E 'xds_generation|kds_delta|store_bucket|go_goroutines|go_memstats_heap|resources_count|process_cpu' \
+    > "$OUT/${prefix}metrics.txt"
+
+  echo "  [$name] CPU profile (${CPU_SECS}s)..."
+  go tool pprof -proto "$ep/debug/pprof/profile?seconds=${CPU_SECS}" > "$OUT/${prefix}cpu.pb.gz"
+
+  echo "  [$name] heap..."
+  go tool pprof -proto "$ep/debug/pprof/heap" > "$OUT/${prefix}heap.pb.gz"
+
+  echo "  [$name] goroutine..."
+  go tool pprof -proto "$ep/debug/pprof/goroutine" > "$OUT/${prefix}goroutine.pb.gz"
+
+  echo "  [$name] mutex..."
+  go tool pprof -proto "$ep/debug/pprof/mutex" > "$OUT/${prefix}mutex.pb.gz"
+
+  echo "  [$name] block..."
+  go tool pprof -proto "$ep/debug/pprof/block" > "$OUT/${prefix}block.pb.gz"
+
+  echo "  [$name] trace (${TRACE_SECS}s)..."
+  curl -sf -o "$OUT/${prefix}trace.out" "$ep/debug/pprof/trace?seconds=${TRACE_SECS}"
+}
+
+echo "Collecting profiles: $LABEL → $OUT"
+
+if [[ -n "$ENDPOINTS" ]]; then
+  pids=()
+  for pair in $ENDPOINTS; do
+    name=${pair%%=*}
+    ep=${pair#*=}
+    collect_one "$name" "$ep" "${name}-" &
+    pids+=($!)
+  done
+  wait "${pids[@]}"
+else
+  collect_one cp "$SINGLE_EP" ""
+fi
+
+echo "Done."
+ls -lh "$OUT/"

--- a/tools/perf-test/collect-profiles.sh
+++ b/tools/perf-test/collect-profiles.sh
@@ -4,7 +4,7 @@
 # Usage: collect-profiles.sh <label> [endpoint_url]
 #
 # Env:
-#   OUT_DIR     — base directory for profiles (default: ./profiles)
+#   OUT_DIR     — base directory for profiles (default: <script dir>/profiles)
 #   ENDPOINTS   — space-separated list of "<name>=<url>" pairs.
 #                 If set, overrides the positional endpoint argument and
 #                 collects from every endpoint in parallel. Each profile is
@@ -21,9 +21,10 @@
 #     collect-profiles.sh wave1
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LABEL=${1:-manual}
 SINGLE_EP=${2:-http://localhost:5680}
-OUT_DIR=${OUT_DIR:-./profiles}
+OUT_DIR=${OUT_DIR:-"$SCRIPT_DIR/profiles"}
 CPU_SECS=${CPU_SECS:-30}
 TRACE_SECS=${TRACE_SECS:-5}
 
@@ -35,7 +36,7 @@ collect_one() {
   echo "  [$name] metrics snapshot..."
   curl -sf "$ep/metrics" \
     | grep -E 'xds_generation|kds_delta|store_bucket|go_goroutines|go_memstats_heap|resources_count|process_cpu' \
-    > "$OUT/${prefix}metrics.txt"
+    > "$OUT/${prefix}metrics.txt" || true
 
   echo "  [$name] CPU profile (${CPU_SECS}s)..."
   go tool pprof -proto "$ep/debug/pprof/profile?seconds=${CPU_SECS}" > "$OUT/${prefix}cpu.pb.gz"

--- a/tools/perf-test/deploy-wave.sh
+++ b/tools/perf-test/deploy-wave.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# deploy-wave.sh — deploy a wave of fake-service workloads into a Kuma-injected cluster
+#
+# Usage: deploy-wave.sh <wave_num> <num_namespaces> <services_per_ns> <replicas>
+#
+# Env:
+#   KUBE_CONTEXT  — kubectl context (default: current context)
+#   NS_PREFIX     — namespace prefix (default: perf-wave)
+#   IMAGE         — workload image (default: nicholasjackson/fake-service:v0.26.2)
+#
+# Example:
+#   KUBE_CONTEXT=gke_my-project_us-central1_perf deploy-wave.sh 1 5 5 2   # 50 DPs
+set -e
+
+WAVE=$1
+NS_COUNT=$2
+SVC_COUNT=$3
+REPLICAS=$4
+
+CTX_ARG=()
+[[ -n "$KUBE_CONTEXT" ]] && CTX_ARG=(--context="$KUBE_CONTEXT")
+NS_PREFIX=${NS_PREFIX:-perf-wave}
+IMAGE=${IMAGE:-nicholasjackson/fake-service:v0.26.2}
+
+if [[ -z "$WAVE" || -z "$NS_COUNT" || -z "$SVC_COUNT" || -z "$REPLICAS" ]]; then
+  cat <<USAGE
+Usage: $0 <wave_num> <num_namespaces> <services_per_ns> <replicas>
+
+Reference wave sizing:
+  $0 1 5  5 2   # 50 DPs
+  $0 2 10 5 2   # 100 DPs (150 cumulative)
+  $0 3 20 5 3   # 300 DPs (450 cumulative)
+  $0 4 30 10 3  # 900 DPs (1350 cumulative)
+  $0 5 20 10 5  # 1000 DPs (2350 cumulative)
+USAGE
+  exit 1
+fi
+
+render_workload() {
+  local j=$1
+  cat <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: svc-${j}
+spec:
+  replicas: $REPLICAS
+  selector:
+    matchLabels:
+      app: svc-${j}
+  template:
+    metadata:
+      labels:
+        app: svc-${j}
+    spec:
+      containers:
+      - name: fake-service
+        image: ${IMAGE}
+        ports:
+        - containerPort: 9090
+        env:
+        - name: LISTEN_ADDR
+          value: "0.0.0.0:9090"
+        - name: NAME
+          value: "svc-${j}"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-${j}
+spec:
+  selector:
+    app: svc-${j}
+  ports:
+  - port: 9090
+YAML
+}
+
+echo "Deploying wave $WAVE: ${NS_COUNT} namespaces × ${SVC_COUNT} services × ${REPLICAS} replicas"
+
+for i in $(seq 1 "$NS_COUNT"); do
+  NS="${NS_PREFIX}${WAVE}-${i}"
+  kubectl "${CTX_ARG[@]}" create namespace "$NS" --dry-run=client -o yaml | kubectl "${CTX_ARG[@]}" apply -f -
+  kubectl "${CTX_ARG[@]}" label namespace "$NS" kuma.io/sidecar-injection=enabled --overwrite
+
+  for j in $(seq 1 "$SVC_COUNT"); do
+    render_workload "$j" | kubectl "${CTX_ARG[@]}" -n "$NS" apply -f -
+  done
+done
+
+echo "Wave $WAVE deployed. Waiting for pods to be ready..."
+for i in $(seq 1 "$NS_COUNT"); do
+  NS="${NS_PREFIX}${WAVE}-${i}"
+  kubectl "${CTX_ARG[@]}" -n "$NS" wait --for=condition=available deployment --all --timeout=300s 2>/dev/null || true
+done
+echo "Wave $WAVE ready."

--- a/tools/perf-test/deploy-wave.sh
+++ b/tools/perf-test/deploy-wave.sh
@@ -95,8 +95,15 @@ for i in $(seq 1 "$NS_COUNT"); do
 done
 
 echo "Wave $WAVE deployed. Waiting for pods to be ready..."
+FAILED_NAMESPACES=()
 for i in $(seq 1 "$NS_COUNT"); do
   NS="${NS_PREFIX}${WAVE}-${i}"
-  kubectl "${CTX_ARG[@]}" -n "$NS" wait --for=condition=available deployment --all --timeout=300s 2>/dev/null || true
+  if ! kubectl "${CTX_ARG[@]}" -n "$NS" wait --for=condition=available deployment --all --timeout=300s; then
+    FAILED_NAMESPACES+=("$NS")
+  fi
 done
+if [[ ${#FAILED_NAMESPACES[@]} -gt 0 ]]; then
+  echo "Wave $WAVE failed: deployments not available in: ${FAILED_NAMESPACES[*]}" >&2
+  exit 1
+fi
 echo "Wave $WAVE ready."

--- a/tools/perf-test/dump-prometheus.sh
+++ b/tools/perf-test/dump-prometheus.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# dump-prometheus.sh — pull Kuma CP metrics from Prometheus for offline analysis
+#
+# Grabs a set of Go runtime, xDS, KDS, and store metrics as Prometheus
+# range queries and saves them as JSON files. Assumes Prometheus is reachable
+# at $PROM_URL (default: http://localhost:9090 — start a port-forward first).
+#
+# Env:
+#   PROM_URL       — Prometheus base URL (default: http://localhost:9090)
+#   OUT_DIR        — output dir (default: ./profiles/prometheus)
+#   WINDOW_MINUTES — how far back to query (default: 150)
+#   STEP           — range query step in seconds (default: 15)
+#   NAMESPACE      — Kuma CP namespace for container/pod metrics (default: kuma-system)
+set -e
+
+PROM_URL=${PROM_URL:-http://localhost:9090}
+OUT_DIR=${OUT_DIR:-./profiles/prometheus}
+WINDOW_MINUTES=${WINDOW_MINUTES:-150}
+STEP=${STEP:-15}
+NAMESPACE=${NAMESPACE:-kuma-system}
+
+END=$(date +%s)
+START=$((END - WINDOW_MINUTES * 60))
+
+mkdir -p "$OUT_DIR"
+echo "Window: $START → $END (${WINDOW_MINUTES}min) | step=${STEP}s | prom=$PROM_URL"
+
+# Verify Prometheus is reachable
+curl -sf "$PROM_URL/api/v1/query?query=up" > /dev/null || {
+  echo "ERROR: Prometheus at $PROM_URL not reachable" >&2
+  exit 1
+}
+
+CP_METRIC_FILTER="namespace=\"${NAMESPACE}\",container=\"control-plane\""
+
+metrics=(
+  # Go runtime
+  "go_goroutines"
+  "go_memstats_heap_inuse_bytes"
+  "go_memstats_heap_alloc_bytes"
+  "go_memstats_heap_objects"
+  "go_memstats_sys_bytes"
+  "go_memstats_stack_inuse_bytes"
+  "go_gc_duration_seconds_sum"
+  "process_cpu_seconds_total"
+  "rate(process_cpu_seconds_total[1m])"
+
+  # xDS
+  "xds_generation_count"
+  "xds_generation_sum"
+  "xds_generation_errors"
+  "xds_streams_active"
+  "xds_requests_received"
+  "xds_responses_sent"
+
+  # KDS
+  "kds_delta_generation_count"
+  "kds_delta_generation_sum"
+  "kds_delta_generation_errors"
+  "kds_delta_streams_active"
+  "kds_delta_requests_received"
+  "kds_delta_responses_sent"
+
+  # Store
+  "store_count"
+  "store_sum"
+  "store_conflicts"
+  "resources_count"
+
+  # Histogram quantiles (p50/p99)
+  "histogram_quantile(0.50, sum(rate(xds_generation_bucket[1m])) by (le))"
+  "histogram_quantile(0.99, sum(rate(xds_generation_bucket[1m])) by (le))"
+  "histogram_quantile(0.99, sum(rate(kds_delta_generation_bucket[1m])) by (le))"
+  "histogram_quantile(0.99, sum(rate(store_bucket[1m])) by (le, operation, resource_type))"
+
+  # Container-level (correlates with pod restarts / scheduling)
+  "container_memory_working_set_bytes{${CP_METRIC_FILTER}}"
+  "container_memory_rss{${CP_METRIC_FILTER}}"
+  "rate(container_cpu_usage_seconds_total{${CP_METRIC_FILTER}}[1m])"
+  "kube_pod_container_status_restarts_total{namespace=\"${NAMESPACE}\"}"
+  "kube_pod_container_status_ready{namespace=\"${NAMESPACE}\"}"
+)
+
+for metric in "${metrics[@]}"; do
+  fname=$(echo "$metric" | tr '(){}=",[]' '_________' | tr -s '_' | tr -d ' ')
+  curl -sG "$PROM_URL/api/v1/query_range" \
+    --data-urlencode "query=$metric" \
+    --data-urlencode "start=$START" \
+    --data-urlencode "end=$END" \
+    --data-urlencode "step=$STEP" \
+    > "$OUT_DIR/${fname}.json"
+
+  n=$(python3 -c "import json; print(len(json.load(open('$OUT_DIR/${fname}.json'))['data']['result']))" 2>/dev/null || echo "err")
+  echo "  $metric: $n series"
+done
+
+echo ""
+count=$(find "$OUT_DIR" -maxdepth 1 -type f | wc -l | tr -d ' ')
+echo "Dumped $count files → $OUT_DIR"
+du -sh "$OUT_DIR"

--- a/tools/perf-test/dump-prometheus.sh
+++ b/tools/perf-test/dump-prometheus.sh
@@ -7,14 +7,15 @@
 #
 # Env:
 #   PROM_URL       — Prometheus base URL (default: http://localhost:9090)
-#   OUT_DIR        — output dir (default: ./profiles/prometheus)
+#   OUT_DIR        — output dir (default: <script dir>/profiles/prometheus)
 #   WINDOW_MINUTES — how far back to query (default: 150)
 #   STEP           — range query step in seconds (default: 15)
 #   NAMESPACE      — Kuma CP namespace for container/pod metrics (default: kuma-system)
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROM_URL=${PROM_URL:-http://localhost:9090}
-OUT_DIR=${OUT_DIR:-./profiles/prometheus}
+OUT_DIR=${OUT_DIR:-"$SCRIPT_DIR/profiles/prometheus"}
 WINDOW_MINUTES=${WINDOW_MINUTES:-150}
 STEP=${STEP:-15}
 NAMESPACE=${NAMESPACE:-kuma-system}

--- a/tools/perf-test/policy-scenarios.sh
+++ b/tools/perf-test/policy-scenarios.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# policy-scenarios.sh — Phase 4 policy/KDS load scenarios
+#
+# Runs these scenarios against an already-deployed DP fleet:
+#   baseline          — no user policies, snapshots CPU + metrics
+#   spread            — N policies targeting N different Dataplane label selectors
+#   single-dp         — N policies all targeting the same Dataplane label selector
+#   spread-update     — update every spread policy in a tight loop
+#   single-dp-update  — update every single-dp policy in a tight loop
+#   delete            — bulk delete all user-origin MeshTimeout policies
+#
+# Assumes:
+#   - a zone CP with wave1-style fake-service deployments already running
+#   - DP pods have an `app=svc-<N>` label (from deploy-wave.sh)
+#   - mesh has MeshService.Mode=Exclusive and MeshIdentity configured
+#   - CP has KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED=true
+#
+# Env:
+#   KUBE_CONTEXT   — kubectl context (required if not default)
+#   OUT_DIR        — profile output dir (default: ./profiles)
+#   ENDPOINTS      — space-separated "<name>=<url>" pairs (same format as run-waves.sh)
+#   N              — policies per scenario (default: 50)
+#   APP_LABELS     — distinct app label values for the SPREAD scenario
+#                    (default: "svc-1 svc-2 svc-3 svc-4 svc-5 svc-6 svc-7 svc-8 svc-9 svc-10")
+#   SINGLE_APP     — target label for SINGLE-DP scenario (default: svc-1)
+#   CPU_SECS       — CPU profile duration (default: 60)
+set -e
+
+OUT_DIR=${OUT_DIR:-./profiles}
+ENDPOINTS=${ENDPOINTS:-"cp=http://localhost:5680"}
+N=${N:-50}
+APP_LABELS=${APP_LABELS:-"svc-1 svc-2 svc-3 svc-4 svc-5 svc-6 svc-7 svc-8 svc-9 svc-10"}
+SINGLE_APP=${SINGLE_APP:-svc-1}
+CPU_SECS=${CPU_SECS:-60}
+
+CTX_ARG=()
+[[ -n "$KUBE_CONTEXT" ]] && CTX_ARG=(--context="$KUBE_CONTEXT")
+
+COLLECT_CPU_PIDS=()
+
+collect_cpu_bg() {
+  local label=$1 secs=$2
+  mkdir -p "$OUT_DIR/$label"
+  COLLECT_CPU_PIDS=()
+  for pair in $ENDPOINTS; do
+    local name=${pair%%=*}
+    local ep=${pair#*=}
+    go tool pprof -proto "$ep/debug/pprof/profile?seconds=${secs}" \
+      > "$OUT_DIR/$label/${name}-cpu.pb.gz" &
+    COLLECT_CPU_PIDS+=($!)
+  done
+}
+
+wait_cpu() {
+  wait "${COLLECT_CPU_PIDS[@]}"
+}
+
+collect_heap_metrics() {
+  local label=$1
+  mkdir -p "$OUT_DIR/$label"
+  for pair in $ENDPOINTS; do
+    local name=${pair%%=*}
+    local ep=${pair#*=}
+    curl -sf "$ep/metrics" \
+      | grep -E 'kds_delta|resources_count|xds_generation|go_goroutines|go_memstats_heap' \
+      > "$OUT_DIR/$label/${name}-metrics.txt"
+    go tool pprof -proto "$ep/debug/pprof/heap" > "$OUT_DIR/$label/${name}-heap.pb.gz"
+  done
+  echo "  collected $label"
+}
+
+apply_policy() {
+  local name=$1 app=$2 timeout=$3
+  kubectl "${CTX_ARG[@]}" apply -f - <<EOF
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: ${name}
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+    kuma.io/origin: zone
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: "${app}"
+  to:
+  - targetRef:
+      kind: Mesh
+    default:
+      http:
+        requestTimeout: ${timeout}s
+EOF
+}
+
+# ── Baseline ─────────────────────────────────────────────────────────────────
+echo "=== Baseline ==="
+collect_cpu_bg p4-baseline 30
+wait_cpu
+collect_heap_metrics p4-baseline
+
+# ── Scenario A: SPREAD ───────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario A: SPREAD — $N policies across distinct Dataplane label selectors ==="
+collect_cpu_bg p4-spread-create "$CPU_SECS"
+
+read -ra apps <<< "$APP_LABELS"
+n_apps=${#apps[@]}
+for i in $(seq 1 "$N"); do
+  app=${apps[$(( (i - 1) % n_apps ))]}
+  apply_policy "spread-${i}" "$app" "$((i % 10 + 1))"
+done
+wait_cpu
+sleep 30
+collect_heap_metrics p4-spread-create
+
+# ── Scenario B: SINGLE DP ────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario B: SINGLE DP — $N policies → app=$SINGLE_APP ==="
+collect_cpu_bg p4-single-create "$CPU_SECS"
+for i in $(seq 1 "$N"); do
+  apply_policy "single-${i}" "$SINGLE_APP" "$((i % 10 + 1))"
+done
+wait_cpu
+sleep 30
+collect_heap_metrics p4-single-create
+
+# ── Updates: spread ──────────────────────────────────────────────────────────
+echo ""
+echo "=== Updates: spread ==="
+collect_cpu_bg p4-spread-update "$CPU_SECS"
+for i in $(seq 1 "$N"); do
+  kubectl "${CTX_ARG[@]}" -n kuma-system patch meshtimeout "spread-${i}" \
+    --type merge -p '{"spec":{"to":[{"targetRef":{"kind":"Mesh"},"default":{"http":{"requestTimeout":"99s"}}}]}}'
+done
+wait_cpu
+collect_heap_metrics p4-spread-update
+
+# ── Updates: single-dp ───────────────────────────────────────────────────────
+echo ""
+echo "=== Updates: single-dp ==="
+collect_cpu_bg p4-single-update "$CPU_SECS"
+for i in $(seq 1 "$N"); do
+  kubectl "${CTX_ARG[@]}" -n kuma-system patch meshtimeout "single-${i}" \
+    --type merge -p '{"spec":{"to":[{"targetRef":{"kind":"Mesh"},"default":{"http":{"requestTimeout":"99s"}}}]}}'
+done
+wait_cpu
+collect_heap_metrics p4-single-update
+
+# ── Bulk delete ──────────────────────────────────────────────────────────────
+echo ""
+echo "=== Bulk delete ==="
+collect_cpu_bg p4-delete "$CPU_SECS"
+kubectl "${CTX_ARG[@]}" -n kuma-system delete meshtimeout -l kuma.io/origin=zone 2>&1 || true
+wait_cpu
+collect_heap_metrics p4-delete
+
+echo ""
+echo "=== Phase 4 complete. Profiles in $OUT_DIR ==="
+for d in p4-baseline p4-spread-create p4-single-create p4-spread-update p4-single-update p4-delete; do
+  [[ -d "$OUT_DIR/$d" ]] && echo "  $d: $(du -sh "$OUT_DIR/$d" | cut -f1)"
+done

--- a/tools/perf-test/policy-scenarios.sh
+++ b/tools/perf-test/policy-scenarios.sh
@@ -17,7 +17,7 @@
 #
 # Env:
 #   KUBE_CONTEXT   — kubectl context (required if not default)
-#   OUT_DIR        — profile output dir (default: ./profiles)
+#   OUT_DIR        — profile output dir (default: <script dir>/profiles)
 #   ENDPOINTS      — space-separated "<name>=<url>" pairs (same format as run-waves.sh)
 #   N              — policies per scenario (default: 50)
 #   APP_LABELS     — distinct app label values for the SPREAD scenario
@@ -26,7 +26,8 @@
 #   CPU_SECS       — CPU profile duration (default: 60)
 set -e
 
-OUT_DIR=${OUT_DIR:-./profiles}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR=${OUT_DIR:-"$SCRIPT_DIR/profiles"}
 ENDPOINTS=${ENDPOINTS:-"cp=http://localhost:5680"}
 N=${N:-50}
 APP_LABELS=${APP_LABELS:-"svc-1 svc-2 svc-3 svc-4 svc-5 svc-6 svc-7 svc-8 svc-9 svc-10"}
@@ -63,7 +64,7 @@ collect_heap_metrics() {
     local ep=${pair#*=}
     curl -sf "$ep/metrics" \
       | grep -E 'kds_delta|resources_count|xds_generation|go_goroutines|go_memstats_heap' \
-      > "$OUT_DIR/$label/${name}-metrics.txt"
+      > "$OUT_DIR/$label/${name}-metrics.txt" || true
     go tool pprof -proto "$ep/debug/pprof/heap" > "$OUT_DIR/$label/${name}-heap.pb.gz"
   done
   echo "  collected $label"

--- a/tools/perf-test/run-waves.sh
+++ b/tools/perf-test/run-waves.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# run-waves.sh — run a progressive load ramp (Phase 3) and collect profiles per wave
+#
+# Deploys waves 1..N incrementally, waits for stabilization after each, and captures
+# pprof profiles + metrics snapshots from one or more CPs.
+#
+# Env:
+#   KUBE_CONTEXT     — kubectl context (required if not default)
+#   OUT_DIR          — profile output directory (default: ./profiles)
+#   ENDPOINTS        — space-separated "<name>=<url>" pairs (e.g.
+#                      "zone=http://localhost:5680 global=http://34.10.179.32:5680")
+#                      Defaults to "cp=http://localhost:5680".
+#   STABILIZE_SECS   — seconds to wait after each wave before profiling (default: 300)
+#   WAVES            — override the default wave definition. Space-separated entries
+#                      of "wave_num:num_ns:svc_per_ns:replicas".
+#                      Default: "1:5:5:2 2:10:5:2 3:20:5:3 4:30:10:3 5:20:10:5"
+#
+# Example:
+#   KUBE_CONTEXT=gke_my-project_us-central1_perf \
+#   ENDPOINTS="zone=http://localhost:5680 global=http://34.10.179.32:5680" \
+#     ./run-waves.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR=${OUT_DIR:-./profiles}
+STABILIZE_SECS=${STABILIZE_SECS:-300}
+ENDPOINTS=${ENDPOINTS:-"cp=http://localhost:5680"}
+WAVES=${WAVES:-"1:5:5:2 2:10:5:2 3:20:5:3 4:30:10:3 5:20:10:5"}
+
+export KUBE_CONTEXT OUT_DIR ENDPOINTS
+
+# Sanity check: every endpoint must respond
+for pair in $ENDPOINTS; do
+  name=${pair%%=*}
+  ep=${pair#*=}
+  curl -sf --connect-timeout 3 "$ep/debug/pprof/" > /dev/null || {
+    echo "ERROR: $name ($ep) is not reachable" >&2
+    exit 1
+  }
+done
+
+mkdir -p "$OUT_DIR"
+
+echo "=== Phase 3: Progressive Load Ramp ==="
+echo "Waves: $WAVES"
+echo "Endpoints: $ENDPOINTS"
+echo ""
+
+for wave_entry in $WAVES; do
+  IFS=':' read -r wave ns_count svc_count replicas <<< "$wave_entry"
+
+  echo ""
+  echo "--- Wave $wave ($ns_count ns × $svc_count svc × $replicas replicas) ---"
+  bash "$SCRIPT_DIR/deploy-wave.sh" "$wave" "$ns_count" "$svc_count" "$replicas"
+
+  echo "Stabilizing ${STABILIZE_SECS}s..."
+  sleep "$STABILIZE_SECS"
+
+  bash "$SCRIPT_DIR/collect-profiles.sh" "wave${wave}"
+done
+
+echo ""
+echo "=== All waves complete. Profiles in $OUT_DIR ==="

--- a/tools/perf-test/run-waves.sh
+++ b/tools/perf-test/run-waves.sh
@@ -6,7 +6,7 @@
 #
 # Env:
 #   KUBE_CONTEXT     — kubectl context (required if not default)
-#   OUT_DIR          — profile output directory (default: ./profiles)
+#   OUT_DIR          — profile output directory (default: <script dir>/profiles)
 #   ENDPOINTS        — space-separated "<name>=<url>" pairs (e.g.
 #                      "zone=http://localhost:5680 global=http://34.10.179.32:5680")
 #                      Defaults to "cp=http://localhost:5680".
@@ -22,7 +22,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-OUT_DIR=${OUT_DIR:-./profiles}
+OUT_DIR=${OUT_DIR:-"$SCRIPT_DIR/profiles"}
 STABILIZE_SECS=${STABILIZE_SECS:-300}
 ENDPOINTS=${ENDPOINTS:-"cp=http://localhost:5680"}
 WAVES=${WAVES:-"1:5:5:2 2:10:5:2 3:20:5:3 4:30:10:3 5:20:10:5"}


### PR DESCRIPTION
## Motivation

Need a reusable, committed toolkit for running Kuma CP performance tests
against a real cluster and capturing profiles + metrics for offline
analysis. Has been used to drive the perf investigation tracked in #16183
and its subissues.

## Implementation information

Adds `tools/perf-test/` with five driver scripts and a README:

- `deploy-wave.sh` — deploy N namespaces x M services x R replicas of
  fake-service with sidecar injection enabled
- `collect-profiles.sh` — grab cpu, heap, goroutine, mutex, block, trace
  and a `/metrics` snapshot from one or more CP endpoints in parallel
- `run-waves.sh` — progressive load ramp (default: 50 → 2350 DPs),
  stabilize + profile after each wave
- `policy-scenarios.sh` — policy/KDS scenarios (spread, single-DP,
  updates, bulk delete) against an already-deployed fleet
- `dump-prometheus.sh` — pull Go runtime, xDS, KDS, and store metrics as
  Prometheus range queries (JSON) for offline analysis

All scripts are env-var-driven with sensible defaults for local k3d/kind
runs; `ENDPOINTS="zone=... global=..."` enables multi-zone profiling with
a prefix-per-CP on output files. `tools/perf-test/profiles/` is gitignored
so results stay local.

Alternatives considered: keep the scripts in a gist or in a private repo.
Rejected because the perf investigation that produced the umbrella issue
needs to be reproducible by anyone on future releases; a committed,
documented toolkit makes that practical.

## Supporting documentation

- Umbrella issue: #16183
- README with usage and analysis hints: `tools/perf-test/README.md`

> Changelog: skip