### PR TITLE
fix(policy): race condition when listener state is switched from `Ignored` to `Ready`

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -299,9 +299,6 @@ func (n *Dataplane_Networking) GetInboundForPort(port uint32) *Dataplane_Network
 func (n *Dataplane_Networking) InboundsSelectedBySectionName(sectionName string) []InboundInterface {
 	var selectedInbounds []InboundInterface
 	for _, inbound := range n.Inbound {
-		if inbound.State == Dataplane_Networking_Inbound_Ignored {
-			continue
-		}
 		if sectionName == "" || inbound.GetSectionName() == sectionName {
 			selectedInbounds = append(selectedInbounds, n.ToInboundInterface(inbound))
 		}

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -139,6 +139,74 @@ var _ = Describe("Dataplane_Networking", func() {
 		})
 	})
 
+	Describe("InboundsSelectedBySectionName()", func() {
+		type testCase struct {
+			sectionName string
+			expected    []InboundInterface
+		}
+
+		DescribeTable("should select inbounds regardless of their state",
+			func(given testCase) {
+				networking := &Dataplane_Networking{
+					Address: "192.168.0.1",
+					Inbound: []*Dataplane_Networking_Inbound{
+						{
+							Name:  "main-port",
+							Port:  80,
+							State: Dataplane_Networking_Inbound_Ignored,
+						},
+						{
+							Name:  "secondary-port",
+							Port:  443,
+							State: Dataplane_Networking_Inbound_Ready,
+						},
+					},
+				}
+
+				selectedInbounds := networking.InboundsSelectedBySectionName(given.sectionName)
+
+				Expect(selectedInbounds).To(ConsistOf(given.expected))
+			},
+			Entry("empty sectionName selects all inbounds", testCase{
+				expected: []InboundInterface{
+					{
+						DataplaneAdvertisedIP: "192.168.0.1",
+						DataplaneIP:           "192.168.0.1",
+						DataplanePort:         80,
+						WorkloadIP:            "192.168.0.1",
+						WorkloadPort:          80,
+						InboundName:           "main-port",
+					},
+					{
+						DataplaneAdvertisedIP: "192.168.0.1",
+						DataplaneIP:           "192.168.0.1",
+						DataplanePort:         443,
+						WorkloadIP:            "192.168.0.1",
+						WorkloadPort:          443,
+						InboundName:           "secondary-port",
+					},
+				},
+			}),
+			Entry("matching sectionName selects ignored inbound", testCase{
+				sectionName: "main-port",
+				expected: []InboundInterface{
+					{
+						DataplaneAdvertisedIP: "192.168.0.1",
+						DataplaneIP:           "192.168.0.1",
+						DataplanePort:         80,
+						WorkloadIP:            "192.168.0.1",
+						WorkloadPort:          80,
+						InboundName:           "main-port",
+					},
+				},
+			}),
+			Entry("non-matching sectionName selects no inbounds", testCase{
+				sectionName: "unknown-port",
+				expected:    []InboundInterface{},
+			}),
+		)
+	})
+
 	Describe("GetHealthyInbounds()", func() {
 		It("should return only healty inbounds", func() {
 			networking := &Dataplane_Networking{

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -325,9 +325,6 @@ func isSupportedProxyType(supportedTypes []common_api.TargetRefProxyType, dppTyp
 func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.DataplaneResource, gateway *core_mesh.MeshGatewayResource) ([]core_rules.InboundListener, []core_rules.InboundListenerHostname, bool) {
 	inbounds := []core_rules.InboundListener{}
 	for _, inbound := range dpp.Spec.GetNetworking().GetInbound() {
-		if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
-			continue
-		}
 		if tagsSelector.Matches(inbound.Tags) {
 			intf := dpp.Spec.GetNetworking().ToInboundInterface(inbound)
 			inbounds = append(inbounds, core_rules.InboundListener{

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/07.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/07.golden.yaml
@@ -1,3 +1,20 @@
-items: []
+items:
+- creationTime: "0001-01-01T00:00:00Z"
+  kri: kri_mtp_mesh-1___mtp-1_
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: mtp-1
+  spec:
+    from:
+    - default:
+        action: Allow
+      targetRef:
+        kind: Mesh
+    targetRef:
+      kind: MeshServiceSubset
+      name: web
+      tags:
+        version: v1
+  type: MeshTrafficPermission
 next: null
 total: 0

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/07.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/07.policies.yaml
@@ -1,4 +1,4 @@
-# 07. policies do not select anything because inbound is ignored
+# 07. policies select ignored inbounds by tags
 type: MeshTrafficPermission
 mesh: mesh-1
 name: mtp-1


### PR DESCRIPTION
## Motivation

When using [Argo Rollouts](https://kuma.io/docs/2.13.x/production/cp-deployment/kubernetes/#argo-cd) feature in Kuma, the inbound listeners can be in `Ignored` state. This state acts as a way to "warmup" the listener so it can start handling the traffic the moment the pod is selected by the Service's `selector`. Inbound listener in `Ignored` state is going to receive certificates, however it's not advertised to other workloads as an endpoint.

Inbound listeners in `Ignored` state can't be targeted by policies. I didn't find any explanation why, only the line in the original MADR: https://github.com/kumahq/kuma/blob/d9db25dd25de9e3fd99fb01bda4b4c01233067e1/docs/madr/decisions/032-add-inbound-in-runtime.md?plain=1#L89

The fact that MeshTrafficPermission can't be applied to `Ignored` listener but will be applied once the state is switched to `Ready` creates a race condition:

1. Service doesn't select the DPP, listener is in `Ignored` state
2. Service `selector` picks up the DPP, the listener state is `Ready`
3. Inbound listener in `Ready` state is advertised as an endpoint to other workloads
4. Inbound listener in `Ready` state receives MeshTrafficPermission rules

3 and 4 are happening concurrently. That's why clients might experience 

```
RBAC: access denied
```

error for a short period of time.


## Implementation information

We should apply policies to Ignored listeners. It's not harmful as no one is supposed to consume the `Ignored` listener.

## Supporting documentation


Fix https://github.com/Kong/kong-mesh/issues/9527

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
