### PR TITLE
feat(xds): expose delta xDS via Helm and fix k8s injection

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -1106,6 +1106,8 @@ experimental:
   inboundTagsDisabled: false
   # -- If true, Envoy admin API binds to a Unix domain socket instead of TCP.
   envoyAdminUnixSocket: true
+  # -- If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW).
+  deltaXds: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -334,6 +334,7 @@ A Helm chart for the Kuma Control Plane
 | experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
 | experimental.inboundTagsDisabled | bool | `false` | If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching. |
 | experimental.envoyAdminUnixSocket | bool | `true` | If true, Envoy admin API binds to a Unix domain socket instead of TCP. |
+| experimental.deltaXds | bool | `false` | If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW). |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |
 | postgres.tls.mode | string | `"disable"` | Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull" |
 | postgres.tls.disableSSLSNI | bool | `false` | Whether to disable SNI the postgres `sslsni` option. |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -337,6 +337,10 @@ env:
 - name: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
   value: "true"
 {{- end }}
+{{- if .Values.experimental.deltaXds }}
+- name: KUMA_EXPERIMENTAL_DELTA_XDS
+  value: "true"
+{{- end }}
 - name: KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET
   value: {{ .Values.experimental.envoyAdminUnixSocket | quote }}
 {{- if and .Values.cni.enabled .Values.cni.taintController.enabled }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -1106,6 +1106,8 @@ experimental:
   inboundTagsDisabled: false
   # -- If true, Envoy admin API binds to a Unix domain socket instead of TCP.
   envoyAdminUnixSocket: true
+  # -- If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW).
+  deltaXds: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -1106,6 +1106,8 @@ experimental:
   inboundTagsDisabled: false
   # -- If true, Envoy admin API binds to a Unix domain socket instead of TCP.
   envoyAdminUnixSocket: true
+  # -- If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW).
+  deltaXds: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -41,6 +41,7 @@ type DataplaneProxyFactory struct {
 	unifiedResourceNamingEnabled bool
 	otelPipeEnabled              bool
 	spireEnabled                 bool
+	deltaXdsEnabled              bool
 }
 
 func NewDataplaneProxyFactory(
@@ -58,6 +59,7 @@ func NewDataplaneProxyFactory(
 	unifiedResourceNamingEnabled bool,
 	otelPipeEnabled bool,
 	spireEnabled bool,
+	deltaXdsEnabled bool,
 ) *DataplaneProxyFactory {
 	return &DataplaneProxyFactory{
 		ControlPlaneURL:              controlPlaneURL,
@@ -74,6 +76,7 @@ func NewDataplaneProxyFactory(
 		unifiedResourceNamingEnabled: unifiedResourceNamingEnabled,
 		otelPipeEnabled:              otelPipeEnabled,
 		spireEnabled:                 spireEnabled,
+		deltaXdsEnabled:              deltaXdsEnabled,
 	}
 }
 
@@ -369,6 +372,13 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 		envVars["KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED"] = kube_core.EnvVar{
 			Name:  "KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED",
 			Value: "true",
+		}
+	}
+
+	if i.deltaXdsEnabled {
+		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT"] = kube_core.EnvVar{
+			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+			Value: "DELTA_GRPC",
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -310,6 +310,12 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 			Value: "true",
 		}
 	}
+	if i.deltaXdsEnabled {
+		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT"] = kube_core.EnvVar{
+			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+			Value: "DELTA_GRPC",
+		}
+	}
 	if xdsTransportProtocol, exist := metadata.Annotations(podAnnotations).GetString(metadata.KumaXdsTransportProtocolVariant); exist {
 		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT"] = kube_core.EnvVar{
 			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
@@ -372,13 +378,6 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 		envVars["KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED"] = kube_core.EnvVar{
 			Name:  "KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED",
 			Value: "true",
-		}
-	}
-
-	if i.deltaXdsEnabled {
-		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT"] = kube_core.EnvVar{
-			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
-			Value: "DELTA_GRPC",
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -405,6 +405,7 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 			rt.Config().BootstrapServer.Params.EnvoyAdminUnixSocket,
 			rt.Config().Store.Kubernetes.SystemNamespace,
 			rt.Metrics(),
+			rt.Config().Experimental.DeltaXds,
 		)
 		if err != nil {
 			return err

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -96,7 +96,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 		cpURL, caCert, rt.Config().GetEnvoyAdminPort(), rt.Config().GetEnvoyReadinessPort(),
 		cfg.SidecarContainer.DataplaneContainer, cfg.BuiltinDNS,
 		false, rt.Config().BootstrapServer.Params.EnvoyAdminUnixSocket, false, false, 0,
-		cfg.UnifiedResourceNamingEnabled, cfg.OtelPipeEnabled, cfg.Spire.Enabled,
+		cfg.UnifiedResourceNamingEnabled, cfg.OtelPipeEnabled, cfg.Spire.Enabled, rt.Config().Experimental.DeltaXds,
 	)
 
 	kubeConfig := mgr.GetConfig()

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -107,6 +107,7 @@ func New(
 	envoyAdminUnixSocket bool,
 	systemNamespace string,
 	metrics core_metrics.Metrics,
+	deltaXdsEnabled bool,
 ) (*KumaInjector, error) {
 	var caCert string
 	if cfg.CaCertFile != "" {
@@ -138,7 +139,7 @@ func New(
 			cfg.BuiltinDNS, cfg.SidecarContainer.WaitForDataplaneReady, envoyAdminUnixSocket,
 			sidecarContainersEnabled,
 			cfg.VirtualProbesEnabled, cfg.ApplicationProbeProxyPort, cfg.UnifiedResourceNamingEnabled,
-			cfg.OtelPipeEnabled, cfg.Spire.Enabled,
+			cfg.OtelPipeEnabled, cfg.Spire.Enabled, deltaXdsEnabled,
 		),
 		systemNamespace: systemNamespace,
 		metrics:         im,

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -92,7 +92,7 @@ spec:
 				var cfg conf.Injector
 				Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 				cfg.CaCertFile = caCertPath
-				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, sidecarsEnabled, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
+				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, sidecarsEnabled, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				// and create mesh
@@ -887,7 +887,7 @@ spec:
 			var cfg conf.Injector
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -993,7 +993,7 @@ spec:
 			var cfg conf.Injector
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -1064,4 +1064,119 @@ spec:
 			cfgFile: "inject.config.yaml",
 		}),
 	)
+
+	Describe("delta xDS injection", func() {
+		const (
+			defaultMesh = `
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default`
+			defaultNamespace = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kuma.io/sidecar-injection: enabled`
+		)
+
+		newInjector := func(deltaXdsEnabled bool) *inject.KumaInjector {
+			var cfg conf.Injector
+			ExpectWithOffset(1, config.Load(filepath.Join("testdata", "inject.config.yaml"), &cfg)).To(Succeed())
+			cfg.CaCertFile = caCertPath
+			inj, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil, deltaXdsEnabled)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			return inj
+		}
+
+		injectPod := func(injector *inject.KumaInjector, podYAML string) *kube_core.Pod {
+			decoder := serializer.NewCodecFactory(k8sClientScheme).UniversalDeserializer()
+
+			obj, _, err := decoder.Decode([]byte(defaultMesh), nil, nil)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, k8sClient.Create(context.Background(), obj.(kube_client.Object))).To(Succeed())
+
+			ns, _, err := decoder.Decode([]byte(defaultNamespace), nil, nil)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, k8sClient.Update(context.Background(), ns.(kube_client.Object))).To(Succeed())
+
+			pod := &kube_core.Pod{}
+			ExpectWithOffset(1, yaml.Unmarshal([]byte(podYAML), pod)).To(Succeed())
+			ExpectWithOffset(1, injector.InjectKuma(context.Background(), pod)).To(Succeed())
+			return pod
+		}
+
+		sidecarEnv := func(pod *kube_core.Pod) []kube_core.EnvVar {
+			for _, c := range pod.Spec.Containers {
+				if c.Name == k8s_util.KumaSidecarContainerName {
+					return c.Env
+				}
+			}
+			return nil
+		}
+
+		It("sets DELTA_GRPC transport on the injected sidecar", func() {
+			pod := injectPod(newInjector(true), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox`)
+
+			Expect(sidecarEnv(pod)).To(ContainElement(kube_core.EnvVar{
+				Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+				Value: "DELTA_GRPC",
+			}))
+		})
+
+		It("allows per-pod xds-transport-protocol-variant annotation to override deltaXds", func() {
+			// The per-pod annotation is applied after deltaXdsEnabled, so it takes precedence.
+			pod := injectPod(newInjector(true), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  annotations:
+    kuma.io/xds-transport-protocol-variant: "GRPC"
+  labels:
+    run: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox`)
+
+			Expect(sidecarEnv(pod)).To(ContainElement(kube_core.EnvVar{
+				Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+				Value: "GRPC",
+			}))
+		})
+
+		It("allows kuma.io/sidecar-env-vars to override the transport variant", func() {
+			// sidecar-env-vars runs after deltaXdsEnabled, so the annotation wins.
+			pod := injectPod(newInjector(true), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  annotations:
+    kuma.io/sidecar-env-vars: "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT=GRPC"
+  labels:
+    run: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox`)
+
+			Expect(sidecarEnv(pod)).To(ContainElement(kube_core.EnvVar{
+				Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+				Value: "GRPC",
+			}))
+		})
+	})
 }, Ordered)


### PR DESCRIPTION
## Motivation

Delta xDS (DELTA_GRPC transport) was already wired into the Go config and xDS bootstrap code but had no way to enable it through Helm. The only workaround was patching `controlPlane.config` manually. This adds `experimental.deltaXds` to the chart so the flag is installable the normal way. Also, it was missing injection on k8s level.

## Implementation information

Added `experimental.deltaXds (default: false)` to the Helm values and wired `KUMA_EXPERIMENTAL_DELTA_XDS` into the control plane deployment. DataplaneProxyFactory and KumaInjector now accept the flag; when it's on, every injected sidecar gets `KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT=DELTA_GRPC`.


Fix: https://github.com/kumahq/kuma/issues/16405