### PR TITLE
fix(meshidentity): env-aware UsesWorkloadLabel

### DIFF
--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/helpers.go
@@ -78,7 +78,11 @@ func BestMatched(
 	return matches[0].policy, true
 }
 
-func (i *MeshIdentity) getSpiffeIDTemplate(env config_core.EnvironmentType) string {
+// SpiffeIDPathTemplate returns the path portion of the SPIFFE ID template that
+// will be used when rendering the SPIFFE ID for a dataplane. It falls back to
+// an environment-specific default when the MeshIdentity does not specify a
+// custom path.
+func (i *MeshIdentity) SpiffeIDPathTemplate(env config_core.EnvironmentType) string {
 	var defaultSpiffeIDPathTemplate string
 	switch env {
 	case config_core.KubernetesEnvironment:
@@ -86,14 +90,17 @@ func (i *MeshIdentity) getSpiffeIDTemplate(env config_core.EnvironmentType) stri
 	case config_core.UniversalEnvironment:
 		defaultSpiffeIDPathTemplate = defaultUniversalSpiffeIDPathTemplate
 	}
+	if i.SpiffeID == nil {
+		return defaultSpiffeIDPathTemplate
+	}
+	return pointer.DerefOr(i.SpiffeID.Path, defaultSpiffeIDPathTemplate)
+}
+
+func (i *MeshIdentity) getSpiffeIDTemplate(env config_core.EnvironmentType) string {
 	builder := strings.Builder{}
 	builder.WriteString("spiffe://")
 	builder.WriteString("{{ .TrustDomain }}")
-	if i.SpiffeID != nil {
-		builder.WriteString(pointer.DerefOr(i.SpiffeID.Path, defaultSpiffeIDPathTemplate))
-	} else {
-		builder.WriteString(defaultSpiffeIDPathTemplate)
-	}
+	builder.WriteString(i.SpiffeIDPathTemplate(env))
 	return builder.String()
 }
 
@@ -192,10 +199,9 @@ var (
 
 // UsesWorkloadLabel checks if this MeshIdentity's SPIFFE ID path template contains
 // the workload reference in the form of {{ label "kuma.io/workload" }} or {{ .Workload }}.
-func (i *MeshIdentity) UsesWorkloadLabel() bool {
-	if i.SpiffeID == nil || i.SpiffeID.Path == nil {
-		return false
-	}
-	path := *i.SpiffeID.Path
+// The environment is taken into account because the default Universal path template
+// references .Workload even when no custom path is configured.
+func (i *MeshIdentity) UsesWorkloadLabel(env config_core.EnvironmentType) bool {
+	path := i.SpiffeIDPathTemplate(env)
 	return workloadLabelRegex.MatchString(path) || workloadPlaceholderRegex.MatchString(path)
 }

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/helpers_test.go
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/helpers_test.go
@@ -259,7 +259,7 @@ var _ = Describe("MeshIdentity Helper", func() {
 	})
 
 	DescribeTable("UsesWorkloadLabel",
-		func(pathTemplate *string, expected bool) {
+		func(env config_core.EnvironmentType, pathTemplate *string, expected bool) {
 			// given
 			mi := &meshidentity_api.MeshIdentity{}
 			if pathTemplate != nil {
@@ -269,18 +269,20 @@ var _ = Describe("MeshIdentity Helper", func() {
 			}
 
 			// when
-			result := mi.UsesWorkloadLabel()
+			result := mi.UsesWorkloadLabel(env)
 
 			// then
 			Expect(result).To(Equal(expected))
 		},
-		Entry("nil SpiffeID", nil, false),
-		Entry("uses workload label", pointer.To("/ns/{{ .Namespace }}/workload/{{ label \"kuma.io/workload\" }}"), true),
-		Entry("uses workload label with extra spaces", pointer.To("/workload/{{  label  \"kuma.io/workload\"  }}"), true),
-		Entry("uses .Workload placeholder", pointer.To("/ns/{{ .Namespace }}/workload/{{ .Workload }}"), true),
-		Entry("uses .Workload placeholder with extra spaces", pointer.To("/workload/{{  .Workload  }}"), true),
-		Entry("does not use workload label", pointer.To("/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}"), false),
-		Entry("uses different label", pointer.To("/ns/{{ .Namespace }}/label/{{ label \"app\" }}"), false),
-		Entry("empty path", pointer.To(""), false),
+		Entry("nil SpiffeID on Kubernetes uses default SA template", config_core.KubernetesEnvironment, nil, false),
+		Entry("nil SpiffeID on Universal falls back to default workload template", config_core.UniversalEnvironment, nil, true),
+		Entry("uses workload label", config_core.KubernetesEnvironment, pointer.To("/ns/{{ .Namespace }}/workload/{{ label \"kuma.io/workload\" }}"), true),
+		Entry("uses workload label with extra spaces", config_core.KubernetesEnvironment, pointer.To("/workload/{{  label  \"kuma.io/workload\"  }}"), true),
+		Entry("uses .Workload placeholder", config_core.KubernetesEnvironment, pointer.To("/ns/{{ .Namespace }}/workload/{{ .Workload }}"), true),
+		Entry("uses .Workload placeholder with extra spaces", config_core.KubernetesEnvironment, pointer.To("/workload/{{  .Workload  }}"), true),
+		Entry("does not use workload label", config_core.KubernetesEnvironment, pointer.To("/ns/{{ .Namespace }}/sa/{{ .ServiceAccount }}"), false),
+		Entry("uses different label", config_core.KubernetesEnvironment, pointer.To("/ns/{{ .Namespace }}/label/{{ label \"app\" }}"), false),
+		Entry("empty path on Kubernetes", config_core.KubernetesEnvironment, pointer.To(""), false),
+		Entry("empty path on Universal", config_core.UniversalEnvironment, pointer.To(""), false),
 	)
 })

--- a/pkg/xds/server/callbacks/workload_label_validator.go
+++ b/pkg/xds/server/callbacks/workload_label_validator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
 	"github.com/kumahq/kuma/v2/pkg/core"
 	meshidentity_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshidentity/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/manager"
@@ -14,7 +15,6 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/core/resources/store"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
-	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
 
 var workloadLabelLog = core.Log.WithName("xds").WithName("workload-label-validator")
@@ -22,14 +22,16 @@ var workloadLabelLog = core.Log.WithName("xds").WithName("workload-label-validat
 // WorkloadLabelValidator validates that dataplanes have the required kuma.io/workload label
 // when they are selected by a MeshIdentity that uses the workload label in its SPIFFE ID path template.
 type WorkloadLabelValidator struct {
-	rm manager.ReadOnlyResourceManager
+	rm  manager.ReadOnlyResourceManager
+	env config_core.EnvironmentType
 }
 
 var _ DataplaneCallbacks = &WorkloadLabelValidator{}
 
-func NewWorkloadLabelValidator(rm manager.ReadOnlyResourceManager) *WorkloadLabelValidator {
+func NewWorkloadLabelValidator(rm manager.ReadOnlyResourceManager, env config_core.EnvironmentType) *WorkloadLabelValidator {
 	return &WorkloadLabelValidator{
-		rm: rm,
+		rm:  rm,
+		env: env,
 	}
 }
 
@@ -67,12 +69,12 @@ func (v *WorkloadLabelValidator) OnProxyConnected(
 		return nil
 	}
 
-	if !matched.Spec.UsesWorkloadLabel() {
+	if !matched.Spec.UsesWorkloadLabel(v.env) {
 		return nil
 	}
 
 	if _, ok := labels[metadata.KumaWorkload]; !ok {
-		pathTemplate := pointer.Deref(matched.Spec.SpiffeID.Path)
+		pathTemplate := matched.Spec.SpiffeIDPathTemplate(v.env)
 		miName := matched.Meta.GetName()
 		errMsg := fmt.Errorf(
 			"missing required label '%s' - dataplane is selected by MeshIdentity '%s' with path template '%s'",

--- a/pkg/xds/server/callbacks/workload_label_validator_test.go
+++ b/pkg/xds/server/callbacks/workload_label_validator_test.go
@@ -9,6 +9,7 @@ import (
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	meshidentity_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshidentity/api/v1alpha1"
 	core_manager "github.com/kumahq/kuma/v2/pkg/core/resources/manager"
@@ -30,7 +31,7 @@ var _ = Describe("Workload Label Validator", func() {
 	BeforeEach(func() {
 		memStore := memory.NewStore()
 		resManager = core_manager.NewResourceManager(memStore)
-		validator = NewWorkloadLabelValidator(resManager)
+		validator = NewWorkloadLabelValidator(resManager, config_core.KubernetesEnvironment)
 		streamIDCounter = 1
 
 		err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
@@ -200,6 +201,30 @@ var _ = Describe("Workload Label Validator", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mi-more-specific"))
+		})
+	})
+
+	Context("Universal environment with default SPIFFE ID path", func() {
+		// The default Universal path template is "/workload/{{ .Workload }}", so a
+		// MeshIdentity that does not set a custom path still requires the workload
+		// label on the dataplane. Regression for https://github.com/kumahq/kuma bug
+		// where UsesWorkloadLabel ignored the default template and admitted DPs
+		// without the label, producing an unparsable SPIFFE ID downstream.
+		It("should deny connection when MeshIdentity has no path and dataplane has no workload label", func() {
+			universalValidator := NewWorkloadLabelValidator(resManager, config_core.UniversalEnvironment)
+
+			createMeshIdentity("mi-default", "default",
+				map[string]string{"kuma.io/service": "universal-svc"}, nil)
+
+			dp := createDataplane("universal-dp", "default", map[string]string{
+				"kuma.io/service": "universal-svc",
+			})
+
+			err := universalValidator.OnProxyConnected(streamIDCounter, core_model.ResourceKey{Mesh: "default", Name: "universal-dp"}, context.Background(), core_xds.DataplaneMetadata{Resource: dp, ProxyType: mesh_proto.DataplaneProxyType})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required label 'kuma.io/workload'"))
+			Expect(err.Error()).To(ContainSubstring("/workload/{{ .Workload }}"))
 		})
 	})
 

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -42,7 +42,7 @@ func RegisterXDS(
 
 	authenticator := rt.XDS().PerProxyTypeAuthenticator()
 	authCallbacks := auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
-	workloadLabelValidator := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewWorkloadLabelValidator(rt.ReadOnlyResourceManager()))
+	workloadLabelValidator := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewWorkloadLabelValidator(rt.ReadOnlyResourceManager(), rt.Config().Environment))
 
 	dpLifecycle := xds_callbacks.DataplaneCallbacksToXdsCallbacks(
 		xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration))


### PR DESCRIPTION
## Motivation

`UsesWorkloadLabel` on `MeshIdentity` has a bug. It returns `false` when `SpiffeID` or `SpiffeID.Path` is nil - but that's exactly when `getSpiffeIDTemplate` in Universal mode falls back to `/workload/{{ .Workload }}`. So the template really does use the workload label, the helper just lies about it.

Bites in `WorkloadLabelValidator`. It asks the helper, gets `false`, returns early. A DP without `kuma.io/workload` sails through. Then `GetSpiffeID` renders the default with an empty `.Workload` and you get `spiffe://<td>/workload/`. `spiffeid.FromString` chokes on that with a useless parse error instead of a clear "you forgot the label" rejection at connect time.

## What changed

- pulled the default-fallback logic into `SpiffeIDPathTemplate(env)` so there's one source of truth
- `UsesWorkloadLabel` now takes an env and uses that helper - same behaviour on k8s, correct behaviour on Universal
- validator carries the env, passes it through, and reuses `SpiffeIDPathTemplate` for the error message (also dodges a nil-deref on `matched.Spec.SpiffeID.Path`)
- `RegisterXDS` wires `rt.Config().Environment` in
- added a Universal regression test in the validator suite and updated the helper table test to cover both envs
