### PR TITLE
fix(store): reject non-positive page size and negative offset

### DIFF
--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -238,6 +238,17 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 		}),
 	)
 
+	DescribeTable("should reject invalid pagination params",
+		func(query string) {
+			response, err := http.Get("http://" + apiServer.Address() + "/meshes/mesh1/dataplanes+insights?" + query)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(400))
+		},
+		Entry("zero size", "size=0"),
+		Entry("negative size", "size=-1"),
+		Entry("negative offset", "size=10&offset=-1"),
+	)
+
 	It("should paginate correctly", func() {
 		// when
 		response, err := http.Get("http://" + apiServer.Address() + "/meshes/mesh1/dataplanes+insights?size=1")

--- a/pkg/api-server/pagination.go
+++ b/pkg/api-server/pagination.go
@@ -27,6 +27,9 @@ func pagination(request *restful.Request) (page, error) {
 			return page{}, types.InvalidPageSize
 		}
 		pageSize = p
+		if pageSize <= 0 {
+			return page{}, types.InvalidPageSize
+		}
 		if pageSize > maxPageSize {
 			return page{}, types.NewMaxPageSizeExceeded(pageSize, maxPageSize)
 		}

--- a/pkg/api-server/pagination.go
+++ b/pkg/api-server/pagination.go
@@ -28,7 +28,7 @@ func pagination(request *restful.Request) (page, error) {
 		}
 		pageSize = p
 		if pageSize <= 0 {
-			return page{}, types.InvalidPageSize
+			return page{}, &types.InvalidPageSizeError{Reason: "must be greater than 0"}
 		}
 		if pageSize > maxPageSize {
 			return page{}, types.NewMaxPageSizeExceeded(pageSize, maxPageSize)

--- a/pkg/api-server/service_insight_endpoints.go
+++ b/pkg/api-server/service_insight_endpoints.go
@@ -177,6 +177,9 @@ func (s *serviceInsightEndpoints) paginateResources(request *restful.Request, re
 		if err != nil {
 			return store.ErrorInvalid(fmt.Sprintf("invalid offset: %s", err.Error()))
 		}
+		if o < 0 {
+			return store.ErrorInvalid("invalid offset: must be non-negative")
+		}
 		offset = o
 	}
 

--- a/pkg/core/resources/store/pagination_store.go
+++ b/pkg/core/resources/store/pagination_store.go
@@ -92,6 +92,9 @@ func (p *paginationStore) List(ctx context.Context, list model.ResourceList, opt
 			if err != nil {
 				return ErrorInvalid(fmt.Sprintf("invalid offset: %s", err.Error()))
 			}
+			if o < 0 {
+				return ErrorInvalid("invalid offset: must be non-negative")
+			}
 			offset = o
 		}
 	}

--- a/pkg/core/resources/store/pagination_store.go
+++ b/pkg/core/resources/store/pagination_store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 
@@ -94,6 +95,9 @@ func (p *paginationStore) List(ctx context.Context, list model.ResourceList, opt
 			}
 			if o < 0 {
 				return ErrorInvalid("invalid offset: must be non-negative")
+			}
+			if o > math.MaxInt-pageSize {
+				return ErrorInvalid("invalid offset: exceeds maximum value")
 			}
 			offset = o
 		}


### PR DESCRIPTION
## Motivation

Lack of validation allowed to pass negative offset

## Implementation information

- pkg/api-server/pagination.go: reject size <= 0 with InvalidPageSize alongside the existing > maxPageSize check.
- pkg/core/resources/store/pagination_store.go: reject parsed offset < 0 with ErrorInvalid before it reaches the slice index.
