### PR TITLE
test(unit): replace sleep with eventually

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -33,6 +33,11 @@ var _ = Describe("Full sync tests", func() {
 		zones := make(map[string]store.ResourceStore)
 		wg := sync.WaitGroup{}
 		done := make(chan struct{})
+		closeOnce := sync.Once{}
+		DeferCleanup(func() {
+			closeOnce.Do(func() { close(done) })
+			wg.Wait()
+		})
 
 		for _, file := range files {
 			if before, ok := strings.CutSuffix(file.Name(), ".input.yaml"); ok {
@@ -106,8 +111,5 @@ var _ = Describe("Full sync tests", func() {
 				g.Expect(out).To(matchers.MatchGoldenEqual(folder, goldenFile), "zone %s", zoneName)
 			}, "30s", "250ms").Should(Succeed())
 		}
-
-		close(done)
-		wg.Wait()
 	}, test.EntriesAsFolder("full_sync"))
 })

--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -95,16 +95,19 @@ var _ = Describe("Full sync tests", func() {
 			})
 		}
 
-		// Wait for some time to ensure sync was complete
-		time.Sleep(time.Second * 5)
+		// Wait until all stores converge to their expected golden state.
+		// Using Eventually instead of a fixed sleep avoids flakes on
+		// slow CI runners where 5s may not be enough for full sync.
+		for zoneName, zoneStore := range zones {
+			goldenFile := zoneName + ".golden.yaml"
+			Eventually(func(g Gomega) {
+				out, err := test_store.ExtractResources(ctx, zoneStore)
+				g.Expect(err).To(Succeed())
+				g.Expect(out).To(matchers.MatchGoldenEqual(folder, goldenFile), "zone %s", zoneName)
+			}, "30s", "250ms").Should(Succeed())
+		}
+
 		close(done)
 		wg.Wait()
-
-		// Compare golden files
-		for zoneName, zoneStore := range zones {
-			out, err := test_store.ExtractResources(ctx, zoneStore)
-			Expect(err).To(Succeed())
-			Expect(out).To(matchers.MatchGoldenEqual(folder, zoneName+".golden.yaml"), "zone %s", zoneName)
-		}
 	}, test.EntriesAsFolder("full_sync"))
 })

--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -103,6 +103,11 @@ var _ = Describe("Full sync tests", func() {
 		// Wait until all stores converge to their expected golden state.
 		// Using Eventually instead of a fixed sleep avoids flakes on
 		// slow CI runners where 5s may not be enough for full sync.
+		// When regenerating golden files, Eventually writes partial state on
+		// the first match — sleep first to let full sync complete.
+		if os.Getenv("UPDATE_GOLDEN_FILES") != "" {
+			time.Sleep(5 * time.Second)
+		}
 		for zoneName, zoneStore := range zones {
 			goldenFile := zoneName + ".golden.yaml"
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
## Motivation

The full sync integration test used a hard-coded `time.Sleep(5s)` to wait for KDS sync to complete before checking golden files. On slow CI runners this wasn't always enough, causing flakes where zone-to-global resources hadn't arrived yet.

## Implementation information

 Replace the fixed sleep with `Eventually` polling (up to 30s, 250ms interval). Fast runners still pass in ~1-2s, slow ones get the headroom they need.

## Supporting documentation

> Changelog: skip

Fix: https://github.com/kumahq/kuma/issues/13101
