### PR TITLE
refactor(oapi): rename GlobalInsight base

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -667,9 +667,9 @@ components:
           type: integer
           description: Number of meshes
           example: 3
-    schemas-GlobalInsight:
+    GlobalInsightBase:
       type: object
-      title: GlobalInsight
+      title: GlobalInsightBase
       description: Global Insight contains statistics for all main resources
       required:
         - createdAt
@@ -712,7 +712,7 @@ components:
           description: A map of resource names to their corresponding statistics
     GlobalInsight:
       allOf:
-        - $ref: '#/components/schemas/schemas-GlobalInsight'
+        - $ref: '#/components/schemas/GlobalInsightBase'
     InspectHostnames:
       type: object
       title: InspectHostnames

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -116,7 +116,31 @@ type FullStatus struct {
 }
 
 // GlobalInsight Global Insight contains statistics for all main resources
-type GlobalInsight = SchemasGlobalInsight
+type GlobalInsight = GlobalInsightBase
+
+// GlobalInsightBase Global Insight contains statistics for all main resources
+type GlobalInsightBase struct {
+	// CreatedAt Time of Global Insight creation
+	CreatedAt time.Time `json:"createdAt"`
+
+	// Dataplanes Dataplane proxy statistics
+	Dataplanes DataplanesStats `json:"dataplanes"`
+
+	// Meshes Mesh statistics
+	Meshes MeshesStats `json:"meshes"`
+
+	// Policies Policies statistics
+	Policies PoliciesStats `json:"policies"`
+
+	// Resources A map of resource names to their corresponding statistics
+	Resources map[string]ResourceStats `json:"resources"`
+
+	// Services Mesh services statistics
+	Services ServicesStats `json:"services"`
+
+	// Zones Zones statistics
+	Zones ZonesStats `json:"zones"`
+}
 
 // Index Some metadata about the service
 type Index struct {
@@ -222,30 +246,6 @@ type ZonesStats struct {
 
 	// ZoneIngresses Zone Ingresses statistics
 	ZoneIngresses BaseStatus `json:"zoneIngresses"`
-}
-
-// SchemasGlobalInsight Global Insight contains statistics for all main resources
-type SchemasGlobalInsight struct {
-	// CreatedAt Time of Global Insight creation
-	CreatedAt time.Time `json:"createdAt"`
-
-	// Dataplanes Dataplane proxy statistics
-	Dataplanes DataplanesStats `json:"dataplanes"`
-
-	// Meshes Mesh statistics
-	Meshes MeshesStats `json:"meshes"`
-
-	// Policies Policies statistics
-	Policies PoliciesStats `json:"policies"`
-
-	// Resources A map of resource names to their corresponding statistics
-	Resources map[string]ResourceStats `json:"resources"`
-
-	// Services Mesh services statistics
-	Services ServicesStats `json:"services"`
-
-	// Zones Zones statistics
-	Zones ZonesStats `json:"zones"`
 }
 
 // DataplaneNetworkingLayoutResponse Dataplane networking layout. It contains information most important information about dataplane and lists of available inbounds and outbounds

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4510,9 +4510,9 @@ components:
           type: integer
           description: Number of meshes
           example: 3
-    schemas-GlobalInsight:
+    GlobalInsightBase:
       type: object
-      title: GlobalInsight
+      title: GlobalInsightBase
       description: Global Insight contains statistics for all main resources
       required:
         - createdAt
@@ -4555,7 +4555,7 @@ components:
           description: A map of resource names to their corresponding statistics
     GlobalInsight:
       allOf:
-        - $ref: '#/components/schemas/schemas-GlobalInsight'
+        - $ref: '#/components/schemas/GlobalInsightBase'
     InspectHostnames:
       type: object
       title: InspectHostnames


### PR DESCRIPTION
## Motivation

When downstream projects extend the GlobalInsight schema, the bundled OpenAPI spec ends up with duplicate definitions - the original and the extended version side by side.

This surfaced after bumping @redocly/cli from 2.26.0 to 2.28.0 in #16313. The v2.27.1 release [fixed component renaming conflict detection](https://github.com/Redocly/redocly-cli/releases/tag/%40redocly/cli%402.27.1):

> Fixed an issue where `--component-renaming-conflicts-severity` ignored conflicts when different files had components with the same name but different content.
> **Warning:** Autogenerated component names and `$ref` paths in bundled documents may differ from older releases.

When a downstream project's GlobalInsight (with extra fields) differs from Kuma's GlobalInsight, the bundler now correctly identifies them as distinct and renames one to `GlobalInsight-2`.

## Implementation information

Rename `schemas-GlobalInsight` to `GlobalInsightBase` in `api/openapi/specs/api.yaml`. The `GlobalInsight` schema now references `GlobalInsightBase` via allOf. Downstream projects can extend the base directly - the bundler no longer sees them as duplicates.