### PR TITLE
fix(xds): allow stale stream takeover during dataplane reconnect

### DIFF
--- a/pkg/xds/metrics/metrics.go
+++ b/pkg/xds/metrics/metrics.go
@@ -8,11 +8,13 @@ import (
 )
 
 type Metrics struct {
-	XdsGenerations          *prometheus.HistogramVec
-	XdsGenerationsErrors    prometheus.Counter
-	KubeAuthCache           *prometheus.CounterVec
-	CertExpirationTimestamp *prometheus.GaugeVec
-	SnapshotResources       *prometheus.HistogramVec
+	XdsGenerations                         *prometheus.HistogramVec
+	XdsGenerationsErrors                   prometheus.Counter
+	KubeAuthCache                          *prometheus.CounterVec
+	CertExpirationTimestamp                *prometheus.GaugeVec
+	SnapshotResources                      *prometheus.HistogramVec
+	XdsStreamStaleOwnerTakeovers           *prometheus.CounterVec
+	XdsStreamRegistrationInProgressRetries *prometheus.CounterVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -37,15 +39,33 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		Help:    "Distribution of resource counts per xDS snapshot by resource type.",
 		Buckets: prometheus.ExponentialBuckets(1, 2, 12),
 	}, []string{"resource_type"})
-	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationTimestamp, snapshotResources); err != nil {
+	xdsStreamStaleOwnerTakeovers := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "xds_stream_stale_owner_takeovers_total",
+		Help: "Total number of stale xDS stream owners replaced by a new stream",
+	}, []string{"mesh", "proxy_type"})
+	xdsStreamRegistrationInProgressRetries := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "xds_stream_registration_in_progress_retries_total",
+		Help: "Total number of xDS stream requests rejected because another registration is in progress",
+	}, []string{"mesh", "proxy_type"})
+	if err := metrics.BulkRegister(
+		xdsGenerations,
+		xdsGenerationsErrors,
+		kubeAuthCache,
+		certExpirationTimestamp,
+		snapshotResources,
+		xdsStreamStaleOwnerTakeovers,
+		xdsStreamRegistrationInProgressRetries,
+	); err != nil {
 		return nil, err
 	}
 
 	return &Metrics{
-		XdsGenerations:          xdsGenerations,
-		XdsGenerationsErrors:    xdsGenerationsErrors,
-		KubeAuthCache:           kubeAuthCache,
-		CertExpirationTimestamp: certExpirationTimestamp,
-		SnapshotResources:       snapshotResources,
+		XdsGenerations:                         xdsGenerations,
+		XdsGenerationsErrors:                   xdsGenerationsErrors,
+		KubeAuthCache:                          kubeAuthCache,
+		CertExpirationTimestamp:                certExpirationTimestamp,
+		SnapshotResources:                      snapshotResources,
+		XdsStreamStaleOwnerTakeovers:           xdsStreamStaleOwnerTakeovers,
+		XdsStreamRegistrationInProgressRetries: xdsStreamRegistrationInProgressRetries,
 	}, nil
 }

--- a/pkg/xds/server/callbacks/dataplane_callbacks.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks.go
@@ -5,10 +5,13 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	util_xds "github.com/kumahq/kuma/v2/pkg/util/xds"
+	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
 )
 
 // DataplaneCallbacks are XDS callbacks that keep the context of Kuma Dataplane.
@@ -28,6 +31,7 @@ type DataplaneCallbacks interface {
 
 type xdsCallbacks struct {
 	callbacks DataplaneCallbacks
+	metrics   *xds_metrics.Metrics
 	util_xds.NoopCallbacks
 
 	sync.RWMutex
@@ -35,14 +39,22 @@ type xdsCallbacks struct {
 	dpDeltaStreams map[core_xds.StreamID]dpStream
 	// we don't need separate map for stream because we use here resource key
 	activeStreams map[core_model.ResourceKey]core_xds.StreamID
+	// connectingStream tracks streams that are currently in the process of registering
+	// (i.e. OnProxyConnected has been called but has not yet returned). This prevents
+	// a concurrent stream for the same dpKey from racing past the activeStreams guard
+	// before registration completes, which would cause OnProxyConnected to be invoked
+	// twice for the same dataplane.
+	connectingStream map[core_model.ResourceKey]core_xds.StreamID
 }
 
-func DataplaneCallbacksToXdsCallbacks(callbacks DataplaneCallbacks) util_xds.MultiXDSCallbacks {
+func DataplaneCallbacksToXdsCallbacks(callbacks DataplaneCallbacks, metrics *xds_metrics.Metrics) util_xds.MultiXDSCallbacks {
 	return &xdsCallbacks{
-		callbacks:      callbacks,
-		dpStreams:      map[core_xds.StreamID]dpStream{},
-		dpDeltaStreams: map[core_xds.StreamID]dpStream{},
-		activeStreams:  map[core_model.ResourceKey]core_xds.StreamID{},
+		callbacks:        callbacks,
+		metrics:          metrics,
+		dpStreams:        map[core_xds.StreamID]dpStream{},
+		dpDeltaStreams:   map[core_xds.StreamID]dpStream{},
+		activeStreams:    map[core_model.ResourceKey]core_xds.StreamID{},
+		connectingStream: map[core_model.ResourceKey]core_xds.StreamID{},
 	}
 }
 
@@ -99,7 +111,16 @@ func (d *xdsCallbacks) onStreamClosed(streamID core_xds.StreamID, getDpStream fu
 
 	d.Lock()
 	if streamDpKey != nil {
-		delete(d.activeStreams, *streamDpKey)
+		// Guard by stream ID: a stale-owner takeover may have already replaced
+		// this stream as the active owner. Only remove the entry if we are still
+		// the current owner, so the new owner's registration is not clobbered.
+		if d.activeStreams[*streamDpKey] == streamID {
+			delete(d.activeStreams, *streamDpKey)
+		}
+		// Safety cleanup: remove any in-progress connecting entry for this stream.
+		if d.connectingStream[*streamDpKey] == streamID {
+			delete(d.connectingStream, *streamDpKey)
+		}
 	}
 	delete(getDpStream(), streamID)
 	d.Unlock()
@@ -143,22 +164,56 @@ func (d *xdsCallbacks) onStreamRequest(streamID core_xds.StreamID, request util_
 		return nil
 	}
 
-	var streamInfo dpStream
-	_, alreadyConnected := d.activeStreams[dpKey]
-	if !alreadyConnected {
-		streamInfo = getDpStream()[streamID]
-		streamInfo.dp = &dpKey
-		getDpStream()[streamID] = streamInfo
+	// If another stream is already registering for this dpKey, return RESOURCE_EXHAUSTED
+	// so Envoy applies backoff before retrying, rather than hammering the CP.
+	if connectingStreamID, registering := d.connectingStream[dpKey]; registering && connectingStreamID != streamID {
+		d.incrementInProgressRetries(dpKey.Mesh, string(metadata.GetProxyType()))
+		d.Unlock()
+		return status.Error(codes.ResourceExhausted, "registration in progress for this node, try again later")
+	}
 
+	var streamInfo dpStream
+	ownerStreamID, alreadyConnected := d.activeStreams[dpKey]
+	if alreadyConnected {
+		// Check whether the existing owner's stream context is already cancelled.
+		// Under high dataplane churn a narrow window exists between gRPC GOAWAY/FIN
+		// (which cancels the stream context) and the CP processing OnStreamClosed
+		// (which removes the activeStreams entry). If we hit that window a new stream
+		// would otherwise be rejected even though the old one is truly gone.
+		ownerCtx := getDpStream()[ownerStreamID].ctx
+		if ownerCtx == nil || ownerCtx.Err() == nil {
+			// Owner is still alive — reject the incoming stream to avoid races.
+			d.Unlock()
+			// we don't allow more than one active stream from a data plane as there can be race conditions
+			return errors.New("there is already an active stream from this node, try again later")
+		}
+		// Owner's context is cancelled — it is stale. Allow the new stream to take
+		// over. The stale owner's OnStreamClosed will still fire and call
+		// OnProxyDisconnected only if stream state still exists. Evict stale stream
+		// state here so OnStreamClosed for the stale owner does not disconnect the
+		// replacement stream's watchdog lifecycle.
+		delete(getDpStream(), ownerStreamID)
+		d.incrementStaleTakeovers(dpKey.Mesh, string(metadata.GetProxyType()))
+	}
+
+	streamInfo = getDpStream()[streamID]
+	streamInfo.dp = &dpKey
+	getDpStream()[streamID] = streamInfo
+	d.connectingStream[dpKey] = streamID
+	d.Unlock()
+
+	err = d.callbacks.OnProxyConnected(streamID, dpKey, streamInfo.ctx, *metadata)
+
+	d.Lock()
+	if d.connectingStream[dpKey] == streamID {
+		delete(d.connectingStream, dpKey)
+	}
+	if err == nil {
 		d.activeStreams[dpKey] = streamID
 	}
 	d.Unlock()
 
-	if !alreadyConnected {
-		return d.callbacks.OnProxyConnected(streamID, dpKey, streamInfo.ctx, *metadata)
-	}
-	// we don't allow more than one active stream from a data plane as there can be race conditions
-	return errors.New("there is already an active stream from this node, try again later")
+	return err
 }
 
 func (d *xdsCallbacks) onStreamOpen(ctx context.Context, streamID core_xds.StreamID, getDpStream func() map[core_xds.StreamID]dpStream) error {
@@ -182,3 +237,17 @@ func (n *NoopDataplaneCallbacks) OnProxyDisconnected(_ context.Context, _ core_x
 }
 
 var _ DataplaneCallbacks = &NoopDataplaneCallbacks{}
+
+func (d *xdsCallbacks) incrementStaleTakeovers(mesh, proxyType string) {
+	if d.metrics == nil {
+		return
+	}
+	d.metrics.XdsStreamStaleOwnerTakeovers.WithLabelValues(mesh, proxyType).Inc()
+}
+
+func (d *xdsCallbacks) incrementInProgressRetries(mesh, proxyType string) {
+	if d.metrics == nil {
+		return
+	}
+	d.metrics.XdsStreamRegistrationInProgressRetries.WithLabelValues(mesh, proxyType).Inc()
+}

--- a/pkg/xds/server/callbacks/dataplane_callbacks_test.go
+++ b/pkg/xds/server/callbacks/dataplane_callbacks_test.go
@@ -2,43 +2,89 @@ package callbacks_test
 
 import (
 	"context"
+	"sync"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
 	util_xds_v3 "github.com/kumahq/kuma/v2/pkg/util/xds/v3"
+	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
 	. "github.com/kumahq/kuma/v2/pkg/xds/server/callbacks"
 )
 
 type countingDpCallbacks struct {
+	mu                         sync.Mutex
 	OnProxyConnectedCounter    int
 	OnProxyDisconnectedCounter int
 }
 
 func (c *countingDpCallbacks) OnProxyConnected(streamID core_xds.StreamID, dpKey core_model.ResourceKey, ctx context.Context, metadata core_xds.DataplaneMetadata) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.OnProxyConnectedCounter++
 	return nil
 }
 
 func (c *countingDpCallbacks) OnProxyDisconnected(ctx context.Context, streamID core_xds.StreamID, dpKey core_model.ResourceKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.OnProxyDisconnectedCounter++
 }
 
 var _ DataplaneCallbacks = &countingDpCallbacks{}
 
+type blockingConnectCallbacks struct {
+	mu                      sync.Mutex
+	started                 chan struct{}
+	release                 chan struct{}
+	blockOn                 int
+	OnProxyConnectedCounter int
+}
+
+func (c *blockingConnectCallbacks) OnProxyConnected(core_xds.StreamID, core_model.ResourceKey, context.Context, core_xds.DataplaneMetadata) error {
+	c.mu.Lock()
+	c.OnProxyConnectedCounter++
+	if c.blockOn == 0 {
+		c.blockOn = 1
+	}
+	if c.OnProxyConnectedCounter == c.blockOn {
+		close(c.started)
+		c.mu.Unlock()
+		<-c.release
+		return nil
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *blockingConnectCallbacks) OnProxyDisconnected(context.Context, core_xds.StreamID, core_model.ResourceKey) {
+}
+
+var _ DataplaneCallbacks = &blockingConnectCallbacks{}
+
 var _ = Describe("Dataplane Callbacks", func() {
 	countingCallbacks := &countingDpCallbacks{}
-	callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(countingCallbacks))
+	callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(countingCallbacks, nil))
 
 	node := &envoy_core.Node{
 		Id: "default.example",
 		Metadata: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
+				core_xds.FieldDataplaneProxyType: {
+					Kind: &structpb.Value_StringValue{
+						StringValue: string(mesh_proto.DataplaneProxyType),
+					},
+				},
 				"dataplane.token": {
 					Kind: &structpb.Value_StringValue{
 						StringValue: "token",
@@ -95,4 +141,198 @@ var _ = Describe("Dataplane Callbacks", func() {
 		// then OnProxyDisconnected should not be called twice
 		Expect(countingCallbacks.OnProxyDisconnectedCounter).To(Equal(1))
 	})
+
+	It("should takeover stale active stream", func() {
+		countingCallbacks := &countingDpCallbacks{}
+		callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(countingCallbacks, nil))
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		err := callbacks.OnStreamOpen(ctx1, 1, "")
+		Expect(err).ToNot(HaveOccurred())
+		err = callbacks.OnStreamRequest(1, &req)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Mark owner stream as stale before cleanup callback runs.
+		cancel1()
+
+		err = callbacks.OnStreamOpen(context.Background(), 2, "")
+		Expect(err).ToNot(HaveOccurred())
+		err = callbacks.OnStreamRequest(2, &req)
+		Expect(err).ToNot(HaveOccurred())
+
+		callbacks.OnStreamClosed(1, node)
+		callbacks.OnStreamClosed(2, node)
+
+		countingCallbacks.mu.Lock()
+		defer countingCallbacks.mu.Unlock()
+		Expect(countingCallbacks.OnProxyConnectedCounter).To(Equal(2))
+		Expect(countingCallbacks.OnProxyDisconnectedCounter).To(Equal(1))
+	})
+
+	It("should return resource exhausted while registration in progress", func() {
+		blockingCallbacks := &blockingConnectCallbacks{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+			blockOn: 1,
+		}
+		callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(blockingCallbacks, nil))
+
+		err := callbacks.OnStreamOpen(context.Background(), 1, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		resultCh := make(chan error, 1)
+		go func() {
+			resultCh <- callbacks.OnStreamRequest(1, &req)
+		}()
+
+		Eventually(blockingCallbacks.started).Should(BeClosed())
+
+		err = callbacks.OnStreamOpen(context.Background(), 2, "")
+		Expect(err).ToNot(HaveOccurred())
+		err = callbacks.OnStreamRequest(2, &req)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.ResourceExhausted))
+
+		close(blockingCallbacks.release)
+		Expect(<-resultCh).ToNot(HaveOccurred())
+	})
+
+	It("should not remove new owner from activeStreams when stale owner stream closes", func() {
+		// This test verifies the owner-ID guard in onStreamClosed: when a stale
+		// stream is taken over by a new one, the stale owner's OnStreamClosed must
+		// not evict the new owner's entry from activeStreams.
+		errorCh := make(chan error, 1)
+		countingCallbacks := &countingDpCallbacks{}
+		callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(countingCallbacks, nil))
+
+		// Stream 1 opens and registers.
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		Expect(callbacks.OnStreamOpen(ctx1, 1, "")).To(Succeed())
+		Expect(callbacks.OnStreamRequest(1, &req)).To(Succeed())
+
+		// Cancel ctx to make stream 1 stale.
+		cancel1()
+
+		// Stream 2 registers via stale takeover.
+		Expect(callbacks.OnStreamOpen(context.Background(), 2, "")).To(Succeed())
+		Expect(callbacks.OnStreamRequest(2, &req)).To(Succeed())
+
+		// Stream 1 (stale owner) closes; the owner-ID guard should prevent it from
+		// removing stream 2 from activeStreams.
+		callbacks.OnStreamClosed(1, node)
+
+		// Stream 3 should now be rejected because stream 2 is still the active owner.
+		Expect(callbacks.OnStreamOpen(context.Background(), 3, "")).To(Succeed())
+		go func() {
+			errorCh <- callbacks.OnStreamRequest(3, &req)
+		}()
+		Eventually(errorCh).Should(Receive(MatchError(ContainSubstring("already an active stream"))))
+
+		// Clean up stream 2.
+		callbacks.OnStreamClosed(2, node)
+		callbacks.OnStreamClosed(3, node)
+
+		countingCallbacks.mu.Lock()
+		defer countingCallbacks.mu.Unlock()
+		Expect(countingCallbacks.OnProxyConnectedCounter).To(Equal(2))
+	})
+
+	It("should allow only one winner in concurrent stale takeover race", func() {
+		countingCallbacks := &countingDpCallbacks{}
+		callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(countingCallbacks, nil))
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		Expect(callbacks.OnStreamOpen(ctx1, 1, "")).To(Succeed())
+		Expect(callbacks.OnStreamRequest(1, &req)).To(Succeed())
+
+		// Mark stream 1 as stale before cleanup callback runs.
+		cancel1()
+
+		Expect(callbacks.OnStreamOpen(context.Background(), 2, "")).To(Succeed())
+		Expect(callbacks.OnStreamOpen(context.Background(), 3, "")).To(Succeed())
+
+		results := make(chan error, 2)
+		go func() { results <- callbacks.OnStreamRequest(2, &req) }()
+		go func() { results <- callbacks.OnStreamRequest(3, &req) }()
+
+		err1 := <-results
+		err2 := <-results
+
+		successes := 0
+		failures := 0
+		for _, err := range []error{err1, err2} {
+			if err == nil {
+				successes++
+				continue
+			}
+			failures++
+			Expect(
+				status.Code(err) == codes.ResourceExhausted ||
+					err.Error() == "there is already an active stream from this node, try again later",
+			).To(BeTrue())
+		}
+
+		Expect(successes).To(Equal(1))
+		Expect(failures).To(Equal(1))
+
+		callbacks.OnStreamClosed(1, node)
+		callbacks.OnStreamClosed(2, node)
+		callbacks.OnStreamClosed(3, node)
+	})
+
+	It("should increment stale takeover and in-progress retry counters", func() {
+		baseMetrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		xdsMetrics, err := xds_metrics.NewMetrics(baseMetrics)
+		Expect(err).ToNot(HaveOccurred())
+
+		blocker := &blockingConnectCallbacks{
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+			blockOn: 2,
+		}
+		callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(blocker, xdsMetrics))
+
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		Expect(callbacks.OnStreamOpen(ctx1, 1, "")).To(Succeed())
+		Expect(callbacks.OnStreamRequest(1, &req)).To(Succeed())
+		cancel1()
+
+		// stale owner takeover path
+		Expect(callbacks.OnStreamOpen(context.Background(), 2, "")).To(Succeed())
+		resultCh := make(chan error, 1)
+		go func() {
+			resultCh <- callbacks.OnStreamRequest(2, &req)
+		}()
+
+		Eventually(blocker.started).Should(BeClosed())
+
+		// connecting in-progress retry path
+		Expect(callbacks.OnStreamOpen(context.Background(), 3, "")).To(Succeed())
+		err = callbacks.OnStreamRequest(3, &req)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.ResourceExhausted))
+
+		close(blocker.release)
+		Expect(<-resultCh).ToNot(HaveOccurred())
+
+		inProgressCounter, err := readCounter(xdsMetrics.XdsStreamRegistrationInProgressRetries.WithLabelValues("default", string(mesh_proto.DataplaneProxyType)))
+		Expect(err).ToNot(HaveOccurred())
+		staleCounter, err := readCounter(xdsMetrics.XdsStreamStaleOwnerTakeovers.WithLabelValues("default", string(mesh_proto.DataplaneProxyType)))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(staleCounter).To(Equal(float64(1)))
+		Expect(inProgressCounter).To(Equal(float64(1)))
+
+		callbacks.OnStreamClosed(1, node)
+		callbacks.OnStreamClosed(2, node)
+		callbacks.OnStreamClosed(3, node)
+	})
 })
+
+func readCounter(counter interface{ Write(*dto.Metric) error }) (float64, error) {
+	metric := &dto.Metric{}
+	if err := counter.Write(metric); err != nil {
+		return 0, err
+	}
+	return metric.GetCounter().GetValue(), nil
+}

--- a/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
+++ b/pkg/xds/server/callbacks/dataplane_lifecycle_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Dataplane Lifecycle", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
 		dpLifecycle := NewDataplaneLifecycle(ctx, resManager, authenticator, 0*time.Second, cpInstanceID, 0*time.Second)
-		callbacks = util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(dpLifecycle))
+		callbacks = util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(dpLifecycle, nil))
 
 		err := resManager.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker.go
@@ -43,6 +43,11 @@ func (t *dataplaneSyncTracker) OnProxyConnected(streamID core_xds.StreamID, dpKe
 	// We use OnProxyConnected because there should be only one watchdog for given dataplane.
 	t.Lock()
 	defer t.Unlock()
+	if dpWatchdog := t.watchdogs[dpKey]; dpWatchdog != nil {
+		dpWatchdog.cancelFunc()
+		<-dpWatchdog.stopped
+		dataplaneSyncTrackerLog.V(1).Info("existing watchdog for a Dataplane stopped", "dpKey", dpKey, "streamID", streamID)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	state := &watchdogState{

--- a/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
+++ b/pkg/xds/server/callbacks/dataplane_sync_tracker_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Sync", func() {
 	Describe("dataplaneSyncTracker", func() {
 		It("should not fail when ADS stream is closed before Watchdog is even created", func() {
 			// setup
-			tracker := DataplaneCallbacksToXdsCallbacks(NewDataplaneSyncTracker(nil))
+			tracker := DataplaneCallbacksToXdsCallbacks(NewDataplaneSyncTracker(nil), nil)
 
 			// given
 			ctx := context.Background()
@@ -46,7 +46,7 @@ var _ = Describe("Sync", func() {
 		It("should not fail when Envoy presents invalid Node ID", func() {
 			// setup
 			tracker := NewDataplaneSyncTracker(nil)
-			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
+			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker, nil))
 
 			// given
 			ctx := context.Background()
@@ -85,7 +85,7 @@ var _ = Describe("Sync", func() {
 					close(watchdogCh)
 				})
 			}))
-			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
+			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker, nil))
 
 			// given
 			ctx := context.Background()
@@ -141,7 +141,7 @@ var _ = Describe("Sync", func() {
 					cleanupDone.Store(true)
 				})
 			}))
-			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
+			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker, nil))
 
 			// when one stream for backend-01 is connected and request is sent
 			streamID1 := int64(1)
@@ -202,7 +202,7 @@ var _ = Describe("Sync", func() {
 				watchdogDone: watchdogDone,
 			}
 			tracker := NewDataplaneSyncTracker(factory)
-			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker))
+			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker, nil))
 
 			// given
 			ctx := context.Background()
@@ -228,6 +228,48 @@ var _ = Describe("Sync", func() {
 
 			By("waiting for Watchdog to stop")
 			Eventually(watchdogDone).Should(BeClosed())
+		}))
+
+		It("should stop stale watchdog and keep new owner watchdog running", test.Within(5*time.Second, func() {
+			var started atomic.Int32
+			var stopped atomic.Int32
+			var active atomic.Int32
+
+			tracker := NewDataplaneSyncTracker(sync.DataplaneWatchdogFactoryFunc(func(key core_model.ResourceKey, _ *core_xds.DataplaneMetadata) util_xds_v3.Watchdog {
+				return util_xds_v3.WatchdogFunc(func(ctx context.Context) {
+					started.Add(1)
+					active.Add(1)
+					<-ctx.Done()
+					active.Add(-1)
+					stopped.Add(1)
+				})
+			}))
+			callbacks := util_xds_v3.AdaptCallbacks(DataplaneCallbacksToXdsCallbacks(tracker, nil))
+
+			node := &envoy_core.Node{Id: "default.backend-01"}
+			req := &envoy_sd.DiscoveryRequest{Node: node}
+
+			ctx1, cancel1 := context.WithCancel(context.Background())
+			Expect(callbacks.OnStreamOpen(ctx1, 1, "")).To(Succeed())
+			Expect(callbacks.OnStreamRequest(1, req)).To(Succeed())
+			Eventually(started.Load).Should(Equal(int32(1)))
+			Eventually(active.Load).Should(Equal(int32(1)))
+
+			// Mark stream 1 as stale before cleanup callback runs.
+			cancel1()
+
+			Expect(callbacks.OnStreamOpen(context.Background(), 2, "")).To(Succeed())
+			Expect(callbacks.OnStreamRequest(2, req)).To(Succeed())
+			Eventually(started.Load).Should(Equal(int32(2)))
+
+			// Closing stale stream should only stop stale watchdog and keep new one running.
+			callbacks.OnStreamClosed(1, node)
+			Eventually(stopped.Load).Should(Equal(int32(1)))
+			Consistently(active.Load).Should(Equal(int32(1)))
+
+			callbacks.OnStreamClosed(2, node)
+			Eventually(stopped.Load).Should(Equal(int32(2)))
+			Eventually(active.Load).Should(Equal(int32(0)))
 		}))
 	})
 })

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -42,10 +42,12 @@ func RegisterXDS(
 
 	authenticator := rt.XDS().PerProxyTypeAuthenticator()
 	authCallbacks := auth.NewCallbacks(rt.ReadOnlyResourceManager(), authenticator, auth.DPNotFoundRetry{}) // no need to retry on DP Not Found because we are creating DP in DataplaneLifecycle callback
-	workloadLabelValidator := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewWorkloadLabelValidator(rt.ReadOnlyResourceManager(), rt.Config().Environment))
+	workloadLabelValidator := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewWorkloadLabelValidator(rt.ReadOnlyResourceManager(), rt.Config().Environment), nil)
 
 	dpLifecycle := xds_callbacks.DataplaneCallbacksToXdsCallbacks(
-		xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration))
+		xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration),
+		xdsMetrics,
+	)
 	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks, xdsMetrics)
 	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks)
 	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks)
@@ -55,7 +57,7 @@ func RegisterXDS(
 		return err
 	}
 
-	syncTracker := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory))
+	syncTracker := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(watchdogFactory), xdsMetrics)
 	dpStatusTracker := DefaultDataplaneStatusTracker(rt, envoyCpCtx.Secrets, otelStatusCache)
 
 	callbacks := util_xds_v3.CallbacksChain{


### PR DESCRIPTION
## Motivation
<!-- Why are we doing this change -->
Under high dataplane churn, Kuma can briefly observe two xDS streams for the same dataplane. In that window, the old stream may already be stale, but the control plane can still treat it as active until `OnStreamClosed` is processed.

At scale, CP under load, I have seen this issue lasts for long. When DPP fails readiness K8s restarts the pod.

## Implementation information
<!-- Explain how this was done and potentially alternatives considered and discarded -->

This change updates dataplane xDS stream ownership handling so a reconnecting stream can take over when the existing owner is already stale.

If the existing owner stream is still live, the new stream is rejected as before. If its context is already cancelled, the new stream is allowed to become the owner immediately. During takeover, stale stream state is removed so the old stream's later `OnStreamClosed` callback does not tear down state belonging to the replacement stream.

The existing connect-phase guard remains in place. If another stream arrives while registration for the same dataplane is still in progress, it is rejected with `RESOURCE_EXHAUSTED` so Envoy backs off and retries cleanly.

The sync tracker was also updated to stop the previous watchdog before replacing it on reconnect.

Added coverage for:
- concurrent stale-owner takeover races
- reconnect metric increments
- watchdog lifecycle during stale-owner replacement

## Supporting documentation
<!-- Is there a MADR? An Issue? A related PR? -->
`existing watchdog for a Dataplane stopped` is getting logged after watchdog stopped message, means another stream connected before CP could cleanup existing connection:
<img width="2241" height="166" alt="image" src="https://github.com/user-attachments/assets/9ed20187-2969-4cd4-8394-ea784f1f0db6" />

The `xds_stream_stale_owner_takeovers_total` metrics shows the number of times a stale owner was evicted and replaced:
<img width="929" height="114" alt="image" src="https://github.com/user-attachments/assets/eec347aa-99fc-420f-9503-3e39f5926ba3" />

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->
