### PR TITLE
fix(kuma-cp): expose deltaXds via Helm

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -1102,6 +1102,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, use Delta xDS to deliver configuration changes to sidecars.
+  deltaXds: false
   # -- If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching.
   inboundTagsDisabled: false
   # -- If true, Envoy admin API binds to a Unix domain socket instead of TCP.

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -332,6 +332,7 @@ A Helm chart for the Kuma Control Plane
 | experimental.ebpf.tcAttachIface | string | `""` | Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty |
 | experimental.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs which will be installed can be found |
 | experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
+| experimental.deltaXds | bool | `false` | If true, use Delta xDS to deliver configuration changes to sidecars. |
 | experimental.inboundTagsDisabled | bool | `false` | If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching. |
 | experimental.envoyAdminUnixSocket | bool | `true` | If true, Envoy admin API binds to a Unix domain socket instead of TCP. |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -333,6 +333,10 @@ env:
 - name: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   value: "true"
 {{- end }}
+{{- if .Values.experimental.deltaXds }}
+- name: KUMA_EXPERIMENTAL_DELTA_XDS
+  value: "true"
+{{- end }}
 {{- if .Values.experimental.inboundTagsDisabled }}
 - name: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
   value: "true"

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -1102,6 +1102,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, use Delta xDS to deliver configuration changes to sidecars.
+  deltaXds: false
   # -- If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching.
   inboundTagsDisabled: false
   # -- If true, Envoy admin API binds to a Unix domain socket instead of TCP.

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -1102,6 +1102,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, use Delta xDS to deliver configuration changes to sidecars.
+  deltaXds: false
   # -- If true, inbound tags are not generated for dataplanes. Used with label-based MeshService matching.
   inboundTagsDisabled: false
   # -- If true, Envoy admin API binds to a Unix domain socket instead of TCP.


### PR DESCRIPTION
## Motivation
Delta XDS was missing from helm

## Implementation
- expose experimental.deltaXds in Helm values
- map the value to KUMA_EXPERIMENTAL_DELTA_XDS in control-plane env vars
- include regenerated Helm docs output

fix https://github.com/kumahq/kuma/issues/16405