### PR TITLE
ci(actions): harden stability monitor workflow

### DIFF
--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -6,7 +6,7 @@ on:
     # in ci-stability.sh skips ticks where CI is still in flight, so idle
     # ticks are cheap and tighter cadence = faster flake detection.
     - cron: "*/30 18-23 * * 1-5"   # Mon-Fri evenings
-    - cron: "*/30 0-6 * * 2-6"     # Mon-Fri nights (UTC day rolls over)
+    - cron: "*/30 0-6 * * 1-5"     # Mon-Fri early mornings (00:00-06:59 UTC)
     - cron: "*/30 * * * 0,6"       # Weekends, all day
   workflow_dispatch:
 

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -1,25 +1,31 @@
-name: Check CI stability for PRs with "ci/verify-stability" or "ci/verify-stability-merge-master" label
+name: Check CI stability for PRs with "ci/verify-stability" label
 
 on:
   schedule:
-    # Monday to Friday: Every 2 hours from 8 PM to 8 AM CEST
-    - cron: "0 18 * * 1-5"
-    - cron: "0 20 * * 1-5"
-    - cron: "0 22 * * 1-5"
-    - cron: "0 0 * * 1-5"
-    - cron: "0 2 * * 2-6"
-    - cron: "0 4 * * 2-6"
-    - cron: "0 6 * * 2-6"
-    # Saturday and Sunday: Every 2 hours all day
-    - cron: "0 */2 * * 6,0"
-  workflow_dispatch:  # Allows manual trigger from GitHub Actions UI
+    # Outside business hours, UTC. Every 30 min — the pending-check guard
+    # in ci-stability.sh skips ticks where CI is still in flight, so idle
+    # ticks are cheap and tighter cadence = faster flake detection.
+    - cron: "*/30 18-23 * * 1-5"   # Mon-Fri evenings
+    - cron: "*/30 0-6 * * 2-6"     # Mon-Fri nights (UTC day rolls over)
+    - cron: "*/30 * * * 0,6"       # Weekends, all day
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-stability
+  cancel-in-progress: false
+
 env:
   GH_USER: "github-actions[bot]"
   GH_EMAIL: "<41898282+github-actions[bot]@users.noreply.github.com>"
-permissions: {}
+  STABILITY_CONSECUTIVE_GREEN_THRESHOLD: "5"
+  STABILITY_MAX_HISTORY: "20"
+
 jobs:
   trigger-ci:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Generate GitHub app token
         id: github-app-token
@@ -30,54 +36,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ steps.github-app-token.outputs.token }}
-      - name: Get open pull requests and save to file
-        run: |
-          gh pr list --json number,labels > open_prs.json
+      - name: List open PRs
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
-      - name: Process PRs
-        id: process_prs
         run: |
-          cat open_prs.json
-          pr_numbers_with_verify_stability=$(jq -r -c '.[] | select(.labels[]?.name == "ci/verify-stability") | .number' open_prs.json | tr '\n' ' ')
-          pr_numbers_with_verify_stability_merge_master=$(jq -r '.[] | select(.labels[]?.name == "ci/verify-stability-merge-master") | .number' open_prs.json | tr '\n' ' ')
-          echo "PRs with 'ci/verify-stability' label: $pr_numbers_with_verify_stability"
-          echo "PRs with 'ci/verify-stability-merge-master' label: $pr_numbers_with_verify_stability_merge_master"
-          echo "pr_numbers_with_verify_stability=$pr_numbers_with_verify_stability" >> "$GITHUB_OUTPUT"
-          echo "pr_numbers_with_verify_stability_merge_master=$pr_numbers_with_verify_stability_merge_master" >> "$GITHUB_OUTPUT"
+          gh pr list \
+            --state open \
+            --limit 200 \
+            --json number,labels,headRefName,headRepositoryOwner,state \
+            > open_prs.json
+      - name: Process PRs with ci/verify-stability label
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
-      - name: Merge master branch (if applicable) and push a single commit
-        if: steps.process_prs.outputs.pr_numbers_with_verify_stability != ''
-        run: |
-          eval "pr_numbers=(${{ steps.process_prs.outputs.pr_numbers_with_verify_stability }})"
-          for pr_number in "${pr_numbers[@]}"; do
-            current_datetime=$(date +"%Y-%m-%d %H:%M:%S")
-            echo "Processing PR #$pr_number"
-
-            # Fetch PR details to get the base branch (original branch name)
-            pr_branch=$(gh pr view "$pr_number" --json headRefName --jq '.headRefName')
-            echo "The original branch for PR #$pr_number is $pr_branch"
-            git fetch origin "pull/$pr_number/head:$pr_branch"
-            git checkout "$pr_branch"
-
-            git config user.name "${GH_USER}"
-            git config user.email "${GH_EMAIL}"
-          
-            # Check if the PR needs to merge with master
-            if echo "${{ steps.process_prs.outputs.pr_numbers_with_verify_stability_merge_master }}" | grep -wq "$pr_number"; then
-              echo "Merging master into PR #$pr_number"
-              git fetch origin master
-              git merge origin/master --no-ff --no-commit
-              git commit --allow-empty -m "Merge master into PR #$pr_number"
-            fi
-          
-            # Commit an empty commit to trigger the CI
-            echo "Pushing empty commit to trigger CI for PR #$pr_number on $current_datetime"
-            git commit --allow-empty -m "Trigger CI for PR #$pr_number on $current_datetime"
-            git push origin "$pr_branch"
-          done
-        env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: bash .github/workflows/scripts/ci-stability.sh open_prs.json

--- a/.github/workflows/scripts/ci-stability.sh
+++ b/.github/workflows/scripts/ci-stability.sh
@@ -45,12 +45,17 @@ decode_state() { printf '%s' "$1" | base64 -d 2>/dev/null; }
 # ---- sticky comment helpers -------------------------------------------------
 
 fetch_sticky_comment() {
-  # Prints the sticky comment JSON ({id, body}) or empty.
-  local pr=$1
-  gh api "repos/${OWNER}/${REPO}/issues/${pr}/comments" --paginate 2>/dev/null |
-    jq -c --arg marker "$STICKY_MARKER" '
-      [.[] | select(.body | contains($marker))] | first // empty
-    '
+  # Prints the sticky comment JSON ({id, body}) on stdout, or empty if no
+  # matching comment exists. Returns non-zero on API failure so callers can
+  # distinguish "no such comment" from "couldn't reach GitHub" — important
+  # to avoid creating duplicate sticky comments on transient errors.
+  local pr=$1 json
+  if ! json=$(gh api "repos/${OWNER}/${REPO}/issues/${pr}/comments" --paginate 2>/dev/null); then
+    return 1
+  fi
+  printf '%s' "$json" | jq -c --arg marker "$STICKY_MARKER" '
+    [.[] | select(.body | contains($marker))] | first // empty
+  '
 }
 
 extract_state() {
@@ -75,6 +80,7 @@ render_comment() {
   run_count=$(jq '.runs | length' <<<"$state")
   flaky=$(jq -r --argjson total "$run_count" '
     [.runs[] | select(.result == "fail") | .failed_jobs[]?]
+    | sort
     | group_by(.)
     | map({job: .[0], count: length})
     | sort_by(-.count)
@@ -110,10 +116,11 @@ render_comment() {
 }
 
 upsert_sticky_comment() {
-  local pr=$1 body=$2 existing comment_id
-  existing=$(fetch_sticky_comment "$pr")
-  if [[ -n "$existing" ]]; then
-    comment_id=$(jq -r '.id' <<<"$existing")
+  # Create or patch the sticky comment. `$3` is the known comment id (from an
+  # earlier successful fetch) or empty. Passing it in avoids a redundant API
+  # call that could fail mid-iteration and produce a duplicate sticky comment.
+  local pr=$1 body=$2 comment_id=${3:-}
+  if [[ -n "$comment_id" ]]; then
     gh api "repos/${OWNER}/${REPO}/issues/comments/${comment_id}" \
       --method PATCH -f body="$body" >/dev/null
   else
@@ -124,10 +131,16 @@ upsert_sticky_comment() {
 # ---- check-run inspection ---------------------------------------------------
 
 fetch_checks() {
-  # Emits "bucket name" lines for the PR's current HEAD checks.
-  local pr=$1
-  gh pr checks "$pr" --json name,bucket 2>/dev/null |
-    jq -r '.[] | "\(.bucket) \(.name)"'
+  # Emits "bucket name" lines for the PR's current HEAD checks on stdout.
+  # Returns non-zero on API failure. Note: `gh pr checks` exits non-zero
+  # when any check is failing/pending, so we can't rely on its exit code
+  # alone — we treat empty/invalid output as the failure signal.
+  local pr=$1 json
+  json=$(gh pr checks "$pr" --json name,bucket 2>/dev/null) || true
+  if [[ -z "$json" ]] || ! printf '%s' "$json" | jq empty 2>/dev/null; then
+    return 1
+  fi
+  printf '%s' "$json" | jq -r '.[] | "\(.bucket) \(.name)"'
 }
 
 # ---- per-PR pipeline --------------------------------------------------------
@@ -163,9 +176,15 @@ process_pr() {
   head_sha=$(jq -r '.headRefOid'  <<<"$pr_json")
 
   # --- observe current check status ---
+  # fetch_checks returns non-zero on API failure; skip this PR rather than
+  # silently proceeding and bypassing the pending-check guard.
   local checks has_pending=0 has_failed=0
   local -a failed_jobs=()
-  checks=$(fetch_checks "$pr")
+  if ! checks=$(fetch_checks "$pr"); then
+    warn "PR #${pr}: could not fetch check status"
+    summary "- ⚠️ PR #${pr}: checks fetch failed"
+    return
+  fi
   if [[ -n "$checks" ]]; then
     while read -r bucket name; do
       [[ -z "$bucket" ]] && continue
@@ -185,9 +204,17 @@ process_pr() {
   fi
 
   # --- load prior state ---
-  local sticky_json state
-  sticky_json=$(fetch_sticky_comment "$pr")
+  # Skip the PR entirely on comment-fetch failure rather than proceeding with
+  # empty state (which would overwrite an existing sticky with blank history
+  # once the upsert re-resolves the comment).
+  local sticky_json sticky_id="" state
+  if ! sticky_json=$(fetch_sticky_comment "$pr"); then
+    warn "PR #${pr}: could not fetch existing comments"
+    summary "- ⚠️ PR #${pr}: comment fetch failed"
+    return
+  fi
   if [[ -n "$sticky_json" ]]; then
+    sticky_id=$(jq -r '.id' <<<"$sticky_json")
     state=$(extract_state "$(jq -r '.body' <<<"$sticky_json")")
   else
     state='{"runs":[]}'
@@ -240,7 +267,7 @@ process_pr() {
 
 ---
 ✅ **Auto-stopped** after ${consec_green} consecutive green stability runs. Removed \`ci/verify-stability\` label."
-    upsert_sticky_comment "$pr" "$body"
+    upsert_sticky_comment "$pr" "$body" "$sticky_id"
     summary "- ✅ PR #${pr}: auto-stopped (${consec_green} consecutive greens)"
     return
   fi
@@ -261,12 +288,19 @@ process_pr() {
   git config user.email "${GH_EMAIL}"
 
   # --- optional master merge ---
+  # `git merge --no-ff --no-commit` exits 0 when the PR is already up-to-date
+  # with master, leaving nothing staged. Guard the commit on actual staged
+  # changes so we don't produce a spurious "Merge master" empty commit.
   local merge_note=""
   if (( do_merge )); then
     git fetch --quiet origin master
     if git merge origin/master --no-ff --no-commit --quiet 2>/dev/null; then
-      git commit --quiet --allow-empty -m "Merge master into PR #${pr}"
-      merge_note=" (merged master)"
+      if ! git diff --cached --quiet; then
+        git commit --quiet -m "Merge master into PR #${pr}"
+        merge_note=" (merged master)"
+      else
+        merge_note=" (master already merged)"
+      fi
     else
       warn "PR #${pr}: merge conflict with master"
       git merge --abort 2>/dev/null || true
@@ -295,7 +329,7 @@ Workflow run: ${RUN_URL}"
     return
   fi
 
-  upsert_sticky_comment "$pr" "$(render_comment "$state")"
+  upsert_sticky_comment "$pr" "$(render_comment "$state")" "$sticky_id"
 
   log "PR #${pr}: observed=${result}, triggered run #${new_run_number}${merge_note}"
   summary "- 🔁 PR #${pr}: observed \`${result}\` on \`${head_sha:0:7}\`, triggered run #${new_run_number}${merge_note}"

--- a/.github/workflows/scripts/ci-stability.sh
+++ b/.github/workflows/scripts/ci-stability.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+#
+# Process open PRs with the "ci/verify-stability" label:
+#   1. Observe check-run status for the current HEAD of each PR.
+#   2. Append the observation to a sticky rollup comment (per PR) that
+#      tracks run history and surfaces likely-flaky jobs.
+#   3. Push an empty commit to re-trigger CI, unless a stop condition
+#      is met (fork, pending checks, N consecutive greens).
+#
+# Inputs:
+#   $1                                  Path to JSON file from `gh pr list`
+#   env GH_USER, GH_EMAIL               Git identity for trigger commits
+#   env GITHUB_TOKEN                    Token with contents+PR write scope
+#   env STABILITY_CONSECUTIVE_GREEN_THRESHOLD  (default: 5)
+#   env STABILITY_MAX_HISTORY                  (default: 20)
+
+set -uo pipefail
+
+readonly OPEN_PRS_FILE="${1:-open_prs.json}"
+readonly OWNER="${GITHUB_REPOSITORY%%/*}"
+readonly REPO="${GITHUB_REPOSITORY##*/}"
+readonly RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+readonly STICKY_MARKER="<!-- ci-stability-bot -->"
+readonly CONFLICT_MARKER="<!-- ci-stability-merge-conflict -->"
+readonly STATE_PREFIX="<!-- ci-stability-state: "
+readonly STATE_SUFFIX=" -->"
+readonly GREEN_THRESHOLD="${STABILITY_CONSECUTIVE_GREEN_THRESHOLD:-5}"
+readonly MAX_HISTORY="${STABILITY_MAX_HISTORY:-20}"
+
+log()  { printf '::notice::%s\n' "$*"; }
+warn() { printf '::warning::%s\n' "$*"; }
+err()  { printf '::error::%s\n' "$*"; }
+
+summary() {
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] && printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"
+}
+
+# ---- state encoding ---------------------------------------------------------
+# State is a JSON blob persisted inside the sticky comment as base64 in an
+# HTML comment marker. Base64 sidesteps all markdown/escape concerns.
+
+encode_state() { printf '%s' "$1" | base64 -w0; }
+decode_state() { printf '%s' "$1" | base64 -d 2>/dev/null; }
+
+# ---- sticky comment helpers -------------------------------------------------
+
+fetch_sticky_comment() {
+  # Prints the sticky comment JSON ({id, body}) or empty.
+  local pr=$1
+  gh api "repos/${OWNER}/${REPO}/issues/${pr}/comments" --paginate 2>/dev/null |
+    jq -c --arg marker "$STICKY_MARKER" '
+      [.[] | select(.body | contains($marker))] | first // empty
+    '
+}
+
+extract_state() {
+  local body=$1 encoded decoded
+  encoded=$(printf '%s' "$body" |
+    sed -n "s|.*${STATE_PREFIX}\([^ ]*\)${STATE_SUFFIX}.*|\1|p" | head -n1)
+  if [[ -z "$encoded" ]]; then
+    printf '{"runs":[]}'
+    return
+  fi
+  decoded=$(decode_state "$encoded")
+  if [[ -z "$decoded" ]] || ! printf '%s' "$decoded" | jq empty 2>/dev/null; then
+    printf '{"runs":[]}'
+    return
+  fi
+  printf '%s' "$decoded"
+}
+
+render_comment() {
+  local state=$1
+  local run_count flaky history encoded
+  run_count=$(jq '.runs | length' <<<"$state")
+  flaky=$(jq -r --argjson total "$run_count" '
+    [.runs[] | select(.result == "fail") | .failed_jobs[]?]
+    | group_by(.)
+    | map({job: .[0], count: length})
+    | sort_by(-.count)
+    | .[] | select(.count >= 2)
+    | "- `\(.job)` — failed \(.count) of \($total) run(s)"
+  ' <<<"$state")
+  history=$(jq -r --argjson max "$MAX_HISTORY" '
+    .runs | .[-$max:] | reverse | .[] |
+    "| \(.number) | \(.observed_at) | [`\(.sha[0:7])`](\(.commit_url)) | " +
+    (if   .result == "pass" then "✅ pass"
+     elif .result == "fail" then "❌ fail"
+     else .result end) +
+    " | \((.failed_jobs // []) | join(\"<br>\")) | [logs](\(.observed_run_url)) |"
+  ' <<<"$state")
+  encoded=$(encode_state "$state")
+
+  {
+    printf '%s\n' "$STICKY_MARKER"
+    printf '## 🔁 CI Stability Monitor\n\n'
+    printf 'This PR has `ci/verify-stability` enabled — CI is re-triggered outside business hours to surface flaky tests.\n\n'
+    printf -- '- **Stop:** remove the `ci/verify-stability` label\n'
+    printf -- '- **Auto-stop:** after %s consecutive green runs\n' "$GREEN_THRESHOLD"
+    printf -- '- **Observations recorded:** %s\n\n' "$run_count"
+    if [[ -n "$flaky" ]]; then
+      printf '### ⚠️ Likely flaky jobs\n%s\n\n' "$flaky"
+    fi
+    printf '### History\n'
+    printf '| # | Observed (UTC) | Commit | Result | Failed jobs | Stability run |\n'
+    printf '|---|----------------|--------|--------|-------------|---------------|\n'
+    [[ -n "$history" ]] && printf '%s\n' "$history"
+    printf '\n%s%s%s\n' "$STATE_PREFIX" "$encoded" "$STATE_SUFFIX"
+  }
+}
+
+upsert_sticky_comment() {
+  local pr=$1 body=$2 existing comment_id
+  existing=$(fetch_sticky_comment "$pr")
+  if [[ -n "$existing" ]]; then
+    comment_id=$(jq -r '.id' <<<"$existing")
+    gh api "repos/${OWNER}/${REPO}/issues/comments/${comment_id}" \
+      --method PATCH -f body="$body" >/dev/null
+  else
+    gh pr comment "$pr" --body "$body" >/dev/null
+  fi
+}
+
+# ---- check-run inspection ---------------------------------------------------
+
+fetch_checks() {
+  # Emits "bucket name" lines for the PR's current HEAD checks.
+  local pr=$1
+  gh pr checks "$pr" --json name,bucket 2>/dev/null |
+    jq -r '.[] | "\(.bucket) \(.name)"'
+}
+
+# ---- per-PR pipeline --------------------------------------------------------
+
+process_pr() {
+  local pr=$1 do_merge=$2
+
+  log "PR #${pr}: processing"
+
+  local pr_json
+  if ! pr_json=$(gh pr view "$pr" \
+      --json headRefName,headRepositoryOwner,state,headRefOid 2>/dev/null); then
+    warn "PR #${pr}: could not fetch PR details"
+    summary "- ⚠️ PR #${pr}: details fetch failed"
+    return
+  fi
+
+  if [[ "$(jq -r '.state' <<<"$pr_json")" != "OPEN" ]]; then
+    log "PR #${pr}: not open, skipping"
+    return
+  fi
+
+  local head_owner
+  head_owner=$(jq -r '.headRepositoryOwner.login' <<<"$pr_json")
+  if [[ "$head_owner" != "$OWNER" ]]; then
+    warn "PR #${pr}: head repo is fork \`${head_owner}\`, cannot push"
+    summary "- ⏭️ PR #${pr}: skipped (fork \`${head_owner}\`)"
+    return
+  fi
+
+  local branch head_sha
+  branch=$(jq   -r '.headRefName' <<<"$pr_json")
+  head_sha=$(jq -r '.headRefOid'  <<<"$pr_json")
+
+  # --- observe current check status ---
+  local checks has_pending=0 has_failed=0
+  local -a failed_jobs=()
+  checks=$(fetch_checks "$pr")
+  if [[ -n "$checks" ]]; then
+    while read -r bucket name; do
+      [[ -z "$bucket" ]] && continue
+      case "$bucket" in
+        pending)       has_pending=1 ;;
+        fail)          has_failed=1; failed_jobs+=("$name") ;;
+        cancel)        has_failed=1; failed_jobs+=("$name (cancelled)") ;;
+        pass|skipping) ;;
+      esac
+    done <<<"$checks"
+  fi
+
+  if (( has_pending )); then
+    log "PR #${pr}: checks pending on ${head_sha:0:7}, not triggering"
+    summary "- ⏳ PR #${pr}: pending on \`${head_sha:0:7}\`"
+    return
+  fi
+
+  # --- load prior state ---
+  local sticky_json state
+  sticky_json=$(fetch_sticky_comment "$pr")
+  if [[ -n "$sticky_json" ]]; then
+    state=$(extract_state "$(jq -r '.body' <<<"$sticky_json")")
+  else
+    state='{"runs":[]}'
+  fi
+
+  # --- record observation if definitive ---
+  local result="none"
+  if [[ -n "$checks" ]]; then
+    if (( has_failed )); then result="fail"; else result="pass"; fi
+  fi
+  if [[ "$result" != "none" ]]; then
+    local now_utc failed_json run_number observation
+    now_utc=$(date -u +"%Y-%m-%d %H:%M")
+    if (( ${#failed_jobs[@]} > 0 )); then
+      failed_json=$(printf '%s\n' "${failed_jobs[@]}" | jq -R . | jq -s .)
+    else
+      failed_json='[]'
+    fi
+    run_number=$(( $(jq '.runs | length' <<<"$state") + 1 ))
+    observation=$(jq -n \
+      --argjson n "$run_number" \
+      --arg observed_at "$now_utc" \
+      --arg sha "$head_sha" \
+      --arg commit_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${head_sha}" \
+      --arg run_url "$RUN_URL" \
+      --arg result "$result" \
+      --argjson failed "$failed_json" '
+      {
+        number: $n, observed_at: $observed_at, sha: $sha,
+        commit_url: $commit_url, observed_run_url: $run_url,
+        result: $result, failed_jobs: $failed
+      }')
+    state=$(jq --argjson obs "$observation" --argjson max "$MAX_HISTORY" \
+      '.runs += [$obs] | .runs = (.runs | .[-$max:])' <<<"$state")
+  fi
+
+  # --- auto-stop after N consecutive greens ---
+  local consec_green
+  consec_green=$(jq -r '
+    ([.runs[].result] | reverse) as $r |
+    ($r | map(. == "pass") | index(false)) // ($r | length)
+  ' <<<"$state")
+  if (( consec_green >= GREEN_THRESHOLD )); then
+    log "PR #${pr}: ${consec_green} consecutive green runs, removing label"
+    gh pr edit "$pr" --remove-label "ci/verify-stability"              >/dev/null 2>&1 || true
+    gh pr edit "$pr" --remove-label "ci/verify-stability-merge-master" >/dev/null 2>&1 || true
+    local body
+    body=$(render_comment "$state")
+    body="${body}
+
+---
+✅ **Auto-stopped** after ${consec_green} consecutive green stability runs. Removed \`ci/verify-stability\` label."
+    upsert_sticky_comment "$pr" "$body"
+    summary "- ✅ PR #${pr}: auto-stopped (${consec_green} consecutive greens)"
+    return
+  fi
+
+  # --- fetch & checkout PR branch (local temp ref) ---
+  local local_ref="refs/stability/pr-${pr}"
+  if ! git fetch --quiet --force origin "pull/${pr}/head:${local_ref}" 2>/dev/null; then
+    warn "PR #${pr}: failed to fetch pull ref"
+    summary "- ⚠️ PR #${pr}: fetch failed"
+    return
+  fi
+  if ! git -c advice.detachedHead=false checkout --quiet "${local_ref}"; then
+    warn "PR #${pr}: checkout failed"
+    summary "- ⚠️ PR #${pr}: checkout failed"
+    return
+  fi
+  git config user.name  "${GH_USER}"
+  git config user.email "${GH_EMAIL}"
+
+  # --- optional master merge ---
+  local merge_note=""
+  if (( do_merge )); then
+    git fetch --quiet origin master
+    if git merge origin/master --no-ff --no-commit --quiet 2>/dev/null; then
+      git commit --quiet --allow-empty -m "Merge master into PR #${pr}"
+      merge_note=" (merged master)"
+    else
+      warn "PR #${pr}: merge conflict with master"
+      git merge --abort 2>/dev/null || true
+      gh pr edit "$pr" --remove-label "ci/verify-stability-merge-master" \
+        >/dev/null 2>&1 || true
+      gh pr comment "$pr" --body "${CONFLICT_MARKER}
+⚠️ **CI stability monitor**: could not merge \`master\` into this PR — **conflicts detected**.
+
+Removing the \`ci/verify-stability-merge-master\` label. Rebase or merge \`master\` manually, then re-add the label to resume auto-merges. Regular \`ci/verify-stability\` triggers will continue." >/dev/null 2>&1 || true
+      merge_note=" (master merge conflict)"
+      summary "- ⚠️ PR #${pr}: merge conflict with master"
+    fi
+  fi
+
+  # --- push empty trigger commit ---
+  local new_run_number trigger_msg
+  new_run_number=$(( $(jq '.runs | length' <<<"$state") + 1 ))
+  trigger_msg="ci(stability): trigger run #${new_run_number} for PR #${pr}
+
+Workflow run: ${RUN_URL}"
+  git commit --quiet --allow-empty -m "$trigger_msg"
+  if ! git push --quiet origin "HEAD:refs/heads/${branch}"; then
+    err "PR #${pr}: push failed"
+    summary "- ❌ PR #${pr}: push failed"
+    git update-ref -d "$local_ref" 2>/dev/null || true
+    return
+  fi
+
+  upsert_sticky_comment "$pr" "$(render_comment "$state")"
+
+  log "PR #${pr}: observed=${result}, triggered run #${new_run_number}${merge_note}"
+  summary "- 🔁 PR #${pr}: observed \`${result}\` on \`${head_sha:0:7}\`, triggered run #${new_run_number}${merge_note}"
+
+  git update-ref -d "$local_ref" 2>/dev/null || true
+}
+
+# ---- main -------------------------------------------------------------------
+
+main() {
+  if [[ ! -f "$OPEN_PRS_FILE" ]]; then
+    err "PR list file not found: $OPEN_PRS_FILE"
+    exit 1
+  fi
+
+  summary "# 🔁 CI Stability monitor"
+  summary ""
+  summary "Workflow run: ${RUN_URL}"
+  summary ""
+  summary "## Processed PRs"
+
+  local prs_stability prs_merge
+  prs_stability=$(jq -r '.[] | select(.labels[]?.name == "ci/verify-stability") | .number' "$OPEN_PRS_FILE")
+  prs_merge=$(jq     -r '.[] | select(.labels[]?.name == "ci/verify-stability-merge-master") | .number' "$OPEN_PRS_FILE")
+
+  if [[ -z "$prs_stability" ]]; then
+    log "No PRs with ci/verify-stability label"
+    summary "_No PRs with \`ci/verify-stability\` label._"
+    return 0
+  fi
+
+  declare -A merge_set=()
+  while read -r p; do
+    [[ -n "$p" ]] && merge_set["$p"]=1
+  done <<<"$prs_merge"
+
+  while read -r pr; do
+    [[ -z "$pr" ]] && continue
+    local do_merge=0
+    [[ -n "${merge_set[$pr]:-}" ]] && do_merge=1
+    process_pr "$pr" "$do_merge" || warn "PR #${pr}: processing error (continuing)"
+  done <<<"$prs_stability"
+}
+
+main "$@"

--- a/.github/workflows/scripts/ci-stability.sh
+++ b/.github/workflows/scripts/ci-stability.sh
@@ -94,8 +94,8 @@ render_comment() {
   {
     printf '%s\n' "$STICKY_MARKER"
     printf '## 🔁 CI Stability Monitor\n\n'
-    printf 'This PR has `ci/verify-stability` enabled — CI is re-triggered outside business hours to surface flaky tests.\n\n'
-    printf -- '- **Stop:** remove the `ci/verify-stability` label\n'
+    printf "This PR has \`ci/verify-stability\` enabled — CI is re-triggered outside business hours to surface flaky tests.\n\n"
+    printf -- "- **Stop:** remove the \`ci/verify-stability\` label\n"
     printf -- '- **Auto-stop:** after %s consecutive green runs\n' "$GREEN_THRESHOLD"
     printf -- '- **Observations recorded:** %s\n\n' "$run_count"
     if [[ -n "$flaky" ]]; then


### PR DESCRIPTION
## Motivation

The \`ci/verify-stability\` workflow has correctness bugs and gives PR authors
no visibility into what it's doing. Specifically:

- PRs from forks silently create orphan branches on upstream (push target
  bug) — the fork PR never actually gets re-triggered.
- One failing PR (merge conflict, auth hiccup) aborts the whole loop and
  later PRs are skipped.
- It pushes empty commits even when CI is still running, stacking runs
  and wasting cycles.
- Authors only see empty trigger commits with no context — no way to tell
  which runs passed/failed or which jobs are flaky without digging
  through the Checks tab run by run.

## Implementation information

**Correctness**

- Fetch \`headRepositoryOwner\` and skip fork PRs (cannot push to them
  from this workflow; warn in step summary).
- Wrap each PR in isolated processing so one failure doesn't stop the
  loop.
- Master merge conflict → \`git merge --abort\`, drop the
  \`ci/verify-stability-merge-master\` label, post a conflict comment.
  Plain stability triggers continue.
- Inspect \`gh pr checks\` bucket before each trigger: if \`pending\`, skip
  this tick entirely (no observation, no push). Makes idle ticks cheap
  and enables tighter cadence.
- \`gh pr list --limit 200\` (default is 30, silently drops PRs past that).
- \`concurrency.group: ci-stability\` + \`timeout-minutes: 20\`.
- \`fetch-depth: 1\` (only needs pull ref + master, both explicit fetches).

**UX / flake detection**

- Sticky rollup comment per PR (\`<!-- ci-stability-bot -->\` marker)
  with: intro/stop instructions, flaky-job aggregation section, and a
  history table (run # · observed time · commit · ✅/❌ · failed jobs ·
  link to the stability workflow run).
- State persisted as base64-JSON inside an HTML comment marker in the
  sticky comment itself — single source of truth, survives across
  scheduled runs, capped to last 20 entries.
- Auto-stop after 5 consecutive green runs: removes both stability
  labels and posts a confirmation. Thresholds exposed as workflow env
  vars (\`STABILITY_CONSECUTIVE_GREEN_THRESHOLD\`, \`STABILITY_MAX_HISTORY\`).
- Trigger commit messages now include the workflow run URL.
- Per-tick \`\$GITHUB_STEP_SUMMARY\` lists each PR's outcome (triggered /
  skipped-fork / pending / auto-stopped / conflict).

**Cadence**

- Tighter cron: every 30 min during the existing off-business-hours
  windows (Mon-Fri 18:00-06:59 UTC + weekends). The pending-check guard
  means ticks during in-flight CI are ~30s of runner time with no push,
  so flakes surface much faster without extra spam.

**Structure**

- Extracted the bash logic into \`.github/workflows/scripts/ci-stability.sh\`
  (~290 lines). Workflow yaml stays a thin wrapper — easier to review
  and shellcheck than a 300-line inline heredoc.

### Required GitHub App permissions

The app backing \`APP_ID\`/\`APP_PRIVATE_KEY\` must have:

- \`contents: write\` (push trigger commits — already required)
- \`pull_requests: write\` (edit labels, post/patch comments — **new
  requirement** for the UX features)
- \`issues: write\` (comment PATCH endpoint)

If those aren't already granted, the new comment/label calls are all
wrapped in \`|| true\` so the core trigger still works — the UX features
just silently no-op until perms are bumped.

### Alternatives considered

- **Inline the bash in yaml**: rejected, ~300 lines of bash in a
  heredoc is painful to edit, can't be shellchecked, and has no syntax
  highlighting.
- **Store state in a separate branch or artifact**: rejected, adds
  moving parts. Embedding base64 JSON in the sticky comment is
  self-contained and survives workflow-history expiration.
- **GitHub Check Runs API for flake surface**: could complement the
  sticky comment, but requires additional permissions and a separate
  API dance. Left for a follow-up if the comment UX proves insufficient.

## Supporting documentation

None.

> Changelog: skip