### PR TITLE
fix(xds): skip SNI when BackendRef port not found

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -54,7 +54,10 @@ func GenerateClusters(
 			if meshCtx.IsExternalService(serviceName) {
 				switch {
 				case isMeshExternalService(meshCtx.EndpointMap[serviceName]):
-					sni := SniForBackendRef(service.BackendRef().RealResourceBackendRef(), meshCtx, systemNamespace)
+					sni, ok := SniForBackendRef(service.BackendRef().RealResourceBackendRef(), meshCtx, systemNamespace)
+					if !ok {
+						continue
+					}
 					if proxy.WorkloadIdentity != nil {
 						// MeshExternalService is only routable through zone egress in workload-identity mode.
 						// Skip cluster generation if no zone egress SANs are available.
@@ -143,7 +146,10 @@ func GenerateClusters(
 								}
 							}
 						}
-						sni := SniForBackendRef(realResourceRef, meshCtx, systemNamespace)
+						sni, ok := SniForBackendRef(realResourceRef, meshCtx, systemNamespace)
+						if !ok {
+							continue
+						}
 						// ClientSideMultiIdentitiesMTLS validate MTLS enabled on the mesh
 						if proxy.WorkloadIdentity != nil {
 							upstreamCtx, err := UpstreamTLSContext(proxy, sni, Identities(realResourceRef, meshCtx, true))
@@ -233,11 +239,14 @@ func SniForBackendRef(
 	backendRef *resolve.RealResourceBackendRef,
 	meshCtx xds_context.MeshContext,
 	systemNamespace string,
-) string {
-	var port int32
+) (string, bool) {
 	dest := meshCtx.GetServiceByKRI(backendRef.Resource)
-	if p, ok := dest.FindPortByName(backendRef.Resource.SectionName); ok {
-		port = p.GetValue()
+	if dest == nil {
+		return "", false
+	}
+	p, ok := dest.FindPortByName(backendRef.Resource.SectionName)
+	if !ok {
+		return "", false
 	}
 	resource := dest.(core_model.Resource)
 	name := core_model.GetDisplayName(resource.GetMeta())
@@ -245,7 +254,7 @@ func SniForBackendRef(
 		name = resource.(*meshservice_api.MeshServiceResource).SNIName(systemNamespace)
 	}
 
-	return tls.SNIForResource(name, resource.GetMeta().GetMesh(), resource.Descriptor().Name, port, nil)
+	return tls.SNIForResource(name, resource.GetMeta().GetMesh(), resource.Descriptor().Name, p.GetValue(), nil), true
 }
 
 func Identities(

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core"
 	meshmultizoneservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -54,10 +55,12 @@ func GenerateClusters(
 			if meshCtx.IsExternalService(serviceName) {
 				switch {
 				case isMeshExternalService(meshCtx.EndpointMap[serviceName]):
-					sni, ok := SniForBackendRef(service.BackendRef().RealResourceBackendRef(), meshCtx, systemNamespace)
+					realResourceRef := service.BackendRef().RealResourceBackendRef()
+					dest, port, ok := DestinationPortFromRef(meshCtx, realResourceRef)
 					if !ok {
 						continue
 					}
+					sni := SniForBackendRef(realResourceRef, dest, port, systemNamespace)
 					if proxy.WorkloadIdentity != nil {
 						// MeshExternalService is only routable through zone egress in workload-identity mode.
 						// Skip cluster generation if no zone egress SANs are available.
@@ -133,23 +136,19 @@ func GenerateClusters(
 					}
 				} else {
 					if realResourceRef := service.BackendRef().RealResourceBackendRef(); realResourceRef != nil {
-						tlsReady = true // tls readiness is only relevant for MeshService
-						if common_api.TargetRefKind(realResourceRef.Resource.ResourceType) == common_api.MeshService {
-							dest := meshCtx.GetServiceByKRI(realResourceRef.Resource)
-							if dest != nil {
-								ms := dest.(*meshservice_api.MeshServiceResource)
-								// we only check TLS status for local service
-								// services that are synced can be accessed only with TLS through ZoneIngress
-								tlsReady = !ms.IsLocalMeshService() || ms.Status.TLS.Status == meshservice_api.TLSReady
-								if port, found := ms.FindPortByName(realResourceRef.Resource.SectionName); found {
-									protocol = port.GetProtocol()
-								}
-							}
-						}
-						sni, ok := SniForBackendRef(realResourceRef, meshCtx, systemNamespace)
+						dest, port, ok := DestinationPortFromRef(meshCtx, realResourceRef)
 						if !ok {
 							continue
 						}
+						tlsReady = true // tls readiness is only relevant for MeshService
+						if common_api.TargetRefKind(realResourceRef.Resource.ResourceType) == common_api.MeshService {
+							ms := dest.(*meshservice_api.MeshServiceResource)
+							// we only check TLS status for local service
+							// services that are synced can be accessed only with TLS through ZoneIngress
+							tlsReady = !ms.IsLocalMeshService() || ms.Status.TLS.Status == meshservice_api.TLSReady
+							protocol = port.GetProtocol()
+						}
+						sni := SniForBackendRef(realResourceRef, dest, port, systemNamespace)
 						// ClientSideMultiIdentitiesMTLS validate MTLS enabled on the mesh
 						if proxy.WorkloadIdentity != nil {
 							upstreamCtx, err := UpstreamTLSContext(proxy, sni, Identities(realResourceRef, meshCtx, true))
@@ -237,24 +236,16 @@ func UpstreamTLSContext(proxy *core_xds.Proxy, sni string, sans []string) (*envo
 
 func SniForBackendRef(
 	backendRef *resolve.RealResourceBackendRef,
-	meshCtx xds_context.MeshContext,
+	dest core.Destination,
+	port core.Port,
 	systemNamespace string,
-) (string, bool) {
-	dest := meshCtx.GetServiceByKRI(backendRef.Resource)
-	if dest == nil {
-		return "", false
-	}
-	p, ok := dest.FindPortByName(backendRef.Resource.SectionName)
-	if !ok {
-		return "", false
-	}
-	resource := dest.(core_model.Resource)
-	name := core_model.GetDisplayName(resource.GetMeta())
+) string {
+	name := core_model.GetDisplayName(dest.GetMeta())
 	if backendRef.Resource.ResourceType == meshservice_api.MeshServiceType {
-		name = resource.(*meshservice_api.MeshServiceResource).SNIName(systemNamespace)
+		name = dest.(*meshservice_api.MeshServiceResource).SNIName(systemNamespace)
 	}
 
-	return tls.SNIForResource(name, resource.GetMeta().GetMesh(), resource.Descriptor().Name, p.GetValue(), nil), true
+	return tls.SNIForResource(name, dest.GetMeta().GetMesh(), dest.Descriptor().Name, port.GetValue(), nil)
 }
 
 func Identities(

--- a/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
@@ -1,8 +1,6 @@
 package meshroute_test
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -12,14 +10,9 @@ import (
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/resolve"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/xds/meshroute"
-	"github.com/kumahq/kuma/v2/pkg/test"
 	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
 )
-
-func TestMeshRoute(t *testing.T) {
-	test.RunSpecs(t, "MeshRoute Suite")
-}
 
 func meshCtxWith(ms *meshservice_api.MeshServiceResource) xds_context.MeshContext {
 	return xds_context.MeshContext{

--- a/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
@@ -1,0 +1,92 @@
+package meshroute_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
+	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/resolve"
+	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/xds/meshroute"
+	"github.com/kumahq/kuma/v2/pkg/test"
+	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
+	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+)
+
+func TestMeshRoute(t *testing.T) {
+	test.RunSpecs(t, "MeshRoute Suite")
+}
+
+func meshCtxWith(ms *meshservice_api.MeshServiceResource) xds_context.MeshContext {
+	return xds_context.MeshContext{
+		BaseMeshContext: &xds_context.BaseMeshContext{
+			DestinationIndex: xds_context.NewDestinationIndex([]core_model.Resource{ms}),
+		},
+	}
+}
+
+var _ = Describe("SniForBackendRef", func() {
+	DescribeTable("should return SNI and true when port is found",
+		func(sectionName string) {
+			ms := builders.MeshService().
+				WithName("backend").
+				WithMesh("default").
+				AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
+				Build()
+
+			id := kri.WithSectionName(kri.From(ms), sectionName)
+			ref := &resolve.RealResourceBackendRef{Resource: id}
+
+			sni, ok := meshroute.SniForBackendRef(ref, meshCtxWith(ms), "")
+
+			Expect(ok).To(BeTrue())
+			Expect(sni).NotTo(BeEmpty())
+			Expect(sni).To(ContainSubstring(".8080."))
+		},
+		Entry("by port name", "http"),
+		Entry("by port value", "8080"),
+	)
+
+	It("returns empty string and false when sectionName does not match any port", func() {
+		ms := builders.MeshService().
+			WithName("backend").
+			WithMesh("default").
+			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
+			Build()
+
+		id := kri.WithSectionName(kri.From(ms), "grpc")
+		ref := &resolve.RealResourceBackendRef{Resource: id}
+
+		sni, ok := meshroute.SniForBackendRef(ref, meshCtxWith(ms), "")
+
+		Expect(ok).To(BeFalse())
+		Expect(sni).To(BeEmpty())
+	})
+
+	It("returns empty string and false when service is not in the index", func() {
+		ms := builders.MeshService().
+			WithName("backend").
+			WithMesh("default").
+			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
+			Build()
+
+		// empty index — service not registered
+		emptyCtx := xds_context.MeshContext{
+			BaseMeshContext: &xds_context.BaseMeshContext{
+				DestinationIndex: xds_context.NewDestinationIndex(),
+			},
+		}
+
+		id := kri.WithSectionName(kri.From(ms), "http")
+		ref := &resolve.RealResourceBackendRef{Resource: id}
+
+		sni, ok := meshroute.SniForBackendRef(ref, emptyCtx, "")
+
+		Expect(ok).To(BeFalse())
+		Expect(sni).To(BeEmpty())
+	})
+})

--- a/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
@@ -7,23 +7,13 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
-	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/resolve"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/xds/meshroute"
 	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
-	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
 )
 
-func meshCtxWith(ms *meshservice_api.MeshServiceResource) xds_context.MeshContext {
-	return xds_context.MeshContext{
-		BaseMeshContext: &xds_context.BaseMeshContext{
-			DestinationIndex: xds_context.NewDestinationIndex([]core_model.Resource{ms}),
-		},
-	}
-}
-
 var _ = Describe("SniForBackendRef", func() {
-	DescribeTable("should return SNI and true when port is found",
+	DescribeTable("returns SNI built from resolved port",
 		func(sectionName string) {
 			ms := builders.MeshService().
 				WithName("backend").
@@ -31,12 +21,14 @@ var _ = Describe("SniForBackendRef", func() {
 				AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
 				Build()
 
+			port, ok := ms.FindPortByName(sectionName)
+			Expect(ok).To(BeTrue())
+
 			id := kri.WithSectionName(kri.From(ms), sectionName)
 			ref := &resolve.RealResourceBackendRef{Resource: id}
 
-			sni, ok := meshroute.SniForBackendRef(ref, meshCtxWith(ms), "")
+			sni := meshroute.SniForBackendRef(ref, ms, port, "")
 
-			Expect(ok).To(BeTrue())
 			Expect(sni).NotTo(BeEmpty())
 			Expect(sni).To(ContainSubstring(".8080."))
 		},
@@ -44,42 +36,22 @@ var _ = Describe("SniForBackendRef", func() {
 		Entry("by port value", "8080"),
 	)
 
-	It("returns empty string and false when sectionName does not match any port", func() {
+	It("uses SNIName for MeshService destination", func() {
 		ms := builders.MeshService().
 			WithName("backend").
 			WithMesh("default").
 			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
 			Build()
 
-		id := kri.WithSectionName(kri.From(ms), "grpc")
-		ref := &resolve.RealResourceBackendRef{Resource: id}
-
-		sni, ok := meshroute.SniForBackendRef(ref, meshCtxWith(ms), "")
-
-		Expect(ok).To(BeFalse())
-		Expect(sni).To(BeEmpty())
-	})
-
-	It("returns empty string and false when service is not in the index", func() {
-		ms := builders.MeshService().
-			WithName("backend").
-			WithMesh("default").
-			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
-			Build()
-
-		// empty index — service not registered
-		emptyCtx := xds_context.MeshContext{
-			BaseMeshContext: &xds_context.BaseMeshContext{
-				DestinationIndex: xds_context.NewDestinationIndex(),
-			},
-		}
+		port, ok := ms.FindPortByName("http")
+		Expect(ok).To(BeTrue())
 
 		id := kri.WithSectionName(kri.From(ms), "http")
+		id.ResourceType = meshservice_api.MeshServiceType
 		ref := &resolve.RealResourceBackendRef{Resource: id}
 
-		sni, ok := meshroute.SniForBackendRef(ref, emptyCtx, "")
+		sni := meshroute.SniForBackendRef(ref, ms, port, "kuma-system")
 
-		Expect(ok).To(BeFalse())
-		Expect(sni).To(BeEmpty())
+		Expect(sni).To(ContainSubstring(ms.SNIName("kuma-system")))
 	})
 })

--- a/pkg/plugins/policies/core/xds/meshroute/suite_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/suite_test.go
@@ -1,0 +1,11 @@
+package meshroute_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestMeshRoute(t *testing.T) {
+	test.RunSpecs(t, "MeshRoute Suite")
+}

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -164,7 +164,10 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 	protocol := route.InferServiceProtocol(port.GetProtocol(), routeProtocol)
 
 	service := destinationname.MustResolve(false, dest, port)
-	sni := meshroute.SniForBackendRef(backendRef, meshCtx, systemNamespace)
+	sni, ok := meshroute.SniForBackendRef(backendRef, meshCtx, systemNamespace)
+	if !ok {
+		return nil, "", nil
+	}
 	edsClusterBuilder := clusters.NewClusterBuilder(proxy.APIVersion, service).
 		Configure(
 			clusters.EdsCluster(),

--- a/pkg/plugins/runtime/gateway/cluster_generator.go
+++ b/pkg/plugins/runtime/gateway/cluster_generator.go
@@ -164,10 +164,7 @@ func (c *ClusterGenerator) generateRealBackendRefCluster(
 	protocol := route.InferServiceProtocol(port.GetProtocol(), routeProtocol)
 
 	service := destinationname.MustResolve(false, dest, port)
-	sni, ok := meshroute.SniForBackendRef(backendRef, meshCtx, systemNamespace)
-	if !ok {
-		return nil, "", nil
-	}
+	sni := meshroute.SniForBackendRef(backendRef, dest, port, systemNamespace)
 	edsClusterBuilder := clusters.NewClusterBuilder(proxy.APIVersion, service).
 		Configure(
 			clusters.EdsCluster(),


### PR DESCRIPTION
## Motivation

When a BackendRef doesn't select any actual port (port not found in destination), `SniForBackendRef` was still building an SNI using port `0`, producing an incorrect SNI value. This could also panic if the destination service itself is nil.

Fixes https://github.com/kumahq/kuma/issues/13842

## Implementation information

Callers of `SniForBackendRef` now resolve the destination and port up-front via `DestinationPortFromRef`, which returns `(dest, port, ok)`. When `ok == false` (destination missing or `SectionName` does not match a port), callers skip cluster generation (`continue` in loops, early `return nil, "", nil` in the gateway generator) instead of falling back to port `0`.

`SniForBackendRef` now takes the already-resolved port as input, so the SNI is always built from a real port value.

> Changelog: fix(xds): skip SNI when BackendRef port not found