### PR TITLE
test(e2e): wait until requests stabilize

### DIFF
--- a/test/e2e_env/kubernetes/gateway/cross-mesh.go
+++ b/test/e2e_env/kubernetes/gateway/cross-mesh.go
@@ -173,7 +173,7 @@ func CrossMeshGatewayOnKubernetes() {
 				kubernetes.Cluster, gatewayMesh,
 				gatewayAddr,
 				gatewayClientNamespaceOtherMesh,
-			), "30s", "1s").Should(Succeed())
+			), "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
 			Consistently(FailToProxyRequestToGateway(
 				kubernetes.Cluster,
 				gatewayAddr,


### PR DESCRIPTION
## Motivation

1. Adding the second mesh (cross-mesh-gateway2) triggers cert regeneration for all DPs ("Another mesh has been added or removed"), causing a ~1s TLS disruption
2. The gateway generator in `pkg/plugins/runtime/gateway/generator.go:164-170` mutates the cached MeshGateway object's listener tags, causing the VIP allocator to detect a Modify change for `gateway.mesh` in all meshes (the outbound entry's tag set gains kuma.io/zone: default on second calculation)
3. The previous `Eventually(SuccessfullyProxy, "30s", "1s")` would catch a single success in the brief stable window between xDS pushes, then `Consistently(FailToProxy).ShouldNot(Succeed())` would immediately fail as the cert rotation disruption continued

## Implementation information

Wait until requests are stable

## Supporting documentation

> Changelog: skip