### PR TITLE
feat(helm): move mesh proxy service defaults

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -814,6 +814,22 @@ zoneProxyImage:
   # -- The pause image tag
   tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
 
+# Default service settings for mesh zone proxies. Used as fallback when
+# meshes[].ingress.service or meshes[].egress.service fields are not set.
+meshZoneProxyDefaults:
+  ingress:
+    service:
+      # -- Default Service type for zone ingress.
+      type: LoadBalancer
+      # -- Default port for zone ingress Service.
+      port: 10001
+  egress:
+    service:
+      # -- Default Service type for zone egress.
+      type: ClusterIP
+      # -- Default port for zone egress Service.
+      port: 10002
+
 # List of meshes to deploy zone proxies for.
 meshes:
   - # -- The mesh must already exist or be created separately; this Helm chart will not create it.
@@ -832,6 +848,12 @@ meshes:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
         name: ""
+        # -- (string) Per-mesh override for Service type. Falls back to
+        # meshZoneProxyDefaults.ingress.service.type when unset.
+        type: null
+        # -- (int) Per-mesh override for Service port. Falls back to
+        # meshZoneProxyDefaults.ingress.service.port when unset.
+        port: null
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
@@ -867,6 +889,12 @@ meshes:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
         name: ""
+        # -- (string) Per-mesh override for Service type. Falls back to
+        # meshZoneProxyDefaults.egress.service.type when unset.
+        type: null
+        # -- (int) Per-mesh override for Service port. Falls back to
+        # meshZoneProxyDefaults.egress.service.port when unset.
+        port: null
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -823,12 +823,18 @@ meshZoneProxyDefaults:
       type: LoadBalancer
       # -- Default port for zone ingress Service.
       port: 10001
+      # -- Container port the zone ingress listens on. Do not change unless the
+      # zone proxy binary is reconfigured.
+      targetPort: 10001
   egress:
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
       # -- Default port for zone egress Service.
       port: 10002
+      # -- Container port the zone egress listens on. Do not change unless the
+      # zone proxy binary is reconfigured.
+      targetPort: 10002
 
 # List of meshes to deploy zone proxies for.
 meshes:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -856,10 +856,10 @@ meshes:
         name: ""
         # -- (string) Per-mesh override for Service type. Falls back to
         # meshZoneProxyDefaults.ingress.service.type when unset.
-        type: null
+        type:
         # -- (int) Per-mesh override for Service port. Falls back to
         # meshZoneProxyDefaults.ingress.service.port when unset.
-        port: null
+        port:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
@@ -897,10 +897,10 @@ meshes:
         name: ""
         # -- (string) Per-mesh override for Service type. Falls back to
         # meshZoneProxyDefaults.egress.service.type when unset.
-        type: null
+        type:
         # -- (int) Per-mesh override for Service port. Falls back to
         # meshZoneProxyDefaults.egress.service.port when unset.
-        port: null
+        port:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
@@ -769,7 +769,7 @@ spec:
       terminationGracePeriodSeconds: 40
       containers:
         - name: pause
-          image: registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a
+          image: "registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
@@ -828,7 +828,7 @@ spec:
       terminationGracePeriodSeconds: 40
       containers:
         - name: pause
-          image: registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a
+          image: "registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -231,11 +231,19 @@ A Helm chart for the Kuma Control Plane
 | zoneProxyImage.registry | string | `"registry.k8s.io"` | The pause image registry |
 | zoneProxyImage.repository | string | `"pause"` | The pause image repository |
 | zoneProxyImage.tag | string | `"3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"` | The pause image tag |
+| meshZoneProxyDefaults.ingress.service.type | string | `"LoadBalancer"` | Default Service type for zone ingress. |
+| meshZoneProxyDefaults.ingress.service.port | int | `10001` | Default port for zone ingress Service. |
+| meshZoneProxyDefaults.ingress.service.targetPort | int | `10001` | Container port the zone ingress listens on. Do not change unless the zone proxy binary is reconfigured. |
+| meshZoneProxyDefaults.egress.service.type | string | `"ClusterIP"` | Default Service type for zone egress. |
+| meshZoneProxyDefaults.egress.service.port | int | `10002` | Default port for zone egress Service. |
+| meshZoneProxyDefaults.egress.service.targetPort | int | `10002` | Container port the zone egress listens on. Do not change unless the zone proxy binary is reconfigured. |
 | meshes[0].name | string | `"default"` | The mesh must already exist or be created separately; this Helm chart will not create it. |
 | meshes[0].ingress.enabled | bool | `false` | Deploy a zone ingress for this mesh. |
 | meshes[0].ingress.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
 | meshes[0].ingress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
 | meshes[0].ingress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride) |
+| meshes[0].ingress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.ingress.service.type when unset. |
+| meshes[0].ingress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.ingress.service.port when unset. |
 | meshes[0].ingress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
 | meshes[0].ingress.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
 | meshes[0].ingress.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
@@ -246,6 +254,8 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].egress.replicas | int | `1` |  |
 | meshes[0].egress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
 | meshes[0].egress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride) |
+| meshes[0].egress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.egress.service.type when unset. |
+| meshes[0].egress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.egress.service.port when unset. |
 | meshes[0].egress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
 | meshes[0].egress.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
 | meshes[0].egress.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-service.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-service.yaml
@@ -1,13 +1,13 @@
 {{- range $meshEntry := .Values.meshes }}
 {{- $meshName := $meshEntry.name }}
 
-{{- /* Build list of enabled roles with their defaults */ -}}
+{{- /* Build list of enabled roles with their defaults from meshZoneProxyDefaults */ -}}
 {{- $roles := list }}
 {{- if and $meshEntry.ingress $meshEntry.ingress.enabled }}
-{{- $roles = append $roles (dict "role" "ingress" "cfg" $meshEntry.ingress "defaultType" "LoadBalancer" "defaultPort" 10001) }}
+{{- $roles = append $roles (dict "role" "ingress" "cfg" $meshEntry.ingress "defaults" $.Values.meshZoneProxyDefaults.ingress) }}
 {{- end }}
 {{- if and $meshEntry.egress $meshEntry.egress.enabled }}
-{{- $roles = append $roles (dict "role" "egress" "cfg" $meshEntry.egress "defaultType" "ClusterIP" "defaultPort" 10002) }}
+{{- $roles = append $roles (dict "role" "egress" "cfg" $meshEntry.egress "defaults" $.Values.meshZoneProxyDefaults.egress) }}
 {{- end }}
 
 {{- range $roleEntry := $roles }}
@@ -29,11 +29,11 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: {{ default $roleEntry.defaultType (and $cfg.service $cfg.service.type) }}
+  type: {{ default $roleEntry.defaults.service.type (and $cfg.service $cfg.service.type) }}
   ports:
-    - port: {{ default $roleEntry.defaultPort (and $cfg.service $cfg.service.port) }}
+    - port: {{ default $roleEntry.defaults.service.port (and $cfg.service $cfg.service.port) }}
       protocol: TCP
-      targetPort: {{ $roleEntry.defaultPort }}
+      targetPort: {{ $roleEntry.defaults.service.port }}
   selector:
     {{- include "kuma.mesh.zoneproxy.selectorLabels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 4 }}
   {{- with (and $cfg.service $cfg.service.spec) }}

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-service.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-service.yaml
@@ -33,7 +33,7 @@ spec:
   ports:
     - port: {{ default $roleEntry.defaults.service.port (and $cfg.service $cfg.service.port) }}
       protocol: TCP
-      targetPort: {{ $roleEntry.defaults.service.port }}
+      targetPort: {{ $roleEntry.defaults.service.targetPort }}
   selector:
     {{- include "kuma.mesh.zoneproxy.selectorLabels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 4 }}
   {{- with (and $cfg.service $cfg.service.spec) }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -823,12 +823,18 @@ meshZoneProxyDefaults:
       type: LoadBalancer
       # -- Default port for zone ingress Service.
       port: 10001
+      # -- Container port the zone ingress listens on. Do not change unless the
+      # zone proxy binary is reconfigured.
+      targetPort: 10001
   egress:
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
       # -- Default port for zone egress Service.
       port: 10002
+      # -- Container port the zone egress listens on. Do not change unless the
+      # zone proxy binary is reconfigured.
+      targetPort: 10002
 
 # List of meshes to deploy zone proxies for.
 meshes:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -814,6 +814,22 @@ zoneProxyImage:
   # -- The pause image tag
   tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
 
+# Default service settings for mesh zone proxies. Used as fallback when
+# meshes[].ingress.service or meshes[].egress.service fields are not set.
+meshZoneProxyDefaults:
+  ingress:
+    service:
+      # -- Default Service type for zone ingress.
+      type: LoadBalancer
+      # -- Default port for zone ingress Service.
+      port: 10001
+  egress:
+    service:
+      # -- Default Service type for zone egress.
+      type: ClusterIP
+      # -- Default port for zone egress Service.
+      port: 10002
+
 # List of meshes to deploy zone proxies for.
 meshes:
   - # -- The mesh must already exist or be created separately; this Helm chart will not create it.
@@ -832,6 +848,12 @@ meshes:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
         name: ""
+        # -- (string) Per-mesh override for Service type. Falls back to
+        # meshZoneProxyDefaults.ingress.service.type when unset.
+        type:
+        # -- (int) Per-mesh override for Service port. Falls back to
+        # meshZoneProxyDefaults.ingress.service.port when unset.
+        port:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
@@ -867,6 +889,12 @@ meshes:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
         name: ""
+        # -- (string) Per-mesh override for Service type. Falls back to
+        # meshZoneProxyDefaults.egress.service.type when unset.
+        type:
+        # -- (int) Per-mesh override for Service port. Falls back to
+        # meshZoneProxyDefaults.egress.service.port when unset.
+        port:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -814,6 +814,28 @@ zoneProxyImage:
   # -- The pause image tag
   tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
 
+# Default service settings for mesh zone proxies. Used as fallback when
+# meshes[].ingress.service or meshes[].egress.service fields are not set.
+meshZoneProxyDefaults:
+  ingress:
+    service:
+      # -- Default Service type for zone ingress.
+      type: LoadBalancer
+      # -- Default port for zone ingress Service.
+      port: 10001
+      # -- Container port the zone ingress listens on. Do not change unless the
+      # zone proxy binary is reconfigured.
+      targetPort: 10001
+  egress:
+    service:
+      # -- Default Service type for zone egress.
+      type: ClusterIP
+      # -- Default port for zone egress Service.
+      port: 10002
+      # -- Container port the zone egress listens on. Do not change unless the
+      # zone proxy binary is reconfigured.
+      targetPort: 10002
+
 # List of meshes to deploy zone proxies for.
 meshes:
   - # -- The mesh must already exist or be created separately; this Helm chart will not create it.
@@ -832,6 +854,12 @@ meshes:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
         name: ""
+        # -- (string) Per-mesh override for Service type. Falls back to
+        # meshZoneProxyDefaults.ingress.service.type when unset.
+        type:
+        # -- (int) Per-mesh override for Service port. Falls back to
+        # meshZoneProxyDefaults.ingress.service.port when unset.
+        port:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
@@ -867,6 +895,12 @@ meshes:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
         name: ""
+        # -- (string) Per-mesh override for Service type. Falls back to
+        # meshZoneProxyDefaults.egress.service.type when unset.
+        type:
+        # -- (int) Per-mesh override for Service port. Falls back to
+        # meshZoneProxyDefaults.egress.service.port when unset.
+        port:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}


### PR DESCRIPTION
## Motivation

The mesh zone proxy Service defaults (type/port/targetPort) were hardcoded in the template, making them invisible to users and impossible to override via parent charts. If these defaults changed in a future chart version, users would get the new values silently on upgrade.

## Implementation information

Add `meshZoneProxyDefaults` section to values.yaml with ingress/egress service defaults. Update the template to reference these values instead of hardcoded strings.

`targetPort` is split from `port` so the listener port on the pod can be documented independently of the Service port (changing it requires reconfiguring the zone proxy binary, but it is now a user-visible knob instead of a hidden constant).

```yaml
meshZoneProxyDefaults:
  ingress:
    service:
      type: LoadBalancer
      port: 10001
      targetPort: 10001
  egress:
    service:
      type: ClusterIP
      port: 10002
      targetPort: 10002
```

Per-mesh overrides via `meshes[].ingress.service.type/port` still work and take precedence.

## Supporting documentation

xrel: https://github.com/Kong/kong-mesh/issues/9409

> Changelog: feat(kuma-cp): add mesh-scoped zone proxies