### PR TITLE
fix(intercp): raise gRPC message size limits to match KDS

### DIFF
--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -150,7 +150,7 @@ func buildRuntime(appCtx context.Context, cfg kuma_cp.Config) (core_runtime.Runt
 	resourceManager := builder.ResourceManager()
 	kdsContext := kds_context.DefaultContext(appCtx, resourceManager, cfg)
 	builder.WithKDSContext(kdsContext)
-	builder.WithInterCPClientPool(intercp.DefaultClientPool())
+	builder.WithInterCPClientPool(intercp.DefaultClientPool(int(cfg.Multizone.Global.KDS.MaxMsgSize)))
 
 	if cfg.Mode == config_core.Global {
 		kdsEnvoyAdminClient := kds_envoyadmin.NewClient(

--- a/pkg/intercp/client/client.go
+++ b/pkg/intercp/client/client.go
@@ -28,7 +28,7 @@ type Conn interface {
 	GetState() connectivity.State
 }
 
-func New(serverURL string, tlsCfg *TLSConfig) (Conn, error) {
+func New(serverURL string, tlsCfg *TLSConfig, maxMsgSize int) (Conn, error) {
 	url, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, err
@@ -54,5 +54,9 @@ func New(serverURL string, tlsCfg *TLSConfig) (Conn, error) {
 	dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler(
 		otelgrpc.WithFilter(filters.Not(filters.ServiceName(system_proto.InterCpPingService_ServiceDesc.ServiceName))),
 	)))
+	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(maxMsgSize),
+		grpc.MaxCallSendMsgSize(maxMsgSize),
+	))
 	return grpc.NewClient(url.Host, dialOpts...)
 }

--- a/pkg/intercp/client/client.go
+++ b/pkg/intercp/client/client.go
@@ -51,12 +51,14 @@ func New(serverURL string, tlsCfg *TLSConfig, maxMsgSize int) (Conn, error) {
 	default:
 		return nil, errors.Errorf("unsupported scheme %q. Use one of %s", url.Scheme, []string{"grpc", "grpcs"})
 	}
-	dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler(
-		otelgrpc.WithFilter(filters.Not(filters.ServiceName(system_proto.InterCpPingService_ServiceDesc.ServiceName))),
-	)))
-	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
-		grpc.MaxCallRecvMsgSize(maxMsgSize),
-		grpc.MaxCallSendMsgSize(maxMsgSize),
-	))
+	dialOpts = append(dialOpts,
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+			otelgrpc.WithFilter(filters.Not(filters.ServiceName(system_proto.InterCpPingService_ServiceDesc.ServiceName))),
+		)),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMsgSize),
+			grpc.MaxCallSendMsgSize(maxMsgSize),
+		),
+	)
 	return grpc.NewClient(url.Host, dialOpts...)
 }

--- a/pkg/intercp/components.go
+++ b/pkg/intercp/components.go
@@ -29,6 +29,7 @@ var log = core.Log.WithName("inter-cp")
 
 func Setup(rt runtime.Runtime) error {
 	cfg := rt.Config().InterCp
+	maxMsgSize := int(rt.Config().Multizone.Global.KDS.MaxMsgSize)
 	defaults := &intercp_tls.DefaultsComponent{
 		ResManager: rt.ResourceManager(),
 		Log:        log.WithName("defaults"),
@@ -58,7 +59,7 @@ func Setup(rt runtime.Runtime) error {
 			ClientCert: certs.client,
 		})
 
-		interCpServer, err := server.New(cfg.Server, rt.Metrics(), certs.server, certs.ca, instance.Id)
+		interCpServer, err := server.New(cfg.Server, rt.Metrics(), certs.server, certs.ca, instance.Id, maxMsgSize)
 		if err != nil {
 			return errors.Wrap(err, "could not start inter-cp server")
 		}
@@ -97,8 +98,10 @@ func Setup(rt runtime.Runtime) error {
 	)
 }
 
-func DefaultClientPool() *client.Pool {
-	return client.NewPool(client.New, 5*time.Minute, core.Now)
+func DefaultClientPool(maxMsgSize int) *client.Pool {
+	return client.NewPool(func(serverURL string, tlsCfg *client.TLSConfig) (client.Conn, error) {
+		return client.New(serverURL, tlsCfg, maxMsgSize)
+	}, 5*time.Minute, core.Now)
 }
 
 func PooledEnvoyAdminClientFn(pool *client.Pool) envoyadmin.NewClientFn {

--- a/pkg/intercp/server/server.go
+++ b/pkg/intercp/server/server.go
@@ -47,9 +47,12 @@ func New(
 	certificate tls.Certificate,
 	caCert x509.Certificate,
 	instanceId string,
+	maxMsgSize int,
 ) (*InterCpServer, error) {
 	grpcOptions := []grpc.ServerOption{
 		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
+		grpc.MaxRecvMsgSize(maxMsgSize),
+		grpc.MaxSendMsgSize(maxMsgSize),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time:    grpcKeepAliveTime,
 			Timeout: grpcKeepAliveTime,

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -126,7 +126,7 @@ func BuilderFor(appCtx context.Context, cfg kuma_cp.Config) (*core_runtime.Build
 		DataplaneToken: tokens_builtin.NewDataplaneTokenIssuer(builder.ResourceManager()),
 		ZoneToken:      tokens_builtin.NewZoneTokenIssuer(builder.ResourceManager()),
 	})
-	builder.WithInterCPClientPool(intercp.DefaultClientPool())
+	builder.WithInterCPClientPool(intercp.DefaultClientPool(int(builder.Config().Multizone.Global.KDS.MaxMsgSize)))
 	builder.WithMultitenancy(multitenant.SingleTenant)
 	builder.WithPgxConfigCustomizationFn(config.NoopPgxConfigCustomizationFn)
 


### PR DESCRIPTION
## Motivation

When running Global CP in HA mode (multiple instances), admin operations like config dump are forwarded between instances over the inter-CP gRPC channel. That channel was using gRPC's default 4MB message limit, which caused `ResourceExhausted` errors for data planes with a large Envoy config.

## Implementation information

The fix raises the limit on both sides (server and client), tying it to `Multizone.Global.KDS.MaxMsgSize`, the same config that already controls the KDS mux channel, so there is one place to tune rather than two.
