### PR TITLE
fix(meshaccesslog): deduplicate access logs for shared inbound port

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -160,6 +160,7 @@ func applyToInbounds(
 	workloadKRI string,
 	inboundTagsDisabled bool,
 ) error {
+	configured := map[core_rules.InboundListener]struct{}{}
 	for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
 		iface := dataplane.Spec.Networking.ToInboundInterface(inbound)
 
@@ -167,10 +168,14 @@ func applyToInbounds(
 			Address: iface.DataplaneIP,
 			Port:    iface.DataplanePort,
 		}
+		if _, ok := configured[listenerKey]; ok {
+			continue
+		}
 		listener, ok := inboundListeners[listenerKey]
 		if !ok {
 			continue
 		}
+		configured[listenerKey] = struct{}{}
 		protocol := core_meta.ParseProtocol(inbound.GetProtocolFallback())
 		conf := rules_inbound.MatchesAllIncomingTraffic[api.Conf](rules.InboundRules[listenerKey])
 		kumaValues := listeners_v3.KumaValues{

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -82,6 +82,7 @@ var _ = Describe("MeshAccessLog", func() {
 		dataplaneLabels     map[string]string
 		inboundTagsDisabled bool
 		inboundName         string
+		extraInbounds       []*builders.InboundBuilder
 	}
 	DescribeTable("should generate proper Envoy config",
 		func(given sidecarTestCase) {
@@ -123,6 +124,9 @@ var _ = Describe("MeshAccessLog", func() {
 				WithName("backend").
 				WithMesh("default").
 				AddInbound(inboundBuilder)
+			for _, extra := range given.extraInbounds {
+				dpBuilder = dpBuilder.AddInbound(extra)
+			}
 			if given.dataplaneLabels != nil {
 				dpBuilder = dpBuilder.WithLabels(given.dataplaneLabels)
 			}
@@ -737,6 +741,65 @@ var _ = Describe("MeshAccessLog", func() {
 				},
 			},
 			expectedListeners: []string{"inbound_route.listener.golden.yaml"},
+		}),
+		Entry("inbound with two services on the same port does not duplicate access log", sidecarTestCase{
+			resources: []core_xds.Resource{{
+				Name:   "inbound",
+				Origin: metadata.OriginInbound,
+				Resource: NewInboundListenerBuilder(envoy_common.APIV3, "127.0.0.1", 17777, core_xds.SocketAddressProtocolTCP).
+					Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
+						Configure(HttpConnectionManager("127.0.0.1:17777", false, nil, true)).
+						Configure(
+							HttpInboundRoutes(
+								envoy_names.GetInboundRouteName("backend"),
+								"backend",
+								envoy_common.Routes{
+									{
+										Clusters: []envoy_common.Cluster{envoy_common.NewCluster(
+											envoy_common.WithService("backend"),
+											envoy_common.WithWeight(100),
+										)},
+									},
+								},
+							),
+						),
+					)).MustBuild(),
+			}},
+			extraInbounds: []*builders.InboundBuilder{
+				builders.Inbound().
+					WithService("backend-canary").
+					WithAddress("127.0.0.1").
+					WithPort(17777).
+					WithTags(map[string]string{
+						mesh_proto.ProtocolTag: "http",
+					}),
+			},
+			fromRules: core_rules.FromRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "127.0.0.1", Port: 17777}: {{
+						Subset: subsetutils.Subset{},
+						Conf: api.Conf{
+							Backends: &[]api.Backend{{
+								File: &api.FileBackend{
+									Path: "/tmp/log",
+								},
+							}},
+						},
+					}},
+				},
+				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
+					{Address: "127.0.0.1", Port: 17777}: {{
+						Conf: &api.Rule{Default: api.Conf{
+							Backends: &[]api.Backend{{
+								File: &api.FileBackend{
+									Path: "/tmp/log",
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			expectedListeners: []string{"inbound_route_duplicate_port.listener.golden.yaml"},
 		}),
 		Entry("inbound route with inbound tags disabled", sidecarTestCase{
 			resources: []core_xds.Resource{{

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/inbound_route_duplicate_port.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/inbound_route_duplicate_port.listener.golden.yaml
@@ -1,0 +1,47 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 17777
+enableReusePort: false
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      accessLog:
+      - name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "unknown" "backend" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/log
+      httpFilters:
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      internalAddressConfig:
+        cidrRanges:
+        - addressPrefix: 127.0.0.1
+          prefixLen: 32
+        - addressPrefix: ::1
+          prefixLen: 128
+      routeConfig:
+        name: inbound:backend
+        requestHeadersToRemove:
+        - x-kuma-tags
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: backend
+          routes:
+          - match:
+              prefix: /
+            route:
+              cluster: backend
+              timeout: 0s
+      statPrefix: "127_0_0_1_17777"
+name: inbound:127.0.0.1:17777
+trafficDirection: INBOUND


### PR DESCRIPTION
## Motivation

When a Kubernetes pod exposes multiple services on the same port (e.g., stable + canary), the dataplane spec contains multiple inbound entries with the same `IP:port`. `MeshAccessLog` iterated over all inbounds and called `configureListener` on the same listener pointer for each match, appending access log entries repeatedly. `applyToInbounds` now tracks configured listener keys and skips duplicates.

## Implementation information

  - `applyToInbounds`: skip inbounds that map to an already-configured listener
  - Added a regression test with two inbounds sharing the same port
