### PR TITLE
refactor(oapi): remove GlobalInsight schema alias

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -710,9 +710,6 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/ResourceStats'
           description: A map of resource names to their corresponding statistics
-    GlobalInsight:
-      allOf:
-        - $ref: '#/components/schemas/GlobalInsightBase'
     InspectHostnames:
       type: object
       title: InspectHostnames
@@ -796,7 +793,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GlobalInsight'
+            $ref: '#/components/schemas/GlobalInsightBase'
           examples:
             Single control plane response:
               $ref: '#/components/examples/GlobalInsightExample'

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -115,9 +115,6 @@ type FullStatus struct {
 	Total             int `json:"total"`
 }
 
-// GlobalInsight Global Insight contains statistics for all main resources
-type GlobalInsight = GlobalInsightBase
-
 // GlobalInsightBase Global Insight contains statistics for all main resources
 type GlobalInsightBase struct {
 	// CreatedAt Time of Global Insight creation
@@ -254,8 +251,8 @@ type DataplaneNetworkingLayoutResponse = DataplaneNetworkingLayout
 // GetDataplaneXDSConfigResponse defines model for GetDataplaneXDSConfigResponse.
 type GetDataplaneXDSConfigResponse = DataplaneXDSConfig
 
-// GlobalInsightResponse defines model for GlobalInsightResponse.
-type GlobalInsightResponse = GlobalInsight
+// GlobalInsightResponse Global Insight contains statistics for all main resources
+type GlobalInsightResponse = GlobalInsightBase
 
 // InboundPolicyConfResponse defines model for InboundPolicyConfResponse.
 type InboundPolicyConfResponse = externalRef0.InboundPoliciesList

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4553,9 +4553,6 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/ResourceStats'
           description: A map of resource names to their corresponding statistics
-    GlobalInsight:
-      allOf:
-        - $ref: '#/components/schemas/GlobalInsightBase'
     InspectHostnames:
       type: object
       title: InspectHostnames
@@ -19963,7 +19960,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GlobalInsight'
+            $ref: '#/components/schemas/GlobalInsightBase'
           examples:
             Single control plane response:
               $ref: '#/components/examples/GlobalInsightExample'

--- a/pkg/insights/globalinsight/cached_global_insight_service.go
+++ b/pkg/insights/globalinsight/cached_global_insight_service.go
@@ -26,7 +26,7 @@ func NewCachedGlobalInsightService(globalInsightService GlobalInsightService, te
 	}
 }
 
-func (gis *cachedGlobalInsightService) GetGlobalInsight(ctx context.Context) (*api_types.GlobalInsight, error) {
+func (gis *cachedGlobalInsightService) GetGlobalInsight(ctx context.Context) (*api_types.GlobalInsightBase, error) {
 	tenantID, err := gis.tenants.GetID(ctx)
 	if err != nil {
 		return nil, err
@@ -42,5 +42,5 @@ func (gis *cachedGlobalInsightService) GetGlobalInsight(ctx context.Context) (*a
 		return insight, nil
 	}
 
-	return obj.(*api_types.GlobalInsight), nil
+	return obj.(*api_types.GlobalInsightBase), nil
 }

--- a/pkg/insights/globalinsight/global_insight_service.go
+++ b/pkg/insights/globalinsight/global_insight_service.go
@@ -13,7 +13,7 @@ import (
 )
 
 type GlobalInsightService interface {
-	GetGlobalInsight(ctx context.Context) (*api_types.GlobalInsight, error)
+	GetGlobalInsight(ctx context.Context) (*api_types.GlobalInsightBase, error)
 }
 
 type defaultGlobalInsightService struct {
@@ -26,8 +26,8 @@ func NewDefaultGlobalInsightService(resourceStore core_store.ResourceStore) Glob
 	return &defaultGlobalInsightService{resourceStore: resourceStore}
 }
 
-func (gis *defaultGlobalInsightService) GetGlobalInsight(ctx context.Context) (*api_types.GlobalInsight, error) {
-	globalInsights := &api_types.GlobalInsight{CreatedAt: core.Now()}
+func (gis *defaultGlobalInsightService) GetGlobalInsight(ctx context.Context) (*api_types.GlobalInsightBase, error) {
+	globalInsights := &api_types.GlobalInsightBase{CreatedAt: core.Now()}
 
 	meshInsights := &mesh.MeshInsightResourceList{}
 	if err := gis.resourceStore.List(ctx, meshInsights); err != nil {
@@ -61,7 +61,7 @@ func (gis *defaultGlobalInsightService) GetGlobalInsight(ctx context.Context) (*
 
 func (gis *defaultGlobalInsightService) aggregateDataplanes(
 	meshInsights *mesh.MeshInsightResourceList,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) {
 	for _, meshInsight := range meshInsights.GetItems() {
 		dataplanesByType := meshInsight.GetSpec().(*mesh_proto.MeshInsight).GetDataplanesByType()
@@ -88,7 +88,7 @@ func (gis *defaultGlobalInsightService) aggregateDataplanes(
 
 func (gis *defaultGlobalInsightService) aggregatePolicies(
 	meshInsights *mesh.MeshInsightResourceList,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) {
 	for _, meshInsight := range meshInsights.GetItems() {
 		policies := meshInsight.GetSpec().(*mesh_proto.MeshInsight).GetPolicies()
@@ -101,7 +101,7 @@ func (gis *defaultGlobalInsightService) aggregatePolicies(
 
 func (gis *defaultGlobalInsightService) aggregateResources(
 	meshInsights *mesh.MeshInsightResourceList,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) {
 	globalInsight.Resources = map[string]api_types.ResourceStats{}
 	for _, meshInsight := range meshInsights.GetItems() {
@@ -118,7 +118,7 @@ func (gis *defaultGlobalInsightService) aggregateResources(
 
 func (gis *defaultGlobalInsightService) aggregateServices(
 	ctx context.Context,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) error {
 	serviceInsights := &mesh.ServiceInsightResourceList{}
 	if err := gis.resourceStore.List(ctx, serviceInsights); err != nil {
@@ -161,7 +161,7 @@ func updateServiceStatus(serviceStatus mesh_proto.ServiceInsight_Service_Status,
 
 func (gis *defaultGlobalInsightService) aggregateZoneControlPlanes(
 	ctx context.Context,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) error {
 	zoneInsights := &system.ZoneInsightResourceList{}
 	if err := gis.resourceStore.List(ctx, zoneInsights); err != nil {
@@ -180,7 +180,7 @@ func (gis *defaultGlobalInsightService) aggregateZoneControlPlanes(
 
 func (gis *defaultGlobalInsightService) aggregateZoneIngresses(
 	ctx context.Context,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) error {
 	zoneIngressInsights := &mesh.ZoneIngressInsightResourceList{}
 	if err := gis.resourceStore.List(ctx, zoneIngressInsights); err != nil {
@@ -199,7 +199,7 @@ func (gis *defaultGlobalInsightService) aggregateZoneIngresses(
 
 func (gis *defaultGlobalInsightService) aggregateZoneEgresses(
 	ctx context.Context,
-	globalInsight *api_types.GlobalInsight,
+	globalInsight *api_types.GlobalInsightBase,
 ) error {
 	zoneEgressInsights := &mesh.ZoneEgressInsightResourceList{}
 	if err := gis.resourceStore.List(ctx, zoneEgressInsights); err != nil {


### PR DESCRIPTION
## Motivation

The `GlobalInsight` schema alias wrapped `GlobalInsightBase` with `allOf`, adding no value. This caused name collisions (`GlobalInsight-2`) when bundling Kuma specs with downstream projects that define their own `GlobalInsight` extending `GlobalInsightBase`.

## Implementation information

- Remove `GlobalInsight` alias schema from `api.yaml`
- Update `GlobalInsightResponse` to reference `GlobalInsightBase` directly
- Update Go code to use `GlobalInsightBase` type

## Supporting documentation

Follow-up to #16327 which renamed `GlobalInsight` to `GlobalInsightBase`.