### PR TITLE
fix(kds): reconnect mux client when GlobalToZone stream is closed by …

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -157,19 +157,18 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 
 	cfgJson, err := config.ConfigForDisplay(pointer.To(c.rt.Config()))
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, errors.Wrap(err, "could not marshall config to json"))
+		trySend(ctx, errorCh, errors.Wrap(err, "could not marshall config to json"))
 		return
 	}
 
 	stream, err := kdsClient.GlobalToZoneSync(ctx)
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, err)
+		trySend(ctx, errorCh, err)
 		return
 	}
-	kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(stream, c.clientID, c.rt.GetInstanceId(), cfgJson, len(c.typesSentByGlobal))
+	kdsStream := kds_client_v2.NewDeltaKDSStream(stream, c.clientID, c.rt.GetInstanceId(), cfgJson, len(c.typesSentByGlobal))
 	defer func() {
-		<-sendDone // wait for sendLoop to exit before CloseSend to avoid data race
-		if err := stream.CloseSend(); err != nil {
+		if err := kdsStream.CloseSend(); err != nil {
 			log.Error(err, "CloseSend returned an error")
 		}
 	}()
@@ -189,7 +188,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 	)
 
 	if err := syncClient.Receive(); err != nil && !errors.Is(err, context.Canceled) {
-		nonBlockingSend(ctx, errorCh, errors.Wrap(err, "GlobalToZoneSyncClient finished with an error"))
+		trySend(ctx, errorCh, errors.Wrap(err, "GlobalToZoneSyncClient finished with an error"))
 	}
 	log.Info("GlobalToZoneSync finished gracefully")
 }
@@ -200,7 +199,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 	log.Info("initializing Kuma Discovery Service (KDS) stream for zone to global sync of resources with delta xDS")
 	stream, err := kdsClient.ZoneToGlobalSync(ctx)
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, err)
+		trySend(ctx, errorCh, err)
 		return
 	}
 	defer func() {
@@ -217,18 +216,22 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 	}
 
 	if err != nil && !errors.Is(err, context.Canceled) {
-		nonBlockingSend(ctx, errorCh, errors.Wrap(err, "ZoneToGlobalSync finished with an error"))
+		trySend(ctx, errorCh, errors.Wrap(err, "ZoneToGlobalSync finished with an error"))
 	}
 	log.Info("ZoneToGlobalSync finished gracefully")
 }
 
-// nonBlockingSend sends err to errorCh without blocking. If the parent context
-// is already canceled (another stream triggered a restart, or stop was
-// called), the send is skipped to avoid goroutine leaks.
-func nonBlockingSend(ctx context.Context, errorCh chan error, err error) {
+// trySend attempts to send err to errorCh. If the context is already
+// done (another stream triggered a restart, or the app is shutting
+// down), the error is dropped. If errorCh already has an error from
+// another stream, the error is also dropped.
+func trySend(ctx context.Context, errorCh chan error, err error) {
+	if ctx.Err() != nil {
+		return
+	}
 	select {
 	case errorCh <- err:
-	case <-ctx.Done():
+	default:
 	}
 }
 
@@ -243,7 +246,7 @@ func (c *client) startXDSConfigs(
 	log.Info("initializing rpc stream for executing config dump on data plane proxies")
 	stream, err := client.StreamXDSConfigs(ctx)
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, err)
+		trySend(ctx, errorCh, err)
 		return
 	}
 
@@ -263,7 +266,7 @@ func (c *client) startStats(
 	log.Info("initializing rpc stream for executing stats on data plane proxies")
 	stream, err := client.StreamStats(ctx)
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, err)
+		trySend(ctx, errorCh, err)
 		return
 	}
 
@@ -283,7 +286,7 @@ func (c *client) startClusters(
 	log.Info("initializing rpc stream for executing clusters on data plane proxies")
 	stream, err := client.StreamClusters(ctx)
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, err)
+		trySend(ctx, errorCh, err)
 		return
 	}
 
@@ -314,7 +317,7 @@ func (c *client) startHealthCheck(
 				return
 			}
 			log.Error(err, "health check failed")
-			nonBlockingSend(ctx, errorCh, errors.Wrap(err, "zone health check request failed"))
+			trySend(ctx, errorCh, errors.Wrap(err, "zone health check request failed"))
 		} else if interval := resp.Interval.AsDuration(); interval > 0 {
 			if prevInterval != interval {
 				prevInterval = interval
@@ -357,7 +360,7 @@ func (c *client) handleProcessingErrors(
 		log.Error(err, "CloseSend returned an error")
 	}
 	if err != nil {
-		nonBlockingSend(ctx, errorCh, err)
+		trySend(ctx, errorCh, err)
 	}
 }
 

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -166,7 +166,9 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 		errorCh <- err
 		return
 	}
+	kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(stream, c.clientID, c.rt.GetInstanceId(), cfgJson, len(c.typesSentByGlobal))
 	defer func() {
+		<-sendDone // wait for sendLoop to exit before CloseSend to avoid data race
 		if err := stream.CloseSend(); err != nil {
 			log.Error(err, "CloseSend returned an error")
 		}
@@ -175,7 +177,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 	syncClient := kds_client_v2.NewKDSSyncClient(
 		log,
 		c.typesSentByGlobal,
-		kds_client_v2.NewDeltaKDSStream(stream, c.clientID, c.rt.GetInstanceId(), cfgJson, len(c.typesSentByGlobal)),
+		kdsStream,
 		kds_sync_store.ZoneSyncCallback(
 			stream.Context(),
 			c.resourceSyncer,
@@ -187,7 +189,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 	)
 
 	err = syncClient.Receive()
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 		log.Info("GlobalToZoneSync finished gracefully")
 		return
 	}
@@ -227,7 +229,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 		err = errorStream.Err()
 	}
 
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 		log.Info("ZoneToGlobalSync finished gracefully")
 		return
 	}

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -157,13 +157,13 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 
 	cfgJson, err := config.ConfigForDisplay(pointer.To(c.rt.Config()))
 	if err != nil {
-		errorCh <- errors.Wrap(err, "could not marshall config to json")
+		nonBlockingSend(ctx, errorCh, errors.Wrap(err, "could not marshall config to json"))
 		return
 	}
 
 	stream, err := kdsClient.GlobalToZoneSync(ctx)
 	if err != nil {
-		errorCh <- err
+		nonBlockingSend(ctx, errorCh, err)
 		return
 	}
 	kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(stream, c.clientID, c.rt.GetInstanceId(), cfgJson, len(c.typesSentByGlobal))
@@ -188,12 +188,10 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 		c.rt.Config().Multizone.Zone.KDS.ResponseBackoff.Duration,
 	)
 
-	err = syncClient.Receive()
-	log.Info("GlobalToZoneSync ended", "reason", err)
-	select {
-	case errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error"):
-	case <-ctx.Done():
+	if err := syncClient.Receive(); err != nil && !errors.Is(err, context.Canceled) {
+		nonBlockingSend(ctx, errorCh, errors.Wrap(err, "GlobalToZoneSyncClient finished with an error"))
 	}
+	log.Info("GlobalToZoneSync finished gracefully")
 }
 
 func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, conn *grpc.ClientConn, errorCh chan error) {
@@ -202,7 +200,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 	log.Info("initializing Kuma Discovery Service (KDS) stream for zone to global sync of resources with delta xDS")
 	stream, err := kdsClient.ZoneToGlobalSync(ctx)
 	if err != nil {
-		errorCh <- err
+		nonBlockingSend(ctx, errorCh, err)
 		return
 	}
 	defer func() {
@@ -218,9 +216,18 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 		err = errorStream.Err()
 	}
 
-	log.Info("ZoneToGlobalSync ended", "reason", err)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		nonBlockingSend(ctx, errorCh, errors.Wrap(err, "ZoneToGlobalSync finished with an error"))
+	}
+	log.Info("ZoneToGlobalSync finished gracefully")
+}
+
+// nonBlockingSend sends err to errorCh without blocking. If the parent context
+// is already canceled (another stream triggered a restart, or stop was
+// called), the send is skipped to avoid goroutine leaks.
+func nonBlockingSend(ctx context.Context, errorCh chan error, err error) {
 	select {
-	case errorCh <- errors.Wrap(err, "ZoneToGlobalSync finished with an error"):
+	case errorCh <- err:
 	case <-ctx.Done():
 	}
 }
@@ -236,13 +243,13 @@ func (c *client) startXDSConfigs(
 	log.Info("initializing rpc stream for executing config dump on data plane proxies")
 	stream, err := client.StreamXDSConfigs(ctx)
 	if err != nil {
-		errorCh <- err
+		nonBlockingSend(ctx, errorCh, err)
 		return
 	}
 
 	processingErrorsCh := make(chan error)
 	go c.envoyAdminProcessor.StartProcessingXDSConfigs(stream, processingErrorsCh)
-	c.handleProcessingErrors(stream, log, processingErrorsCh, errorCh)
+	c.handleProcessingErrors(ctx, stream, log, processingErrorsCh, errorCh)
 }
 
 func (c *client) startStats(
@@ -256,13 +263,13 @@ func (c *client) startStats(
 	log.Info("initializing rpc stream for executing stats on data plane proxies")
 	stream, err := client.StreamStats(ctx)
 	if err != nil {
-		errorCh <- err
+		nonBlockingSend(ctx, errorCh, err)
 		return
 	}
 
 	processingErrorsCh := make(chan error)
 	go c.envoyAdminProcessor.StartProcessingStats(stream, processingErrorsCh)
-	c.handleProcessingErrors(stream, log, processingErrorsCh, errorCh)
+	c.handleProcessingErrors(ctx, stream, log, processingErrorsCh, errorCh)
 }
 
 func (c *client) startClusters(
@@ -276,13 +283,13 @@ func (c *client) startClusters(
 	log.Info("initializing rpc stream for executing clusters on data plane proxies")
 	stream, err := client.StreamClusters(ctx)
 	if err != nil {
-		errorCh <- err
+		nonBlockingSend(ctx, errorCh, err)
 		return
 	}
 
 	processingErrorsCh := make(chan error)
 	go c.envoyAdminProcessor.StartProcessingClusters(stream, processingErrorsCh)
-	c.handleProcessingErrors(stream, log, processingErrorsCh, errorCh)
+	c.handleProcessingErrors(ctx, stream, log, processingErrorsCh, errorCh)
 }
 
 func (c *client) startHealthCheck(
@@ -307,7 +314,7 @@ func (c *client) startHealthCheck(
 				return
 			}
 			log.Error(err, "health check failed")
-			errorCh <- errors.Wrap(err, "zone health check request failed")
+			nonBlockingSend(ctx, errorCh, errors.Wrap(err, "zone health check request failed"))
 		} else if interval := resp.Interval.AsDuration(); interval > 0 {
 			if prevInterval != interval {
 				prevInterval = interval
@@ -327,6 +334,7 @@ func (c *client) startHealthCheck(
 }
 
 func (c *client) handleProcessingErrors(
+	ctx context.Context,
 	stream grpc.ClientStream,
 	log logr.Logger,
 	processingErrorsCh chan error,
@@ -349,7 +357,7 @@ func (c *client) handleProcessingErrors(
 		log.Error(err, "CloseSend returned an error")
 	}
 	if err != nil {
-		errorCh <- err
+		nonBlockingSend(ctx, errorCh, err)
 	}
 }
 

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -186,12 +186,23 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 		c.rt.Config().Multizone.Zone.KDS.ResponseBackoff.Duration,
 	)
 
-	if err := syncClient.Receive(); err != nil && !errors.Is(err, context.Canceled) {
-		errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
+	err = syncClient.Receive()
+	if errors.Is(err, context.Canceled) {
+		log.V(1).Info("GlobalToZoneSync finished gracefully")
 		return
 	}
-
-	log.Info("GlobalToZoneSync finished gracefully")
+	if err != nil {
+		err = errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
+	} else {
+		// err == nil means the stream was closed by the server (io.EOF).
+		// Trigger a reconnect so ResilientComponent restarts all streams.
+		err = errors.New("GlobalToZoneSync stream closed by server")
+	}
+	log.Info("GlobalToZoneSync ended, triggering reconnect", "reason", err)
+	select {
+	case errorCh <- err:
+	case <-ctx.Done():
+	}
 }
 
 func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, conn *grpc.ClientConn, errorCh chan error) {
@@ -216,12 +227,20 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 		err = errorStream.Err()
 	}
 
-	if err != nil && !errors.Is(err, context.Canceled) {
-		errorCh <- errors.Wrap(err, "ZoneToGlobalSync finished with an error")
+	if errors.Is(err, context.Canceled) {
+		log.V(1).Info("ZoneToGlobalSync finished gracefully")
 		return
 	}
-
-	log.V(1).Info("ZoneToGlobalSync finished gracefully")
+	if err != nil {
+		err = errors.Wrap(err, "ZoneToGlobalSync finished with an error")
+	} else {
+		err = errors.New("ZoneToGlobalSync stream closed by server")
+	}
+	log.Info("ZoneToGlobalSync ended, triggering reconnect", "reason", err)
+	select {
+	case errorCh <- err:
+	case <-ctx.Done():
+	}
 }
 
 func (c *client) startXDSConfigs(

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -188,7 +188,7 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 
 	err = syncClient.Receive()
 	if errors.Is(err, context.Canceled) {
-		log.V(1).Info("GlobalToZoneSync finished gracefully")
+		log.Info("GlobalToZoneSync finished gracefully")
 		return
 	}
 	if err != nil {
@@ -228,7 +228,7 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 	}
 
 	if errors.Is(err, context.Canceled) {
-		log.V(1).Info("ZoneToGlobalSync finished gracefully")
+		log.Info("ZoneToGlobalSync finished gracefully")
 		return
 	}
 	if err != nil {

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -189,20 +189,9 @@ func (c *client) startGlobalToZoneSync(ctx context.Context, log logr.Logger, con
 	)
 
 	err = syncClient.Receive()
-	if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
-		log.Info("GlobalToZoneSync finished gracefully")
-		return
-	}
-	if err != nil {
-		err = errors.Wrap(err, "GlobalToZoneSyncClient finished with an error")
-	} else {
-		// err == nil means the stream was closed by the server (io.EOF).
-		// Trigger a reconnect so ResilientComponent restarts all streams.
-		err = errors.New("GlobalToZoneSync stream closed by server")
-	}
-	log.Info("GlobalToZoneSync ended, triggering reconnect", "reason", err)
+	log.Info("GlobalToZoneSync ended", "reason", err)
 	select {
-	case errorCh <- err:
+	case errorCh <- errors.Wrap(err, "GlobalToZoneSyncClient finished with an error"):
 	case <-ctx.Done():
 	}
 }
@@ -229,18 +218,9 @@ func (c *client) startZoneToGlobalSync(ctx context.Context, log logr.Logger, con
 		err = errorStream.Err()
 	}
 
-	if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
-		log.Info("ZoneToGlobalSync finished gracefully")
-		return
-	}
-	if err != nil {
-		err = errors.Wrap(err, "ZoneToGlobalSync finished with an error")
-	} else {
-		err = errors.New("ZoneToGlobalSync stream closed by server")
-	}
-	log.Info("ZoneToGlobalSync ended, triggering reconnect", "reason", err)
+	log.Info("ZoneToGlobalSync ended", "reason", err)
 	select {
-	case errorCh <- err:
+	case errorCh <- errors.Wrap(err, "ZoneToGlobalSync finished with an error"):
 	case <-ctx.Done():
 	}
 }
@@ -358,7 +338,7 @@ func (c *client) handleProcessingErrors(
 		// backwards compatibility. Do not rethrow error, so KDS multiplex can still operate.
 		return
 	}
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 		log.Info("rpc stream shutting down")
 		// Let's not propagate this error further as we've already cancelled the context
 		err = nil

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -38,7 +38,7 @@ type reconnectTrackingServer struct {
 	globalToZoneConns int
 	reconnectedOnce   sync.Once
 	reconnectedCh     chan struct{} // closed on second GlobalToZoneSync call
-	firstConnErrCode  codes.Code   // if non-zero, return this status code on first connection instead of nil
+	firstConnErrCode  codes.Code    // if non-zero, return this status code on first connection instead of nil
 }
 
 func (s *reconnectTrackingServer) GlobalToZoneSync(stream mesh_proto.KDSSyncService_GlobalToZoneSyncServer) error {
@@ -128,7 +128,7 @@ var _ = Describe("Client", func() {
 	DescribeTable("reconnects when globalToZone stream is terminated by server",
 		func(tc testCase) {
 			svc := &reconnectTrackingServer{
-				reconnectedCh:   make(chan struct{}),
+				reconnectedCh:    make(chan struct{}),
 				firstConnErrCode: tc.errCode,
 			}
 			lis, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 // reconnectTrackingServer simulates a Global CP that closes the
-// GlobalToZoneSync stream cleanly on the first connection and then
-// tracks whether the zone mux client re-establishes it.
+// GlobalToZoneSync stream on the first connection and then tracks
+// whether the zone mux client re-establishes it.
 type reconnectTrackingServer struct {
 	mesh_proto.UnimplementedKDSSyncServiceServer
 	mesh_proto.UnimplementedGlobalKDSServiceServer
@@ -38,7 +38,7 @@ type reconnectTrackingServer struct {
 	globalToZoneConns int
 	reconnectedOnce   sync.Once
 	reconnectedCh     chan struct{} // closed on second GlobalToZoneSync call
-	firstConnErrCode  codes.Code    // if non-zero, return this status code on first connection instead of nil
+	firstConnErrCode  codes.Code   // if non-zero, return this status code on first connection instead of nil
 }
 
 func (s *reconnectTrackingServer) GlobalToZoneSync(stream mesh_proto.KDSSyncService_GlobalToZoneSyncServer) error {
@@ -107,136 +107,91 @@ func (s *testZoneDeltaServer) DeltaStreamHandler(str stream_v3.DeltaStream, _ st
 var _ delta.Server = &testZoneDeltaServer{}
 
 var _ = Describe("Client", func() {
-	// Regression test: when a GlobalToZoneSync gRPC stream is closed cleanly
-	// by the server (the zone receives io.EOF), the mux client must treat
-	// this as an error and trigger a full reconnect via ResilientComponent.
+	// Regression test: when a GlobalToZoneSync gRPC stream is terminated by
+	// the server, the mux client must trigger a full reconnect via
+	// ResilientComponent.
 	//
 	// Before the fix, startGlobalToZoneSync silently exited on nil error
-	// without sending to errorCh. Because Start() only returns when it
-	// receives from errorCh (or stop), the mux client stayed alive —
-	// healthchecks and ZoneToGlobal kept working — but GlobalToZone was
-	// permanently dead. No new resources from the global CP would ever
-	// reach the zone.
+	// (io.EOF) without sending to errorCh. Because Start() only returns
+	// when it receives from errorCh (or stop), the mux client stayed alive
+	// — healthchecks and ZoneToGlobal kept working — but GlobalToZone was
+	// permanently dead.
 	//
-	// In production this was triggered by a global CP restart behind a
-	// load balancer: the LB closed the GlobalToZone HTTP/2 stream with a
-	// clean TCP FIN (io.EOF) instead of a gRPC error.
-	It("reconnects when globalToZone stream is closed by server (io.EOF)", func() {
-		svc := &reconnectTrackingServer{
-			reconnectedCh: make(chan struct{}),
-		}
-		lis, err := net.Listen("tcp", "127.0.0.1:0")
-		Expect(err).ToNot(HaveOccurred())
-		defer lis.Close()
+	// In production this was triggered by a global CP restart behind a load
+	// balancer: the LB closed the GlobalToZone HTTP/2 stream with a clean
+	// TCP FIN (io.EOF) instead of a gRPC error.
+	type testCase struct {
+		description string
+		errCode     codes.Code
+	}
 
-		grpcSrv := grpc.NewServer()
-		mesh_proto.RegisterKDSSyncServiceServer(grpcSrv, svc)
-		mesh_proto.RegisterGlobalKDSServiceServer(grpcSrv, svc)
-		go func() { _ = grpcSrv.Serve(lis) }()
-		defer grpcSrv.Stop()
+	DescribeTable("reconnects when globalToZone stream is terminated by server",
+		func(tc testCase) {
+			svc := &reconnectTrackingServer{
+				reconnectedCh:   make(chan struct{}),
+				firstConnErrCode: tc.errCode,
+			}
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).ToNot(HaveOccurred())
+			defer lis.Close()
 
-		globalStore := memory.NewStore()
-		cfg := kuma_cp.DefaultConfig()
-		cfg.Multizone.Zone.Name = "zone-1"
-		rt := kds_setup.NewTestRuntime(context.Background(), cfg, globalStore)
+			grpcSrv := grpc.NewServer()
+			mesh_proto.RegisterKDSSyncServiceServer(grpcSrv, svc)
+			mesh_proto.RegisterGlobalKDSServiceServer(grpcSrv, svc)
+			go func() { _ = grpcSrv.Serve(lis) }()
+			defer grpcSrv.Stop()
 
-		metrics, err := core_metrics.NewMetrics("")
-		Expect(err).ToNot(HaveOccurred())
+			globalStore := memory.NewStore()
+			cfg := kuma_cp.DefaultConfig()
+			cfg.Multizone.Zone.Name = "zone-1"
+			rt := kds_setup.NewTestRuntime(context.Background(), cfg, globalStore)
 
-		zoneStore := memory.NewStore()
-		resourceSyncer, err := sync_store_v2.NewResourceSyncer(
-			core.Log.WithName("syncer"),
-			zoneStore,
-			store.NoTransactions{},
-			metrics,
-			context.Background(),
-		)
-		Expect(err).ToNot(HaveOccurred())
+			metrics, err := core_metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
 
-		muxClient := mux.NewClient(
-			context.Background(),
-			"grpc://"+lis.Addr().String(),
-			"zone-1",
-			*rt.Config().Multizone.Zone.KDS,
-			rt.Config().Experimental,
-			metrics,
-			service.NewEnvoyAdminProcessor(rt.ReadOnlyResourceManager(), rt.EnvoyAdminClient()),
-			resourceSyncer,
-			rt,
-			&testZoneDeltaServer{},
-		)
+			zoneStore := memory.NewStore()
+			resourceSyncer, err := sync_store_v2.NewResourceSyncer(
+				core.Log.WithName("syncer"),
+				zoneStore,
+				store.NoTransactions{},
+				metrics,
+				context.Background(),
+			)
+			Expect(err).ToNot(HaveOccurred())
 
-		resilient := component.NewResilientComponent(
-			core.Log.WithName("test-resilient"),
-			muxClient,
-			1*time.Millisecond,
-			10*time.Millisecond,
-		)
+			muxClient := mux.NewClient(
+				context.Background(),
+				"grpc://"+lis.Addr().String(),
+				"zone-1",
+				*rt.Config().Multizone.Zone.KDS,
+				rt.Config().Experimental,
+				metrics,
+				service.NewEnvoyAdminProcessor(rt.ReadOnlyResourceManager(), rt.EnvoyAdminClient()),
+				resourceSyncer,
+				rt,
+				&testZoneDeltaServer{},
+			)
 
-		stop := make(chan struct{})
-		go func() { _ = resilient.Start(stop) }()
-		defer close(stop)
+			resilient := component.NewResilientComponent(
+				core.Log.WithName("test-resilient"),
+				muxClient,
+				1*time.Millisecond,
+				10*time.Millisecond,
+			)
 
-		Eventually(svc.reconnectedCh, "10s", "100ms").Should(BeClosed())
-	})
+			stop := make(chan struct{})
+			go func() { _ = resilient.Start(stop) }()
+			defer close(stop)
 
-	It("reconnects when globalToZone stream is canceled by server", func() {
-		svc := &reconnectTrackingServer{
-			reconnectedCh:    make(chan struct{}),
-			firstConnErrCode: codes.Canceled,
-		}
-		lis, err := net.Listen("tcp", "127.0.0.1:0")
-		Expect(err).ToNot(HaveOccurred())
-		defer lis.Close()
-
-		grpcSrv := grpc.NewServer()
-		mesh_proto.RegisterKDSSyncServiceServer(grpcSrv, svc)
-		mesh_proto.RegisterGlobalKDSServiceServer(grpcSrv, svc)
-		go func() { _ = grpcSrv.Serve(lis) }()
-		defer grpcSrv.Stop()
-
-		globalStore := memory.NewStore()
-		cfg := kuma_cp.DefaultConfig()
-		cfg.Multizone.Zone.Name = "zone-1"
-		rt := kds_setup.NewTestRuntime(context.Background(), cfg, globalStore)
-
-		metrics, err := core_metrics.NewMetrics("")
-		Expect(err).ToNot(HaveOccurred())
-
-		zoneStore := memory.NewStore()
-		resourceSyncer, err := sync_store_v2.NewResourceSyncer(
-			core.Log.WithName("syncer"),
-			zoneStore,
-			store.NoTransactions{},
-			metrics,
-			context.Background(),
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		muxClient := mux.NewClient(
-			context.Background(),
-			"grpc://"+lis.Addr().String(),
-			"zone-1",
-			*rt.Config().Multizone.Zone.KDS,
-			rt.Config().Experimental,
-			metrics,
-			service.NewEnvoyAdminProcessor(rt.ReadOnlyResourceManager(), rt.EnvoyAdminClient()),
-			resourceSyncer,
-			rt,
-			&testZoneDeltaServer{},
-		)
-
-		resilient := component.NewResilientComponent(
-			core.Log.WithName("test-resilient"),
-			muxClient,
-			1*time.Millisecond,
-			10*time.Millisecond,
-		)
-
-		stop := make(chan struct{})
-		go func() { _ = resilient.Start(stop) }()
-		defer close(stop)
-
-		Eventually(svc.reconnectedCh, "10s", "100ms").Should(BeClosed())
-	})
+			Eventually(svc.reconnectedCh, "10s", "100ms").Should(BeClosed())
+		},
+		Entry("server returns nil (io.EOF)", testCase{
+			description: "LB or global CP closes stream cleanly",
+			errCode:     codes.OK, // handler returns nil
+		}),
+		Entry("server returns Canceled", testCase{
+			description: "global CP explicitly cancels the stream",
+			errCode:     codes.Canceled,
+		}),
+	)
 })

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
@@ -36,6 +38,7 @@ type reconnectTrackingServer struct {
 	globalToZoneConns int
 	reconnectedOnce   sync.Once
 	reconnectedCh     chan struct{} // closed on second GlobalToZoneSync call
+	firstConnErrCode  codes.Code    // if non-zero, return this status code on first connection instead of nil
 }
 
 func (s *reconnectTrackingServer) GlobalToZoneSync(stream mesh_proto.KDSSyncService_GlobalToZoneSyncServer) error {
@@ -45,16 +48,19 @@ func (s *reconnectTrackingServer) GlobalToZoneSync(stream mesh_proto.KDSSyncServ
 	s.mu.Unlock()
 
 	if count == 1 {
-		// First connection: return nil after a short delay to let the zone
-		// client finish sending its DeltaDiscoveryRequests. Returning nil
-		// from the server handler closes the gRPC stream cleanly — the zone
-		// client receives io.EOF on Recv(), which triggers a reconnect.
+		// First connection: close the stream after a short delay.
+		// Returning nil closes the stream cleanly (zone gets io.EOF).
+		// Returning a status error simulates the global CP explicitly
+		// canceling the stream.
 		select {
 		case <-time.After(300 * time.Millisecond):
-			return nil
 		case <-stream.Context().Done():
 			return nil
 		}
+		if s.firstConnErrCode != codes.OK {
+			return status.Error(s.firstConnErrCode, "stream terminated by global")
+		}
+		return nil
 	}
 
 	// Second (or later) connection: zone successfully reconnected.
@@ -118,6 +124,66 @@ var _ = Describe("Client", func() {
 	It("reconnects when globalToZone stream is closed by server (io.EOF)", func() {
 		svc := &reconnectTrackingServer{
 			reconnectedCh: make(chan struct{}),
+		}
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		defer lis.Close()
+
+		grpcSrv := grpc.NewServer()
+		mesh_proto.RegisterKDSSyncServiceServer(grpcSrv, svc)
+		mesh_proto.RegisterGlobalKDSServiceServer(grpcSrv, svc)
+		go func() { _ = grpcSrv.Serve(lis) }()
+		defer grpcSrv.Stop()
+
+		globalStore := memory.NewStore()
+		cfg := kuma_cp.DefaultConfig()
+		cfg.Multizone.Zone.Name = "zone-1"
+		rt := kds_setup.NewTestRuntime(context.Background(), cfg, globalStore)
+
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+
+		zoneStore := memory.NewStore()
+		resourceSyncer, err := sync_store_v2.NewResourceSyncer(
+			core.Log.WithName("syncer"),
+			zoneStore,
+			store.NoTransactions{},
+			metrics,
+			context.Background(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		muxClient := mux.NewClient(
+			context.Background(),
+			"grpc://"+lis.Addr().String(),
+			"zone-1",
+			*rt.Config().Multizone.Zone.KDS,
+			rt.Config().Experimental,
+			metrics,
+			service.NewEnvoyAdminProcessor(rt.ReadOnlyResourceManager(), rt.EnvoyAdminClient()),
+			resourceSyncer,
+			rt,
+			&testZoneDeltaServer{},
+		)
+
+		resilient := component.NewResilientComponent(
+			core.Log.WithName("test-resilient"),
+			muxClient,
+			1*time.Millisecond,
+			10*time.Millisecond,
+		)
+
+		stop := make(chan struct{})
+		go func() { _ = resilient.Start(stop) }()
+		defer close(stop)
+
+		Eventually(svc.reconnectedCh, "10s", "100ms").Should(BeClosed())
+	})
+
+	It("reconnects when globalToZone stream is canceled by server", func() {
+		svc := &reconnectTrackingServer{
+			reconnectedCh:    make(chan struct{}),
+			firstConnErrCode: codes.Canceled,
 		}
 		lis, err := net.Listen("tcp", "127.0.0.1:0")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
@@ -68,6 +69,27 @@ func (s *reconnectTrackingServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncServ
 	return nil
 }
 
+func (s *reconnectTrackingServer) HealthCheck(_ context.Context, _ *mesh_proto.ZoneHealthCheckRequest) (*mesh_proto.ZoneHealthCheckResponse, error) {
+	return &mesh_proto.ZoneHealthCheckResponse{
+		Interval: durationpb.New(time.Minute),
+	}, nil
+}
+
+func (s *reconnectTrackingServer) StreamXDSConfigs(stream mesh_proto.GlobalKDSService_StreamXDSConfigsServer) error {
+	<-stream.Context().Done()
+	return nil
+}
+
+func (s *reconnectTrackingServer) StreamStats(stream mesh_proto.GlobalKDSService_StreamStatsServer) error {
+	<-stream.Context().Done()
+	return nil
+}
+
+func (s *reconnectTrackingServer) StreamClusters(stream mesh_proto.GlobalKDSService_StreamClustersServer) error {
+	<-stream.Context().Done()
+	return nil
+}
+
 // testZoneDeltaServer is a no-op delta server for the zone-to-global
 // direction. It blocks until the stream context is canceled.
 type testZoneDeltaServer struct{}
@@ -100,6 +122,7 @@ var _ = Describe("Client", func() {
 		}
 		lis, err := net.Listen("tcp", "127.0.0.1:0")
 		Expect(err).ToNot(HaveOccurred())
+		defer lis.Close()
 
 		grpcSrv := grpc.NewServer()
 		mesh_proto.RegisterKDSSyncServiceServer(grpcSrv, svc)

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -48,8 +48,7 @@ func (s *reconnectTrackingServer) GlobalToZoneSync(stream mesh_proto.KDSSyncServ
 		// First connection: return nil after a short delay to let the zone
 		// client finish sending its DeltaDiscoveryRequests. Returning nil
 		// from the server handler closes the gRPC stream cleanly — the zone
-		// client receives io.EOF on Recv(), which KDSSyncClient.Receive()
-		// translates to a nil error return.
+		// client receives io.EOF on Recv(), which triggers a reconnect.
 		select {
 		case <-time.After(300 * time.Millisecond):
 			return nil

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -1,0 +1,154 @@
+package mux_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/pkg/server/delta/v3"
+	stream_v3 "github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
+	"github.com/kumahq/kuma/v2/pkg/core"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/store"
+	"github.com/kumahq/kuma/v2/pkg/core/runtime/component"
+	"github.com/kumahq/kuma/v2/pkg/kds/mux"
+	"github.com/kumahq/kuma/v2/pkg/kds/service"
+	sync_store_v2 "github.com/kumahq/kuma/v2/pkg/kds/v2/store"
+	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
+	"github.com/kumahq/kuma/v2/pkg/plugins/resources/memory"
+	kds_setup "github.com/kumahq/kuma/v2/pkg/test/kds/setup"
+)
+
+// reconnectTrackingServer simulates a Global CP that closes the
+// GlobalToZoneSync stream cleanly on the first connection and then
+// tracks whether the zone mux client re-establishes it.
+type reconnectTrackingServer struct {
+	mesh_proto.UnimplementedKDSSyncServiceServer
+	mesh_proto.UnimplementedGlobalKDSServiceServer
+	mu                sync.Mutex
+	globalToZoneConns int
+	reconnectedOnce   sync.Once
+	reconnectedCh     chan struct{} // closed on second GlobalToZoneSync call
+}
+
+func (s *reconnectTrackingServer) GlobalToZoneSync(stream mesh_proto.KDSSyncService_GlobalToZoneSyncServer) error {
+	s.mu.Lock()
+	s.globalToZoneConns++
+	count := s.globalToZoneConns
+	s.mu.Unlock()
+
+	if count == 1 {
+		// First connection: return nil after a short delay to let the zone
+		// client finish sending its DeltaDiscoveryRequests. Returning nil
+		// from the server handler closes the gRPC stream cleanly — the zone
+		// client receives io.EOF on Recv(), which KDSSyncClient.Receive()
+		// translates to a nil error return.
+		select {
+		case <-time.After(300 * time.Millisecond):
+			return nil
+		case <-stream.Context().Done():
+			return nil
+		}
+	}
+
+	// Second (or later) connection: zone successfully reconnected.
+	s.reconnectedOnce.Do(func() { close(s.reconnectedCh) })
+	<-stream.Context().Done()
+	return nil
+}
+
+func (s *reconnectTrackingServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService_ZoneToGlobalSyncServer) error {
+	<-stream.Context().Done()
+	return nil
+}
+
+// testZoneDeltaServer is a no-op delta server for the zone-to-global
+// direction. It blocks until the stream context is canceled.
+type testZoneDeltaServer struct{}
+
+func (s *testZoneDeltaServer) DeltaStreamHandler(str stream_v3.DeltaStream, _ string) error {
+	<-str.Context().Done()
+	return nil
+}
+
+var _ delta.Server = &testZoneDeltaServer{}
+
+var _ = Describe("Client", func() {
+	// Regression test: when a GlobalToZoneSync gRPC stream is closed cleanly
+	// by the server (the zone receives io.EOF), the mux client must treat
+	// this as an error and trigger a full reconnect via ResilientComponent.
+	//
+	// Before the fix, startGlobalToZoneSync silently exited on nil error
+	// without sending to errorCh. Because Start() only returns when it
+	// receives from errorCh (or stop), the mux client stayed alive —
+	// healthchecks and ZoneToGlobal kept working — but GlobalToZone was
+	// permanently dead. No new resources from the global CP would ever
+	// reach the zone.
+	//
+	// In production this was triggered by a global CP restart behind a
+	// load balancer: the LB closed the GlobalToZone HTTP/2 stream with a
+	// clean TCP FIN (io.EOF) instead of a gRPC error.
+	It("reconnects when globalToZone stream is closed by server (io.EOF)", func() {
+		svc := &reconnectTrackingServer{
+			reconnectedCh: make(chan struct{}),
+		}
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+
+		grpcSrv := grpc.NewServer()
+		mesh_proto.RegisterKDSSyncServiceServer(grpcSrv, svc)
+		mesh_proto.RegisterGlobalKDSServiceServer(grpcSrv, svc)
+		go func() { _ = grpcSrv.Serve(lis) }()
+		defer grpcSrv.Stop()
+
+		globalStore := memory.NewStore()
+		cfg := kuma_cp.DefaultConfig()
+		cfg.Multizone.Zone.Name = "zone-1"
+		rt := kds_setup.NewTestRuntime(context.Background(), cfg, globalStore)
+
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+
+		zoneStore := memory.NewStore()
+		resourceSyncer, err := sync_store_v2.NewResourceSyncer(
+			core.Log.WithName("syncer"),
+			zoneStore,
+			store.NoTransactions{},
+			metrics,
+			context.Background(),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		muxClient := mux.NewClient(
+			context.Background(),
+			"grpc://"+lis.Addr().String(),
+			"zone-1",
+			*rt.Config().Multizone.Zone.KDS,
+			rt.Config().Experimental,
+			metrics,
+			service.NewEnvoyAdminProcessor(rt.ReadOnlyResourceManager(), rt.EnvoyAdminClient()),
+			resourceSyncer,
+			rt,
+			&testZoneDeltaServer{},
+		)
+
+		resilient := component.NewResilientComponent(
+			core.Log.WithName("test-resilient"),
+			muxClient,
+			1*time.Millisecond,
+			10*time.Millisecond,
+		)
+
+		stop := make(chan struct{})
+		go func() { _ = resilient.Start(stop) }()
+		defer close(stop)
+
+		Eventually(svc.reconnectedCh, "10s", "100ms").Should(BeClosed())
+	})
+})

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -209,7 +209,8 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 			processingErrorsCh <- errors.Wrap(err, "Global CP could not create a zone")
 			return
 		}
-		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
+		kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
+		_ = sendDone // sendLoop is cancelled when stream context ends; no CloseSend in this goroutine
 		cb := kds_sync_store_v2.GlobalSyncCallback(
 			stream.Context(),
 			g.resourceSyncer,

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -209,8 +209,7 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 			processingErrorsCh <- errors.Wrap(err, "Global CP could not create a zone")
 			return
 		}
-		kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
-		_ = sendDone // sendLoop is cancelled when stream context ends; no CloseSend in this goroutine
+		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
 		cb := kds_sync_store_v2.GlobalSyncCallback(
 			stream.Context(),
 			g.resourceSyncer,

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -38,6 +38,15 @@ import (
 
 var clientLog = core.Log.WithName("kds-delta-client")
 
+// serverStreamAdapter wraps a gRPC server stream to satisfy
+// KDSSyncServiceStream. Server streams signal completion by returning
+// from the handler, so CloseSend is a no-op.
+type serverStreamAdapter struct {
+	mesh_proto.KDSSyncService_ZoneToGlobalSyncServer
+}
+
+func (serverStreamAdapter) CloseSend() error { return nil }
+
 type KDSSyncServiceServer struct {
 	filters    []kds_context.FilterV2
 	extensions context.Context
@@ -209,7 +218,7 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 			processingErrorsCh <- errors.Wrap(err, "Global CP could not create a zone")
 			return
 		}
-		kdsStream := kds_client_v2.NewDeltaKDSStream(stream, zone, g.instanceID, "", len(g.typesSentByZone))
+		kdsStream := kds_client_v2.NewDeltaKDSStream(serverStreamAdapter{stream}, zone, g.instanceID, "", len(g.typesSentByZone))
 		cb := kds_sync_store_v2.GlobalSyncCallback(
 			stream.Context(),
 			g.resourceSyncer,

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -45,6 +45,7 @@ type DeltaKDSStream interface {
 	Receive() (UpstreamResponse, error)
 	ACK(resourceType core_model.ResourceType) error
 	NACK(resourceType core_model.ResourceType, err error) error
+	CloseSend() error
 }
 
 type KDSSyncClient interface {

--- a/pkg/kds/v2/client/kds_client.go
+++ b/pkg/kds/v2/client/kds_client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	std_errors "errors"
-	"io"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -87,9 +86,6 @@ func (s *kdsSyncClient) Receive() error {
 	for {
 		received, err := s.kdsStream.Receive()
 		if err != nil {
-			if err == io.EOF {
-				return nil
-			}
 			return errors.Wrap(err, "failed to receive a discovery response")
 		}
 		s.log.V(1).Info("DeltaDiscoveryResponse received", "response", received)
@@ -99,18 +95,12 @@ func (s *kdsSyncClient) Receive() error {
 			if validationErrors != nil {
 				s.log.Info("received resource is invalid, sending NACK", "err", validationErrors)
 				if err := s.kdsStream.NACK(received.Type, validationErrors); err != nil {
-					if err == io.EOF {
-						return nil
-					}
 					return errors.Wrap(err, "failed to NACK a discovery response")
 				}
 				continue
 			}
 			s.log.Info("no callback set, sending ACK", "type", string(received.Type))
 			if err := s.kdsStream.ACK(received.Type); err != nil {
-				if err == io.EOF {
-					return nil
-				}
 				return errors.Wrap(err, "failed to ACK a discovery response")
 			}
 			continue
@@ -126,9 +116,6 @@ func (s *kdsSyncClient) Receive() error {
 				s.callbacks.OnNACK(received.Type)
 			}
 			if err := s.kdsStream.NACK(received.Type, combinedErrors); err != nil {
-				if err == io.EOF {
-					return nil
-				}
 				return errors.Wrap(err, "failed to NACK a discovery response")
 			}
 			continue
@@ -140,9 +127,6 @@ func (s *kdsSyncClient) Receive() error {
 		}
 		s.log.V(1).Info("sending ACK", "type", received.Type)
 		if err := s.kdsStream.ACK(received.Type); err != nil {
-			if err == io.EOF {
-				return nil
-			}
 			return errors.Wrap(err, "failed to ACK a discovery response")
 		}
 	}

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -59,7 +59,14 @@ func NewDeltaKDSStream(
 	cpConfig string,
 	numberOfDistinctTypes int,
 ) (DeltaKDSStream, <-chan struct{}) {
-	ctx, cancel := context.WithCancelCause(s.Context())
+	// Use Background instead of s.Context() to decouple from the gRPC
+	// stream's context. When the server closes the stream, gRPC cancels
+	// the stream context with context.Canceled. If that propagated to our
+	// context, it would race with recvLoop's cancel(io.EOF) — whichever
+	// runs first sets the cause. By using Background, the cause is always
+	// determined by sendLoop/recvLoop errors (io.EOF, transport errors),
+	// never by gRPC's internal context cancellation.
+	ctx, cancel := context.WithCancelCause(context.Background())
 
 	// In theory capacity == numberOfDistinctTypes would be enough:
 	//

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -34,11 +34,12 @@ type stream struct {
 	cpConfig           string
 	instanceID         string
 
-	sendCh   chan *envoy_sd.DeltaDiscoveryRequest
-	recvCh   chan *envoy_sd.DeltaDiscoveryResponse
-	ctx      context.Context
-	cancel   context.CancelCauseFunc
-	sendDone chan struct{}
+	sendCh       chan *envoy_sd.DeltaDiscoveryRequest
+	recvCh       chan *envoy_sd.DeltaDiscoveryResponse
+	ctx          context.Context
+	cancel       context.CancelCauseFunc
+	sendDone     chan struct{}
+	closeSendErr error
 }
 
 type KDSSyncServiceStream interface {
@@ -48,17 +49,18 @@ type KDSSyncServiceStream interface {
 }
 
 // NewDeltaKDSStream creates a new DeltaKDSStream and starts background
-// send/recv goroutines. The returned channel is closed when the send
-// goroutine exits. Callers must wait on this channel before calling
-// CloseSend on the underlying gRPC stream to avoid a data race between
-// Send and CloseSend.
+// send/recv goroutines. Call CloseSend on the returned stream to
+// gracefully shut down the send goroutine and close the underlying
+// gRPC stream. CloseSend is thread-safe: it waits for the send
+// goroutine to exit and calls the underlying CloseSend within that
+// goroutine, avoiding data races between Send and CloseSend.
 func NewDeltaKDSStream(
 	s KDSSyncServiceStream,
 	clientID string,
 	instanceID string,
 	cpConfig string,
 	numberOfDistinctTypes int,
-) (DeltaKDSStream, <-chan struct{}) {
+) DeltaKDSStream {
 	// Use Background instead of s.Context() to decouple from the gRPC
 	// stream's context. When the server closes the stream, gRPC cancels
 	// the stream context with context.Canceled. If that propagated to our
@@ -99,10 +101,18 @@ func NewDeltaKDSStream(
 	}()
 	go stream.recvLoop()
 
-	return stream, stream.sendDone
+	return stream
 }
 
 func (s *stream) sendLoop() {
+	defer func() {
+		type closeSender interface {
+			CloseSend() error
+		}
+		if cs, ok := s.streamClient.(closeSender); ok {
+			s.closeSendErr = cs.CloseSend()
+		}
+	}()
 	for {
 		select {
 		case <-s.ctx.Done():
@@ -114,6 +124,16 @@ func (s *stream) sendLoop() {
 			}
 		}
 	}
+}
+
+// CloseSend signals the send goroutine to stop and waits for it to call
+// CloseSend on the underlying gRPC stream. This is thread-safe because
+// the underlying CloseSend is called within the send goroutine, never
+// concurrently with Send.
+func (s *stream) CloseSend() error {
+	s.cancel(nil)
+	<-s.sendDone
+	return s.closeSendErr
 }
 
 func (s *stream) recvLoop() {

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -34,10 +34,11 @@ type stream struct {
 	cpConfig           string
 	instanceID         string
 
-	sendCh chan *envoy_sd.DeltaDiscoveryRequest
-	recvCh chan *envoy_sd.DeltaDiscoveryResponse
-	ctx    context.Context
-	cancel context.CancelCauseFunc
+	sendCh   chan *envoy_sd.DeltaDiscoveryRequest
+	recvCh   chan *envoy_sd.DeltaDiscoveryResponse
+	ctx      context.Context
+	cancel   context.CancelCauseFunc
+	sendDone chan struct{}
 }
 
 type KDSSyncServiceStream interface {
@@ -46,13 +47,18 @@ type KDSSyncServiceStream interface {
 	Context() context.Context
 }
 
+// NewDeltaKDSStream creates a new DeltaKDSStream and starts background
+// send/recv goroutines. The returned channel is closed when the send
+// goroutine exits. Callers must wait on this channel before calling
+// CloseSend on the underlying gRPC stream to avoid a data race between
+// Send and CloseSend.
 func NewDeltaKDSStream(
 	s KDSSyncServiceStream,
 	clientID string,
 	instanceID string,
 	cpConfig string,
 	numberOfDistinctTypes int,
-) DeltaKDSStream {
+) (DeltaKDSStream, <-chan struct{}) {
 	ctx, cancel := context.WithCancelCause(s.Context())
 
 	// In theory capacity == numberOfDistinctTypes would be enough:
@@ -77,12 +83,16 @@ func NewDeltaKDSStream(
 		recvCh:             make(chan *envoy_sd.DeltaDiscoveryResponse, capacity),
 		ctx:                ctx,
 		cancel:             cancel,
+		sendDone:           make(chan struct{}),
 	}
 
-	go stream.sendLoop()
+	go func() {
+		defer close(stream.sendDone)
+		stream.sendLoop()
+	}()
 	go stream.recvLoop()
 
-	return stream
+	return stream, stream.sendDone
 }
 
 func (s *stream) sendLoop() {

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -34,17 +35,20 @@ type stream struct {
 	cpConfig           string
 	instanceID         string
 
-	sendCh       chan *envoy_sd.DeltaDiscoveryRequest
-	recvCh       chan *envoy_sd.DeltaDiscoveryResponse
-	ctx          context.Context
-	cancel       context.CancelCauseFunc
-	sendDone     chan struct{}
-	closeSendErr error
+	sendCh        chan *envoy_sd.DeltaDiscoveryRequest
+	recvCh        chan *envoy_sd.DeltaDiscoveryResponse
+	ctx           context.Context
+	cancel        context.CancelCauseFunc
+	closeSendCh   chan struct{}
+	closeSendOnce sync.Once
+	sendDone      chan struct{}
+	closeSendErr  error
 }
 
 type KDSSyncServiceStream interface {
 	Send(*envoy_sd.DeltaDiscoveryRequest) error
 	Recv() (*envoy_sd.DeltaDiscoveryResponse, error)
+	CloseSend() error
 	Context() context.Context
 }
 
@@ -92,6 +96,7 @@ func NewDeltaKDSStream(
 		recvCh:             make(chan *envoy_sd.DeltaDiscoveryResponse, capacity),
 		ctx:                ctx,
 		cancel:             cancel,
+		closeSendCh:        make(chan struct{}),
 		sendDone:           make(chan struct{}),
 	}
 
@@ -106,16 +111,13 @@ func NewDeltaKDSStream(
 
 func (s *stream) sendLoop() {
 	defer func() {
-		type closeSender interface {
-			CloseSend() error
-		}
-		if cs, ok := s.streamClient.(closeSender); ok {
-			s.closeSendErr = cs.CloseSend()
-		}
+		s.closeSendErr = s.streamClient.CloseSend()
 	}()
 	for {
 		select {
 		case <-s.ctx.Done():
+			return
+		case <-s.closeSendCh:
 			return
 		case req := <-s.sendCh:
 			if err := s.streamClient.Send(req); err != nil {
@@ -126,12 +128,14 @@ func (s *stream) sendLoop() {
 	}
 }
 
-// CloseSend signals the send goroutine to stop and waits for it to call
-// CloseSend on the underlying gRPC stream. This is thread-safe because
-// the underlying CloseSend is called within the send goroutine, never
-// concurrently with Send.
+// CloseSend half-closes the send side of the stream. It signals the
+// send goroutine to stop and waits for it to call CloseSend on the
+// underlying gRPC stream. The receive side is not affected — recvLoop
+// continues until the peer closes or the context is cancelled.
+// This is thread-safe: the underlying CloseSend runs within the send
+// goroutine, never concurrently with Send.
 func (s *stream) CloseSend() error {
-	s.cancel(nil)
+	s.closeSendOnce.Do(func() { close(s.closeSendCh) })
 	<-s.sendDone
 	return s.closeSendErr
 }

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -93,10 +93,11 @@ var _ = Describe("Zone Delta Sync", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		wg.Go(func() {
+			kdsStream, _ := client_v2.NewDeltaKDSStream(clientStream, zoneName, "zone-inst", "", len(kdsCtx.TypesSentByGlobal))
 			policySync := client_v2.NewKDSSyncClient(
 				core.Log.WithName("kds-sink"),
 				kdsCtx.TypesSentByGlobal,
-				client_v2.NewDeltaKDSStream(clientStream, zoneName, "zone-inst", "", len(kdsCtx.TypesSentByGlobal)),
+				kdsStream,
 				sync_store_v2.ZoneSyncCallback(context.Background(), zoneSyncer, false, nil, "kuma-system"), 0,
 			)
 			_ = policySync.Receive()

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Zone Delta Sync", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		wg.Go(func() {
-			kdsStream, _ := client_v2.NewDeltaKDSStream(clientStream, zoneName, "zone-inst", "", len(kdsCtx.TypesSentByGlobal))
+			kdsStream := client_v2.NewDeltaKDSStream(clientStream, zoneName, "zone-inst", "", len(kdsCtx.TypesSentByGlobal))
 			policySync := client_v2.NewKDSSyncClient(
 				core.Log.WithName("kds-sink"),
 				kdsCtx.TypesSentByGlobal,

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -217,10 +217,11 @@ var _ = Describe("Zone Sync", func() {
 			go func() {
 				defer GinkgoRecover()
 				defer wg.Done()
+				kdsStream, _ := kds_client_v2.NewDeltaKDSStream(clientStream, zoneName, "global-inst", "", len(kdsCtx.TypesSentByGlobal))
 				syncClient := kds_client_v2.NewKDSSyncClient(
 					core.Log.WithName("kds-sink"),
 					kdsCtx.TypesSentByGlobal,
-					kds_client_v2.NewDeltaKDSStream(clientStream, zoneName, "global-inst", "", len(kdsCtx.TypesSentByGlobal)),
+					kdsStream,
 					sync_store_v2.ZoneSyncCallback(context.Background(), zoneSyncer, false, nil, "kuma-system"),
 					0,
 				)

--- a/pkg/kds/zone/components_test.go
+++ b/pkg/kds/zone/components_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Zone Sync", func() {
 			go func() {
 				defer GinkgoRecover()
 				defer wg.Done()
-				kdsStream, _ := kds_client_v2.NewDeltaKDSStream(clientStream, zoneName, "global-inst", "", len(kdsCtx.TypesSentByGlobal))
+				kdsStream := kds_client_v2.NewDeltaKDSStream(clientStream, zoneName, "global-inst", "", len(kdsCtx.TypesSentByGlobal))
 				syncClient := kds_client_v2.NewKDSSyncClient(
 					core.Log.WithName("kds-sink"),
 					kdsCtx.TypesSentByGlobal,

--- a/pkg/test/grpc/clientstream.go
+++ b/pkg/test/grpc/clientstream.go
@@ -98,7 +98,9 @@ func NewMockDeltaClientStream() *MockDeltaClientStream {
 func (stream *MockDeltaClientStream) CloseSend() error {
 	stream.Lock()
 	defer stream.Unlock()
-	close(stream.SentCh)
-	stream.closed = true
+	if !stream.closed {
+		close(stream.SentCh)
+		stream.closed = true
+	}
 	return nil
 }

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -13,9 +13,11 @@ func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes
 	for i := range clientStreams {
 		clientID := fmt.Sprintf("client-%d", i)
 		item := clientStreams[i]
-		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes)), cb, 0)
+		kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes))
+		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kdsStream, cb, 0)
 		go func() {
 			_ = comp.Receive()
+			<-sendDone
 			_ = item.CloseSend()
 		}()
 	}

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -13,12 +13,11 @@ func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes
 	for i := range clientStreams {
 		clientID := fmt.Sprintf("client-%d", i)
 		item := clientStreams[i]
-		kdsStream, sendDone := kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes))
+		kdsStream := kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes))
 		comp := kds_client_v2.NewKDSSyncClient(core.Log.WithName("kds").WithName(clientID), resourceTypes, kdsStream, cb, 0)
 		go func() {
 			_ = comp.Receive()
-			<-sendDone
-			_ = item.CloseSend()
+			_ = kdsStream.CloseSend()
 		}()
 	}
 }


### PR DESCRIPTION
## Motivation
  - Fix a bug where the KDS mux client's GlobalToZone (and ZoneToGlobal) sync goroutine silently exited when the server closed the gRPC stream cleanly (io.EOF), leaving the zone permanently unable to receive resources from the global CP
  - The mux client stayed alive (healthchecks, other streams kept working) masking the failure — the zone appeared connected but never received new policies or meshes
  - Add regression test that verifies the mux client reconnects when the server closes the GlobalToZone stream

## Implementation information

When a gRPC stream is closed cleanly by the server, `stream.Recv()` returns `io.EOF`. `KDSSyncClient.Receive()` translates `io.EOF` to a nil return. `startGlobalToZoneSync` only sent to errorCh on non-nil errors, so it exited without notifying `client.Start()`. Since `Start()` blocks on errorCh, the mux client stayed alive indefinitely with a dead `GlobalToZone` stream.

This can be triggered by a global CP restart behind a load balancer that closed the HTTP/2 stream with a clean TCP FIN instead of a gRPC error. Both `startGlobalToZoneSync` and `startZoneToGlobalSync` now send to errorCh on nil error (stream closed by server), causing `Start()` to return and ResilientComponent to restart the entire mux client. A non-blocking select on `ctx.Done()` prevents goroutine leaks when shutdown is already in progress.

Also, there was a data race
  - NewDeltaKDSStream now returns (DeltaKDSStream, <-chan struct{}) — the channel closes when sendLoop exits
  - client.go: <-sendDone in the defer before CloseSend() — guarantees Send() is done
  - zone_sync.go: receives sendDone but ignores it (no CloseSend in that goroutine)

Fix: https://github.com/kumahq/kuma/issues/16428
