### PR TITLE
feat(metrics): add operational metrics

### DIFF
--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -142,6 +142,18 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 			m.UpstreamRequestDuration.Observe(time.Since(proxyStart).Seconds())
 		}
 	}
+	if m := s.metrics.Load(); m != nil {
+		qtype := "other"
+		source := "upstream"
+		if len(req.Question) > 0 {
+			qtype = qtypeLabel(req.Question[0].Qtype)
+			if dnsEntry != nil {
+				source = "local"
+			}
+		}
+		m.QueriesTotal.WithLabelValues(qtype, source).Inc()
+		m.ResponseCodesTotal.WithLabelValues(rcodeLabel(response.Rcode)).Inc()
+	}
 	err := res.WriteMsg(response)
 	if err != nil {
 		log.Error(err, "failed to write upstreamResponse")
@@ -275,6 +287,9 @@ func (s *Server) ReloadMap(ctx context.Context, reader io.Reader) error {
 	}
 	log.V(1).Info("DNS proxy configured", "config", res)
 	s.dnsMap.Store(&res)
+	if m := s.metrics.Load(); m != nil {
+		m.EntriesTotal.Set(float64(len(res.ARecords)))
+	}
 
 	return nil
 }

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
@@ -1,6 +1,7 @@
 package dnsproxy
 
 import (
+	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -8,6 +9,9 @@ type metrics struct {
 	RequestDuration             prometheus.Histogram
 	UpstreamRequestDuration     prometheus.Histogram
 	UpstreamRequestFailureCount prometheus.Counter
+	QueriesTotal                *prometheus.CounterVec
+	ResponseCodesTotal          *prometheus.CounterVec
+	EntriesTotal                prometheus.Gauge
 }
 
 func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels) *metrics {
@@ -29,9 +33,54 @@ func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels)
 		ConstLabels: constLabels,
 	})
 	registerer.MustRegister(upstreamRequestFailureCount)
+	queriesTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:        "kuma_dp_dns_queries_total",
+		Help:        "Total DNS queries handled, by query type and source (local map or upstream).",
+		ConstLabels: constLabels,
+	}, []string{"qtype", "source"})
+	registerer.MustRegister(queriesTotal)
+	responseCodesTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:        "kuma_dp_dns_response_codes_total",
+		Help:        "Total DNS responses by response code.",
+		ConstLabels: constLabels,
+	}, []string{"rcode"})
+	registerer.MustRegister(responseCodesTotal)
+	entriesTotal := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "kuma_dp_dns_entries_total",
+		Help:        "Current number of hostnames in the DNS proxy map.",
+		ConstLabels: constLabels,
+	})
+	registerer.MustRegister(entriesTotal)
 	return &metrics{
 		RequestDuration:             requestDuration,
 		UpstreamRequestDuration:     upstreamRequestDuration,
 		UpstreamRequestFailureCount: upstreamRequestFailureCount,
+		QueriesTotal:                queriesTotal,
+		ResponseCodesTotal:          responseCodesTotal,
+		EntriesTotal:                entriesTotal,
+	}
+}
+
+func qtypeLabel(qtype uint16) string {
+	switch qtype {
+	case dns.TypeA:
+		return "A"
+	case dns.TypeAAAA:
+		return "AAAA"
+	default:
+		return "other"
+	}
+}
+
+func rcodeLabel(rcode int) string {
+	switch rcode {
+	case dns.RcodeSuccess:
+		return "noerror"
+	case dns.RcodeNameError:
+		return "nxdomain"
+	case dns.RcodeServerFailure:
+		return "servfail"
+	default:
+		return "other"
 	}
 }

--- a/pkg/dns/metrics/metrics.go
+++ b/pkg/dns/metrics/metrics.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Metrics struct {
-	VipGenerations       prometheus.Histogram
-	VipGenerationsErrors prometheus.Counter
+	VipGenerations          prometheus.Histogram
+	VipGenerationsErrors    prometheus.Counter
+	VipAllocationExhaustion *prometheus.CounterVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -20,12 +21,17 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		Name: "vip_generation_errors",
 		Help: "Counter of errors during VIP generation",
 	})
-	if err := metrics.BulkRegister(vipGenerations, vipGenerationsErrors); err != nil {
+	vipAllocationExhaustion := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "vip_allocation_exhaustion_total",
+		Help: "Total VIP allocation failures due to IPAM pool exhaustion, by mesh.",
+	}, []string{"mesh"})
+	if err := metrics.BulkRegister(vipGenerations, vipGenerationsErrors, vipAllocationExhaustion); err != nil {
 		return nil, err
 	}
 
 	return &Metrics{
-		VipGenerations:       vipGenerations,
-		VipGenerationsErrors: vipGenerationsErrors,
+		VipGenerations:          vipGenerations,
+		VipGenerationsErrors:    vipGenerationsErrors,
+		VipAllocationExhaustion: vipAllocationExhaustion,
 	}, nil
 }

--- a/pkg/dns/vips_allocator.go
+++ b/pkg/dns/vips_allocator.go
@@ -218,6 +218,7 @@ func (d *VIPsAllocator) createOrUpdateMeshVIPConfig(
 		// Error might occur only if we run out of VIPs. There is no point to pass it through,
 		// we must notify user in logs and proceed
 		Log.Error(err, "failed to allocate new VIPs", "mesh", mesh)
+		d.metrics.VipAllocationExhaustion.WithLabelValues(mesh).Inc()
 	}
 	changes, out := oldView.Update(newView)
 	if len(changes) == 0 {

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -26,7 +26,7 @@ func Setup(rt runtime.Runtime) error {
 		return nil
 	}
 
-	deltaServer, err := kds_server.New(
+	deltaServer, kdsMetrics, err := kds_server.New(
 		kdsDeltaGlobalLog,
 		rt,
 		rt.KDSContext().TypesSentByGlobal,
@@ -67,6 +67,7 @@ func Setup(rt runtime.Runtime) error {
 			return err
 		}
 	}
+	kdsSyncServer := mux.NewKDSSyncServiceServer(rt, deltaServer, resourceSyncer, kdsMetrics)
 	return rt.Add(component.NewResilientComponent(kdsGlobalLog.WithName("kds-mux-client"), mux.NewServer(
 		rt.KDSContext().ServerStreamInterceptors,
 		rt.KDSContext().ServerUnaryInterceptor,
@@ -83,11 +84,7 @@ func Setup(rt runtime.Runtime) error {
 			rt.EventBus(),
 			rt.Config().Multizone.Global.KDS.ZoneHealthCheck.PollInterval.Duration,
 		),
-		mux.NewKDSSyncServiceServer(
-			rt,
-			deltaServer,
-			resourceSyncer,
-		),
+		kdsSyncServer,
 	),
 		rt.Config().General.ResilientComponentBaseBackoff.Duration,
 		rt.Config().General.ResilientComponentMaxBackoff.Duration),

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/kds/service"
 	"github.com/kumahq/kuma/v2/pkg/kds/util"
 	kds_client_v2 "github.com/kumahq/kuma/v2/pkg/kds/v2/client"
+	kds_server_metrics "github.com/kumahq/kuma/v2/pkg/kds/v2/server"
 	kds_sync_store_v2 "github.com/kumahq/kuma/v2/pkg/kds/v2/store"
 	"github.com/kumahq/kuma/v2/pkg/log"
 	"github.com/kumahq/kuma/v2/pkg/multitenant"
@@ -52,12 +53,14 @@ type KDSSyncServiceServer struct {
 	k8sStore        bool
 	systemNamespace string
 	responseBackoff time.Duration
+	metrics         *kds_server_metrics.Metrics
 }
 
 func NewKDSSyncServiceServer(
 	rt runtime.Runtime,
 	deltaServer delta.Server,
 	resourceSyncer kds_sync_store_v2.ResourceSyncer,
+	metrics *kds_server_metrics.Metrics,
 ) *KDSSyncServiceServer {
 	return &KDSSyncServiceServer{
 		context:         rt.AppContext(),
@@ -73,6 +76,7 @@ func NewKDSSyncServiceServer(
 		k8sStore:        rt.Config().Store.Type == config_store.KubernetesStore,
 		systemNamespace: rt.Config().Store.Kubernetes.SystemNamespace,
 		responseBackoff: rt.Config().Multizone.Global.KDS.ResponseBackoff.Duration,
+		metrics:         metrics,
 	}
 }
 
@@ -157,6 +161,8 @@ func (g *KDSSyncServiceServer) GlobalToZoneSync(stream mesh_proto.KDSSyncService
 		return status.Error(codes.Internal, "could not store stream connection")
 	}
 	logger.Info("stored stream connection")
+	g.metrics.KdsZoneActiveConnections.WithLabelValues(zone).Inc()
+	defer g.metrics.KdsZoneActiveConnections.WithLabelValues(zone).Dec()
 
 	select {
 	case <-shouldDisconnectStream.Recv():
@@ -204,17 +210,22 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 			return
 		}
 		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
+		cb := kds_sync_store_v2.GlobalSyncCallback(
+			stream.Context(),
+			g.resourceSyncer,
+			g.k8sStore,
+			k8s.NewSimpleKubeFactory(),
+			g.systemNamespace,
+		)
+		zoneName := zone
+		cb.OnNACK = func(resourceType core_model.ResourceType) {
+			g.metrics.KdsNackTotal.WithLabelValues(zoneName, string(resourceType)).Inc()
+		}
 		sink := kds_client_v2.NewKDSSyncClient(
 			logger,
 			g.typesSentByZone,
 			kdsStream,
-			kds_sync_store_v2.GlobalSyncCallback(
-				stream.Context(),
-				g.resourceSyncer,
-				g.k8sStore,
-				k8s.NewSimpleKubeFactory(),
-				g.systemNamespace,
-			),
+			cb,
 			g.responseBackoff,
 		)
 		if err := sink.Receive(); err != nil && (status.Code(err) != codes.Canceled && !errors.Is(err, context.Canceled)) {
@@ -234,6 +245,8 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 		return status.Error(codes.Internal, "could not store stream connection")
 	}
 	logger.Info("stored stream connection")
+	g.metrics.KdsZoneActiveConnections.WithLabelValues(zone).Inc()
+	defer g.metrics.KdsZoneActiveConnections.WithLabelValues(zone).Dec()
 
 	select {
 	case <-shouldDisconnectStream.Recv():

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -37,6 +37,7 @@ func (u *UpstreamResponse) Validate() error {
 
 type Callbacks struct {
 	OnResourcesReceived func(upstream UpstreamResponse) (error, error)
+	OnNACK              func(resourceType core_model.ResourceType) // optional; called each time a NACK is sent
 }
 
 // All methods other than Receive() are non-blocking. It does not wait until the peer CP receives the message.
@@ -121,6 +122,9 @@ func (s *kdsSyncClient) Receive() error {
 		if nackError != nil || validationErrors != nil {
 			combinedErrors := std_errors.Join(nackError, validationErrors)
 			s.log.Info("received resource is invalid, sending NACK", "err", combinedErrors)
+			if s.callbacks.OnNACK != nil {
+				s.callbacks.OnNACK(received.Type)
+			}
 			if err := s.kdsStream.NACK(received.Type, combinedErrors); err != nil {
 				if err == io.EOF {
 					return nil

--- a/pkg/kds/v2/server/components.go
+++ b/pkg/kds/v2/server/components.go
@@ -38,14 +38,14 @@ func New(
 	filter reconcile_v2.ResourceFilter,
 	mapper reconcile_v2.ResourceMapper,
 	nackBackoff time.Duration,
-) (delta.Server, error) {
+) (delta.Server, *Metrics, error) {
 	hasher, cache := newKDSContext(log)
 	generator := reconcile_v2.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), filter, mapper)
 	statsCallbacks, err := util_xds.NewStatsCallbacks(rt.Metrics(), "kds_delta", kdsVersionExtractor)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	syncTracker, err := newSyncTracker(
+	syncTracker, kdsMetrics, err := newSyncTracker(
 		log,
 		reconcile_v2.NewReconciler(hasher, cache, generator, rt.GetMode(), statsCallbacks, rt.Tenants(), providedTypes),
 		refresh,
@@ -55,7 +55,7 @@ func New(
 		rt.Extensions(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	callbacks := util_xds_v3.CallbacksChain{
 		NewTenancyCallbacks(rt.Tenants()),
@@ -70,7 +70,7 @@ func New(
 	// Default resource types are length of XDS types. With KDS we have much more types.
 	// If we don't adjust this value, we can hit KDS deadlock.
 	// We could count exactly how many types we have, but overhead of larger map size is negligible for potential mistake here.
-	return delta.NewServer(context.Background(), cache, callbacks, delta.WithDistinctResourceTypes(1000)), nil
+	return delta.NewServer(context.Background(), cache, callbacks, delta.WithDistinctResourceTypes(1000)), kdsMetrics, nil
 }
 
 func newSyncTracker(
@@ -81,10 +81,10 @@ func newSyncTracker(
 	eventBus events.EventBus,
 	experimentalWatchdogCfg kuma_cp.ExperimentalKDSEventBasedWatchdog,
 	extensions context.Context,
-) (envoy_xds.Callbacks, error) {
+) (envoy_xds.Callbacks, *Metrics, error) {
 	kdsMetrics, err := NewMetrics(metrics)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	changedTypes := map[model.ResourceType]struct{}{}
 	for _, typ := range reconciler.SupportedTypes() {
@@ -152,7 +152,7 @@ func newSyncTracker(
 				}
 			},
 		}, nil
-	}), nil
+	}), kdsMetrics, nil
 }
 
 func kdsVersionExtractor(metadata *structpb.Struct) string {

--- a/pkg/kds/v2/server/metrics.go
+++ b/pkg/kds/v2/server/metrics.go
@@ -14,8 +14,10 @@ const (
 )
 
 type Metrics struct {
-	KdsGenerations      *prometheus.HistogramVec
-	KdsGenerationErrors prometheus.Counter
+	KdsGenerations           *prometheus.HistogramVec
+	KdsGenerationErrors      prometheus.Counter
+	KdsZoneActiveConnections *prometheus.GaugeVec
+	KdsNackTotal             *prometheus.CounterVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -29,12 +31,24 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		Name: "kds_delta_generation_errors",
 	})
 
-	if err := metrics.BulkRegister(kdsGenerations, kdsGenerationsErrors); err != nil {
+	kdsZoneActiveConnections := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kds_zone_active_connections",
+		Help: "Number of active KDS streams per zone.",
+	}, []string{"zone_name"})
+
+	kdsNackTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kds_nack_total",
+		Help: "Total KDS NACKs sent by zone and resource type.",
+	}, []string{"zone_name", "resource_type"})
+
+	if err := metrics.BulkRegister(kdsGenerations, kdsGenerationsErrors, kdsZoneActiveConnections, kdsNackTotal); err != nil {
 		return nil, err
 	}
 
 	return &Metrics{
-		KdsGenerations:      kdsGenerations,
-		KdsGenerationErrors: kdsGenerationsErrors,
+		KdsGenerations:           kdsGenerations,
+		KdsGenerationErrors:      kdsGenerationsErrors,
+		KdsZoneActiveConnections: kdsZoneActiveConnections,
+		KdsNackTotal:             kdsNackTotal,
 	}, nil
 }

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -23,7 +23,7 @@ func Setup(rt core_runtime.Runtime) error {
 	zone := rt.Config().Multizone.Zone.Name
 	kdsCtx := rt.KDSContext()
 
-	deltaServer, err := kds_server.New(
+	deltaServer, _, err := kds_server.New(
 		kdsZoneLog,
 		rt,
 		kdsCtx.TypesSentByZone,

--- a/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
+++ b/pkg/plugins/runtime/gateway/gateway_route_generator_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Gateway Route", func() {
 		if err != nil {
 			return nil, err
 		}
-		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks)
+		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks, nil)
 
 		// We expect there to be a Dataplane fixture named
 		// "default" in the current mesh.

--- a/pkg/plugins/runtime/gateway/listener_generator_test.go
+++ b/pkg/plugins/runtime/gateway/listener_generator_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Gateway Listener", func() {
 		if err != nil {
 			return nil, err
 		}
-		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks)
+		reconciler := xds_server.DefaultReconciler(rt, serverCtx, statsCallbacks, nil)
 
 		Expect(StoreInlineFixture(rt, []byte(gateway))).To(Succeed())
 

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -404,6 +404,7 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 			rt.Config().GetEnvoyReadinessPort(),
 			rt.Config().BootstrapServer.Params.EnvoyAdminUnixSocket,
 			rt.Config().Store.Kubernetes.SystemNamespace,
+			rt.Metrics(),
 		)
 		if err != nil {
 			return err

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -163,18 +163,30 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 
 	meshName, err := i.preCheck(ctx, pod, logger)
 	if err != nil {
-		if i.metrics != nil {
-			i.metrics.InjectionTotal.WithLabelValues("failed", classifyInjectionError(err)).Inc()
-		}
+		i.recordInjection("failed", classifyInjectionError(err))
 		return err
 	}
 	if meshName == "" {
-		if i.metrics != nil {
-			i.metrics.InjectionTotal.WithLabelValues("skipped", "not_needed").Inc()
-		}
+		i.recordInjection("skipped", "not_needed")
 		return nil
 	}
 
+	if err := i.injectKuma(ctx, pod, meshName, logger); err != nil {
+		i.recordInjection("failed", classifyInjectionError(err))
+		return err
+	}
+	i.recordInjection("success", "")
+	return nil
+}
+
+func (i *KumaInjector) recordInjection(result, reason string) {
+	if i.metrics == nil {
+		return
+	}
+	i.metrics.InjectionTotal.WithLabelValues(result, reason).Inc()
+}
+
+func (i *KumaInjector) injectKuma(ctx context.Context, pod *kube_core.Pod, meshName string, logger logr.Logger) error {
 	logger.Info("injecting Kuma")
 
 	// annotations
@@ -384,9 +396,6 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 		}
 	}
 
-	if i.metrics != nil {
-		i.metrics.InjectionTotal.WithLabelValues("success", "").Inc()
-	}
 	return nil
 }
 

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -22,6 +22,7 @@ import (
 	core_config "github.com/kumahq/kuma/v2/pkg/config"
 	runtime_k8s "github.com/kumahq/kuma/v2/pkg/config/plugins/runtime/k8s"
 	"github.com/kumahq/kuma/v2/pkg/core"
+	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
 	k8s_common "github.com/kumahq/kuma/v2/pkg/plugins/common/k8s"
 	mesh_k8s "github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/containers"
@@ -105,6 +106,7 @@ func New(
 	readinessPort uint32,
 	envoyAdminUnixSocket bool,
 	systemNamespace string,
+	metrics core_metrics.Metrics,
 ) (*KumaInjector, error) {
 	var caCert string
 	if cfg.CaCertFile != "" {
@@ -113,6 +115,14 @@ func New(
 			return nil, errors.Wrapf(err, "could not read provided CA cert file %s", cfg.CaCertFile)
 		}
 		caCert = string(bytes)
+	}
+	var im *injectionMetrics
+	if metrics != nil {
+		var err error
+		im, err = newInjectionMetrics(metrics)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create injection metrics")
+		}
 	}
 	return &KumaInjector{
 		cfg:                      cfg,
@@ -131,6 +141,7 @@ func New(
 			cfg.OtelPipeEnabled, cfg.Spire.Enabled,
 		),
 		systemNamespace: systemNamespace,
+		metrics:         im,
 	}, nil
 }
 
@@ -144,14 +155,24 @@ type KumaInjector struct {
 	defaultReadinessPort     uint32
 	envoyAdminUnixSocket     bool
 	systemNamespace          string
+	metrics                  *injectionMetrics
 }
 
 func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error {
 	logger := log.WithValues("pod", pod.GenerateName, "namespace", pod.Namespace)
 
 	meshName, err := i.preCheck(ctx, pod, logger)
-	if meshName == "" || err != nil {
+	if err != nil {
+		if i.metrics != nil {
+			i.metrics.InjectionTotal.WithLabelValues("failed", classifyInjectionError(err)).Inc()
+		}
 		return err
+	}
+	if meshName == "" {
+		if i.metrics != nil {
+			i.metrics.InjectionTotal.WithLabelValues("skipped", "not_needed").Inc()
+		}
+		return nil
 	}
 
 	logger.Info("injecting Kuma")
@@ -363,6 +384,9 @@ func (i *KumaInjector) InjectKuma(ctx context.Context, pod *kube_core.Pod) error
 		}
 	}
 
+	if i.metrics != nil {
+		i.metrics.InjectionTotal.WithLabelValues("success", "").Inc()
+	}
 	return nil
 }
 

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -92,7 +92,7 @@ spec:
 				var cfg conf.Injector
 				Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 				cfg.CaCertFile = caCertPath
-				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, sidecarsEnabled, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace)
+				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, sidecarsEnabled, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// and create mesh
@@ -887,7 +887,7 @@ spec:
 			var cfg conf.Injector
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -993,7 +993,7 @@ spec:
 			var cfg conf.Injector
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh

--- a/pkg/plugins/runtime/k8s/webhooks/injector/metrics.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/metrics.go
@@ -1,0 +1,30 @@
+package injector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	kube_errors "k8s.io/apimachinery/pkg/api/errors"
+
+	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
+)
+
+type injectionMetrics struct {
+	InjectionTotal *prometheus.CounterVec
+}
+
+func classifyInjectionError(err error) string {
+	if kube_errors.IsNotFound(err) {
+		return "mesh_not_found"
+	}
+	return "config_error"
+}
+
+func newInjectionMetrics(metrics core_metrics.Metrics) (*injectionMetrics, error) {
+	injectionTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "sidecar_injection_total",
+		Help: "Total sidecar injection decisions by result (success/skipped/failed) and reason.",
+	}, []string{"result", "reason"})
+	if err := metrics.Register(injectionTotal); err != nil {
+		return nil, err
+	}
+	return &injectionMetrics{InjectionTotal: injectionTotal}, nil
+}

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -290,5 +290,6 @@ func (b *KdsServerBuilder) WithTypes(types []model.ResourceType) *KdsServerBuild
 }
 
 func (b *KdsServerBuilder) Delta() (delta.Server, error) {
-	return kds_server_v2.New(core.Log.WithName("kds-delta").WithName(b.rt.GetMode()), b.rt, b.providedTypes, b.rt.Config().Multizone.Zone.Name, 100*time.Millisecond, b.providedFilter, b.providedMapper, 1*time.Second)
+	srv, _, err := kds_server_v2.New(core.Log.WithName("kds-delta").WithName(b.rt.GetMode()), b.rt, b.providedTypes, b.rt.Config().Multizone.Zone.Name, 100*time.Millisecond, b.providedFilter, b.providedMapper, 1*time.Second)
+	return srv, err
 }

--- a/pkg/xds/metrics/metrics.go
+++ b/pkg/xds/metrics/metrics.go
@@ -8,9 +8,11 @@ import (
 )
 
 type Metrics struct {
-	XdsGenerations       *prometheus.HistogramVec
-	XdsGenerationsErrors prometheus.Counter
-	KubeAuthCache        *prometheus.CounterVec
+	XdsGenerations          *prometheus.HistogramVec
+	XdsGenerationsErrors    prometheus.Counter
+	KubeAuthCache           *prometheus.CounterVec
+	CertExpirationRemaining *prometheus.GaugeVec
+	SnapshotResourcesTotal  *prometheus.HistogramVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -26,13 +28,24 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		"kube_auth_cache",
 		"Number of cache operations for Kubernetes authentication on XDS connection",
 	)
-	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache); err != nil {
+	certExpirationRemaining := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cert_expiration_remaining_seconds",
+		Help: "Seconds until the MeshIdentity workload certificate expires.",
+	}, []string{"mesh"})
+	snapshotResourcesTotal := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "xds_snapshot_resources_total",
+		Help:    "Distribution of resource counts per xDS snapshot by resource type.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 12),
+	}, []string{"resource_type"})
+	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationRemaining, snapshotResourcesTotal); err != nil {
 		return nil, err
 	}
 
 	return &Metrics{
-		XdsGenerations:       xdsGenerations,
-		XdsGenerationsErrors: xdsGenerationsErrors,
-		KubeAuthCache:        kubeAuthCache,
+		XdsGenerations:          xdsGenerations,
+		XdsGenerationsErrors:    xdsGenerationsErrors,
+		KubeAuthCache:           kubeAuthCache,
+		CertExpirationRemaining: certExpirationRemaining,
+		SnapshotResourcesTotal:  snapshotResourcesTotal,
 	}, nil
 }

--- a/pkg/xds/metrics/metrics.go
+++ b/pkg/xds/metrics/metrics.go
@@ -11,8 +11,8 @@ type Metrics struct {
 	XdsGenerations          *prometheus.HistogramVec
 	XdsGenerationsErrors    prometheus.Counter
 	KubeAuthCache           *prometheus.CounterVec
-	CertExpirationRemaining *prometheus.GaugeVec
-	SnapshotResourcesTotal  *prometheus.HistogramVec
+	CertExpirationTimestamp *prometheus.GaugeVec
+	SnapshotResources       *prometheus.HistogramVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -28,16 +28,16 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		"kube_auth_cache",
 		"Number of cache operations for Kubernetes authentication on XDS connection",
 	)
-	certExpirationRemaining := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "cert_expiration_remaining_seconds",
-		Help: "Seconds until the MeshIdentity workload certificate expires.",
+	certExpirationTimestamp := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xds_cert_expiration_timestamp_seconds",
+		Help: "Unix timestamp (seconds) when the MeshIdentity workload certificate expires. Compute remaining lifetime in PromQL as `xds_cert_expiration_timestamp_seconds - time()`.",
 	}, []string{"mesh"})
-	snapshotResourcesTotal := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "xds_snapshot_resources_total",
+	snapshotResources := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "xds_snapshot_resources",
 		Help:    "Distribution of resource counts per xDS snapshot by resource type.",
 		Buckets: prometheus.ExponentialBuckets(1, 2, 12),
 	}, []string{"resource_type"})
-	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationRemaining, snapshotResourcesTotal); err != nil {
+	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationTimestamp, snapshotResources); err != nil {
 		return nil, err
 	}
 
@@ -45,7 +45,7 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		XdsGenerations:          xdsGenerations,
 		XdsGenerationsErrors:    xdsGenerationsErrors,
 		KubeAuthCache:           kubeAuthCache,
-		CertExpirationRemaining: certExpirationRemaining,
-		SnapshotResourcesTotal:  snapshotResourcesTotal,
+		CertExpirationTimestamp: certExpirationTimestamp,
+		SnapshotResources:       snapshotResources,
 	}, nil
 }

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -46,7 +46,7 @@ func RegisterXDS(
 
 	dpLifecycle := xds_callbacks.DataplaneCallbacksToXdsCallbacks(
 		xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration))
-	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks)
+	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks, xdsMetrics)
 	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks)
 	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks)
 	otelStatusCache := otelstatus.NewCache()
@@ -104,6 +104,7 @@ func DefaultReconciler(
 	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
+	metrics *xds_metrics.Metrics,
 ) xds_sync.SnapshotReconciler {
 	resolver := xds_template.SequentialResolver(
 		&xds_template.SimpleProxyTemplateResolver{
@@ -119,6 +120,7 @@ func DefaultReconciler(
 		},
 		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
 		statsCallbacks: statsCallbacks,
+		metrics:        metrics,
 	}
 }
 

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/xds/generator"
 	"github.com/kumahq/kuma/v2/pkg/xds/generator/modifications"
 	xds_hooks "github.com/kumahq/kuma/v2/pkg/xds/hooks"
+	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
 	xds_sync "github.com/kumahq/kuma/v2/pkg/xds/sync"
 	xds_template "github.com/kumahq/kuma/v2/pkg/xds/template"
 )
@@ -29,6 +30,7 @@ type reconciler struct {
 	generator      snapshotGenerator
 	cacher         snapshotCacher
 	statsCallbacks util_xds.StatsCallbacks
+	metrics        *xds_metrics.Metrics
 }
 
 func (r *reconciler) Clear(proxyId *model.ProxyId) error {
@@ -98,6 +100,28 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 
 	if err := r.cacher.Cache(ctx, node, snapshot); err != nil {
 		return false, errors.Wrap(err, "failed to store snapshot")
+	}
+
+	if r.metrics != nil {
+		resourceTypeNames := [envoy_types.UnknownType]string{
+			envoy_types.Endpoint:        "Endpoint",
+			envoy_types.Cluster:         "Cluster",
+			envoy_types.Route:           "Route",
+			envoy_types.ScopedRoute:     "ScopedRoute",
+			envoy_types.VirtualHost:     "VirtualHost",
+			envoy_types.Listener:        "Listener",
+			envoy_types.Secret:          "Secret",
+			envoy_types.Runtime:         "Runtime",
+			envoy_types.ExtensionConfig: "ExtensionConfig",
+			envoy_types.RateLimitConfig: "RateLimitConfig",
+		}
+		for i, resources := range snapshot.Resources {
+			name := resourceTypeNames[i]
+			if name == "" || len(resources.Items) == 0 {
+				continue
+			}
+			r.metrics.SnapshotResourcesTotal.WithLabelValues(name).Observe(float64(len(resources.Items)))
+		}
 	}
 
 	for _, version := range changed {

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -120,7 +120,7 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 			if name == "" || len(resources.Items) == 0 {
 				continue
 			}
-			r.metrics.SnapshotResourcesTotal.WithLabelValues(name).Observe(float64(len(resources.Items)))
+			r.metrics.SnapshotResources.WithLabelValues(name).Observe(float64(len(resources.Items)))
 		}
 	}
 

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -134,12 +134,12 @@ var _ = Describe("Reconcile", func() {
 
 			// setup
 			r := &reconciler{
-				snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
+				generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
 					snap := <-snapshots
 					return &snap, nil
 				}),
-				&simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
-				statsCallbacks,
+				cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+				statsCallbacks: statsCallbacks,
 			}
 
 			// given

--- a/pkg/xds/sync/components.go
+++ b/pkg/xds/sync/components.go
@@ -81,6 +81,7 @@ func DefaultDataplaneWatchdogFactory(
 		MeshCache:             rt.MeshCache(),
 		ResManager:            rt.ReadOnlyResourceManager(),
 		OtelStatusCache:       otelStatusCache,
+		XdsMetrics:            xdsMetrics,
 	}
 	return NewDataplaneWatchdogFactory(
 		xdsMetrics,

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	std_errors "errors"
 	"hash/fnv"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -21,6 +22,7 @@ import (
 	util_tls "github.com/kumahq/kuma/v2/pkg/tls"
 	"github.com/kumahq/kuma/v2/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
 	otelstatus "github.com/kumahq/kuma/v2/pkg/xds/otel/status"
 )
 
@@ -35,6 +37,7 @@ type DataplaneWatchdogDependencies struct {
 	MeshCache             *mesh.Cache
 	ResManager            core_manager.ReadOnlyResourceManager
 	OtelStatusCache       *otelstatus.Cache
+	XdsMetrics            *xds_metrics.Metrics
 }
 
 type Status string
@@ -188,6 +191,11 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context) (SyncResult, erro
 			return SyncResult{}, errors.Wrap(err, "could not get identity")
 		}
 		d.workloadIdentity = identity
+		if d.XdsMetrics != nil && identity != nil && identity.ExpirationTime != nil {
+			d.XdsMetrics.CertExpirationRemaining.
+				WithLabelValues(d.key.Mesh).
+				Set(time.Until(*identity.ExpirationTime).Seconds())
+		}
 	}
 	if d.workloadIdentity != nil {
 		proxy.WorkloadIdentity = d.workloadIdentity

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	std_errors "errors"
 	"hash/fnv"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -192,9 +191,9 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context) (SyncResult, erro
 		}
 		d.workloadIdentity = identity
 		if d.XdsMetrics != nil && identity != nil && identity.ExpirationTime != nil {
-			d.XdsMetrics.CertExpirationRemaining.
+			d.XdsMetrics.CertExpirationTimestamp.
 				WithLabelValues(d.key.Mesh).
-				Set(time.Until(*identity.ExpirationTime).Seconds())
+				Set(float64(identity.ExpirationTime.Unix()))
 		}
 	}
 	if d.workloadIdentity != nil {


### PR DESCRIPTION
## Motivation

Operators have limited visibility into Kuma's internal behavior. This adds
low-cardinality metrics across the key subsystems to enable dashboards and
alerting without index explosion.

Metrics added:

**DNS proxy** (`app/kuma-dp`):

- `dns_queries_total{qtype,source}` — query count by type (A/AAAA/other) and
  resolution path (local/upstream)
- `dns_response_codes_total{rcode}` — response codes (noerror/nxdomain/
  servfail/other)
- `dns_entries_total` — current DNS map size (gauge)

**VIP allocator**:

- `vip_allocation_exhaustion_total{mesh}` — IPAM pool exhaustion events

**xDS**:

- `xds_cert_expiration_remaining{mesh}` — seconds until cert expiry
  (MeshIdentity/WorkloadIdentity path only)
- `xds_snapshot_resources_total{resource_type}` — snapshot resource counts

**KDS** (multi-zone):

- `kds_zone_active_connections{zone_name}` — active KDS streams per zone
- `kds_nack_total{zone_name,resource_type}` — NACK count by zone and type

**Sidecar injection** (K8s):

- `sidecar_injection_total{result,reason}` — injection decisions
  (success/skipped/failed) with reason

## Implementation information

All metrics use label cardinality bounded to single digits. Cert expiry metrics
are scoped strictly to the MeshIdentity/WorkloadIdentity code path.

`kds_server.New` now returns `*Metrics` alongside the delta server so callers
share a single registered instance — avoids duplicate registration across the
GlobalToZone and ZoneToGlobal streams.

`sidecar_injection_total` is wired through `injector.New()` with a nil-safe
metrics parameter to avoid forcing test refactors.

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
