### PR TITLE
test(e2e): fix loadbalancing test

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -191,6 +191,16 @@ spec:
 				g.Expect(zoneIngressesGlobal).To(Equal(2))
 			}, "3m", "1s").Should(Succeed())
 
+			// Wait for zone ingresses to sync from global to individual zones.
+			Eventually(func(g Gomega) {
+				zoneIngressesK8sZone, err := NumberOfResources(zoneK8s, mesh.ZoneIngressResourceTypeDescriptor)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(zoneIngressesK8sZone).To(Equal(2))
+				zoneIngressesUniversalZone, err := NumberOfResources(zoneUniversal, mesh.ZoneIngressResourceTypeDescriptor)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(zoneIngressesUniversalZone).To(Equal(2))
+			}, "3m", "1s").Should(Succeed())
+
 			// then
 			Consistently(func(g Gomega) {
 				policiesGlobal, err := NumberOfResources(global, meshtimeout.MeshTimeoutResourceTypeDescriptor)

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -369,23 +369,27 @@ spec:
 
 		Expect(NewClusterSetup().Install(YamlUniversal(meshLoadBalancingStrategyDemoClientMeshRoute)).Setup(multizone.Global)).To(Succeed())
 
-		// and generate some traffic
-		_, err := client.CollectResponsesAndFailures(
-			multizone.KubeZone2, "demo-client-mesh-route", "test-server-mesh-route_locality-aware-lb_svc_80.mesh",
-			client.WithNumberOfRequests(200),
-			client.NoFail(),
-			client.WithoutRetries(),
-			client.FromKubernetesPod(namespace, "demo-client-mesh-route"),
-		)
-		Expect(err).ToNot(HaveOccurred())
+		// then - wait for MLBS EDS to converge before measuring the distribution
+		Eventually(func(g Gomega) {
+			g.Expect(resetCounter(multizone.KubeZone2, "demo-client-mesh-route", namespace)).To(Succeed())
 
-		// then
-		failedRequests, err := collectMetric(multizone.KubeZone2, "demo-client-mesh-route", namespace, "test-server-mesh-route_locality-aware-lb_svc_80-ce3d32a0f959e460.upstream_rq_5xx")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(failedRequests).To(BeNumerically("~", 100, 25))
-		successRequests, err := collectMetric(multizone.KubeZone2, "demo-client-mesh-route", namespace, "test-server-mesh-route_locality-aware-lb_svc_80-70a8d85bc2519528.upstream_rq_2xx")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(successRequests).To(BeNumerically("~", 100, 25))
+			_, err := client.CollectResponsesAndFailures(
+				multizone.KubeZone2, "demo-client-mesh-route", "test-server-mesh-route_locality-aware-lb_svc_80.mesh",
+				client.WithNumberOfRequests(200),
+				client.NoFail(),
+				client.WithoutRetries(),
+				client.FromKubernetesPod(namespace, "demo-client-mesh-route"),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			failedRequests, err := collectMetric(multizone.KubeZone2, "demo-client-mesh-route", namespace, "test-server-mesh-route_locality-aware-lb_svc_80-ce3d32a0f959e460.upstream_rq_5xx")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(failedRequests).To(BeNumerically("~", 100, 25))
+
+			successRequests, err := collectMetric(multizone.KubeZone2, "demo-client-mesh-route", namespace, "test-server-mesh-route_locality-aware-lb_svc_80-70a8d85bc2519528.upstream_rq_2xx")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(successRequests).To(BeNumerically("~", 100, 25))
+		}, "60s", "10s").Should(Succeed())
 	})
 }
 

--- a/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
+++ b/test/e2e_env/multizone/localityawarelb/locality_aware_multizone_hybrid.go
@@ -343,9 +343,6 @@ spec:
 			),
 		)
 
-		// clean stats
-		Expect(resetCounter(multizone.KubeZone2, "demo-client-mesh-route", namespace)).To(Succeed())
-
 		// when load balancing policy created
 		meshLoadBalancingStrategyDemoClientMeshRoute := utils.FromTemplate(Default, `
 type: MeshLoadBalancingStrategy


### PR DESCRIPTION
## Motivation

When the MLBS is applied at line 370, the control plane pushes updated EDS to remove kuma-5 (UniZone2) endpoints from the cluster. Before that push arrives, 37 requests (~18%) hit kuma-5 and return 2xx instead of 5xx. This consistently gives 65 5xx instead of ~100, below the ±25 tolerance.

## Implementation information

Wrapped the traffic generation and metric assertions in Eventually("60s", "10s") with a counter reset each iteration. This retries until EDS has fully converged and the 50/50 split produces the expected failure distribution. The FlakeAttempts(3) decorator can be removed from this test too, but that's a separate cleanup.

## Supporting documentation

> Changelog: skip
