### PR TITLE
feat(api): add spiffe_id to dataplane _overview

### DIFF
--- a/api/mesh/v1alpha1/dataplane_overview.pb.go
+++ b/api/mesh/v1alpha1/dataplane_overview.pb.go
@@ -28,8 +28,11 @@ type DataplaneOverview struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Dataplane        *Dataplane             `protobuf:"bytes,1,opt,name=dataplane,proto3" json:"dataplane,omitempty"`
 	DataplaneInsight *DataplaneInsight      `protobuf:"bytes,2,opt,name=dataplane_insight,json=dataplaneInsight,proto3" json:"dataplane_insight,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// SPIFFE ID of the dataplane in the format spiffe://<mesh>/<service>.
+	// Populated only when the dataplane has inbound services.
+	SpiffeId      string `protobuf:"bytes,3,opt,name=spiffe_id,json=spiffeId,proto3" json:"spiffe_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DataplaneOverview) Reset() {
@@ -76,14 +79,22 @@ func (x *DataplaneOverview) GetDataplaneInsight() *DataplaneInsight {
 	return nil
 }
 
+func (x *DataplaneOverview) GetSpiffeId() string {
+	if x != nil {
+		return x.SpiffeId
+	}
+	return ""
+}
+
 var File_api_mesh_v1alpha1_dataplane_overview_proto protoreflect.FileDescriptor
 
 const file_api_mesh_v1alpha1_dataplane_overview_proto_rawDesc = "" +
 	"\n" +
-	"*api/mesh/v1alpha1/dataplane_overview.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a!api/mesh/v1alpha1/dataplane.proto\x1a)api/mesh/v1alpha1/dataplane_insight.proto\x1a\x17validate/validate.proto\"\xed\x01\n" +
+	"*api/mesh/v1alpha1/dataplane_overview.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a!api/mesh/v1alpha1/dataplane.proto\x1a)api/mesh/v1alpha1/dataplane_insight.proto\x1a\x17validate/validate.proto\"\x8a\x02\n" +
 	"\x11DataplaneOverview\x12E\n" +
 	"\tdataplane\x18\x01 \x01(\v2\x1d.kuma.mesh.v1alpha1.DataplaneB\b\xfaB\x05\x8a\x01\x02\x10\x01R\tdataplane\x12Q\n" +
-	"\x11dataplane_insight\x18\x02 \x01(\v2$.kuma.mesh.v1alpha1.DataplaneInsightR\x10dataplaneInsight:>\xaa\x8c\x89\xa6\x018\n" +
+	"\x11dataplane_insight\x18\x02 \x01(\v2$.kuma.mesh.v1alpha1.DataplaneInsightR\x10dataplaneInsight\x12\x1b\n" +
+	"\tspiffe_id\x18\x03 \x01(\tR\bspiffeId:>\xaa\x8c\x89\xa6\x018\n" +
 	"\x19DataplaneOverviewResource\x12\x11DataplaneOverview\"\x04mesh0\x01`\x01B-Z+github.com/kumahq/kuma/v2/api/mesh/v1alpha1b\x06proto3"
 
 var (

--- a/api/mesh/v1alpha1/dataplane_overview.proto
+++ b/api/mesh/v1alpha1/dataplane_overview.proto
@@ -20,4 +20,8 @@ message DataplaneOverview {
   Dataplane dataplane = 1 [(validate.rules).message.required = true];
 
   DataplaneInsight dataplane_insight = 2;
+
+  // SPIFFE ID of the dataplane in the format spiffe://<mesh>/<service>.
+  // Populated only when the dataplane has inbound services.
+  string spiffe_id = 3;
 }

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -698,6 +698,11 @@ components:
                 type: object
               type: array
           type: object
+        spiffeId:
+          description: |-
+            SPIFFE ID of the dataplane in the format spiffe://<mesh>/<service>.
+            Populated only when the dataplane has inbound services.
+          type: string
       type: object
 info:
   x-ref-schema-name: DataplaneOverview

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -11,6 +11,10 @@
                 "dataplane_insight": {
                     "$ref": "#/definitions/kuma.mesh.v1alpha1.DataplaneInsight",
                     "additionalProperties": true
+                },
+                "spiffe_id": {
+                    "type": "string",
+                    "description": "SPIFFE ID of the dataplane in the format spiffe://\u003cmesh\u003e/\u003cservice\u003e. Populated only when the dataplane has inbound services."
                 }
             },
             "additionalProperties": true,

--- a/pkg/core/resources/apis/mesh/dataplane_overview.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview.go
@@ -1,6 +1,8 @@
 package mesh
 
 import (
+	"fmt"
+
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/model"
 )
@@ -18,6 +20,7 @@ func NewDataplaneOverviews(dataplanes DataplaneResourceList, insights DataplaneI
 			Spec: &mesh_proto.DataplaneOverview{
 				Dataplane:        dataplane.Spec,
 				DataplaneInsight: nil,
+				SpiffeId:         dataplaneSpiffeID(dataplane.Meta.GetMesh(), dataplane.Spec),
 			},
 		}
 		insight, exists := insightsByKey[model.MetaToResourceKey(overview.Meta)]
@@ -30,4 +33,22 @@ func NewDataplaneOverviews(dataplanes DataplaneResourceList, insights DataplaneI
 		Pagination: dataplanes.Pagination,
 		Items:      items,
 	}
+}
+
+// dataplaneSpiffeID returns the SPIFFE ID for a dataplane based on its first inbound service
+// or gateway service tag. Returns empty string when no service can be determined.
+func dataplaneSpiffeID(mesh string, dp *mesh_proto.Dataplane) string {
+	if dp == nil {
+		return ""
+	}
+	var svc string
+	if inbounds := dp.GetNetworking().GetInbound(); len(inbounds) > 0 {
+		svc = inbounds[0].Tags[mesh_proto.ServiceTag]
+	} else if gw := dp.GetNetworking().GetGateway(); gw != nil {
+		svc = gw.Tags[mesh_proto.ServiceTag]
+	}
+	if svc == "" {
+		return ""
+	}
+	return fmt.Sprintf("spiffe://%s/%s", mesh, svc)
 }

--- a/pkg/core/resources/apis/mesh/dataplane_overview_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_overview_test.go
@@ -49,6 +49,44 @@ var _ = Describe("DataplaneOverview", func() {
 			Expect(overviews.Items[1].Spec.Dataplane).To(MatchProto(dataplanes.Items[1].Spec))
 			Expect(overviews.Items[1].Spec.DataplaneInsight).To(BeNil())
 		})
+
+		DescribeTable("should populate spiffe_id from service tag",
+			func(dp *mesh_proto.Dataplane, mesh string, expectedSpiffeID string) {
+				dataplanes := DataplaneResourceList{Items: []*DataplaneResource{
+					{
+						Meta: &model.ResourceMeta{Name: "dp1", Mesh: mesh},
+						Spec: dp,
+					},
+				}}
+				overviews := NewDataplaneOverviews(dataplanes, DataplaneInsightResourceList{})
+				Expect(overviews.Items).To(HaveLen(1))
+				Expect(overviews.Items[0].Spec.SpiffeId).To(Equal(expectedSpiffeID))
+			},
+			Entry("inbound with service tag", &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+						{Tags: map[string]string{mesh_proto.ServiceTag: "backend"}},
+					},
+				},
+			}, "default", "spiffe://default/backend"),
+			Entry("gateway with service tag", &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+						Tags: map[string]string{mesh_proto.ServiceTag: "my-gateway"},
+					},
+				},
+			}, "prod", "spiffe://prod/my-gateway"),
+			Entry("no inbounds and no gateway", &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{},
+			}, "default", ""),
+			Entry("inbound without service tag", &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+						{Tags: map[string]string{"version": "v1"}},
+					},
+				},
+			}, "default", ""),
+		)
 	})
 
 	Context("GetStatus", func() {

--- a/pkg/core/resources/apis/mesh/zz_generated.resources.go
+++ b/pkg/core/resources/apis/mesh/zz_generated.resources.go
@@ -444,6 +444,18 @@ func (t *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, ins
 		}
 		overview.DataplaneInsight = ins
 	}
+	if dp := overview.Dataplane; dp != nil {
+		mesh := resource.GetMeta().GetMesh()
+		var svc string
+		if inbounds := dp.GetNetworking().GetInbound(); len(inbounds) > 0 {
+			svc = inbounds[0].Tags[mesh_proto.ServiceTag]
+		} else if gw := dp.GetNetworking().GetGateway(); gw != nil {
+			svc = gw.Tags[mesh_proto.ServiceTag]
+		}
+		if svc != "" {
+			overview.SpiffeId = fmt.Sprintf("spiffe://%s/%s", mesh, svc)
+		}
+	}
 	return t.SetSpec(overview)
 }
 

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -305,6 +305,20 @@ func (t *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight mod
 		}
 		overview.{{$baseType}}Insight = ins
 	}
+{{- if eq $baseType "Dataplane" }}
+	if dp := overview.Dataplane; dp != nil {
+		mesh := resource.GetMeta().GetMesh()
+		var svc string
+		if inbounds := dp.GetNetworking().GetInbound(); len(inbounds) > 0 {
+			svc = inbounds[0].Tags[{{$pkg}}.ServiceTag]
+		} else if gw := dp.GetNetworking().GetGateway(); gw != nil {
+			svc = gw.Tags[{{$pkg}}.ServiceTag]
+		}
+		if svc != "" {
+			overview.SpiffeId = fmt.Sprintf("spiffe://%s/%s", mesh, svc)
+		}
+	}
+{{- end }}
 	return t.SetSpec(overview)
 }
 {{- end }}


### PR DESCRIPTION
## Motivation

The GUI (kumahq/kuma-gui#4526) needs to display the SPIFFE ID of a dataplane. Currently there's no direct way to get this from the API without inspecting xDS config or stats. This exposes `spiffe_id` directly in the `_overview` endpoint.

## Implementation information

Added `spiffe_id` string field (proto field 3) to `DataplaneOverview` proto message. The field is populated from the first inbound service's `kuma.io/service` tag, falling back to the gateway's service tag if no inbounds exist.

Changes:
- `api/mesh/v1alpha1/dataplane_overview.proto`: new `spiffe_id` field
- `api/mesh/v1alpha1/dataplane_overview.pb.go`: regenerated
- `tools/resource-gen/pkg/generator/main.go`: template update to populate `SpiffeId` in `SetOverviewSpec` for Dataplane overviews
- `pkg/core/resources/apis/mesh/zz_generated.resources.go`: regenerated
- `pkg/core/resources/apis/mesh/dataplane_overview.go`: populate `SpiffeId` in `NewDataplaneOverviews`
- `pkg/core/resources/apis/mesh/dataplane_overview_test.go`: table-driven tests for SPIFFE ID population
- OpenAPI/schema docs: regenerated

Format: `spiffe://<mesh>/<service>`

> Changelog: feat(api): add spiffe_id to dataplane _overview