### PR TITLE
fix(api-server): harden localhost admin auth

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,7 +32,39 @@ Or via environment variable: `KUMA_DNS_SERVER_DOMAIN=mesh`
 
 Review your `HostnameGenerator` resources and ensure their `spec.template` values produce valid [RFC 1123](https://tools.ietf.org/html/rfc1123) DNS subdomains for all inputs.
 
+### localhost-admin is restricted to direct loopback; CORS is now opt-in
 
+The defaults have been tightened:
+
+- `LocalhostIsAdmin` still defaults to `true`, but only direct loopback requests are promoted to admin.
+- `CorsAllowedDomains` now defaults to `[]` / empty (was `[".*"]`).
+
+The `LocalhostIsAdmin` restriction also applies to release branches as a security fix: the authenticator now only grants admin when the request is a **direct** loopback call (loopback `RemoteAddr`, loopback `Host`, no proxy-hop headers, and a matching `Origin` if present). Browsers connecting over loopback from a non-localhost page are no longer promoted to admin.
+
+**Action required:**
+
+_Local bootstrap / development (Universal mode)_
+
+If you rely on `LocalhostIsAdmin` for initial kumactl setup, keep using direct loopback access or switch to token-based authentication with `kumactl config control-planes add --auth-type=tokens`.
+
+_Reverse-proxy / CORS users_
+
+If your deployment relies on cross-origin API access (e.g., a custom GUI on a different port), set the allowed domains explicitly:
+
+```yaml
+# kuma-cp config
+apiServer:
+  corsAllowedDomains:
+    - "https://my-gui.example.com"
+```
+
+or via environment variable:
+
+```sh
+KUMA_API_SERVER_CORS_ALLOWED_DOMAINS=https://my-gui.example.com
+```
+
+The Helm chart already sets `KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN=false` and is not affected by the `LocalhostIsAdmin` default.
 
 ### CPU limits removed from `kuma-init` and `kuma-sidecar` containers
 

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -200,8 +200,7 @@ apiServer:
   # If true, then API Server will operate in read only mode (serving GET requests)
   readOnly: false # ENV: KUMA_API_SERVER_READ_ONLY
   # Allowed domains for Cross-Origin Resource Sharing. The value can be either domain or regexp
-  corsAllowedDomains:
-    - ".*" # ENV: KUMA_API_SERVER_CORS_ALLOWED_DOMAINS
+  corsAllowedDomains: [] # ENV: KUMA_API_SERVER_CORS_ALLOWED_DOMAINS
   # Can be used if you use a reverse proxy
   rootUrl: "" # ENV: KUMA_API_SERVER_ROOT_URL
   # The path to serve the API from

--- a/pkg/api-server/api_server_suite_test.go
+++ b/pkg/api-server/api_server_suite_test.go
@@ -71,6 +71,9 @@ func NewTestApiServerConfigurer() *testApiServerConfigurer {
 		store:  memory.NewStore(),
 	}
 	t.config.GUI.Enabled = false
+	t.config.HTTP.Interface = "127.0.0.1"
+	t.config.HTTPS.Interface = "127.0.0.1"
+	t.config.Authn.LocalhostIsAdmin = true
 	return t
 }
 

--- a/pkg/api-server/auth_test.go
+++ b/pkg/api-server/auth_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Auth test", func() {
 			cfg.HTTPS.TlsCertFile = certPath
 			cfg.HTTPS.TlsKeyFile = keyPath
 			cfg.Authn.Type = certs.PluginName
+			cfg.Authn.LocalhostIsAdmin = true
 			cfg.Auth.ClientCertsDir = filepath.Join("..", "..", "test", "certs", "client")
 		}).WithAccessConfigMutator(func(cfg *access.AccessConfig) {
 			cfg.Static.ControlPlaneMetadata.Groups = []string{"mesh-system:authenticated"}
@@ -118,6 +119,49 @@ var _ = Describe("Auth test", func() {
 		// then
 		Expect(rr.Code).To(Equal(403))
 		Expect(rr.Body.Bytes()).To(matchers.MatchGoldenJSON(path.Join("testdata", "auth-admin-https-bad-creds.golden.json")))
+	})
+
+	It("should block admin access when Origin is a cross-origin domain (PoC for H1 #3631894)", func() {
+		// This simulates a browser fetch() from evil.com to localhost:5681.
+		// The browser connects over loopback, but the Origin header reveals a
+		// non-localhost origin.  LocalhostAuthenticator must NOT grant admin.
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/secrets", http.NoBody)
+		req.RemoteAddr = "127.0.0.1:54321"
+		req.Host = fmt.Sprintf("localhost:%d", httpPort)
+		req.Header.Set("Origin", "https://evil.com")
+		rr := httptest.NewRecorder()
+		apiServer.Handler().ServeHTTP(rr, req)
+
+		// then
+		Expect(rr.Code).To(Equal(403))
+	})
+
+	It("should grant admin when Origin is same-origin localhost (GUI use case)", func() {
+		// Simulates the Kuma GUI: browser on localhost fetching from the same
+		// localhost:port.  Origin matches Host, so admin should be granted.
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/secrets", http.NoBody)
+		req.RemoteAddr = "127.0.0.1:54321"
+		req.Host = fmt.Sprintf("localhost:%d", httpPort)
+		req.Header.Set("Origin", fmt.Sprintf("http://localhost:%d", httpPort))
+		rr := httptest.NewRecorder()
+		apiServer.Handler().ServeHTTP(rr, req)
+
+		// then
+		Expect(rr.Code).To(Equal(200))
+	})
+
+	It("should block admin when a proxy header is present on a loopback request", func() {
+		// X-Forwarded-For on a loopback-sourced request signals a reverse proxy
+		// laundering remote traffic.  Admin must be denied.
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/secrets", http.NoBody)
+		req.RemoteAddr = "127.0.0.1:54321"
+		req.Host = fmt.Sprintf("localhost:%d", httpPort)
+		req.Header.Set("X-Forwarded-For", "203.0.113.1")
+		rr := httptest.NewRecorder()
+		apiServer.Handler().ServeHTTP(rr, req)
+
+		// then
+		Expect(rr.Code).To(Equal(403))
 	})
 
 	It("should be able to access config on localhost using HTTP", func() {

--- a/pkg/api-server/authn/authn_suite_test.go
+++ b/pkg/api-server/authn/authn_suite_test.go
@@ -1,0 +1,11 @@
+package authn_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestAuthn(t *testing.T) {
+	test.RunSpecs(t, "Authn Suite")
+}

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -2,25 +2,85 @@ package authn
 
 import (
 	"net"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/emicklei/go-restful/v3"
 
 	"github.com/kumahq/kuma/v2/pkg/core"
-	rest_errors "github.com/kumahq/kuma/v2/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v2/pkg/core/user"
 )
 
 var log = core.Log.WithName("api-server").WithName("authn")
 
 func LocalhostAuthenticator(request *restful.Request, response *restful.Response, chain *restful.FilterChain) {
-	host, _, err := net.SplitHostPort(request.Request.RemoteAddr)
-	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not parse Remote Address from the Request")
-		return
-	}
-	if host == "127.0.0.1" || host == "::1" {
-		log.V(1).Info("authenticated as admin because requests originates from the same machine")
+	if isDirectLoopbackRequest(request.Request) {
+		log.V(1).Info("authenticated as admin because request is a direct localhost call")
 		request.Request = request.Request.WithContext(user.Ctx(request.Request.Context(), user.Admin.Authenticated()))
 	}
 	chain.ProcessFilter(request, response)
+}
+
+// isDirectLoopbackRequest returns true only when all four conditions hold:
+//   - RemoteAddr is a loopback literal (127.0.0.1 or ::1),
+//   - no proxy-hop headers are present (Forwarded, X-Forwarded-For, X-Real-IP),
+//   - the Host header is itself a loopback literal, and
+//   - if an Origin header is present it is same-origin with the Host.
+//
+// This prevents browsers on the same machine, which connect over loopback,
+// from triggering admin access on behalf of a non-localhost origin.
+func isDirectLoopbackRequest(r *http.Request) bool {
+	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil || !isLoopbackLiteral(remoteHost) {
+		return false
+	}
+	if hasProxyHeaders(r.Header) {
+		return false
+	}
+	if !isLoopbackLiteral(hostWithoutPort(r.Host)) {
+		return false
+	}
+	if r.Header.Get("Sec-Fetch-Site") == "cross-site" {
+		return false
+	}
+	return isSameOriginLoopback(r.Header.Get("Origin"), r.Host)
+}
+
+func isLoopbackLiteral(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func hostWithoutPort(hostport string) string {
+	host, _, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return hostport
+	}
+	return host
+}
+
+func hasProxyHeaders(h http.Header) bool {
+	return h.Get("Forwarded") != "" || h.Get("X-Forwarded-For") != "" || h.Get("X-Real-IP") != ""
+}
+
+func isSameOriginLoopback(origin, requestHost string) bool {
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	if !isLoopbackLiteral(u.Hostname()) {
+		return false
+	}
+	return strings.EqualFold(u.Host, requestHost)
 }

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -53,7 +53,9 @@ func isLoopbackHost(host string) bool {
 	if host == "localhost" {
 		return true
 	}
-	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
 }

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -22,23 +22,24 @@ func LocalhostAuthenticator(request *restful.Request, response *restful.Response
 	chain.ProcessFilter(request, response)
 }
 
-// isDirectLoopbackRequest returns true only when all four conditions hold:
-//   - RemoteAddr is a loopback literal (127.0.0.1 or ::1),
+// isDirectLoopbackRequest returns true only when all conditions hold:
+//   - RemoteAddr is a loopback address,
 //   - no proxy-hop headers are present (Forwarded, X-Forwarded-For, X-Real-IP),
-//   - the Host header is itself a loopback literal, and
+//   - the Host header is localhost or a loopback address,
+//   - the browser did not mark the request as cross-site, and
 //   - if an Origin header is present it is same-origin with the Host.
 //
 // This prevents browsers on the same machine, which connect over loopback,
 // from triggering admin access on behalf of a non-localhost origin.
 func isDirectLoopbackRequest(r *http.Request) bool {
 	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil || !isLoopbackLiteral(remoteHost) {
+	if err != nil || !isLoopbackHost(remoteHost) {
 		return false
 	}
 	if hasProxyHeaders(r.Header) {
 		return false
 	}
-	if !isLoopbackLiteral(hostWithoutPort(r.Host)) {
+	if !isLoopbackHost(hostWithoutPort(r.Host)) {
 		return false
 	}
 	if r.Header.Get("Sec-Fetch-Site") == "cross-site" {
@@ -47,7 +48,7 @@ func isDirectLoopbackRequest(r *http.Request) bool {
 	return isSameOriginLoopback(r.Header.Get("Origin"), r.Host)
 }
 
-func isLoopbackLiteral(host string) bool {
+func isLoopbackHost(host string) bool {
 	host = strings.TrimSuffix(strings.ToLower(host), ".")
 	if host == "localhost" {
 		return true
@@ -79,7 +80,7 @@ func isSameOriginLoopback(origin, requestHost string) bool {
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return false
 	}
-	if !isLoopbackLiteral(u.Hostname()) {
+	if !isLoopbackHost(u.Hostname()) {
 		return false
 	}
 	return strings.EqualFold(u.Host, requestHost)

--- a/pkg/api-server/authn/localhost.go
+++ b/pkg/api-server/authn/localhost.go
@@ -53,6 +53,7 @@ func isLoopbackHost(host string) bool {
 	if host == "localhost" {
 		return true
 	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
 }

--- a/pkg/api-server/authn/localhost_test.go
+++ b/pkg/api-server/authn/localhost_test.go
@@ -53,6 +53,8 @@ var _ = Describe("LocalhostAuthenticator", func() {
 			"127.0.0.1:54321", "localhost:5681", "", nil, true),
 		Entry("direct loopback IPv6, no Origin",
 			"[::1]:54321", "localhost:5681", "", nil, true),
+		Entry("direct loopback IPv6 Host without explicit port",
+			"[::1]:54321", "[::1]", "", nil, true),
 		Entry("direct loopback, same-origin http://localhost",
 			"127.0.0.1:54321", "localhost:5681", "http://localhost:5681", nil, true),
 		Entry("direct loopback, same-origin http://127.0.0.1",

--- a/pkg/api-server/authn/localhost_test.go
+++ b/pkg/api-server/authn/localhost_test.go
@@ -1,0 +1,84 @@
+package authn_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v2/pkg/api-server/authn"
+	"github.com/kumahq/kuma/v2/pkg/core/user"
+)
+
+// runLocalhost runs LocalhostAuthenticator with the given request parameters
+// and returns the name of the resulting user from context.
+func runLocalhost(remoteAddr, host, origin string, extraHeaders map[string]string) string {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+host+"/test", http.NoBody)
+	req.RemoteAddr = remoteAddr
+	req.Host = host
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	rr := httptest.NewRecorder()
+	restfulReq := &restful.Request{Request: req}
+	restfulResp := restful.NewResponse(rr)
+
+	chain := &restful.FilterChain{
+		Target: func(_ *restful.Request, _ *restful.Response) {},
+	}
+	authn.LocalhostAuthenticator(restfulReq, restfulResp, chain)
+
+	return user.FromCtx(restfulReq.Request.Context()).Name
+}
+
+var _ = Describe("LocalhostAuthenticator", func() {
+	DescribeTable("direct loopback requests",
+		func(remoteAddr, host, origin string, extraHeaders map[string]string, expectAdmin bool) {
+			name := runLocalhost(remoteAddr, host, origin, extraHeaders)
+			if expectAdmin {
+				Expect(name).To(Equal(user.Admin.Name))
+			} else {
+				Expect(name).NotTo(Equal(user.Admin.Name))
+			}
+		},
+		// Admin-granted cases
+		Entry("direct loopback IPv4, no Origin",
+			"127.0.0.1:54321", "localhost:5681", "", nil, true),
+		Entry("direct loopback IPv6, no Origin",
+			"[::1]:54321", "localhost:5681", "", nil, true),
+		Entry("direct loopback, same-origin http://localhost",
+			"127.0.0.1:54321", "localhost:5681", "http://localhost:5681", nil, true),
+		Entry("direct loopback, same-origin http://127.0.0.1",
+			"127.0.0.1:54321", "127.0.0.1:5681", "http://127.0.0.1:5681", nil, true),
+		Entry("direct loopback, same-origin Host case",
+			"127.0.0.1:54321", "LOCALHOST:5681", "http://localhost:5681", nil, true),
+		// Blocked cases
+		Entry("cross-origin evil.com",
+			"127.0.0.1:54321", "localhost:5681", "https://evil.com", nil, false),
+		Entry("cross-site browser request without Origin",
+			"127.0.0.1:54321", "localhost:5681", "", map[string]string{"Sec-Fetch-Site": "cross-site"}, false),
+		Entry("cross-origin local app on different port",
+			"127.0.0.1:54321", "localhost:5681", "http://127.0.0.1:3000", nil, false),
+		Entry("X-Forwarded-For header present",
+			"127.0.0.1:54321", "localhost:5681", "", map[string]string{"X-Forwarded-For": "1.2.3.4"}, false),
+		Entry("Forwarded header present",
+			"127.0.0.1:54321", "localhost:5681", "", map[string]string{"Forwarded": "for=1.2.3.4"}, false),
+		Entry("X-Real-IP header present",
+			"127.0.0.1:54321", "localhost:5681", "", map[string]string{"X-Real-IP": "1.2.3.4"}, false),
+		Entry("non-loopback Host (reverse proxy public domain)",
+			"127.0.0.1:54321", "api.example.com", "", nil, false),
+		Entry("Origin: null",
+			"127.0.0.1:54321", "localhost:5681", "null", nil, false),
+		Entry("malformed Origin",
+			"127.0.0.1:54321", "localhost:5681", "not-a-url", nil, false),
+		Entry("remote RemoteAddr is not granted admin",
+			"203.0.113.1:54321", "localhost:5681", "", nil, false),
+	)
+})

--- a/pkg/api-server/authn/localhost_test.go
+++ b/pkg/api-server/authn/localhost_test.go
@@ -16,7 +16,7 @@ import (
 // runLocalhost runs LocalhostAuthenticator with the given request parameters
 // and returns the name of the resulting user from context.
 func runLocalhost(remoteAddr, host, origin string, extraHeaders map[string]string) string {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+host+"/test", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost/test", http.NoBody)
 	req.RemoteAddr = remoteAddr
 	req.Host = host
 	if origin != "" {
@@ -76,6 +76,8 @@ var _ = Describe("LocalhostAuthenticator", func() {
 			"127.0.0.1:54321", "localhost:5681", "", map[string]string{"X-Real-IP": "1.2.3.4"}, false),
 		Entry("non-loopback Host (reverse proxy public domain)",
 			"127.0.0.1:54321", "api.example.com", "", nil, false),
+		Entry("malformed bracketed IPv6 Host",
+			"[::1]:54321", "[::1", "", nil, false),
 		Entry("Origin: null",
 			"127.0.0.1:54321", "localhost:5681", "null", nil, false),
 		Entry("malformed Origin",

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -15,6 +15,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	api_server "github.com/kumahq/kuma/v2/pkg/api-server"
+	config "github.com/kumahq/kuma/v2/pkg/config/api-server"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
@@ -59,6 +60,9 @@ var _ = Describe("Resource Endpoints", func() {
 			m, _ := core_metrics.NewMetrics("Zone")
 			metrics = m
 			return m
+		}).WithConfigMutator(func(cfg *config.ApiServerConfig) {
+			cfg.CorsAllowedDomains = []string{".*"}
+			cfg.Authn.LocalhostIsAdmin = true
 		}))
 	})
 

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -126,12 +126,14 @@ func NewApiServer(
 	}
 	container.Filter(rt.APIServerAuthenticator())
 
-	cors := restful.CrossOriginResourceSharing{
-		ExposeHeaders:  []string{restful.HEADER_AccessControlAllowOrigin},
-		AllowedDomains: serverConfig.CorsAllowedDomains,
-		Container:      container,
+	if len(serverConfig.CorsAllowedDomains) > 0 {
+		cors := restful.CrossOriginResourceSharing{
+			ExposeHeaders:  []string{restful.HEADER_AccessControlAllowOrigin},
+			AllowedDomains: serverConfig.CorsAllowedDomains,
+			Container:      container,
+		}
+		container.Filter(cors.Filter)
 	}
-	container.Filter(cors.Filter)
 
 	// We create a WebService and set up resources endpoints and index endpoint instead of creating WebService
 	// for every resource like /meshes/{mesh}/traffic-permissions, /meshes/{mesh}/traffic-log etc.

--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -243,7 +243,7 @@ func (a *ApiServerConfig) Validate() error {
 func DefaultApiServerConfig() *ApiServerConfig {
 	return &ApiServerConfig{
 		ReadOnly:           false,
-		CorsAllowedDomains: []string{".*"},
+		CorsAllowedDomains: []string{},
 		BasePath:           "/",
 		HTTP: ApiServerHTTPConfig{
 			Enabled:   true,

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -200,8 +200,7 @@ apiServer:
   # If true, then API Server will operate in read only mode (serving GET requests)
   readOnly: false # ENV: KUMA_API_SERVER_READ_ONLY
   # Allowed domains for Cross-Origin Resource Sharing. The value can be either domain or regexp
-  corsAllowedDomains:
-    - ".*" # ENV: KUMA_API_SERVER_CORS_ALLOWED_DOMAINS
+  corsAllowedDomains: [] # ENV: KUMA_API_SERVER_CORS_ALLOWED_DOMAINS
   # Can be used if you use a reverse proxy
   rootUrl: "" # ENV: KUMA_API_SERVER_ROOT_URL
   # The path to serve the API from


### PR DESCRIPTION
## Motivation

Localhost admin auth trusted browser-originated loopback requests. CORS was also open by default.

## Implementation information

- keep localhost admin enabled by default while restricting it to direct loopback
- make CORS opt-in by default
- require loopback `RemoteAddr` and `Host` before granting localhost admin
- deny proxy-hop headers, cross-site fetch metadata, and non-localhost `Origin` headers
- keep the API test harness explicit about localhost admin
