### PR TITLE
chore(dev): add GoLand and VSCode run/debug configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-# IDE: Goland
-.idea/
+# IDE: Goland (run configs committed; ignore everything else)
+.idea/*
+!.idea/runConfigurations/
+!.idea/runConfigurations/*.xml
 
-# IDE: VS Code
-.vscode/
+# IDE: VS Code (launch.json committed; ignore everything else)
+.vscode/*
+!.vscode/launch.json
 
 .ci_tools/
 

--- a/.idea/runConfigurations/e2e_k8s_debug.xml
+++ b/.idea/runConfigurations/e2e_k8s_debug.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Debug E2E Tests (K8s / k3d)" type="GoTestRunConfiguration" factoryName="Go Test">
+    <module name="kuma" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-ldflags=&apos;-X github.com/kumahq/kuma/v2/pkg/version.version=dev&apos;" />
+    <envs>
+      <!-- Set KUMACTLBIN to your local kumactl binary, e.g.:
+           $PROJECT_DIR$/build/artifacts-<goos>-<goarch>/kumactl/kumactl
+           Run 'make build/kumactl' first to produce it. -->
+      <env name="KUMA_K8S_TYPE" value="k3d" />
+      <env name="K3D_CNI" value="flannel" />
+    </envs>
+    <kind value="PACKAGE" />
+    <package value="github.com/kumahq/kuma/v2/test/e2e_env/kubernetes" />
+    <directory value="$PROJECT_DIR$/test/e2e_env/kubernetes" />
+    <filePath value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/kuma_cp_debug_k8s.xml
+++ b/.idea/runConfigurations/kuma_cp_debug_k8s.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Attach to kuma-cp (K8s via Skaffold)" type="GoRemoteRunConfiguration" factoryName="Go Remote">
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="56268" />
+    <option name="MODE" value="ATTACH_TO_PROCESS" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/kuma_cp_run.xml
+++ b/.idea/runConfigurations/kuma_cp_run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run kuma-cp (Universal)" type="GoRunFileConfiguration" factoryName="Go Run File">
+    <module name="kuma" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="run --log-level=info" />
+    <envs>
+      <env name="KUMA_ENVIRONMENT" value="universal" />
+      <env name="KUMA_MULTIZONE_ZONE_NAME" value="zone-1" />
+    </envs>
+    <filePath value="$PROJECT_DIR$/app/kuma-cp/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run kuma-cp (Universal)",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/app/kuma-cp",
+      "args": ["run", "--log-level=info"],
+      "env": {
+        "KUMA_ENVIRONMENT": "universal",
+        "KUMA_MULTIZONE_ZONE_NAME": "zone-1"
+      }
+    },
+    {
+      "name": "Attach to kuma-cp (K8s via Skaffold)",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "host": "localhost",
+      "port": 56268,
+      "apiVersion": 2
+    },
+    {
+      "name": "Debug E2E Tests (K8s / k3d)",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${workspaceFolder}/test/e2e_env/kubernetes",
+      "buildFlags": "-ldflags=-X github.com/kumahq/kuma/v2/pkg/version.version=dev",
+      "env": {
+        // Set KUMACTLBIN to your local kumactl binary path, e.g.:
+        // "${workspaceFolder}/build/artifacts-<goos>-<goarch>/kumactl/kumactl"
+        // Run 'make build/kumactl' first to produce it.
+        "KUMA_K8S_TYPE": "k3d",
+        "K3D_CNI": "flannel"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds IDE run/debug configurations for both GoLand/IntelliJ and VS Code so contributors can start and debug `kuma-cp` without manually configuring each environment from scratch.

Closes #13022

> Note: this supersedes #16364, which was closed. This version addresses the Copilot review feedback: `KUMACTLBIN` is no longer hardcoded to a darwin-arm64 path. It has been removed from the committed configs; each file now includes an inline comment guiding contributors to set it locally after running `make build/kumactl`.

---

## Changes

### GoLand (`.idea/runConfigurations/`)

| File | Purpose |
|------|--------|
| `kuma_cp_run.xml` | Run `kuma-cp` locally in Universal mode (`KUMA_ENVIRONMENT=universal`, `KUMA_MULTIZONE_ZONE_NAME=zone-1`) |
| `kuma_cp_debug_k8s.xml` | Remote attach to `kuma-cp` deployed via `skaffold debug` on `localhost:56268` |
| `e2e_k8s_debug.xml` | Debug E2E tests against a k3d cluster (`KUMA_K8S_TYPE=k3d`, `K3D_CNI=flannel`). `KUMACTLBIN` omitted — set locally per comment in file. |

### VS Code (`.vscode/launch.json`)

| Config | Purpose |
|--------|--------|
| Run kuma-cp (Universal) | Launch `kuma-cp` with `KUMA_ENVIRONMENT=universal` |
| Attach to kuma-cp (K8s via Skaffold) | Remote attach on port `56268` |
| Debug E2E Tests (K8s / k3d) | Launch E2E suite with k3d env vars. `KUMACTLBIN` omitted — set locally per comment in file. |

### `.gitignore`

- `.idea/` → `.idea/*` with `!.idea/runConfigurations/` and `!.idea/runConfigurations/*.xml`
- `.vscode/` → `.vscode/*` with `!.vscode/launch.json`

---

## How to use

**GoLand / IntelliJ:** Open the project — the run configurations appear automatically in the top toolbar dropdown.

**VS Code:** Open the Run & Debug panel (`Ctrl+Shift+D` / `Cmd+Shift+D`) and select a configuration from the dropdown.

For E2E debugging, set `KUMACTLBIN` in your local environment or IDE override:
```
build/artifacts-<GOOS>-<GOARCH>/kumactl/kumactl
```
Run `make build/kumactl` first to produce the binary.

## Motivation

Addresses #13022 — contributors have requested committed run configs to avoid manual IDE setup.

## Supporting documentation

Supersedes #16364.