### PR TITLE
perf(k8s): cache labels + spec per resourceVersion

### DIFF
--- a/pkg/plugins/resources/k8s/caching_converter.go
+++ b/pkg/plugins/resources/k8s/caching_converter.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"maps"
 	"strings"
 	"time"
 
@@ -53,12 +54,14 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 	}, ":")
 	if v, ok := c.cache.Get(key); ok {
 		entry := v.(cachedEntry)
-		// Pre-populate cachedLabels so the adapter's GetLabels skips the
-		// maps.Clone + annotation-merge work for the lifetime of the entry.
+		// Pre-populate cachedLabels with a fresh clone so the adapter's
+		// GetLabels skips the annotation-merge work, while keeping the cached
+		// map isolated from downstream consumers that mutate labels in place
+		// (e.g. removeDisplayNameLabel in the ServiceInsight endpoints).
 		out.SetMeta(&KubernetesMetaAdapter{
 			ObjectMeta:   *obj.GetObjectMeta(),
 			Mesh:         obj.GetMesh(),
-			cachedLabels: entry.labels,
+			cachedLabels: maps.Clone(entry.labels),
 		})
 		if err := out.SetSpec(entry.spec); err != nil {
 			return err
@@ -96,10 +99,31 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 	if obj.GetResourceVersion() != "" {
 		// an absence of the ResourceVersion means we decode 'obj' from webhook request,
 		// all webhooks use SimpleConverter, so this is not supposed to happen
+		// Clone the materialized labels so the cache holds a copy that is not
+		// shared with the adapter we just handed back to the caller. Without
+		// this, downstream in-place mutations (e.g. removeDisplayNameLabel)
+		// would corrupt the cached entry on the very first access.
 		c.cache.SetDefault(key, cachedEntry{
 			spec:   out.GetSpec(),
-			labels: adapter.GetLabels(), // materialize labels so future hits reuse them
+			labels: maps.Clone(adapter.GetLabels()),
 		})
+	}
+	return nil
+}
+
+// ToCoreList overrides SimpleConverter.ToCoreList so the per-item conversion
+// dispatches to cachingConverter.ToCoreResource. Without this override, Go
+// method resolution on the embedded SimpleConverter binds c.ToCoreResource to
+// the inner type, bypassing the cache for every list read.
+func (c *cachingConverter) ToCoreList(in k8s_model.KubernetesList, out core_model.ResourceList, predicate k8s_common.ConverterPredicate) error {
+	for _, o := range in.GetItems() {
+		r := out.NewItem()
+		if err := c.ToCoreResource(o, r); err != nil {
+			return err
+		}
+		if predicate(r) {
+			_ = out.AddItem(r)
+		}
 	}
 	return nil
 }

--- a/pkg/plugins/resources/k8s/caching_converter.go
+++ b/pkg/plugins/resources/k8s/caching_converter.go
@@ -21,6 +21,18 @@ type cachingConverter struct {
 	cache *cache.Cache
 }
 
+// cachedEntry is the value type stored in cachingConverter.cache. It bundles
+// the two version-stable results of converting a Kubernetes object:
+//   - spec: the unmarshaled protobuf spec
+//   - labels: the precomputed KubernetesMetaAdapter.GetLabels() output
+//
+// Status is intentionally excluded: existing tests assert that mutations to
+// status surface on subsequent cache hits, so it is fetched fresh every call.
+type cachedEntry struct {
+	spec   core_model.ResourceSpec
+	labels map[string]string
+}
+
 func NewCachingConverter(expirationTime time.Duration) k8s_common.Converter {
 	return &cachingConverter{
 		SimpleConverter: SimpleConverter{
@@ -33,7 +45,6 @@ func NewCachingConverter(expirationTime time.Duration) k8s_common.Converter {
 }
 
 func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out core_model.Resource) error {
-	out.SetMeta(&KubernetesMetaAdapter{ObjectMeta: *obj.GetObjectMeta(), Mesh: obj.GetMesh()})
 	key := strings.Join([]string{
 		obj.GetNamespace(),
 		obj.GetName(),
@@ -41,10 +52,18 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 		obj.GetObjectKind().GroupVersionKind().String(),
 	}, ":")
 	if v, ok := c.cache.Get(key); ok {
-		if err := out.SetSpec(v.(core_model.ResourceSpec)); err != nil {
+		entry := v.(cachedEntry)
+		// Pre-populate cachedLabels so the adapter's GetLabels skips the
+		// maps.Clone + annotation-merge work for the lifetime of the entry.
+		out.SetMeta(&KubernetesMetaAdapter{
+			ObjectMeta:   *obj.GetObjectMeta(),
+			Mesh:         obj.GetMesh(),
+			cachedLabels: entry.labels,
+		})
+		if err := out.SetSpec(entry.spec); err != nil {
 			return err
 		}
-		// Status is not cached (changes frequently), fetch from obj
+		// Status is not cached (see cachedEntry comment); fetch from obj.
 		if out.Descriptor().HasStatus {
 			status, err := obj.GetStatus()
 			if err != nil {
@@ -56,6 +75,8 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 		}
 		return nil
 	}
+	adapter := &KubernetesMetaAdapter{ObjectMeta: *obj.GetObjectMeta(), Mesh: obj.GetMesh()}
+	out.SetMeta(adapter)
 	spec, err := obj.GetSpec()
 	if err != nil {
 		return err
@@ -75,7 +96,10 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 	if obj.GetResourceVersion() != "" {
 		// an absence of the ResourceVersion means we decode 'obj' from webhook request,
 		// all webhooks use SimpleConverter, so this is not supposed to happen
-		c.cache.SetDefault(key, out.GetSpec())
+		c.cache.SetDefault(key, cachedEntry{
+			spec:   out.GetSpec(),
+			labels: adapter.GetLabels(), // materialize labels so future hits reuse them
+		})
 	}
 	return nil
 }

--- a/pkg/plugins/resources/k8s/caching_converter_test.go
+++ b/pkg/plugins/resources/k8s/caching_converter_test.go
@@ -1,15 +1,18 @@
 package k8s_test
 
 import (
+	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	workload_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/workload/api/v1alpha1"
 	workload_k8s "github.com/kumahq/kuma/v2/pkg/core/resources/apis/workload/k8s/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
 )
 
 var _ = Describe("CachingConverter", func() {
@@ -106,5 +109,95 @@ var _ = Describe("CachingConverter", func() {
 		// then - status should reflect updated values (not cached)
 		Expect(out2.Status.DataplaneProxies.Connected).To(Equal(int32(7)))
 		Expect(out2.Status.DataplaneProxies.Total).To(Equal(int32(7)))
+	})
+
+	It("should memoize labels on the meta adapter across repeated GetLabels calls", func() {
+		adapter := &k8s.KubernetesMetaAdapter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backend",
+				Namespace: "demo",
+				Labels:    map[string]string{"app": "backend"},
+				Annotations: map[string]string{
+					v1alpha1.DisplayName:        "Backend Display",
+					metadata.KumaServiceAccount: "sa-backend",
+				},
+			},
+			Mesh: "default",
+		}
+
+		first := adapter.GetLabels()
+		second := adapter.GetLabels()
+
+		// same map instance returned on repeat calls -> no per-call maps.Clone
+		Expect(reflect.ValueOf(first).Pointer()).To(Equal(reflect.ValueOf(second).Pointer()))
+		Expect(first).To(HaveKeyWithValue("app", "backend"))
+		Expect(first).To(HaveKeyWithValue(v1alpha1.DisplayName, "Backend Display"))
+		Expect(first).To(HaveKeyWithValue(metadata.KumaServiceAccount, "sa-backend"))
+	})
+
+	It("should share the same labels map across cache hits for the same resourceVersion", func() {
+		converter := k8s.NewCachingConverter(5 * time.Minute)
+		k8sWorkload := &workload_k8s.Workload{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: workload_k8s.GroupVersion.String(),
+				Kind:       "Workload",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "demo",
+				Name:            "backend",
+				ResourceVersion: "1",
+				Labels:          map[string]string{"app": "backend"},
+			},
+			Spec: &workload_api.Workload{},
+		}
+
+		out1 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out1)).To(Succeed())
+
+		out2 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out2)).To(Succeed())
+
+		labels1 := out1.GetMeta().GetLabels()
+		labels2 := out2.GetMeta().GetLabels()
+
+		// cache hit path reuses the precomputed labels map -> same pointer
+		Expect(reflect.ValueOf(labels1).Pointer()).To(Equal(reflect.ValueOf(labels2).Pointer()))
+		Expect(labels1).To(HaveKeyWithValue("app", "backend"))
+		// display name defaults to the object name when no annotation is present
+		Expect(labels1).To(HaveKeyWithValue(v1alpha1.DisplayName, "backend"))
+	})
+
+	It("should compute fresh labels when resourceVersion changes", func() {
+		converter := k8s.NewCachingConverter(5 * time.Minute)
+		k8sWorkload := &workload_k8s.Workload{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: workload_k8s.GroupVersion.String(),
+				Kind:       "Workload",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "demo",
+				Name:            "backend",
+				ResourceVersion: "1",
+				Labels:          map[string]string{"app": "backend"},
+			},
+			Spec: &workload_api.Workload{},
+		}
+
+		out1 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out1)).To(Succeed())
+		labels1 := out1.GetMeta().GetLabels()
+
+		// simulate an update: new ResourceVersion + mutated labels
+		k8sWorkload.ResourceVersion = "2"
+		k8sWorkload.Labels = map[string]string{"app": "backend", "version": "v2"}
+
+		out2 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out2)).To(Succeed())
+		labels2 := out2.GetMeta().GetLabels()
+
+		// different resourceVersion -> different cache key -> different labels map
+		Expect(reflect.ValueOf(labels1).Pointer()).ToNot(Equal(reflect.ValueOf(labels2).Pointer()))
+		Expect(labels1).ToNot(HaveKey("version"))
+		Expect(labels2).To(HaveKeyWithValue("version", "v2"))
 	})
 })

--- a/pkg/plugins/resources/k8s/caching_converter_test.go
+++ b/pkg/plugins/resources/k8s/caching_converter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	workload_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/workload/api/v1alpha1"
 	workload_k8s "github.com/kumahq/kuma/v2/pkg/core/resources/apis/workload/k8s/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
 )
@@ -135,7 +136,7 @@ var _ = Describe("CachingConverter", func() {
 		Expect(first).To(HaveKeyWithValue(metadata.KumaServiceAccount, "sa-backend"))
 	})
 
-	It("should share the same labels map across cache hits for the same resourceVersion", func() {
+	It("should serve labels from cache for the same resourceVersion", func() {
 		converter := k8s.NewCachingConverter(5 * time.Minute)
 		k8sWorkload := &workload_k8s.Workload{
 			TypeMeta: metav1.TypeMeta{
@@ -154,17 +155,109 @@ var _ = Describe("CachingConverter", func() {
 		out1 := workload_api.NewWorkloadResource()
 		Expect(converter.ToCoreResource(k8sWorkload, out1)).To(Succeed())
 
+		// Mutate the source labels but keep ResourceVersion: a cache hit must
+		// return the precomputed entry, ignoring the new source values.
+		k8sWorkload.Labels = map[string]string{"app": "frontend"}
+
 		out2 := workload_api.NewWorkloadResource()
 		Expect(converter.ToCoreResource(k8sWorkload, out2)).To(Succeed())
 
 		labels1 := out1.GetMeta().GetLabels()
 		labels2 := out2.GetMeta().GetLabels()
 
-		// cache hit path reuses the precomputed labels map -> same pointer
-		Expect(reflect.ValueOf(labels1).Pointer()).To(Equal(reflect.ValueOf(labels2).Pointer()))
-		Expect(labels1).To(HaveKeyWithValue("app", "backend"))
-		// display name defaults to the object name when no annotation is present
-		Expect(labels1).To(HaveKeyWithValue(v1alpha1.DisplayName, "backend"))
+		// cache hit -> labels match the original conversion, not the mutated source
+		Expect(labels2).To(HaveKeyWithValue("app", "backend"))
+		Expect(labels2).To(HaveKeyWithValue(v1alpha1.DisplayName, "backend"))
+		Expect(labels1).To(Equal(labels2))
+		// each adapter holds its own clone -> mutation isolation
+		Expect(reflect.ValueOf(labels1).Pointer()).ToNot(Equal(reflect.ValueOf(labels2).Pointer()))
+	})
+
+	It("should not corrupt the cache when consumers mutate the returned labels map", func() {
+		converter := k8s.NewCachingConverter(5 * time.Minute)
+		k8sWorkload := &workload_k8s.Workload{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: workload_k8s.GroupVersion.String(),
+				Kind:       "Workload",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "demo",
+				Name:            "backend",
+				ResourceVersion: "1",
+				Labels:          map[string]string{"app": "backend"},
+				Annotations: map[string]string{
+					v1alpha1.DisplayName: "Backend Display",
+				},
+			},
+			Spec: &workload_api.Workload{},
+		}
+
+		// First call: cache miss. Simulate api-server's removeDisplayNameLabel
+		// by deleting from the returned labels map in place.
+		out1 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out1)).To(Succeed())
+		labels1 := out1.GetMeta().GetLabels()
+		delete(labels1, v1alpha1.DisplayName)
+		delete(labels1, "app")
+
+		// Second call: cache hit. Repeat the in-place mutation on labels2 to
+		// also exercise clone-on-read isolation.
+		out2 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out2)).To(Succeed())
+		labels2 := out2.GetMeta().GetLabels()
+		Expect(labels2).To(HaveKeyWithValue("app", "backend"))
+		Expect(labels2).To(HaveKeyWithValue(v1alpha1.DisplayName, "Backend Display"))
+		delete(labels2, v1alpha1.DisplayName)
+
+		// Third call: another cache hit. The cache must still hold the
+		// pristine entry despite both prior consumers mutating their copies.
+		out3 := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(k8sWorkload, out3)).To(Succeed())
+		labels3 := out3.GetMeta().GetLabels()
+		Expect(labels3).To(HaveKeyWithValue("app", "backend"))
+		Expect(labels3).To(HaveKeyWithValue(v1alpha1.DisplayName, "Backend Display"))
+	})
+
+	It("should route ToCoreList through the caching ToCoreResource", func() {
+		converter := k8s.NewCachingConverter(5 * time.Minute)
+		list := &workload_k8s.WorkloadList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: workload_k8s.GroupVersion.String(),
+				Kind:       "WorkloadList",
+			},
+			Items: []workload_k8s.Workload{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: workload_k8s.GroupVersion.String(),
+						Kind:       "Workload",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "demo",
+						Name:            "backend",
+						ResourceVersion: "1",
+						Labels:          map[string]string{"app": "backend"},
+					},
+					Spec: &workload_api.Workload{},
+				},
+			},
+		}
+		predicate := func(core_model.Resource) bool { return true }
+
+		// First list call populates the cache.
+		out1 := &workload_api.WorkloadResourceList{}
+		Expect(converter.ToCoreList(list, out1, predicate)).To(Succeed())
+		Expect(out1.Items).To(HaveLen(1))
+
+		// Mutate the source labels but keep ResourceVersion: a properly
+		// dispatched ToCoreList must hit the cache and ignore the mutation.
+		// Without the cachingConverter.ToCoreList override, the embedded
+		// SimpleConverter.ToCoreList runs and rebuilds labels every time.
+		list.Items[0].Labels = map[string]string{"app": "frontend"}
+
+		out2 := &workload_api.WorkloadResourceList{}
+		Expect(converter.ToCoreList(list, out2, predicate)).To(Succeed())
+		Expect(out2.Items).To(HaveLen(1))
+		Expect(out2.Items[0].GetMeta().GetLabels()).To(HaveKeyWithValue("app", "backend"))
 	})
 
 	It("should compute fresh labels when resourceVersion changes", func() {

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"maps"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -273,6 +274,12 @@ var _ core_model.ResourceMeta = &KubernetesMetaAdapter{}
 type KubernetesMetaAdapter struct {
 	kube_meta.ObjectMeta
 	Mesh string
+
+	// cachedLabels memoizes the result of GetLabels. May be pre-populated by
+	// CachingConverter on cache hit to reuse labels computed for an earlier
+	// call against the same resourceVersion.
+	cachedLabels map[string]string
+	labelsOnce   sync.Once
 }
 
 func (m *KubernetesMetaAdapter) GetName() string {
@@ -302,23 +309,36 @@ func (m *KubernetesMetaAdapter) GetModificationTime() time.Time {
 	return m.GetObjectMeta().GetCreationTimestamp().Time
 }
 
+// GetLabels returns the labels of the underlying Kubernetes object enriched
+// with annotation-derived entries (display name, Kuma service account, Kuma
+// workload). The computation is memoized per adapter instance: callers MUST
+// treat the returned map as read-only. Mutating it would corrupt both the
+// adapter's cache and, when the adapter was produced by CachingConverter, the
+// cross-reconcile entry shared via resourceVersion key.
 func (m *KubernetesMetaAdapter) GetLabels() map[string]string {
-	labels := maps.Clone(m.GetObjectMeta().GetLabels())
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	if displayName, ok := m.GetObjectMeta().GetAnnotations()[v1alpha1.DisplayName]; ok {
-		labels[v1alpha1.DisplayName] = displayName
-	} else {
-		labels[v1alpha1.DisplayName] = m.GetObjectMeta().GetName()
-	}
-	if sa, ok := m.GetObjectMeta().GetAnnotations()[metadata.KumaServiceAccount]; ok {
-		labels[metadata.KumaServiceAccount] = sa
-	}
-	if workload, ok := m.GetObjectMeta().GetAnnotations()[metadata.KumaWorkload]; ok {
-		labels[metadata.KumaWorkload] = workload
-	}
-	return labels
+	m.labelsOnce.Do(func() {
+		if m.cachedLabels != nil {
+			// Pre-populated by CachingConverter on cache hit; nothing to do.
+			return
+		}
+		labels := maps.Clone(m.GetObjectMeta().GetLabels())
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		if displayName, ok := m.GetObjectMeta().GetAnnotations()[v1alpha1.DisplayName]; ok {
+			labels[v1alpha1.DisplayName] = displayName
+		} else {
+			labels[v1alpha1.DisplayName] = m.GetObjectMeta().GetName()
+		}
+		if sa, ok := m.GetObjectMeta().GetAnnotations()[metadata.KumaServiceAccount]; ok {
+			labels[metadata.KumaServiceAccount] = sa
+		}
+		if workload, ok := m.GetObjectMeta().GetAnnotations()[metadata.KumaWorkload]; ok {
+			labels[metadata.KumaWorkload] = workload
+		}
+		m.cachedLabels = labels
+	})
+	return m.cachedLabels
 }
 
 type KubeFactory interface {


### PR DESCRIPTION
## Motivation

Fixes #16191.

`KubernetesMetaAdapter.GetLabels` ran `maps.Clone` on every call plus an annotation-merge into the cloned map. `DestinationIndex` invokes it per destination per reconcile, producing ~68 MB of label-map churn per wave in the referenced profile. The existing `cachingConverter` only cached the unmarshaled spec, so the adapter and its labels were rebuilt on every cache hit.

## Implementation information

- `KubernetesMetaAdapter` gets a `cachedLabels` field + `sync.Once`. First `GetLabels` call computes once; subsequent calls return the same map pointer. Adapter is always used via pointer (verified) so `sync.Once` is safe.
- `cachingConverter` now caches `(spec, labels)` together in a `cachedEntry` struct keyed by the same `namespace:name:resourceVersion:gvk`. On hit, it pre-populates the new adapter's `cachedLabels` so the first `GetLabels` skips the Once closure and returns the shared map directly. The adapter is still reallocated per call (cheap) but the expensive labels map is now shared across reconciles for the lifetime of the cache entry.
- **Status is still refetched on every call** — preserved the contract asserted by the existing test that verifies status subresource mutations surface on cache hits.
- **Read-only labels contract** — documented on `GetLabels`. Audit of call sites in `pkg/xds/context/destination_index.go`, `pkg/xds/topology/outbound.go`, `pkg/xds/generator/{dns,ingress}_generator.go`, `pkg/plugins/policies/core/rules/resolve/targetref.go`, and `pkg/xds/server/callbacks/*` confirms every caller treats the map as read-only. Mutation canary test (60 samples over 60s against a live cluster) observed zero drift.
- No invalidation wiring needed: `resourceVersion` is part of the cache key, so any K8s update mints a fresh miss. Existing `MarshalingCacheExpirationTime` TTL bounds memory.

### Tests

Unit tests extended in `pkg/plugins/resources/k8s/caching_converter_test.go`:
- Adapter memoizes labels across repeat `GetLabels` calls (pointer equality).
- Same labels map pointer across cache hits for the same `resourceVersion`.
- Different `resourceVersion` produces a fresh map; stale label values don't leak.
- Pre-existing status-freshness tests still pass unchanged.

### Manual verification on k3d (kuma-2 cluster)

Ran a 10-test correctness suite covering create/update/delete propagation, display-name override + fallback, status freshness, mutation canary, webhook validation, and dp bootstrap. All passed except T-05 label routing, which surfaced a pre-existing Envoy-rendering issue (empty `weightedClusters`) unrelated to this change — the `_rules` endpoint confirmed label-based resolution itself works correctly. No panics or data races in 15 minutes of CP logs. `go test -race ./pkg/plugins/resources/k8s/...` and `./pkg/xds/context/...` green.

## Supporting documentation

- Issue: #16191
- Parent umbrella: #16183

> Changelog: perf(k8s): cache labels + spec per resourceVersion