### PR TITLE
test(e2e): retry exec on empty stdout in CollectFailure

### DIFF
--- a/test/framework/client/collect.go
+++ b/test/framework/client/collect.go
@@ -450,7 +450,17 @@ func CollectFailure(cluster framework.Cluster, container, destination string, fn
 		}
 	}
 
-	stdout, _, err := cluster.Exec(opts.namespace, appPodName, container, cmd...)
+	// Retry on empty stdout with no exec error: the Kubernetes SPDY exec stream can
+	// close before stdout is delivered when the process exits immediately (e.g. DNS
+	// failure, exit code 6). One retry is enough to recover from the race.
+	var stdout string
+	var err error
+	for range 2 {
+		stdout, _, err = cluster.Exec(opts.namespace, appPodName, container, cmd...)
+		if stdout != "" || err != nil {
+			break
+		}
+	}
 
 	// 1. If we fail to decode the JSON status, return the JSON error,
 	// but prefer the original error if we have it.


### PR DESCRIPTION
## Motivation

`CollectFailure` runs curl via kubectl exec and parses its `--write-out "%{json}"` output. When curl exits immediately (e.g. exit code 6, DNS not found), the Kubernetes SPDY exec stream occasionally tears down before stdout is delivered — leaving an empty buffer on the client side. Since there's no exec-level error in this case, the JSON unmarshal fails and the call returns an error, causing flaky Consistently checks that expect connection failures to remain stable.

## Implementation information

The fix retries the exec once when stdout is empty and err is nil. That combination is never meaningful — real curl outcomes always produce JSON output — so the retry only fires on the transient race.

## Supporting documentation

> Changelog: skip
