### PR TITLE
fix(config): check if domain starts with dot

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,32 @@ does not have any particular instructions.
 
 ## Upgrade to `2.14.x`
 
+### DNS server domain must not start with a dot
+
+The control plane now rejects a DNS server domain configuration that begins with a `.` (e.g., `.mesh`). Previously such a value was silently accepted and produced broken hostname generation.
+
+**Action required:**
+
+If you have `KUMA_DNS_SERVER_DOMAIN` or `dnsServer.domain` set to a value starting with `.`, remove the leading dot:
+
+```yaml
+# kuma-cp config
+dnsServer:
+  domain: mesh   # was: .mesh
+```
+
+Or via environment variable: `KUMA_DNS_SERVER_DOMAIN=mesh`
+
+### HostnameGenerator templates that produce invalid DNS names now fail explicitly
+
+`HostnameGenerator` templates that evaluate to an invalid DNS subdomain (e.g., starting with a dot, containing uppercase letters, or having consecutive dots) now return an error instead of silently generating a broken hostname.
+
+**Action required:**
+
+Review your `HostnameGenerator` resources and ensure their `spec.template` values produce valid [RFC 1123](https://tools.ietf.org/html/rfc1123) DNS subdomains for all inputs.
+
+
+
 ### CPU limits removed from `kuma-init` and `kuma-sidecar` containers
 
 The default CPU limit for injected `kuma-init`, `kuma-sidecar` and `kuma-validation` containers has been removed (set to `0`, meaning no limit). Previously the defaults were `100m` and `1000m` respectively.

--- a/pkg/config/dns-server/config.go
+++ b/pkg/config/dns-server/config.go
@@ -3,6 +3,7 @@ package dns_server
 import (
 	"errors"
 	"net"
+	"strings"
 
 	"github.com/kumahq/kuma/v2/pkg/config"
 )
@@ -22,6 +23,9 @@ type Config struct {
 }
 
 func (g *Config) Validate() error {
+	if strings.HasPrefix(g.Domain, ".") {
+		return errors.New("domain must not start with a dot")
+	}
 	_, _, err := net.ParseCIDR(g.CIDR)
 	if err != nil {
 		return errors.New("CIDR must be valid")

--- a/pkg/config/dns-server/config_test.go
+++ b/pkg/config/dns-server/config_test.go
@@ -1,0 +1,51 @@
+package dns_server_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	dns_server "github.com/kumahq/kuma/v2/pkg/config/dns-server"
+)
+
+var _ = Describe("Config", func() {
+	type testCase struct {
+		config dns_server.Config
+		error  string
+	}
+
+	DescribeTable("should reject invalid config",
+		func(given testCase) {
+			err := given.config.Validate()
+			Expect(err).To(MatchError(given.error))
+		},
+		Entry("domain starts with dot", testCase{
+			config: dns_server.Config{
+				Domain:         ".mesh",
+				CIDR:           "240.0.0.0/4",
+				ServiceVipPort: 80,
+			},
+			error: "domain must not start with a dot",
+		}),
+		Entry("invalid CIDR", testCase{
+			config: dns_server.Config{
+				Domain:         "mesh",
+				CIDR:           "not-a-cidr",
+				ServiceVipPort: 80,
+			},
+			error: "CIDR must be valid",
+		}),
+		Entry("port is zero", testCase{
+			config: dns_server.Config{
+				Domain:         "mesh",
+				CIDR:           "240.0.0.0/4",
+				ServiceVipPort: 0,
+			},
+			error: "port can't be 0",
+		}),
+	)
+
+	It("should accept valid config", func() {
+		cfg := dns_server.DefaultDNSServerConfig()
+		Expect(cfg.Validate()).To(Succeed())
+	})
+})

--- a/pkg/config/dns-server/suite_test.go
+++ b/pkg/config/dns-server/suite_test.go
@@ -1,0 +1,11 @@
+package dns_server_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestDNSServerConfig(t *testing.T) {
+	test.RunSpecs(t, "DNS Server Config Suite")
+}

--- a/pkg/core/resources/apis/hostnamegenerator/hostname/generator.go
+++ b/pkg/core/resources/apis/hostnamegenerator/hostname/generator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s_validation "k8s.io/apimachinery/pkg/util/validation"
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
@@ -314,5 +315,9 @@ func EvaluateTemplate(localZone string, generatorTemplate string, meta model.Res
 	if err != nil {
 		return "", fmt.Errorf("pre evaluation of template with parameters failed with error=%q", err.Error())
 	}
-	return sb.String(), nil
+	generated := sb.String()
+	if violations := k8s_validation.IsDNS1123Subdomain(generated); len(violations) > 0 {
+		return "", fmt.Errorf("generated hostname %q is not a valid DNS name: %s", generated, strings.Join(violations, ", "))
+	}
+	return generated, nil
 }

--- a/pkg/core/resources/apis/hostnamegenerator/hostname/generator_test.go
+++ b/pkg/core/resources/apis/hostnamegenerator/hostname/generator_test.go
@@ -1,0 +1,145 @@
+package hostname_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/hostnamegenerator/hostname"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
+)
+
+var _ = Describe("EvaluateTemplate", func() {
+	type testCase struct {
+		localZone string
+		template  string
+		meta      core_model.ResourceMeta
+		expected  string
+		errMsg    string
+	}
+
+	DescribeTable("should evaluate template",
+		func(given testCase) {
+			result, err := hostname.EvaluateTemplate(given.localZone, given.template, given.meta)
+			if given.errMsg != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(given.errMsg))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(given.expected))
+			}
+		},
+		Entry("basic name template", testCase{
+			template: "{{ .Name }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+			},
+			expected: "backend.mesh",
+		}),
+		Entry("name with namespace", testCase{
+			template: "{{ .Name }}.{{ .Namespace }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+				Labels: map[string]string{
+					mesh_proto.KubeNamespaceTag: "my-ns",
+				},
+			},
+			expected: "backend.my-ns.mesh",
+		}),
+		Entry("uses K8s name component over resource name", testCase{
+			template: "{{ .Name }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name:           "backend.my-ns",
+				Mesh:           "default",
+				NameExtensions: core_model.ResourceNameExtensions{core_model.K8sNameComponent: "backend"},
+			},
+			expected: "backend.mesh",
+		}),
+		Entry("zone from label", testCase{
+			localZone: "local",
+			template:  "{{ .Name }}.{{ .Zone }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+				Labels: map[string]string{
+					mesh_proto.ZoneTag: "zone-1",
+				},
+			},
+			expected: "backend.zone-1.mesh",
+		}),
+		Entry("zone falls back to localZone", testCase{
+			localZone: "local",
+			template:  "{{ .Name }}.{{ .Zone }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+			},
+			expected: "backend.local.mesh",
+		}),
+		Entry("display name from label", testCase{
+			template: "{{ .DisplayName }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend.my-ns",
+				Mesh: "default",
+				Labels: map[string]string{
+					mesh_proto.DisplayName: "backend",
+				},
+			},
+			expected: "backend.mesh",
+		}),
+		Entry("label function", testCase{
+			template: `{{ label "app" }}.mesh`,
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+				Labels: map[string]string{
+					"app": "my-app",
+				},
+			},
+			expected: "my-app.mesh",
+		}),
+		Entry("label function missing key", testCase{
+			template: `{{ label "missing" }}.mesh`,
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+			},
+			errMsg: "pre evaluation of template with parameters failed",
+		}),
+		Entry("invalid template syntax", testCase{
+			template: "{{ .Name[0 }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+			},
+			errMsg: "failed compiling gotemplate error",
+		}),
+		Entry("generated hostname starts with dot", testCase{
+			template: ".{{ .Name }}.mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+			},
+			errMsg: "is not a valid DNS name",
+		}),
+		Entry("generated hostname has uppercase", testCase{
+			template: "{{ .Name }}.Mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "Backend",
+				Mesh: "default",
+			},
+			errMsg: "is not a valid DNS name",
+		}),
+		Entry("generated hostname has consecutive dots", testCase{
+			template: "{{ .Name }}..mesh",
+			meta: &test_model.ResourceMeta{
+				Name: "backend",
+				Mesh: "default",
+			},
+			errMsg: "is not a valid DNS name",
+		}),
+	)
+})

--- a/pkg/core/resources/apis/hostnamegenerator/hostname/suite_test.go
+++ b/pkg/core/resources/apis/hostnamegenerator/hostname/suite_test.go
@@ -1,0 +1,11 @@
+package hostname_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestHostnameGenerator(t *testing.T) {
+	test.RunSpecs(t, "Hostname Generator Suite")
+}


### PR DESCRIPTION
## Motivation

`KUMA_DNS_SERVER_DOMAIN` (default: `mesh`) is used to build DNS entries like `<service>.mesh`. A domain starting with a dot (e.g.`.mesh.local`) would produce invalid hostnames such as `<service>..mesh.local`, causing DNS resolution failures with no clear error at startup.

## Implementation information

Added an early check in `Config.Validate()` (`pkg/config/dns-server/config.go`) that rejects any `Domain` value with a leading dot and returns `"domain must not start with a dot"
