### PR TITLE
ci(github): remove release trigger from workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 on:
-  release: {}
   schedule:
     - cron: 0 7 * * *
   workflow_dispatch:


### PR DESCRIPTION
This was causing problems on release branches because the workflow used was the one the release branch and so it ended up being outdated.

The checklists already mention triggering the workflow manually and there's still a cron to ensure it fixes itself so the release trigger was just superfluous 

Fix https://github.com/Kong/team-mesh/issues/629