### PR TITLE
fix(k8s): honor ignoredServiceSelectorLabels

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -43,10 +43,11 @@ func podReady(pod *kube_core.Pod, container *kube_core.Container) bool {
 }
 
 type InboundConverter struct {
-	NameExtractor       NameExtractor
-	NodeGetter          kube_client.Reader
-	NodeLabelsToCopy    []string
-	InboundTagsDisabled bool
+	NameExtractor                NameExtractor
+	NodeGetter                   kube_client.Reader
+	NodeLabelsToCopy             []string
+	InboundTagsDisabled          bool
+	IgnoredServiceSelectorLabels []string
 }
 
 func (ic *InboundConverter) tagsOrEmpty(tagsFn func() map[string]string) map[string]string {
@@ -84,7 +85,8 @@ func (ic *InboundConverter) inboundForService(zone string, pod *kube_core.Pod, s
 			health.Ready = false
 		}
 
-		if !kube_labels.SelectorFromSet(service.Spec.Selector).Matches(kube_labels.Set(pod.Labels)) {
+		strippedSelector := util_k8s.StripIgnoredSelectorLabels(service.Spec.Selector, ic.IgnoredServiceSelectorLabels)
+		if !kube_labels.SelectorFromSet(strippedSelector).Matches(kube_labels.Set(pod.Labels)) {
 			state = mesh_proto.Dataplane_Networking_Inbound_Ignored
 			health.Ready = false
 		}

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -58,10 +58,11 @@ const (
 type MeshServiceReconciler struct {
 	kube_client.Client
 	kube_event.EventRecorder
-	Log                 logr.Logger
-	Scheme              *kube_runtime.Scheme
-	ResourceConverter   k8s_common.Converter
-	InboundTagsDisabled bool
+	Log                          logr.Logger
+	Scheme                       *kube_runtime.Scheme
+	ResourceConverter            k8s_common.Converter
+	InboundTagsDisabled          bool
+	IgnoredServiceSelectorLabels []string
 }
 
 func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
@@ -372,7 +373,7 @@ func (r *MeshServiceReconciler) setFromClusterIPSvc(_ context.Context, ms *meshs
 	}
 	ms.Labels[metadata.HeadlessService] = "false"
 	if r.InboundTagsDisabled {
-		matchLabels := maps.Clone(svc.Spec.Selector)
+		matchLabels := util.StripIgnoredSelectorLabels(svc.Spec.Selector, r.IgnoredServiceSelectorLabels)
 		if matchLabels == nil {
 			matchLabels = map[string]string{}
 		}
@@ -383,7 +384,7 @@ func (r *MeshServiceReconciler) setFromClusterIPSvc(_ context.Context, ms *meshs
 			},
 		}
 	} else {
-		dpTags := maps.Clone(svc.Spec.Selector)
+		dpTags := util.StripIgnoredSelectorLabels(svc.Spec.Selector, r.IgnoredServiceSelectorLabels)
 		if dpTags == nil {
 			dpTags = map[string]string{}
 		}

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -32,9 +32,10 @@ var _ = Describe("MeshServiceController", func() {
 	var reconciler kube_reconcile.Reconciler
 
 	type testCase struct {
-		inputFile           string
-		outputFile          string
-		inboundTagsDisabled bool
+		inputFile                    string
+		outputFile                   string
+		inboundTagsDisabled          bool
+		ignoredServiceSelectorLabels []string
 	}
 
 	DescribeTable("should reconcile service",
@@ -69,12 +70,13 @@ var _ = Describe("MeshServiceController", func() {
 				Build()
 
 			reconciler = &MeshServiceReconciler{
-				Client:              kubeClient,
-				Log:                 logr.Discard(),
-				Scheme:              k8sClientScheme,
-				EventRecorder:       kube_events.NewFakeRecorder(10),
-				ResourceConverter:   k8s.NewSimpleConverter(),
-				InboundTagsDisabled: given.inboundTagsDisabled,
+				Client:                       kubeClient,
+				Log:                          logr.Discard(),
+				Scheme:                       k8sClientScheme,
+				EventRecorder:                kube_events.NewFakeRecorder(10),
+				ResourceConverter:            k8s.NewSimpleConverter(),
+				InboundTagsDisabled:          given.inboundTagsDisabled,
+				IgnoredServiceSelectorLabels: given.ignoredServiceSelectorLabels,
 			}
 
 			key := kube_types.NamespacedName{
@@ -132,6 +134,11 @@ var _ = Describe("MeshServiceController", func() {
 			inputFile:           "skip-inbound-tags.resources.yaml",
 			outputFile:          "skip-inbound-tags.meshservice.yaml",
 			inboundTagsDisabled: true,
+		}),
+		Entry("with ignored service selector labels", testCase{
+			inputFile:                    "ignored-selector-labels.resources.yaml",
+			outputFile:                   "ignored-selector-labels.meshservice.yaml",
+			ignoredServiceSelectorLabels: []string{"rollouts-pod-template-hash"},
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -42,20 +42,21 @@ func Parse[T any](values []string) ([]T, error) {
 
 var _ = Describe("PodToDataplane(..)", func() {
 	type testCase struct {
-		pod                 string
-		servicesForPod      string
-		otherDataplanes     string
-		otherServices       string
-		otherReplicaSets    string
-		otherJobs           string
-		node                string
-		dataplane           string
-		existingDataplane   string
-		nodeLabelsToCopy    []string
-		workloadLabels      []string
-		inboundTagsDisabled bool
-		meshServicesMode    *mesh_proto.Mesh_MeshServices_Mode
-		expectedErr         string
+		pod                          string
+		servicesForPod               string
+		otherDataplanes              string
+		otherServices                string
+		otherReplicaSets             string
+		otherJobs                    string
+		node                         string
+		dataplane                    string
+		existingDataplane            string
+		nodeLabelsToCopy             []string
+		workloadLabels               []string
+		inboundTagsDisabled          bool
+		ignoredServiceSelectorLabels []string
+		meshServicesMode             *mesh_proto.Mesh_MeshServices_Mode
+		expectedErr                  string
 	}
 	DescribeTable("should convert Pod into a Dataplane YAML version",
 		func(given testCase) {
@@ -135,9 +136,10 @@ var _ = Describe("PodToDataplane(..)", func() {
 						ReplicaSetGetter: replicaSetGetter,
 						JobGetter:        jobGetter,
 					},
-					NodeGetter:          nodeGetter,
-					NodeLabelsToCopy:    given.nodeLabelsToCopy,
-					InboundTagsDisabled: given.inboundTagsDisabled,
+					NodeGetter:                   nodeGetter,
+					NodeLabelsToCopy:             given.nodeLabelsToCopy,
+					InboundTagsDisabled:          given.inboundTagsDisabled,
+					IgnoredServiceSelectorLabels: given.ignoredServiceSelectorLabels,
 				},
 				Zone:              "zone-1",
 				ResourceConverter: k8s.NewSimpleConverter(),
@@ -418,6 +420,12 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod:   "44.services-for-pod.yaml",
 			dataplane:        "44.dataplane.yaml",
 			meshServicesMode: pointer.To(mesh_proto.Mesh_MeshServices_Everywhere),
+		}),
+		Entry("45. Pod with service selector containing ignored label", testCase{
+			pod:                          "45.pod.yaml",
+			servicesForPod:               "45.services-for-pod.yaml",
+			dataplane:                    "45.dataplane.yaml",
+			ignoredServiceSelectorLabels: []string{"rollouts-pod-template-hash"},
 		}),
 	)
 

--- a/pkg/plugins/runtime/k8s/controllers/testdata/45.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/45.dataplane.yaml
@@ -1,0 +1,26 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    k8s.kuma.io/service-account: example
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    kuma.io/workload: example
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health:
+        ready: true
+      port: 8080
+      protocol: tcp
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "80"
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_80
+        kuma.io/zone: zone-1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/45.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/45.pod.yaml
@@ -1,0 +1,20 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 8080
+  serviceAccountName: example
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - name: app
+      ready: true
+      started: true
+    - name: kuma-sidecar
+      ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/45.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/45.services-for-pod.yaml
@@ -1,0 +1,13 @@
+---
+metadata:
+  namespace: demo
+  name: example
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: abc123
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignored-selector-labels.meshservice.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignored-selector-labels.meshservice.yaml
@@ -1,0 +1,32 @@
+items:
+- metadata:
+    labels:
+      k8s.kuma.io/is-headless-service: "false"
+      k8s.kuma.io/service-name: example
+      kuma.io/env: kubernetes
+      kuma.io/managed-by: k8s-controller
+      kuma.io/mesh: default
+    name: example
+    namespace: demo
+    ownerReferences:
+    - apiVersion: v1
+      kind: Service
+      name: example
+      uid: ""
+    resourceVersion: "1"
+  spec:
+    ports:
+    - appProtocol: http
+      name: "80"
+      port: 80
+      targetPort: 8080
+    selector:
+      dataplaneTags:
+        app: example
+        k8s.kuma.io/namespace: demo
+  status:
+    dataplaneProxies: {}
+    tls: {}
+    vips:
+    - ip: 192.168.0.1
+metadata: {}

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignored-selector-labels.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshservice/ignored-selector-labels.resources.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    kuma.io/mesh: default
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: abc123
+  ports:
+    - appProtocol: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  meshServices:
+    mode: Everywhere

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -158,12 +158,13 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		return nil
 	}
 	reconciler := &k8s_controllers.MeshServiceReconciler{
-		Client:              mgr.GetClient(),
-		Log:                 core.Log.WithName("controllers").WithName("MeshService"),
-		Scheme:              mgr.GetScheme(),
-		EventRecorder:       mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
-		ResourceConverter:   converter,
-		InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
+		Client:                       mgr.GetClient(),
+		Log:                          core.Log.WithName("controllers").WithName("MeshService"),
+		Scheme:                       mgr.GetScheme(),
+		EventRecorder:                mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
+		ResourceConverter:            converter,
+		InboundTagsDisabled:          rt.Config().Experimental.InboundTagsDisabled,
+		IgnoredServiceSelectorLabels: rt.Config().Runtime.Kubernetes.Injector.IgnoredServiceSelectorLabels,
 	}
 	return reconciler.SetupWithManager(mgr)
 }
@@ -218,9 +219,10 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 					ReplicaSetGetter: mgr.GetClient(),
 					JobGetter:        mgr.GetClient(),
 				},
-				NodeGetter:          mgr.GetClient(),
-				NodeLabelsToCopy:    rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
-				InboundTagsDisabled: rt.Config().Experimental.InboundTagsDisabled,
+				NodeGetter:                   mgr.GetClient(),
+				NodeLabelsToCopy:             rt.Config().Runtime.Kubernetes.Injector.NodeLabelsToCopy,
+				InboundTagsDisabled:          rt.Config().Experimental.InboundTagsDisabled,
+				IgnoredServiceSelectorLabels: rt.Config().Runtime.Kubernetes.Injector.IgnoredServiceSelectorLabels,
 			},
 			Zone:                rt.Config().Multizone.Zone.Name,
 			SystemNamespace:     rt.Config().Store.Kubernetes.SystemNamespace,

--- a/pkg/plugins/runtime/k8s/util/util.go
+++ b/pkg/plugins/runtime/k8s/util/util.go
@@ -20,12 +20,20 @@ type ServicePredicate func(*kube_core.Service) bool
 
 func MatchServiceThatSelectsPod(pod *kube_core.Pod, ignoredLabels []string) ServicePredicate {
 	return func(svc *kube_core.Service) bool {
-		selector := maps.Clone(svc.Spec.Selector)
-		for _, ignoredLabel := range ignoredLabels {
-			delete(selector, ignoredLabel)
-		}
+		selector := StripIgnoredSelectorLabels(svc.Spec.Selector, ignoredLabels)
 		return kube_labels.SelectorFromSet(selector).Matches(kube_labels.Set(pod.Labels))
 	}
+}
+
+func StripIgnoredSelectorLabels(selector map[string]string, ignoredLabels []string) map[string]string {
+	if selector == nil {
+		return nil
+	}
+	result := maps.Clone(selector)
+	for _, label := range ignoredLabels {
+		delete(result, label)
+	}
+	return result
 }
 
 // According to K8S docs about Service#selector:

--- a/pkg/plugins/runtime/k8s/util/util_test.go
+++ b/pkg/plugins/runtime/k8s/util/util_test.go
@@ -703,4 +703,52 @@ var _ = Describe("Util", func() {
 			Expect(util.ServiceTag(kube_client.ObjectKeyFromObject(svc), &svc.Spec.Ports[0].Port)).To(Equal("example_demo_svc_80"))
 		})
 	})
+
+	Describe("StripIgnoredSelectorLabels", func() {
+		It("should return nil for nil selector", func() {
+			result := util.StripIgnoredSelectorLabels(nil, []string{"foo"})
+			Expect(result).To(BeNil())
+		})
+
+		It("should return clone when ignoredLabels is empty", func() {
+			selector := map[string]string{"app": "demo", "version": "v1"}
+			result := util.StripIgnoredSelectorLabels(selector, nil)
+			Expect(result).To(Equal(selector))
+			result["app"] = "modified"
+			Expect(selector["app"]).To(Equal("demo"))
+		})
+
+		It("should strip matching labels", func() {
+			selector := map[string]string{
+				"app":                        "demo",
+				"rollouts-pod-template-hash": "abc123",
+				"version":                    "v1",
+			}
+			result := util.StripIgnoredSelectorLabels(selector, []string{"rollouts-pod-template-hash"})
+			Expect(result).To(Equal(map[string]string{
+				"app":     "demo",
+				"version": "v1",
+			}))
+		})
+
+		It("should preserve non-matching labels", func() {
+			selector := map[string]string{"app": "demo", "version": "v1"}
+			result := util.StripIgnoredSelectorLabels(selector, []string{"nonexistent"})
+			Expect(result).To(Equal(selector))
+		})
+
+		It("should strip multiple ignored labels", func() {
+			selector := map[string]string{
+				"app":     "demo",
+				"label1":  "val1",
+				"label2":  "val2",
+				"version": "v1",
+			}
+			result := util.StripIgnoredSelectorLabels(selector, []string{"label1", "label2"})
+			Expect(result).To(Equal(map[string]string{
+				"app":     "demo",
+				"version": "v1",
+			}))
+		})
+	})
 })


### PR DESCRIPTION
> [!WARNING]
> not to be reviewed yet

## Motivation

The `runtime.kubernetes.injector.ignoredServiceSelectorLabels` config lets operators strip labels from Service selectors when matching against Pods. This is needed for blue-green deployments using ArgoCD/Argo Rollouts where Services have `rollouts-pod-template-hash` selectors that Pods don't carry.

The config was only honored in `MatchServiceThatSelectsPod` but not in two other codepaths:

- `inboundForService` used raw selector, causing inbounds to flip to Ignored state
- `setFromClusterIPSvc` used raw selector, causing MeshService resources to become Unavailable

This cascade (Ignored inbounds -> VIP removal -> client listeners gone) caused 503 errors from MeshPassthrough.

## Implementation information

- Extracted label stripping into reusable `StripIgnoredSelectorLabels` helper in `util.go`
- Refactored `MatchServiceThatSelectsPod` to use the helper (behavior unchanged)
- Added `IgnoredServiceSelectorLabels` field to `InboundConverter` struct and applied helper in `inboundForService`
- Added `IgnoredServiceSelectorLabels` field to `MeshServiceReconciler` struct and applied helper in `setFromClusterIPSvc` (both branches)
- Wired config from `rt.Config().Runtime.Kubernetes.Injector.IgnoredServiceSelectorLabels` to both structs in `plugin.go`
- Added unit tests for helper, inbound converter, and meshservice controller