### PR TITLE
feat(kuma-dp): gate /ready on DNS proxy config with 15s timeout

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -348,6 +348,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				}
 			}
 
+			var dnsConfigReady <-chan struct{}
 			if cfg.DNS.Enabled && !cfg.Dataplane.IsZoneProxy() {
 				dnsOpts := &dnsserver.Opts{
 					Config:   *cfg,
@@ -370,6 +371,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 					if err := confFetcher.AddHandler(dns_dpapi.PATH, dnsproxyServer.ReloadMap); err != nil {
 						return err
 					}
+					dnsConfigReady = dnsproxyServer.ConfigReady()
 					components = append(components, dnsproxyServer)
 				} else {
 					dnsServer, err := dnsserver.New(dnsOpts)
@@ -423,7 +425,8 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				cfg.DataplaneRuntime.SocketDir,
 				readinessAddr,
 				cfg.Dataplane.ReadinessPort,
-				adminSocketPath)
+				adminSocketPath,
+				dnsConfigReady)
 			components = append(components, readinessReporter)
 
 			if err := rootCtx.ComponentManager.Add(components...); err != nil {

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -288,12 +288,10 @@ func (s *Server) ReloadMap(ctx context.Context, reader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if configuration.ExtraLabels != nil {
-		s.metricsOnce.Do(func() {
-			m := newMetrics(s.registerer, configuration.ExtraLabels)
-			s.metrics.Store(m)
-		})
-	}
+	s.metricsOnce.Do(func() {
+		m := newMetrics(s.registerer, configuration.ExtraLabels)
+		s.metrics.Store(m)
+	})
 	res := dnsMap{
 		ARecords:    make(map[string]*dnsEntry),
 		AAAARecords: make(map[string]*dnsEntry),

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -68,13 +68,14 @@ func WithRegisterer(r prometheus.Registerer) ServerOption {
 // NewServerWithCustomClient is used for testing purposes
 func NewServerWithCustomClient(addresses []string, upstreamClient func(msg *dns.Msg) (*dns.Msg, error), opts ...ServerOption) *Server {
 	s := Server{
-		addresses:      addresses,
-		componentDone:  make(chan struct{}),
-		dnsMap:         atomic.Pointer[dnsMap]{},
-		ready:          make(chan struct{}),
-		configReady:    make(chan struct{}),
-		registerer:     prometheus.DefaultRegisterer,
-		upstreamClient: upstreamClient,
+		addresses:       addresses,
+		componentDone:   make(chan struct{}),
+		dnsMap:          atomic.Pointer[dnsMap]{},
+		ready:           make(chan struct{}),
+		configReady:     make(chan struct{}),
+		registerer:      prometheus.DefaultRegisterer,
+		upstreamClient:  upstreamClient,
+		configReadyTime: time.Now(),
 	}
 	for _, opt := range opts {
 		opt(&s)
@@ -167,7 +168,6 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 
 func (s *Server) Start(stop <-chan struct{}) error {
 	defer close(s.componentDone)
-	s.configReadyTime = time.Now()
 
 	servers := make([]*dns.Server, len(s.addresses))
 	for i, addr := range s.addresses {
@@ -332,10 +332,8 @@ func (s *Server) ReloadMap(ctx context.Context, reader io.Reader) error {
 	log.V(1).Info("DNS proxy configured", "config", res)
 	s.dnsMap.Store(&res)
 	s.configReadyOnce.Do(func() {
-		if !s.configReadyTime.IsZero() {
-			if m := s.metrics.Load(); m != nil {
-				m.ConfigReadyWaitSeconds.Observe(time.Since(s.configReadyTime).Seconds())
-			}
+		if m := s.metrics.Load(); m != nil {
+			m.ConfigReadyWaitSeconds.Observe(time.Since(s.configReadyTime).Seconds())
 		}
 		log.Info("DNS proxy received first configuration", "records", len(res.ARecords))
 		close(s.configReady)

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -30,8 +30,11 @@ type Server struct {
 	registerer    prometheus.Registerer
 	metricsOnce   sync.Once
 	// upstreamClient is used for testing purposes
-	upstreamClient func(msg *dns.Msg) (*dns.Msg, error)
-	ready          chan struct{}
+	upstreamClient  func(msg *dns.Msg) (*dns.Msg, error)
+	ready           chan struct{}
+	configReady     chan struct{}
+	configReadyOnce sync.Once
+	configReadyTime time.Time
 }
 
 func NewServer(addresses []string) (*Server, error) {
@@ -69,6 +72,7 @@ func NewServerWithCustomClient(addresses []string, upstreamClient func(msg *dns.
 		componentDone:  make(chan struct{}),
 		dnsMap:         atomic.Pointer[dnsMap]{},
 		ready:          make(chan struct{}),
+		configReady:    make(chan struct{}),
 		registerer:     prometheus.DefaultRegisterer,
 		upstreamClient: upstreamClient,
 	}
@@ -163,6 +167,7 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 
 func (s *Server) Start(stop <-chan struct{}) error {
 	defer close(s.componentDone)
+	s.configReadyTime = time.Now()
 
 	servers := make([]*dns.Server, len(s.addresses))
 	for i, addr := range s.addresses {
@@ -215,6 +220,11 @@ func (s *Server) Start(stop <-chan struct{}) error {
 		close(s.ready)
 	}
 
+	// Ensure configReady is closed so ConfigReady callers don't block forever.
+	s.configReadyOnce.Do(func() {
+		close(s.configReady)
+	})
+
 	// Shut down all servers. For servers not yet started when we enter this
 	// loop, retry until they start (making Shutdown effective) or their
 	// goroutine exits (meaning they failed to start and are already done).
@@ -261,6 +271,13 @@ func (s *Server) WaitForDone() {
 
 func (s *Server) WaitForReady() {
 	<-s.ready
+}
+
+// ConfigReady returns a channel that is closed once the first DNS configuration
+// has been successfully loaded from Envoy. Use this to gate readiness on DNS
+// proxy being fully initialized, not just the UDP servers being up.
+func (s *Server) ConfigReady() <-chan struct{} {
+	return s.configReady
 }
 
 // ReloadMap replaces the current map in memory so that future calls to the proxy.
@@ -314,6 +331,15 @@ func (s *Server) ReloadMap(ctx context.Context, reader io.Reader) error {
 	}
 	log.V(1).Info("DNS proxy configured", "config", res)
 	s.dnsMap.Store(&res)
+	s.configReadyOnce.Do(func() {
+		if !s.configReadyTime.IsZero() {
+			if m := s.metrics.Load(); m != nil {
+				m.ConfigReadyWaitSeconds.Observe(time.Since(s.configReadyTime).Seconds())
+			}
+		}
+		log.Info("DNS proxy received first configuration", "records", len(res.ARecords))
+		close(s.configReady)
+	})
 	if m := s.metrics.Load(); m != nil {
 		m.EntriesTotal.Set(float64(len(res.ARecords)))
 	}

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
@@ -13,7 +13,6 @@ type metrics struct {
 	ResponseCodesTotal          *prometheus.CounterVec
 	EntriesTotal                prometheus.Gauge
 	ConfigReadyWaitSeconds      prometheus.Histogram
-	ConfigReadyGateBypassed     prometheus.Counter
 }
 
 func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels) *metrics {
@@ -55,17 +54,11 @@ func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels)
 	registerer.MustRegister(entriesTotal)
 	configReadyWaitSeconds := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:        "kuma_dp_dns_config_ready_wait_seconds",
-		Help:        "Time between DNS proxy start and first configuration received from Envoy.",
+		Help:        "Time between DNS proxy creation and first configuration received from Envoy.",
 		ConstLabels: constLabels,
 		Buckets:     []float64{0.1, 0.5, 1, 2, 5, 10, 30},
 	})
 	registerer.MustRegister(configReadyWaitSeconds)
-	configReadyGateBypassed := prometheus.NewCounter(prometheus.CounterOpts{
-		Name:        "kuma_dp_dns_config_ready_gate_bypassed_total",
-		Help:        "Total times the DNS config readiness gate was bypassed due to timeout.",
-		ConstLabels: constLabels,
-	})
-	registerer.MustRegister(configReadyGateBypassed)
 	return &metrics{
 		RequestDuration:             requestDuration,
 		UpstreamRequestDuration:     upstreamRequestDuration,
@@ -74,7 +67,6 @@ func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels)
 		ResponseCodesTotal:          responseCodesTotal,
 		EntriesTotal:                entriesTotal,
 		ConfigReadyWaitSeconds:      configReadyWaitSeconds,
-		ConfigReadyGateBypassed:     configReadyGateBypassed,
 	}
 }
 

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/metrics.go
@@ -12,6 +12,8 @@ type metrics struct {
 	QueriesTotal                *prometheus.CounterVec
 	ResponseCodesTotal          *prometheus.CounterVec
 	EntriesTotal                prometheus.Gauge
+	ConfigReadyWaitSeconds      prometheus.Histogram
+	ConfigReadyGateBypassed     prometheus.Counter
 }
 
 func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels) *metrics {
@@ -51,6 +53,19 @@ func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels)
 		ConstLabels: constLabels,
 	})
 	registerer.MustRegister(entriesTotal)
+	configReadyWaitSeconds := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:        "kuma_dp_dns_config_ready_wait_seconds",
+		Help:        "Time between DNS proxy start and first configuration received from Envoy.",
+		ConstLabels: constLabels,
+		Buckets:     []float64{0.1, 0.5, 1, 2, 5, 10, 30},
+	})
+	registerer.MustRegister(configReadyWaitSeconds)
+	configReadyGateBypassed := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "kuma_dp_dns_config_ready_gate_bypassed_total",
+		Help:        "Total times the DNS config readiness gate was bypassed due to timeout.",
+		ConstLabels: constLabels,
+	})
+	registerer.MustRegister(configReadyGateBypassed)
 	return &metrics{
 		RequestDuration:             requestDuration,
 		UpstreamRequestDuration:     upstreamRequestDuration,
@@ -58,6 +73,8 @@ func newMetrics(registerer prometheus.Registerer, constLabels prometheus.Labels)
 		QueriesTotal:                queriesTotal,
 		ResponseCodesTotal:          responseCodesTotal,
 		EntriesTotal:                entriesTotal,
+		ConfigReadyWaitSeconds:      configReadyWaitSeconds,
+		ConfigReadyGateBypassed:     configReadyGateBypassed,
 	}
 }
 

--- a/app/kuma-dp/pkg/dataplane/readiness/component.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component.go
@@ -2,6 +2,7 @@ package readiness
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -55,12 +56,10 @@ func NewReporter(unixSocketDisabled bool, socketDir string, localIPAddr string, 
 	if dnsConfigReady != nil {
 		deadline = time.Now().Add(dnsConfigGateTimeout)
 	}
-	return NewReporterWithDeadline(unixSocketDisabled, socketDir, localIPAddr, localListenPort, adminSocketPath, dnsConfigReady, deadline)
+	return newReporterWithDeadline(unixSocketDisabled, socketDir, localIPAddr, localListenPort, adminSocketPath, dnsConfigReady, deadline)
 }
 
-// NewReporterWithDeadline is like NewReporter but accepts an explicit DNS gate
-// deadline. Used in tests to exercise the timeout bypass path.
-func NewReporterWithDeadline(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}, dnsConfigDeadline time.Time) *Reporter {
+func newReporterWithDeadline(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}, dnsConfigDeadline time.Time) *Reporter {
 	r := &Reporter{
 		unixSocketDisabled: unixSocketDisabled,
 		socketDir:          socketDir,
@@ -120,9 +119,9 @@ func (r *Reporter) Start(stop <-chan struct{}) error {
 		ErrorLog:          adapter.ToStd(logger),
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
-		if err := server.Serve(lis); err != nil {
+		if err := server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
 	}()

--- a/app/kuma-dp/pkg/dataplane/readiness/component.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component.go
@@ -121,6 +121,9 @@ func (r *Reporter) Start(stop <-chan struct{}) error {
 
 	errCh := make(chan error, 1)
 	go func() {
+		// ErrServerClosed is returned after Shutdown is called; it is not an
+		// actual error and must not be forwarded to avoid blocking the goroutine
+		// on an already-abandoned errCh.
 		if err := server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
@@ -146,7 +149,7 @@ func (r *Reporter) handleReadiness(writer http.ResponseWriter, req *http.Request
 	}
 
 	// Gate readiness on DNS proxy receiving its first config from Envoy.
-	// This ensures mesh-generated DNS names, resolve before app containers start.
+	// This ensures mesh-generated DNS names resolve before app containers start.
 	// After dnsConfigGateTimeout we bypass the gate and log a warning to
 	// avoid blocking deploys when misconfigured.
 	if r.dnsConfigReady != nil && !r.dnsBypassed.Load() {

--- a/app/kuma-dp/pkg/dataplane/readiness/component.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component.go
@@ -20,9 +20,11 @@ import (
 )
 
 const (
-	pathPrefixReady  = "/ready"
-	stateReady       = "READY"
-	stateTerminating = "TERMINATING"
+	pathPrefixReady      = "/ready"
+	stateReady           = "READY"
+	stateNotReady        = "NOT_READY"
+	stateTerminating     = "TERMINATING"
+	dnsConfigGateTimeout = 15 * time.Second
 )
 
 // Reporter reports the health status of this Kuma Dataplane Proxy.
@@ -38,17 +40,35 @@ type Reporter struct {
 	adminSocketPath    string
 	adminClient        *http.Client
 	isTerminating      atomic.Bool
+	// dnsConfigReady, when non-nil, blocks /ready until the DNS proxy has
+	// loaded its first configuration from Envoy. Closed by the DNS proxy
+	// server after the first successful ReloadMap call.
+	dnsConfigReady    <-chan struct{}
+	dnsConfigDeadline time.Time
+	dnsBypassed       atomic.Bool
 }
 
 var logger = core.Log.WithName("readiness")
 
-func NewReporter(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string) *Reporter {
+func NewReporter(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}) *Reporter {
+	var deadline time.Time
+	if dnsConfigReady != nil {
+		deadline = time.Now().Add(dnsConfigGateTimeout)
+	}
+	return NewReporterWithDeadline(unixSocketDisabled, socketDir, localIPAddr, localListenPort, adminSocketPath, dnsConfigReady, deadline)
+}
+
+// NewReporterWithDeadline is like NewReporter but accepts an explicit DNS gate
+// deadline. Used in tests to exercise the timeout bypass path.
+func NewReporterWithDeadline(unixSocketDisabled bool, socketDir string, localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}, dnsConfigDeadline time.Time) *Reporter {
 	r := &Reporter{
 		unixSocketDisabled: unixSocketDisabled,
 		socketDir:          socketDir,
 		localListenPort:    localListenPort,
 		localListenAddr:    localIPAddr,
 		adminSocketPath:    adminSocketPath,
+		dnsConfigReady:     dnsConfigReady,
+		dnsConfigDeadline:  dnsConfigDeadline,
 	}
 	if adminSocketPath != "" {
 		c := httpclient.NewUDS(adminSocketPath, 2*time.Second, 3*time.Second)
@@ -124,6 +144,26 @@ func (r *Reporter) handleReadiness(writer http.ResponseWriter, req *http.Request
 	if r.isTerminating.Load() {
 		r.writeState(writer, req, stateTerminating, http.StatusServiceUnavailable)
 		return
+	}
+
+	// Gate readiness on DNS proxy receiving its first config from Envoy.
+	// This ensures .mesh DNS names resolve before app containers start.
+	// After dnsConfigGateTimeout we bypass the gate and log a warning to
+	// avoid blocking deploys when misconfigured.
+	if r.dnsConfigReady != nil && !r.dnsBypassed.Load() {
+		select {
+		case <-r.dnsConfigReady:
+		default:
+			if time.Now().After(r.dnsConfigDeadline) {
+				if r.dnsBypassed.CompareAndSwap(false, true) {
+					logger.Info("[WARNING] DNS proxy config not received within timeout, bypassing readiness gate",
+						"timeout", dnsConfigGateTimeout)
+				}
+			} else {
+				r.writeState(writer, req, stateNotReady, http.StatusServiceUnavailable)
+				return
+			}
+		}
 	}
 
 	// When admin is on UDS, proxy /ready to Envoy admin so that

--- a/app/kuma-dp/pkg/dataplane/readiness/component.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component.go
@@ -147,7 +147,7 @@ func (r *Reporter) handleReadiness(writer http.ResponseWriter, req *http.Request
 	}
 
 	// Gate readiness on DNS proxy receiving its first config from Envoy.
-	// This ensures .mesh DNS names resolve before app containers start.
+	// This ensures mesh-generated DNS names, resolve before app containers start.
 	// After dnsConfigGateTimeout we bypass the gate and log a warning to
 	// avoid blocking deploys when misconfigured.
 	if r.dnsConfigReady != nil && !r.dnsBypassed.Load() {

--- a/app/kuma-dp/pkg/dataplane/readiness/component_test.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component_test.go
@@ -36,8 +36,12 @@ var _ = Describe("Readiness Reporter", func() {
 			_ = reporter.Start(stopCh)
 		}()
 		Eventually(func() error {
-			_, err := http.Get(baseURL + "/ready")
-			return err
+			resp, err := http.Get(baseURL + "/ready")
+			if err != nil {
+				return err
+			}
+			resp.Body.Close()
+			return nil
 		}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
 	}
 

--- a/app/kuma-dp/pkg/dataplane/readiness/component_test.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component_test.go
@@ -69,8 +69,12 @@ var _ = Describe("Readiness Reporter", func() {
 				_ = reporter.Start(stopCh)
 			}()
 			Eventually(func() error {
-				_, err := http.Get(baseURL + "/ready")
-				return err
+				resp, err := http.Get(baseURL + "/ready")
+				if err != nil {
+					return err
+				}
+				resp.Body.Close()
+				return nil
 			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
 		})
 
@@ -113,8 +117,12 @@ var _ = Describe("Readiness Reporter", func() {
 				_ = reporter.Start(stopCh)
 			}()
 			Eventually(func() error {
-				_, err := http.Get(baseURL + "/ready")
-				return err
+				resp, err := http.Get(baseURL + "/ready")
+				if err != nil {
+					return err
+				}
+				resp.Body.Close()
+				return nil
 			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
 		})
 

--- a/app/kuma-dp/pkg/dataplane/readiness/component_test.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Readiness Reporter", func() {
 		Expect(lis.Close()).To(Succeed())
 
 		baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
-		reporter = readiness.NewReporter(true, "", "127.0.0.1", port, adminSocketPath)
+		reporter = readiness.NewReporter(true, "", "127.0.0.1", port, adminSocketPath, nil)
 		go func() {
 			defer GinkgoRecover()
 			_ = reporter.Start(stopCh)
@@ -45,6 +45,84 @@ var _ = Describe("Readiness Reporter", func() {
 		if stopCh != nil {
 			close(stopCh)
 		}
+	})
+
+	Context("with DNS config gate", func() {
+		var dnsReady chan struct{}
+
+		BeforeEach(func() {
+			stopCh = make(chan struct{})
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).ToNot(HaveOccurred())
+			port = uint32(lis.Addr().(*net.TCPAddr).Port)
+			Expect(lis.Close()).To(Succeed())
+
+			baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+			dnsReady = make(chan struct{})
+			reporter = readiness.NewReporter(true, "", "127.0.0.1", port, "", dnsReady)
+			go func() {
+				defer GinkgoRecover()
+				_ = reporter.Start(stopCh)
+			}()
+			Eventually(func() error {
+				_, err := http.Get(baseURL + "/ready")
+				return err
+			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+		})
+
+		It("returns NOT_READY until DNS config channel is closed", func() {
+			resp, err := http.Get(baseURL + "/ready")
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("NOT_READY"))
+		})
+
+		It("returns READY after DNS config channel is closed", func() {
+			close(dnsReady)
+			Eventually(func() int {
+				resp, err := http.Get(baseURL + "/ready")
+				if err != nil {
+					return 0
+				}
+				resp.Body.Close()
+				return resp.StatusCode
+			}, 5*time.Second, 50*time.Millisecond).Should(Equal(http.StatusOK))
+		})
+	})
+
+	Context("with DNS config gate timeout", func() {
+		BeforeEach(func() {
+			stopCh = make(chan struct{})
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).ToNot(HaveOccurred())
+			port = uint32(lis.Addr().(*net.TCPAddr).Port)
+			Expect(lis.Close()).To(Succeed())
+
+			baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+			dnsReady := make(chan struct{})
+			reporter = readiness.NewReporterWithDeadline(true, "", "127.0.0.1", port, "", dnsReady, time.Now().Add(-time.Second))
+			go func() {
+				defer GinkgoRecover()
+				_ = reporter.Start(stopCh)
+			}()
+			Eventually(func() error {
+				_, err := http.Get(baseURL + "/ready")
+				return err
+			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+		})
+
+		It("bypasses gate and returns READY when deadline is already past", func() {
+			resp, err := http.Get(baseURL + "/ready")
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("READY"))
+		})
 	})
 
 	Context("without admin socket", func() {

--- a/app/kuma-dp/pkg/dataplane/readiness/export_test.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/export_test.go
@@ -1,0 +1,3 @@
+package readiness
+
+var NewReporterWithDeadline = newReporterWithDeadline


### PR DESCRIPTION
## Motivation

 The `kuma.io/wait-for-dataplane-ready` annotation tells the kubelet to hold app containers until the sidecar `/ready` returns 200. That endpoint fires as soon as Envoy reports xDS sync, but the embedded DNS proxy (dnsproxy) gets its VIP records through a separate ConfigFetcher poll of Envoy's `/dns` dynamic-config route. The two paths race.
The result: the kubelet marks the pod ready, the app starts, immediately resolves a `.mesh` name, and gets NXDOMAIN because the DNS map is still empty. The `wait_for_envoy` E2E test (`test/e2e_env/kubernetes/graceful/wait_for_envoy.go`) exercises this path with `restartPolicy: Never`, turning the race into a hard failure rather than a transient one.

## Implementation information

- `dnsproxy.Server` gains `ConfigReady() <-chan struct{}`, closed once after the first successful `ReloadMap`. On shutdown the channel closes too, so no caller blocks.
- `readiness.Reporter` accepts an optional `dnsConfigReady` channel. When set, `/ready` returns 503 until the channel closes. After a 15-second deadline the gate is bypassed with a warning log, avoiding indefinite NotReady on misconfigured deployments.
- `run.go` wires the channel only for the embedded proxy path (`cfg.DNS.ProxyPort != 0`). The CoreDNS path and zone proxies pass nil and are unaffected.
- Metrics: `kuma_dp_dns_config_ready_wait_seconds` histogram (time from start to first config)
- Tests: gate blocks → 503; gate opens → 200; past-deadline reporter bypasses → 200 immediately.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
