### PR TITLE
fix(kuma-cp): allow empty 'to' override

### DIFF
--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -14,9 +14,6 @@ func (r *MeshLoadBalancingStrategyResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef))
-	if len(pointer.Deref(r.Spec.To)) == 0 {
-		verr.AddViolationAt(path.Field("to"), "needs at least one item")
-	}
 	topLevel := pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})
 	verr.AddErrorAt(path, validateTo(topLevel, pointer.Deref(r.Spec.To)))
 	return verr.OrNil()

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -18,10 +18,6 @@ var _ = Describe("validation", func() {
 					Field:   "spec.targetRef.kind",
 					Message: "value 'MeshGatewayRoute' is not supported",
 				},
-				{
-					Field:   "spec.to",
-					Message: "needs at least one item",
-				},
 			},
 			`
 type: MeshLoadBalancingStrategy
@@ -701,6 +697,18 @@ to:
                 type: None
           failoverThreshold:
             percentage: 70
+`),
+		Entry(
+			"empty 'to' allowed as override to disable inherited rules",
+			`
+type: MeshLoadBalancingStrategy
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: Dataplane
+  labels:
+    app: web
+to: []
 `),
 		Entry(
 			"top level MeshGateway",

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -17,9 +17,6 @@ func (r *MeshRetryResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef))
-	if len(pointer.Deref(r.Spec.To)) == 0 {
-		verr.AddViolationAt(path.Field("to"), "needs at least one item")
-	}
 	verr.AddErrorAt(path, validateTo(pointer.Deref(r.Spec.To), pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})))
 	return verr.OrNil()
 }

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
@@ -190,9 +190,16 @@ to:
       kind: Mesh
     default:
       http:
-        retryOn: 
+        retryOn:
           - 500
           - 409
+`),
+			Entry("empty 'to' allowed as override to disable inherited rules", `
+targetRef:
+  kind: Dataplane
+  labels:
+    app: web
+to: []
 `),
 		)
 
@@ -217,18 +224,6 @@ to:
 				// then
 				Expect(actual).To(MatchYAML(given.expected))
 			},
-			Entry("empty 'to' array", testCase{
-				inputYaml: `
-targetRef:
-  kind: MeshService
-  name: backend
-to: []
-`,
-				expected: `
-violations:
-  - field: spec.to
-    message: needs at least one item`,
-			}),
 			Entry("unsupported targetRef kinds in 'to'", testCase{
 				inputYaml: `
 targetRef:


### PR DESCRIPTION
## Motivation

Closes https://github.com/kumahq/kuma/issues/13294.

Several policy validators reject empty `to` lists, which blocks users
from using a narrow-scope policy to disable rules inherited from a
broader policy. Example that currently fails validation:

```yaml
apiVersion: kuma.io/v1alpha1
kind: MeshHealthCheck
metadata:
  name: disable-for-web
spec:
  targetRef:
    kind: Dataplane
    labels:
      app: web
  to: []
```

> Changelog: fix(policies): allow empty 'to' override

## Implementation information

Relaxes the `len(to) == 0` check in:

- `MeshLoadBalancingStrategy` validator
- `MeshRetry` validator

The merge layer (`pkg/plugins/policies/core/rules/merge/merge.go`) already
supports this override semantic: it uses RFC 7396 JSON Merge Patch and
replaces (not appends) slice fields. So a narrower policy with `to: []`
overwrites the inherited `to: [...]` for matched Dataplanes, resulting
in no rules applied (Envoy defaults take over). Only the validators
were blocking the UX; no merge logic changes required.

Policies not touched:

- `MeshRateLimit` — already permits empty `to` on gateway scope
- `MeshHealthCheck` / `MeshHTTPRoute` / `MeshTCPRoute` — no explicit
  length check, already allowed
- `MeshAccessLog` / `MeshCircuitBreaker` / `MeshFaultInjection` /
  `MeshTimeout` — require at least one of `from`/`to`/`rules`, which
  is the right rule for policies that support the `rules` format

Tests updated:

- `meshloadbalancingstrategy/api/v1alpha1/validator_test.go`: drop the
  "needs at least one item" expectation; add a valid case for empty
  `to` override
- `meshretry/api/v1alpha1/validator_test.go`: convert the empty `to`
  error case to a valid case; add an explicit override entry

## Supporting documentation

- Issue: https://github.com/kumahq/kuma/issues/13294
- Merge semantics: `pkg/plugins/policies/core/rules/merge/merge.go`