### PR TITLE
fix(xds): allow delta xDS auth to tolerate omitted node

### DIFF
--- a/pkg/xds/auth/callbacks.go
+++ b/pkg/xds/auth/callbacks.go
@@ -157,9 +157,8 @@ func (a *authCallbacks) stream(streamID core_xds.StreamID, req util_xds.Request,
 
 	if s.nodeID == "" {
 		s.nodeID = req.NodeId()
-	}
-
-	if s.nodeID != req.NodeId() {
+	} else if req.NodeId() != "" && s.nodeID != req.NodeId() {
+		// Delta xDS only requires Node on the first request; subsequent requests may omit it.
 		return stream{}, errors.Errorf("stream was authenticated for ID %s. Received request is for node with ID %s. Node ID cannot be changed after stream is initialized", s.nodeID, req.NodeId())
 	}
 

--- a/pkg/xds/auth/callbacks_test.go
+++ b/pkg/xds/auth/callbacks_test.go
@@ -216,6 +216,34 @@ var _ = Describe("Auth Callbacks", func() {
 		Expect(err).To(MatchError("stream was authenticated for ID default.web-01. Received request is for node with ID default.web-02. Node ID cannot be changed after stream is initialized"))
 	})
 
+	It("should accept delta requests that omit Node after the first request", func() {
+		// given
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{"authorization": "pass"}))
+		streamID := int64(1)
+
+		// when
+		err := callbacks.OnDeltaStreamOpen(ctx, streamID, "")
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when first delta request carries Node
+		err = callbacks.OnStreamDeltaRequest(streamID, &envoy_sd.DeltaDiscoveryRequest{
+			Node: &envoy_core.Node{
+				Id: "default.web-01",
+			},
+		})
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+
+		// when subsequent delta request omits Node (per xDS spec)
+		err = callbacks.OnStreamDeltaRequest(streamID, &envoy_sd.DeltaDiscoveryRequest{})
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("should not authenticate when DP is absent in the CP and it's not passed through Envoy metadata", func() {
 		// given
 		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{"authorization": "pass"}))

--- a/pkg/xds/auth/callbacks_test.go
+++ b/pkg/xds/auth/callbacks_test.go
@@ -218,17 +218,18 @@ var _ = Describe("Auth Callbacks", func() {
 
 	It("should accept delta requests that omit Node after the first request", func() {
 		// given
+		deltaCallbacks := v3.AdaptDeltaCallbacks(auth.NewCallbacks(resManager, testAuth, auth.DPNotFoundRetry{}))
 		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{"authorization": "pass"}))
 		streamID := int64(1)
 
 		// when
-		err := callbacks.OnDeltaStreamOpen(ctx, streamID, "")
+		err := deltaCallbacks.OnDeltaStreamOpen(ctx, streamID, "")
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
 
 		// when first delta request carries Node
-		err = callbacks.OnStreamDeltaRequest(streamID, &envoy_sd.DeltaDiscoveryRequest{
+		err = deltaCallbacks.OnStreamDeltaRequest(streamID, &envoy_sd.DeltaDiscoveryRequest{
 			Node: &envoy_core.Node{
 				Id: "default.web-01",
 			},
@@ -238,10 +239,11 @@ var _ = Describe("Auth Callbacks", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// when subsequent delta request omits Node (per xDS spec)
-		err = callbacks.OnStreamDeltaRequest(streamID, &envoy_sd.DeltaDiscoveryRequest{})
+		err = deltaCallbacks.OnStreamDeltaRequest(streamID, &envoy_sd.DeltaDiscoveryRequest{})
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
+		Expect(testAuth.callCounter).To(Equal(1)) // auth must not be called again when Node is absent
 	})
 
 	It("should not authenticate when DP is absent in the CP and it's not passed through Envoy metadata", func() {


### PR DESCRIPTION
## Motivation

After bumping Envoy from 1.37.2 → 1.38.0 (#16446), enabling delta xDS in a zone caused sidecars to disconnect repeatedly and kuma-cp to peg CPU on cert regen. Kuma's bootstrap sets `set_node_on_first_message_only: true` on the ADS source (`pkg/xds/bootstrap/template_v3.go:194`). Before 1.38 this flag was silently ignored on the Delta-xDS path — the legacy delta mux always sent Node on every request, so Kuma's auth callback's strict `s.nodeID == req.NodeId()` check always passed. Envoy 1.38 finally honors the flag for Delta-xDS (envoyproxy/envoy#42650, guarded by runtime feature `envoy.reloadable_features.xds_legacy_delta_skip_subsequent_node`). With the flag now respected, the second delta request on every stream omits Node per spec, and Kuma rejects it:
 
## Implementation information
`pkg/xds/auth/callbacks.go` — only compare node IDs when the request actually carries one. SOTW behavior is unchanged (its requests always include node); delta now matches the spec.
