### PR TITLE
chore(unit): increase timeout

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -17,7 +17,7 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   test_unit:
-    timeout-minutes: 25
+    timeout-minutes: 30
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Motivation

After upgrade of go to 1.26.2 I noticed timeout of unit test.

## Implementation information

Let's increase timeout and check if they are stable

## Supporting documentation

> Changelog: skip
