### PR TITLE
test(e2e): wait for envoy config to be stable

### DIFF
--- a/test/e2e_env/universal/envoyconfig/builtingateway.go
+++ b/test/e2e_env/universal/envoyconfig/builtingateway.go
@@ -141,7 +141,7 @@ func SetupGatewayCluster() {
 }
 
 func CleanupAfterGatewayTest(policies ...core_model.ResourceTypeDescriptor) func() {
-	return cleanupAfterTest(mesh, policies...)
+	return cleanupAfterTest(mesh, []string{"gateway-proxy"}, policies...)
 }
 
 func CleanupAfterGatewaySuite() {

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -126,7 +126,7 @@ func SetupSidecarCluster() {
 }
 
 func CleanupAfterSidecarTest(policies ...core_model.ResourceTypeDescriptor) func() {
-	return cleanupAfterTest(meshName, policies...)
+	return cleanupAfterTest(meshName, []string{"demo-client", "test-server"}, policies...)
 }
 
 func CleanupAfterSidecarSuite() {

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -239,10 +239,10 @@ func cleanupAfterTest(mesh string, dpps []string, policies ...core_model.Resourc
 	}
 }
 
-// waitConfigStable polls the dataplane xDS config until two consecutive
-// snapshots taken 1s apart are identical, with a generous total budget. This
-// is a cheap way to make sure no async push is in flight before the next test
-// captures its baseline.
+// waitConfigStable polls the dataplane xDS config until three consecutive
+// snapshots taken 1s apart are identical (that is, two consecutive equality
+// checks pass), with a generous total budget. This is a cheap way to make
+// sure no async push is in flight before the next test captures its baseline.
 func waitConfigStable(mesh, dpp string) {
 	var prev string
 	stable := 0

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -223,9 +223,37 @@ func normalizeClusterAddress(cluster map[string]any) {
 	}
 }
 
-func cleanupAfterTest(mesh string, policies ...core_model.ResourceTypeDescriptor) func() {
+func cleanupAfterTest(mesh string, dpps []string, policies ...core_model.ResourceTypeDescriptor) func() {
 	return func() {
 		Expect(DeleteMeshResources(universal.Cluster, mesh, policies...)).To(Succeed())
 		Expect(universal.Cluster.Install(MeshTrafficPermissionAllowAllUniversal(mesh))).To(Succeed())
+		// Wait for the dataplane xDS configs to settle before letting the next
+		// spec start. Without this the next test races envoy convergence: a
+		// resource (e.g. an OpenTelemetry cluster from the previous meshmetric
+		// test) lingers in the snapshot for a few seconds after its parent
+		// policy was deleted, which makes the next golden-file comparison
+		// flake.
+		for _, dpp := range dpps {
+			waitConfigStable(mesh, dpp)
+		}
 	}
+}
+
+// waitConfigStable polls the dataplane xDS config until two consecutive
+// snapshots taken 1s apart are identical, with a generous total budget. This
+// is a cheap way to make sure no async push is in flight before the next test
+// captures its baseline.
+func waitConfigStable(mesh, dpp string) {
+	var prev string
+	stable := 0
+	Eventually(func(g Gomega) {
+		cur := getConfig(mesh, dpp)
+		if cur == prev {
+			stable++
+		} else {
+			stable = 0
+		}
+		prev = cur
+		g.Expect(stable).To(BeNumerically(">=", 2), "dataplane %s xDS not yet stable", dpp)
+	}, "30s", "1s").Should(Succeed())
 }

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/v2/api/openapi/types"

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -224,7 +224,9 @@ func normalizeClusterAddress(cluster map[string]any) {
 }
 
 func cleanupAfterTest(mesh string, dpps []string, policies ...core_model.ResourceTypeDescriptor) func() {
+	GinkgoHelper()
 	return func() {
+		GinkgoHelper()
 		Expect(DeleteMeshResources(universal.Cluster, mesh, policies...)).To(Succeed())
 		Expect(universal.Cluster.Install(MeshTrafficPermissionAllowAllUniversal(mesh))).To(Succeed())
 		// Wait for the dataplane xDS configs to settle before letting the next
@@ -244,6 +246,7 @@ func cleanupAfterTest(mesh string, dpps []string, policies ...core_model.Resourc
 // checks pass), with a generous total budget. This is a cheap way to make
 // sure no async push is in flight before the next test captures its baseline.
 func waitConfigStable(mesh, dpp string) {
+	GinkgoHelper()
 	var prev string
 	stable := 0
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
## Motivation

Noticed a flake

## Implementation information

Sidecars table is Ordered, alphabetic — meshmetric/otel.input.yaml runs immediately before meshmetric/prometheus.input.yaml. Both apply MeshMetric mm-1; otel adds an OpenTelemetry cluster. cleanupAfterTest deleted mm-1 but didn't wait for envoy to drop the cluster, so the next prometheus spec saw the leftover otel cluster and the golden compare timed out. Fix: new waitConfigStable(mesh, dpp) polls getConfig for two consecutive identical snapshots (1 s apart, 30 s budget) per dataplane; called from cleanupAfterTest. Parameterized dpps per caller (the BuiltinGateway suite uses gateway-proxy, not demo-client/test-server).

## Supporting documentation

Part of this PR: https://github.com/kumahq/kuma/pull/16219

> Changelog: skip