### PR TITLE
fix(kds): prevent silent death of globalToZone stream on io.EOF

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -186,11 +186,19 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 		c.rt.Config().Multizone.Zone.KDS.ResponseBackoff.Duration,
 	)
 
-	if err := syncClient.Receive(); err != nil && !errors.Is(err, context.Canceled) {
-		errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
+	if err := syncClient.Receive(); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
+		}
 		return
 	}
 
+	// syncClient.Receive() returns nil when the stream is closed with io.EOF
+	// (e.g. connection to upstream dropped via load balancer). Trigger a reconnect.
+	select {
+	case errorCh <- errors.New("GlobalToZoneSync stream closed by server"):
+	case <-ctx.Done():
+	}
 	log.Info("GlobalToZoneSync finished gracefully")
 }
 

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -175,6 +175,9 @@ func (g *KDSSyncServiceServer) GlobalToZoneSync(stream mesh_proto.KDSSyncService
 		logger.Info("app context done")
 		return status.Error(codes.Unavailable, "stream unavailable")
 	case err := <-processingErrorsCh:
+		if err == nil {
+			return status.Error(codes.Canceled, "stream canceled")
+		}
 		if status.Code(err) == codes.Unimplemented {
 			return errors.Wrap(err, "GlobalToZoneSync rpc stream failed, because Global CP does not implement this rpc. Upgrade Global CP.")
 		}
@@ -234,7 +237,6 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 		}
 
 		logger.V(1).Info("KDSSyncClient finished gracefully")
-		processingErrorsCh <- nil
 	}()
 
 	if err := g.storeStreamConnection(stream.Context(), zone, service.ZoneToGlobal, connectTime); err != nil {
@@ -259,6 +261,9 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 		logger.Info("app context done")
 		return status.Error(codes.Unavailable, "stream unavailable")
 	case err := <-processingErrorsCh:
+		if err == nil {
+			return status.Error(codes.Canceled, "stream canceled")
+		}
 		if status.Code(err) == codes.Unimplemented {
 			return errors.Wrap(err, "ZoneToGlobalSync rpc stream failed, because Global CP does not implement this rpc. Upgrade Global CP.")
 		}


### PR DESCRIPTION
## Motivation

<!-- Why are we doing this change -->

## Implementation information

<!-- Explain how this was done and potentially alternatives considered and discarded -->

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
