### PR TITLE
fix(postgres): retry SafeToRetry errors on reads

### DIFF
--- a/pkg/plugins/resources/postgres/pgx_store.go
+++ b/pkg/plugins/resources/postgres/pgx_store.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"maps"
 	"math/rand"
@@ -16,6 +17,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sethvargo/go-retry"
 
 	config "github.com/kumahq/kuma/v2/pkg/config/plugins/resources/postgres"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -249,25 +251,27 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 
 	statement := `SELECT spec, version, creation_time, modification_time, labels, status FROM resources WHERE name=$1 AND mesh=$2 AND type=$3;`
 	args := []any{opts.Name, opts.Mesh, resource.Descriptor().Name}
-	tx, exist := store.TxFromCtx(ctx)
-	var row pgx.Row
-	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
-		row = pgxTx.QueryRow(ctx, statement, args...)
-	} else {
-		pool := r.pickRoPool()
-		if opts.Consistent {
-			pool = r.pool
-		}
-		row = pool.QueryRow(ctx, statement, args...)
-	}
+	tx, txExist := store.TxFromCtx(ctx)
 
 	var spec string
 	var version int
 	var creationTime, modificationTime time.Time
 	var labels string
 	var status string
-	err := row.Scan(&spec, &version, &creationTime, &modificationTime, &labels, &status)
-	if err == pgx.ErrNoRows {
+	err := retryOnSafeToRetry(ctx, txExist, func() error {
+		var row pgx.Row
+		if pgxTx, ok := tx.(pgx.Tx); txExist && ok {
+			row = pgxTx.QueryRow(ctx, statement, args...)
+		} else {
+			pool := r.pickRoPool()
+			if opts.Consistent {
+				pool = r.pool
+			}
+			row = pool.QueryRow(ctx, statement, args...)
+		}
+		return row.Scan(&spec, &version, &creationTime, &modificationTime, &labels, &status)
+	})
+	if stderrors.Is(err, pgx.ErrNoRows) {
 		return store.ErrorResourceNotFound(resource.Descriptor().Name, opts.Name, opts.Mesh)
 	}
 	if err != nil {
@@ -302,6 +306,31 @@ func (r *pgxResourceStore) Get(ctx context.Context, resource core_model.Resource
 		return store.ErrorResourceConflict(resource.Descriptor().Name, opts.Name, opts.Mesh)
 	}
 	return nil
+}
+
+// retryOnSafeToRetry retries op when pgx returns an error that implements
+// SafeToRetry() == true (no bytes were sent on the wire, so the operation
+// is safe to replay). This closes the race where pgx's statement cache
+// deallocation fails on a connection that died between pool acquire and
+// first use, surfacing as "failed to deallocate cached statement(s): conn
+// closed". Retrying inside an existing transaction is skipped because the
+// transaction is already broken and must be aborted by the caller.
+func retryOnSafeToRetry(ctx context.Context, inTx bool, op func() error) error {
+	if inTx {
+		return op()
+	}
+	backoff := retry.WithMaxRetries(3, retry.NewConstant(10*time.Millisecond))
+	return retry.Do(ctx, backoff, func(ctx context.Context) error {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		var safeToRetry interface{ SafeToRetry() bool }
+		if stderrors.As(err, &safeToRetry) && safeToRetry.SafeToRetry() {
+			return retry.RetryableError(err)
+		}
+		return err
+	})
 }
 
 func (r *pgxResourceStore) pickRoPool() *pgxpool.Pool {
@@ -364,15 +393,17 @@ func (r *pgxResourceStore) List(ctx context.Context, resources core_model.Resour
 	}
 	statement.WriteString(" ORDER BY name, mesh")
 
-	tx, exist := store.TxFromCtx(ctx)
+	tx, txExist := store.TxFromCtx(ctx)
 	var rows pgx.Rows
-	var err error
-	if pgxTx, ok := tx.(pgx.Tx); exist && ok {
-		rows, err = pgxTx.Query(ctx, statement.String(), statementArgs...)
-	} else {
-		rows, err = r.pickRoPool().Query(ctx, statement.String(), statementArgs...)
-	}
-
+	err := retryOnSafeToRetry(ctx, txExist, func() error {
+		var qerr error
+		if pgxTx, ok := tx.(pgx.Tx); txExist && ok {
+			rows, qerr = pgxTx.Query(ctx, statement.String(), statementArgs...)
+		} else {
+			rows, qerr = r.pickRoPool().Query(ctx, statement.String(), statementArgs...)
+		}
+		return qerr
+	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute query: %s", statement.String())
 	}

--- a/pkg/plugins/resources/postgres/retry_internal_test.go
+++ b/pkg/plugins/resources/postgres/retry_internal_test.go
@@ -8,8 +8,8 @@ import (
 
 type safeToRetryErr struct{ safe bool }
 
-func (e *safeToRetryErr) Error() string      { return "conn closed" }
-func (e *safeToRetryErr) SafeToRetry() bool  { return e.safe }
+func (e *safeToRetryErr) Error() string     { return "conn closed" }
+func (e *safeToRetryErr) SafeToRetry() bool { return e.safe }
 
 type wrappedErr struct{ inner error }
 

--- a/pkg/plugins/resources/postgres/retry_internal_test.go
+++ b/pkg/plugins/resources/postgres/retry_internal_test.go
@@ -1,0 +1,127 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type safeToRetryErr struct{ safe bool }
+
+func (e *safeToRetryErr) Error() string      { return "conn closed" }
+func (e *safeToRetryErr) SafeToRetry() bool  { return e.safe }
+
+type wrappedErr struct{ inner error }
+
+func (w *wrappedErr) Error() string { return "wrapped: " + w.inner.Error() }
+func (w *wrappedErr) Unwrap() error { return w.inner }
+
+func TestRetryOnSafeToRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil on success", func(t *testing.T) {
+		calls := 0
+		err := retryOnSafeToRetry(context.Background(), false, func() error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("want 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("retries safe-to-retry errors and eventually succeeds", func(t *testing.T) {
+		calls := 0
+		err := retryOnSafeToRetry(context.Background(), false, func() error {
+			calls++
+			if calls < 3 {
+				return &safeToRetryErr{safe: true}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("want 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("does not retry non-safe errors", func(t *testing.T) {
+		calls := 0
+		sentinel := errors.New("not retryable")
+		err := retryOnSafeToRetry(context.Background(), false, func() error {
+			calls++
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("want sentinel, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("want 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("does not retry errors where SafeToRetry returns false", func(t *testing.T) {
+		calls := 0
+		err := retryOnSafeToRetry(context.Background(), false, func() error {
+			calls++
+			return &safeToRetryErr{safe: false}
+		})
+		if err == nil {
+			t.Fatalf("want error, got nil")
+		}
+		if calls != 1 {
+			t.Fatalf("want 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("unwraps errors via errors.As", func(t *testing.T) {
+		calls := 0
+		err := retryOnSafeToRetry(context.Background(), false, func() error {
+			calls++
+			if calls < 2 {
+				return &wrappedErr{inner: &safeToRetryErr{safe: true}}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("want 2 calls, got %d", calls)
+		}
+	})
+
+	t.Run("skips retry when in transaction", func(t *testing.T) {
+		calls := 0
+		err := retryOnSafeToRetry(context.Background(), true, func() error {
+			calls++
+			return &safeToRetryErr{safe: true}
+		})
+		if err == nil {
+			t.Fatalf("want error, got nil")
+		}
+		if calls != 1 {
+			t.Fatalf("want 1 call (no retry inside tx), got %d", calls)
+		}
+	})
+
+	t.Run("gives up after max retries", func(t *testing.T) {
+		calls := 0
+		err := retryOnSafeToRetry(context.Background(), false, func() error {
+			calls++
+			return &safeToRetryErr{safe: true}
+		})
+		if err == nil {
+			t.Fatalf("want error, got nil")
+		}
+		// 1 initial + 3 retries = 4 calls
+		if calls != 4 {
+			t.Fatalf("want 4 calls, got %d", calls)
+		}
+	})
+}


### PR DESCRIPTION
## Motivation

https://github.com/kumahq/kuma/pull/16128 added SafeToRetry handling to `manager.Upsert`, closing the race for writes where a pooled connection dies between acquire and first query execution. Read paths (`pgxResourceStore.Get` and `List`) call the pool directly and bypass the retry loop entirely, so the same `failed to deallocate cached statement(s): conn closed` error still surfaces on reads.

Datadog logs from production (Kong/mink-charts#1202) on versions that already include the write-side fix confirm residual errors — all are `reconcile failed` on `SELECT ... FROM resources WHERE type=$1`, i.e. `Store.List`. Example:

```
reconcile failed | error.message: failed to execute query: SELECT name, mesh, spec, version, creation_time, modification_time, labels, status FROM resources WHERE type=$1 ORDER BY name, mesh: failed to deallocate cached statement(s): conn closed
```

## Implementation information

Add a package-level `retryOnSafeToRetry` helper and wrap the `QueryRow`+`Scan` in `Get` and the `Query` call in `List` with it. The helper:

- **Skips retry when running inside a transaction** (`store.TxFromCtx`) — the tx is already broken by a dropped connection and must be aborted by the caller; retrying on the same tx would just loop forever.
- **Uses the anonymous `SafeToRetry() bool` interface via `errors.As`** to avoid a direct pgx dependency in unrelated code, matching the pattern from #16128.
- **Backs off with `retry.NewConstant(10ms)` capped at 3 retries** (~40ms worst case) so a stuck pool does not stall reconcile loops.

`List` only retries the initial `Query` call, not row iteration, so there is no risk of duplicated items being appended to the result list if a retry happens after a partial scan.

Unit tests cover: success, retry-then-success, non-retryable errors, `SafeToRetry() == false`, `errors.As` unwrapping, transaction-skip behavior, and max-retry exhaustion.

## Supporting documentation

- Prior fix: #16128
- Datadog issue: Kong/mink-charts#1202

> Changelog: fix(postgres): retry SafeToRetry errors on reads