### PR TITLE
feat(dashboards): add operational panels

### DIFF
--- a/dashboards/grafana/kuma-control-plane.json
+++ b/dashboards/grafana/kuma-control-plane.json
@@ -827,12 +827,81 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "p95 resources per xDS snapshot by type. Rising clusters/endpoints typically indicate mesh fan-out growth.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 212,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "xDS Snapshot Resources (p95 by type)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, resource_type) (rate(xds_snapshot_resources_bucket{job=\"kuma-control-plane\"}[5m])))",
+          "legendFormat": "{{resource_type}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 38
       },
       "id": 113,
       "title": "KDS \u2014 Global Control Plane",
@@ -867,7 +936,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 31
+        "y": 39
       },
       "id": 114,
       "options": {
@@ -923,7 +992,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 31
+        "y": 39
       },
       "id": 115,
       "options": {
@@ -979,7 +1048,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 31
+        "y": 39
       },
       "id": 116,
       "options": {
@@ -1035,7 +1104,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 47
       },
       "id": 117,
       "options": {
@@ -1091,7 +1160,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 47
       },
       "id": 118,
       "options": {
@@ -1120,12 +1189,155 @@
       ]
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Active KDS streams per zone on the Global CP. A zone dropping to 0 indicates loss of connectivity.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 213,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS Active Zone Connections",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (zone_name) (kds_zone_active_connections{job=\"kuma-control-plane\"})",
+          "legendFormat": "{{zone_name}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "KDS NACK rate by zone and resource type. Any sustained non-zero indicates a zone rejecting config from the global CP.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 214,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "KDS NACK Rate",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (zone_name, resource_type) (rate(kds_nack_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{zone_name}} / {{resource_type}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 63
       },
       "id": 119,
       "title": "KDS \u2014 Zone Control Plane",
@@ -1160,7 +1372,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 64
       },
       "id": 120,
       "options": {
@@ -1226,7 +1438,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 64
       },
       "id": 121,
       "options": {
@@ -1259,7 +1471,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 72
       },
       "id": 50,
       "title": "Resources",
@@ -1306,7 +1518,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 73
       },
       "id": 51,
       "options": {
@@ -1379,7 +1591,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 73
       },
       "id": 53,
       "options": {
@@ -1411,12 +1623,85 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "VIP allocation exhaustion events per mesh over the last hour. Any non-zero value means the IPAM pool is full.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "id": 215,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "VIP Allocation Exhaustion (1h)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (mesh) (increase(vip_allocation_exhaustion_total{job=\"kuma-control-plane\"}[1h]))",
+          "legendFormat": "{{mesh}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 89
       },
       "id": 20,
       "title": "Store",
@@ -1459,7 +1744,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 74
+        "y": 90
       },
       "id": 21,
       "options": {
@@ -1528,7 +1813,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 74
+        "y": 90
       },
       "id": 22,
       "options": {
@@ -1613,7 +1898,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 82
+        "y": 98
       },
       "id": 23,
       "options": {
@@ -1651,7 +1936,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 106
       },
       "id": 40,
       "title": "Certificates",
@@ -1694,7 +1979,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 91
+        "y": 107
       },
       "id": 41,
       "options": {
@@ -1775,7 +2060,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 91
+        "y": 107
       },
       "id": 42,
       "options": {
@@ -1854,7 +2139,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 99
+        "y": 115
       },
       "id": 122,
       "options": {
@@ -1910,7 +2195,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 99
+        "y": 115
       },
       "id": 123,
       "options": {
@@ -1943,12 +2228,80 @@
       ]
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time remaining on the MeshIdentity/WorkloadIdentity certificate per mesh. Alert if < 7 days.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 604800
+              },
+              {
+                "color": "green",
+                "value": 2592000
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "id": 211,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "xDS Cert Time Remaining (per mesh)",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "min by (mesh) (xds_cert_expiration_timestamp_seconds{job=\"kuma-control-plane\"} - time())",
+          "legendFormat": "{{mesh}}",
+          "refId": "A"
+        }
+      ],
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 131
       },
       "id": 90,
       "title": "Go Runtime",
@@ -1992,7 +2345,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 108
+        "y": 132
       },
       "id": 91,
       "options": {
@@ -2061,7 +2414,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 108
+        "y": 132
       },
       "id": 92,
       "options": {
@@ -2149,7 +2502,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 108
+        "y": 132
       },
       "id": 93,
       "options": {
@@ -2218,7 +2571,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 116
+        "y": 140
       },
       "id": 94,
       "options": {
@@ -2322,7 +2675,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 116
+        "y": 140
       },
       "id": 95,
       "options": {
@@ -2368,7 +2721,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 124
+        "y": 148
       },
       "id": 100,
       "title": "API Server & Workqueue",
@@ -2411,7 +2764,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 125
+        "y": 149
       },
       "id": 101,
       "options": {
@@ -2480,7 +2833,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 149
       },
       "id": 102,
       "options": {
@@ -2557,7 +2910,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 133
+        "y": 157
       },
       "id": 111,
       "options": {
@@ -2626,7 +2979,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 133
+        "y": 157
       },
       "id": 112,
       "options": {
@@ -2664,7 +3017,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 141
+        "y": 165
       },
       "id": 70,
       "title": "Kubernetes",
@@ -2707,7 +3060,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 142
+        "y": 166
       },
       "id": 71,
       "options": {
@@ -2780,7 +3133,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 142
+        "y": 166
       },
       "id": 72,
       "options": {
@@ -2849,7 +3202,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 150
+        "y": 174
       },
       "id": 73,
       "options": {
@@ -2918,7 +3271,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 150
+        "y": 174
       },
       "id": 74,
       "options": {
@@ -2951,12 +3304,101 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Sidecar injection decisions by outcome. Any failures should be investigated via the 'reason' label.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "failed.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 182
+      },
+      "id": 216,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Sidecar Injection Outcomes",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result, reason) (rate(sidecar_injection_total{job=\"kuma-control-plane\"}[5m]))",
+          "legendFormat": "{{result}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 158
+        "y": 190
       },
       "id": 60,
       "title": "Component Loops",
@@ -2999,7 +3441,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 159
+        "y": 191
       },
       "id": 61,
       "options": {
@@ -3104,7 +3546,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 159
+        "y": 191
       },
       "id": 62,
       "options": {
@@ -3151,7 +3593,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 167
+        "y": 199
       },
       "id": 80,
       "title": "DP Server",
@@ -3194,7 +3636,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 168
+        "y": 200
       },
       "id": 81,
       "options": {
@@ -3263,7 +3705,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 168
+        "y": 200
       },
       "id": 82,
       "options": {
@@ -3301,7 +3743,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 176
+        "y": 208
       },
       "id": 30,
       "title": "gRPC Server",
@@ -3344,7 +3786,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 177
+        "y": 209
       },
       "id": 31,
       "options": {
@@ -3422,7 +3864,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 177
+        "y": 209
       },
       "id": 32,
       "options": {

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -2423,12 +2423,258 @@
       "description": "Local = Kuma DNS resolution time. Upstream = time to forward queries to the upstream resolver (e.g. CoreDNS)."
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS query rate for this workload by query type and resolution path (local map vs upstream).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "qps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 97
+      },
+      "id": 400,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (qtype, source) (rate(kuma_dp_dns_queries_total{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "legendFormat": "{{qtype}} / {{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Queries by Type & Source",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS response codes for this workload. Sustained servfail/nxdomain indicates resolver or upstream problems.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "qps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "servfail"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "nxdomain"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 97
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (rcode) (rate(kuma_dp_dns_response_codes_total{mesh=\"$mesh\"}[5m]) * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "legendFormat": "{{rcode}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Response Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current DNS map size per pod for this workload.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 97
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (pod) (kuma_dp_dns_entries_total{mesh=\"$mesh\"} * on(pod) group_left() envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Map Entries (per pod)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 97
+        "y": 105
       },
       "id": 207,
       "title": "Proxy Health",
@@ -2463,7 +2709,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 98
+        "y": 106
       },
       "id": 208,
       "options": {
@@ -2526,7 +2772,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 98
+        "y": 106
       },
       "id": 209,
       "options": {
@@ -2582,7 +2828,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 98
+        "y": 106
       },
       "id": 210,
       "options": {

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -2455,7 +2455,7 @@
               }
             ]
           },
-          "unit": "qps"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -2528,7 +2528,7 @@
               }
             ]
           },
-          "unit": "qps"
+          "unit": "reqps"
         },
         "overrides": [
           {


### PR DESCRIPTION
## Motivation

Add observability panels to Grafana dashboards covering operational blind spots: xDS snapshot sizing, KDS health, VIP exhaustion, cert expiry, injection outcomes, and DNS internals.

## Implementation information

**Control plane dashboard** (`kuma-control-plane.json`):
- xDS Snapshot Resources (p95 by type) — track cluster/endpoint fan-out growth
- KDS Active Zone Connections — monitor zone CP connectivity
- KDS NACK Rate — surface config rejection issues
- VIP Allocation Exhaustion (1h) — alert before VIP pool runs out
- xDS Cert Time Remaining (per mesh) — track cert renewal health
- Sidecar Injection Outcomes — split success/skip/error injection counts

**Service debug dashboard** (`kuma-service-debug.json`):
- DNS Queries by Type & Source — break down DNS traffic patterns
- DNS Response Codes — surface NXDOMAIN/SERVFAIL spikes
- DNS Map Entries (per pod) — track DNS table size per dataplane

All panels use existing metrics exposed by kuma-cp and kuma-dp; no code changes required.

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
