### PR TITLE
chore(dev): add GoLand/IntelliJ and VS Code run configurations

### DIFF
--- a/.idea/runConfigurations/Debug_E2E_Kubernetes.xml
+++ b/.idea/runConfigurations/Debug_E2E_Kubernetes.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug E2E Tests (Kubernetes)" type="GoTestRunConfiguration" factoryName="Go Test">
+    <module name="kuma" />
+    <working_directory value="$PROJECT_DIR$" />
+    <framework value="gotest" />
+    <kind value="DIRECTORY" />
+    <directory value="$PROJECT_DIR$/test/e2e_env/kubernetes" />
+    <filePath value="$PROJECT_DIR$" />
+    <envs>
+      <env name="KUMACTLBIN" value="$PROJECT_DIR$/build/artifacts-linux-amd64/kumactl/kumactl" />
+      <env name="KUMA_K8S_TYPE" value="k3d" />
+      <env name="K3D_CNI" value="flannel" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Remote_Debug_kuma-cp.xml
+++ b/.idea/runConfigurations/Remote_Debug_kuma-cp.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Remote Debug kuma-cp (Skaffold)" type="GoRemoteRunConfiguration" factoryName="Go Remote">
+    <option name="disconnectOption" value="STOP" />
+    <option name="host" value="localhost" />
+    <option name="port" value="56268" />
+    <option name="mapping" value="$PROJECT_DIR$:/app" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Remote Debug kuma-cp (Skaffold)",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "host": "localhost",
+      "port": 56268,
+      "substitutePath": [
+        {
+          "from": "${workspaceFolder}",
+          "to": "/app"
+        }
+      ]
+    },
+    {
+      "name": "Debug E2E Tests (Kubernetes)",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceFolder}/test/e2e_env/kubernetes",
+      "buildFlags": "-ldflags='-X github.com/kumahq/kuma/v2/pkg/version.Envoy=${env:ENVOY_VERSION} -X github.com/kumahq/kuma/v2/pkg/version.version=${env:KUMA_PRODUCT_VERSION}'",
+      "env": {
+        "KUMACTLBIN": "${input:kumactlBin}",
+        "KUMA_K8S_TYPE": "k3d",
+        "K3D_CNI": "flannel"
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "kumactlBin",
+      "type": "promptString",
+      "description": "Path to the local kumactl binary for your OS/architecture",
+      "default": "${workspaceFolder}/build/artifacts-linux-amd64/kumactl/kumactl"
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

Developers working on Kuma lack shared IDE run configurations for common debug workflows, requiring each contributor to manually configure their IDE. This PR adds shared configs for the two most common debugging scenarios: remote attaching to a running `kuma-cp` (via Skaffold) and launching Kubernetes E2E tests locally.

## Implementation information

Adds three shared configuration files (force-added since `.idea/` and `.vscode/` are gitignored, but these are intentionally shared developer tooling):

**VS Code** (`.vscode/launch.json`):
- `Remote Debug kuma-cp (Skaffold)`: attaches on port 56268 with `substitutePath` mapping `${workspaceFolder} → /app` for correct breakpoint resolution
- `Debug E2E Tests (Kubernetes)`: launches `test/e2e_env/kubernetes` with a `promptString` input for `KUMACTLBIN` so each developer supplies their platform-specific kumactl binary path at run time

**GoLand/IntelliJ** (`.idea/runConfigurations/`):
- `Remote_Debug_kuma-cp.xml`: remote debug config on port 56268 with `mapping $PROJECT_DIR$:/app` for source-level breakpoint resolution (matching the VS Code `substitutePath`)
- `Debug_E2E_Kubernetes.xml`: Go test config targeting `test/e2e_env/kubernetes`; `KUMACTLBIN` defaults to the linux-amd64 build output — developers on other platforms (e.g. darwin-arm64) should update this value locally

## Supporting documentation

No documentation update required — these are developer-only IDE helpers and do not affect runtime behaviour or public APIs.