### PR TITLE
fix(kuma-dp): bridge self metrics to otel path

### DIFF
--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -169,9 +170,14 @@ func (s *Server) Start(stop <-chan struct{}) error {
 	}
 
 	errCh := make(chan error, len(servers))
+	dones := make([]chan struct{}, len(servers))
 	var readyCount atomic.Int32
 	total := int32(len(servers))
 	started := make([]atomic.Bool, len(servers))
+
+	for i := range dones {
+		dones[i] = make(chan struct{})
+	}
 
 	for i, srv := range servers {
 		idx := i
@@ -182,7 +188,11 @@ func (s *Server) Start(stop <-chan struct{}) error {
 			}
 		}
 		go func() {
-			errCh <- srv.ListenAndServe()
+			err := srv.ListenAndServe()
+			// Close done before sending to errCh so that shutdown goroutines
+			// can detect a failed/exited server before draining errCh.
+			close(dones[idx])
+			errCh <- err
 		}()
 	}
 
@@ -205,14 +215,31 @@ func (s *Server) Start(stop <-chan struct{}) error {
 		close(s.ready)
 	}
 
+	// Shut down all servers. For servers not yet started when we enter this
+	// loop, retry until they start (making Shutdown effective) or their
+	// goroutine exits (meaning they failed to start and are already done).
+	var shutdownWg sync.WaitGroup
 	for i, srv := range servers {
-		if !started[i].Load() {
-			continue
-		}
-		if err := srv.Shutdown(); err != nil {
-			log.Error(err, "server shutdown returned an error")
-		}
+		shutdownWg.Add(1)
+		go func(s *dns.Server, startedFlag *atomic.Bool, done <-chan struct{}) {
+			defer shutdownWg.Done()
+			for {
+				if startedFlag.Load() {
+					if err := s.Shutdown(); err != nil {
+						log.Error(err, "server shutdown returned an error")
+					}
+					return
+				}
+				select {
+				case <-done:
+					return // goroutine already exited without starting
+				default:
+					runtime.Gosched()
+				}
+			}
+		}(srv, &started[i], dones[i])
 	}
+	shutdownWg.Wait()
 
 	for i := 0; i < remaining; i++ {
 		if err := <-errCh; err != nil && firstErr == nil {

--- a/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
+++ b/app/kuma-dp/pkg/dataplane/meshmetrics/component.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	prombridge "go.opentelemetry.io/contrib/bridges/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -255,8 +257,14 @@ func startExporter(ctx context.Context, target OtelExportTarget, producer *metri
 	if err != nil {
 		return nil, err
 	}
+	// Surface kuma-dp's own Prometheus metrics (DNS proxy, config fetcher, etc.)
+	// through the OTel pipeline. In the Prometheus backend path the hijacker
+	// HTTP handler already serves these via DefaultGatherer; the OTel path
+	// bypasses that handler, so without this bridge the metrics are lost.
+	selfMetricsBridge := prombridge.NewMetricProducer(prombridge.WithGatherer(prometheus.DefaultGatherer))
 	readerOpts := []sdkmetric.PeriodicReaderOption{
 		sdkmetric.WithInterval(target.RefreshInterval),
+		sdkmetric.WithProducer(selfMetricsBridge),
 	}
 	if producer != nil {
 		readerOpts = append(readerOpts, sdkmetric.WithProducer(producer))


### PR DESCRIPTION
## Motivation

PR #16201 added new Kuma-DP Prometheus metrics (DNS proxy, config fetcher, etc.) registered on `prometheus.DefaultRegisterer`. Under MeshMetric with an OpenTelemetry backend these metrics never reach the pipeline: the OTel path uses `AggregatedProducer` which only HTTP-scrapes Envoy + user apps, so anything registered on the kuma-dp process itself is silently dropped.

The Prometheus backend path is unaffected — the hijacker HTTP handler already serves `DefaultGatherer` on `/meshmetric`.

Symptom: `kuma_dp_dns_*` series are missing from Prometheus when the mesh is configured with a MeshOpenTelemetryBackend. This also silently affects the existing `kuma_dp_envoyconfigfetcher_*` metrics and the `kuma_dp_dns_request_duration_seconds_*` histogram referenced by the workload-debug dashboard.

## Implementation information

Two commits:

1. **`fix(kuma-dp): bridge self metrics to otel path`** — add a second `sdkmetric.Producer` to the `PeriodicReader` in `startExporter` that wraps `prometheus.DefaultGatherer` via `go.opentelemetry.io/contrib/bridges/prometheus`. The bridge package is already a direct dependency — `pkg/plugins/runtime/opentelemetry/metrics.go` uses the same pattern for the control-plane OTel pusher. Both pipe and direct (Envoy-socket) OTel backends flow through `startExporter`, so one change covers both paths. No new deps, no config surface change.

2. **`fix(dns): fix race in multi-listener shutdown`** — drive-by fix for a race exposed by the existing `returns the first listener error when another listener started` test. When one DNS listener fails immediately (e.g. bind `address already in use`) and another is racing to call `NotifyStartedFunc`, the shutdown loop may read `started[i]=false` and skip `Shutdown()`. The drain-errCh loop then blocks forever waiting for an exit signal that never comes. Fix: retry `Shutdown()` in a goroutine until either the server transitions to started or its per-listener `done` channel fires. Hit this as a flake on the original CI run for this PR; ginkgo `-repeat=5` locally is now stable.

Alternatives considered for (1):
- Adding a synthetic `ApplicationToScrape` pointing at the hijacker's own `/meshmetric` path — creates a self-scrape loop and duplicates parse/serialize work.
- Migrating `kuma_dp_dns_*` to native OTel instruments — larger blast radius, breaks the Prometheus backend path which currently works.

## Supporting documentation

Follow-up to #16201.

> Changelog: fix(kuma-dp): ship kuma-dp self metrics to OpenTelemetry backends