### PR TITLE
feat(kuma-dp): check if dns server is ready

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -348,6 +348,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				}
 			}
 
+			var dnsConfigReady <-chan struct{}
 			if cfg.DNS.Enabled && !cfg.Dataplane.IsZoneProxy() {
 				dnsOpts := &dnsserver.Opts{
 					Config:   *cfg,
@@ -370,6 +371,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 					if err := confFetcher.AddHandler(dns_dpapi.PATH, dnsproxyServer.ReloadMap); err != nil {
 						return err
 					}
+					dnsConfigReady = dnsproxyServer.ConfigReady()
 					components = append(components, dnsproxyServer)
 				} else {
 					dnsServer, err := dnsserver.New(dnsOpts)
@@ -423,7 +425,8 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				cfg.DataplaneRuntime.SocketDir,
 				readinessAddr,
 				cfg.Dataplane.ReadinessPort,
-				adminSocketPath)
+				adminSocketPath,
+				dnsConfigReady)
 			components = append(components, readinessReporter)
 
 			if err := rootCtx.ComponentManager.Add(components...); err != nil {

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -30,8 +30,10 @@ type Server struct {
 	registerer    prometheus.Registerer
 	metricsOnce   sync.Once
 	// upstreamClient is used for testing purposes
-	upstreamClient func(msg *dns.Msg) (*dns.Msg, error)
-	ready          chan struct{}
+	upstreamClient  func(msg *dns.Msg) (*dns.Msg, error)
+	ready           chan struct{}
+	configReady     chan struct{}
+	configReadyOnce sync.Once
 }
 
 func NewServer(addresses []string) (*Server, error) {
@@ -69,6 +71,7 @@ func NewServerWithCustomClient(addresses []string, upstreamClient func(msg *dns.
 		componentDone:  make(chan struct{}),
 		dnsMap:         atomic.Pointer[dnsMap]{},
 		ready:          make(chan struct{}),
+		configReady:    make(chan struct{}),
 		registerer:     prometheus.DefaultRegisterer,
 		upstreamClient: upstreamClient,
 	}
@@ -263,6 +266,13 @@ func (s *Server) WaitForReady() {
 	<-s.ready
 }
 
+// ConfigReady returns a channel that is closed once the first DNS configuration
+// has been successfully loaded from Envoy. Use this to gate readiness on DNS
+// proxy being fully initialized, not just the UDP servers being up.
+func (s *Server) ConfigReady() <-chan struct{} {
+	return s.configReady
+}
+
 // ReloadMap replaces the current map in memory so that future calls to the proxy.
 // Because this is called inside the configfetcher there's no need to check if it changed or not.
 func (s *Server) ReloadMap(ctx context.Context, reader io.Reader) error {
@@ -314,6 +324,9 @@ func (s *Server) ReloadMap(ctx context.Context, reader io.Reader) error {
 	}
 	log.V(1).Info("DNS proxy configured", "config", res)
 	s.dnsMap.Store(&res)
+	s.configReadyOnce.Do(func() {
+		close(s.configReady)
+	})
 	if m := s.metrics.Load(); m != nil {
 		m.EntriesTotal.Set(float64(len(res.ARecords)))
 	}

--- a/app/kuma-dp/pkg/dataplane/readiness/component.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component.go
@@ -22,6 +22,7 @@ import (
 const (
 	pathPrefixReady  = "/ready"
 	stateReady       = "READY"
+	stateNotReady    = "NOT_READY"
 	stateTerminating = "TERMINATING"
 )
 
@@ -38,17 +39,22 @@ type Reporter struct {
 	adminSocketPath    string
 	adminClient        *http.Client
 	isTerminating      atomic.Bool
+	// dnsConfigReady, when non-nil, blocks /ready until the DNS proxy has
+	// loaded its first configuration from Envoy. Closed by the DNS proxy
+	// server after the first successful ReloadMap call.
+	dnsConfigReady <-chan struct{}
 }
 
 var logger = core.Log.WithName("readiness")
 
-func NewReporter(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string) *Reporter {
+func NewReporter(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}) *Reporter {
 	r := &Reporter{
 		unixSocketDisabled: unixSocketDisabled,
 		socketDir:          socketDir,
 		localListenPort:    localListenPort,
 		localListenAddr:    localIPAddr,
 		adminSocketPath:    adminSocketPath,
+		dnsConfigReady:     dnsConfigReady,
 	}
 	if adminSocketPath != "" {
 		c := httpclient.NewUDS(adminSocketPath, 2*time.Second, 3*time.Second)
@@ -124,6 +130,18 @@ func (r *Reporter) handleReadiness(writer http.ResponseWriter, req *http.Request
 	if r.isTerminating.Load() {
 		r.writeState(writer, req, stateTerminating, http.StatusServiceUnavailable)
 		return
+	}
+
+	// When DNS proxy is enabled, block readiness until it has loaded its
+	// first configuration from Envoy. This ensures that .mesh DNS names
+	// resolve correctly before any application container starts.
+	if r.dnsConfigReady != nil {
+		select {
+		case <-r.dnsConfigReady:
+		default:
+			r.writeState(writer, req, stateNotReady, http.StatusServiceUnavailable)
+			return
+		}
 	}
 
 	// When admin is on UDS, proxy /ready to Envoy admin so that

--- a/app/kuma-dp/pkg/dataplane/readiness/component_test.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Readiness Reporter", func() {
 		Expect(lis.Close()).To(Succeed())
 
 		baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
-		reporter = readiness.NewReporter(true, "", "127.0.0.1", port, adminSocketPath)
+		reporter = readiness.NewReporter(true, "", "127.0.0.1", port, adminSocketPath, nil)
 		go func() {
 			defer GinkgoRecover()
 			_ = reporter.Start(stopCh)
@@ -45,6 +45,52 @@ var _ = Describe("Readiness Reporter", func() {
 		if stopCh != nil {
 			close(stopCh)
 		}
+	})
+
+	Context("with DNS config gate", func() {
+		var dnsReady chan struct{}
+
+		BeforeEach(func() {
+			stopCh = make(chan struct{})
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).ToNot(HaveOccurred())
+			port = uint32(lis.Addr().(*net.TCPAddr).Port)
+			Expect(lis.Close()).To(Succeed())
+
+			baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+			dnsReady = make(chan struct{})
+			reporter = readiness.NewReporter(true, "", "127.0.0.1", port, "", dnsReady)
+			go func() {
+				defer GinkgoRecover()
+				_ = reporter.Start(stopCh)
+			}()
+			Eventually(func() error {
+				_, err := http.Get(baseURL + "/ready")
+				return err
+			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+		})
+
+		It("returns NOT_READY until DNS config channel is closed", func() {
+			resp, err := http.Get(baseURL + "/ready")
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("NOT_READY"))
+		})
+
+		It("returns READY after DNS config channel is closed", func() {
+			close(dnsReady)
+			Eventually(func() int {
+				resp, err := http.Get(baseURL + "/ready")
+				if err != nil {
+					return 0
+				}
+				resp.Body.Close()
+				return resp.StatusCode
+			}, 5*time.Second, 50*time.Millisecond).Should(Equal(http.StatusOK))
+		})
 	})
 
 	Context("without admin socket", func() {


### PR DESCRIPTION
 ## Motivation

Root cause: a race condition between Envoy readiness and DNS proxy config initialization.
When `kuma.io/wait-for-dataplane-ready: "true"` is set, the `kuma-sidecar` PostStart hook runs `kuma-dp wait --url http://localhost:9902/ready` and blocks container N+1 from starting until `/ready` returns 200. The readiness endpoint returns 200 as soon as Envoy workers start — but at that point, kuma-dp's embedded DNS proxy has not yet scraped its first config from Envoy's `_kuma:dynamicconfig` listener. The configfetcher runs asynchronously and typically delivers the first VIP map ~500ms later.

## Implementation information

Gate readiness on the DNS proxy's first config load using a close-once channel (configReady) in `dnsproxy.Server`:

- dnsproxy.Server gains a `configReady chan struct{} `closed (once, via sync.Once) inside ReloadMap after the first successful `dnsMap.Store`. A `ConfigReady() <-chan struct{}` method exposes it.
- readiness.Reporter gains an optional dnsConfigReady <-chan struct{} field. In handleReadiness, before proxying to Envoy admin, it checks the channel non-blockingly: if not yet closed, returns 503 NOT_READY. This keeps PostStart blocked until the DNS proxy has received its first VIP map.
- In run.go, dnsproxyServer.ConfigReady() is wired into NewReporter only when the embedded DNS proxy is active (ProxyPort != 0). When using CoreDNS, DNS disabled, or zone proxy mode, dnsConfigReady is nil and the gate is skipped — no behavior change for those paths.

The existing ready channel in dnsproxy.Server (signals UDP servers listening) is unchanged.
