### PR TITLE
ci(actions): guard stability against fresh commits

### DIFF
--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -2,12 +2,13 @@ name: Check CI stability for PRs with "ci/verify-stability" label
 
 on:
   schedule:
-    # Outside business hours, UTC. Every 30 min — the pending-check guard
-    # in ci-stability.sh skips ticks where CI is still in flight, so idle
-    # ticks are cheap and tighter cadence = faster flake detection.
-    - cron: "*/30 18-23 * * 1-5"   # Mon-Fri evenings
-    - cron: "*/30 0-6 * * 1-5"     # Mon-Fri early mornings (00:00-06:59 UTC)
-    - cron: "*/30 * * * 0,6"       # Weekends, all day
+    # Outside business hours, UTC. Every 10 min — the pending-check guard
+    # and fresh-commit grace in ci-stability.sh make idle ticks cheap (a few
+    # API calls, no push), so tighter cadence buys faster flake detection
+    # without spamming PRs with extra trigger commits.
+    - cron: "*/10 18-23 * * 1-5"   # Mon-Fri evenings
+    - cron: "*/10 0-6 * * 1-5"     # Mon-Fri early mornings (00:00-06:59 UTC)
+    - cron: "*/10 * * * 0,6"       # Weekends, all day
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/scripts/ci-stability.sh
+++ b/.github/workflows/scripts/ci-stability.sh
@@ -31,6 +31,12 @@ readonly MAX_HISTORY="${STABILITY_MAX_HISTORY:-20}"
 # History column when they fail — only the rollup "Likely flaky jobs"
 # section filters them out.
 readonly FLAKE_EXCLUDE="${STABILITY_FLAKE_EXCLUDE:-check,distributions}"
+# Minimum age (seconds) of HEAD commit before we trust check status. There
+# is a race window between `git push` and GitHub registering all check_runs
+# for the new commit; during that window `gh pr checks` may report only the
+# instant checks (e.g. DCO) and miss the slow ones, leading us to record a
+# false "pass" and push another trigger commit on top of unfinished CI.
+readonly FRESH_COMMIT_GRACE_SECS="${STABILITY_FRESH_COMMIT_GRACE_SECS:-300}"
 
 log()  { printf '::notice::%s\n' "$*"; }
 warn() { printf '::warning::%s\n' "$*"; }
@@ -155,6 +161,23 @@ fetch_checks() {
   printf '%s' "$json" | jq -r '.[] | "\(.bucket) \(.name)"'
 }
 
+# Returns the age (in seconds) of a commit on stdout, or non-zero on failure.
+commit_age_secs() {
+  local sha=$1 committed_at committed_epoch now_epoch
+  if ! committed_at=$(gh api "repos/${OWNER}/${REPO}/commits/${sha}" \
+      --jq '.commit.committer.date' 2>/dev/null); then
+    return 1
+  fi
+  if [[ -z "$committed_at" ]]; then
+    return 1
+  fi
+  if ! committed_epoch=$(date -u -d "$committed_at" +%s 2>/dev/null); then
+    return 1
+  fi
+  now_epoch=$(date -u +%s)
+  printf '%s' "$(( now_epoch - committed_epoch ))"
+}
+
 # ---- per-PR pipeline --------------------------------------------------------
 
 process_pr() {
@@ -186,6 +209,23 @@ process_pr() {
   local branch head_sha
   branch=$(jq   -r '.headRefName' <<<"$pr_json")
   head_sha=$(jq -r '.headRefOid'  <<<"$pr_json")
+
+  # --- fresh-commit grace period ---
+  # Skip if HEAD was committed less than FRESH_COMMIT_GRACE_SECS ago. Without
+  # this guard the gh pr checks rollup may not yet include all the slow
+  # check_runs (only the instant ones like DCO), leading us to misread a
+  # half-registered state as "all pass" and push a trigger over unfinished
+  # CI. Better to wait one tick.
+  local age_secs
+  if age_secs=$(commit_age_secs "$head_sha"); then
+    if (( age_secs < FRESH_COMMIT_GRACE_SECS )); then
+      log "PR #${pr}: HEAD ${head_sha:0:7} too fresh (${age_secs}s < ${FRESH_COMMIT_GRACE_SECS}s)"
+      summary "- ⏳ PR #${pr}: HEAD too fresh (\`${head_sha:0:7}\`, ${age_secs}s old)"
+      return
+    fi
+  else
+    warn "PR #${pr}: could not fetch commit age, proceeding anyway"
+  fi
 
   # --- observe current check status ---
   # fetch_checks returns non-zero on API failure; skip this PR rather than


### PR DESCRIPTION
## Motivation

Reproduced a real bug on PR #16219: the stability monitor pushed run #6
at 11:43:03 — only **74 seconds** after the author's last commit
(\`b06b394\`, a revert pushed at 11:41:49). At that moment \`gh pr
checks\` reported only **one** check run for the new HEAD: \`DCO\`,
which probot completes in ~10 seconds. All the heavy CI checks
(\`build-test-distribute\`, \`check\`, \`distributions\`, etc.) had not
yet been registered by GitHub.

The script saw \`has_pending=0\`, \`has_failed=0\`, computed
\`result="pass"\`, recorded a false-positive observation and pushed a
new trigger commit on top of CI that had not actually started. This
defeats the whole point of the pending-check guard.

Root cause: GitHub eventual consistency between \`git push\` and the
\`/check-runs\` rollup reflecting all the workflows that will run on
the new commit. The window is short (~30-60s) but the cron landing
inside it is exactly the failure mode.

## Implementation information

**Fresh-commit grace period**

Add a \`STABILITY_FRESH_COMMIT_GRACE_SECS\` env var (default \`300\`)
that aborts processing for a PR whose HEAD commit is younger than that
threshold. New helper:

\`\`\`bash
commit_age_secs() {
  # gh api commits/{sha} -> commit.committer.date -> seconds since epoch
}
\`\`\`

Called immediately after we resolve \`head_sha\`, before any check-status
inspection. One extra API call per PR per tick, negligible compared to
the rest of the iteration.

If the API call fails for some reason, we log a warning and proceed —
the existing pending-check guard still catches in-flight CI in the
common case. The grace period is a belt-and-braces fix for the brief
race window only.

**Tighter cadence: every 10 min**

Cron drops from every 30 min to every 10 min in the same off-hours
windows. Why this is now safe to do:

- The pending-check guard already skips ticks where CI is in flight.
- The new fresh-commit grace skips ticks within 5 min of a push.
- An idle tick costs ~30s of runner time and ~5 API calls per labeled
  PR — no \`git push\`, no commit on the PR branch.

Result: faster turnaround between CI completing and the next observation
landing in the sticky comment, without extra trigger spam.

## Supporting documentation

Verified by inspecting the actual log of stability run \`24281731151\`
(11:42:33 UTC) which shows \`observed=pass, triggered run #6\`. Querying
\`/repos/kumahq/kuma/commits/b06b394/check-runs\` confirms only \`DCO\`
existed at that point.

> Changelog: skip