### PR TITLE
feat(helm): add annotations for mesh-scoped proxy and refactor

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -877,15 +877,11 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
-        # Applied to all containers in the pod (pause + injected kuma-sidecar).
-        resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
         # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-        #  priorityClassName, securityContext, containerSecurityContext).
+        #  priorityClassName, securityContext, containerSecurityContext, resources,
+        #  containerResources).
         podSpec: {}
-        # -- Resource requests and limits for the pause container.
-        containerResources: {}
       # -- Horizontal Pod Autoscaler settings.
       hpa:
         enabled: false
@@ -929,15 +925,11 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
-        # Applied to all containers in the pod (pause + injected kuma-sidecar).
-        resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
         # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-        #  priorityClassName, securityContext, containerSecurityContext).
+        #  priorityClassName, securityContext, containerSecurityContext, resources,
+        #  containerResources).
         podSpec: {}
-        # -- Resource requests and limits for the pause container.
-        containerResources: {}
       hpa:
         enabled: false
         minReplicas: 2

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -877,7 +877,7 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Resource requests and limits for the pod (pod-level resources).
+        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
         # Applied to all containers in the pod (pause + injected kuma-sidecar).
         resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
@@ -929,7 +929,7 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Resource requests and limits for the pod (pod-level resources).
+        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
         # Applied to all containers in the pod (pause + injected kuma-sidecar).
         resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -607,6 +607,8 @@ ingress:
   annotations: { }
   # -- Additional pod annotations
   podAnnotations: { }
+  # -- Annotations to add to the Deployment resource.
+  deploymentAnnotations: { }
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -735,6 +737,8 @@ egress:
   annotations: { }
   # -- Additional pod annotations
   podAnnotations: { }
+  # -- Annotations to add to the Deployment resource.
+  deploymentAnnotations: { }
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -844,8 +848,6 @@ meshes:
     ingress:
       # -- Deploy a zone ingress for this mesh.
       enabled: false
-      # -- Number of replicas. Ignored when hpa.enabled is true.
-      replicas: 1
       # -- Per-mesh override for the pause container image. Falls back to
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
@@ -863,15 +865,27 @@ meshes:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
-      # -- Resource requests and limits for the pod (pod-level resources).
-      # Applied to all containers in the pod (pause + injected kuma-sidecar).
-      resources: {}
-      # -- Subset of Kubernetes PodSpec fields applied to the pod template
-      # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-      #  priorityClassName, securityContext, containerSecurityContext).
-      podSpec: {}
-      # -- Resource requests and limits for the pause container.
-      containerResources: {}
+        # -- Annotations to add to the Service resource.
+        annotations: {}
+        # -- Labels to add to the Service resource.
+        labels: {}
+      # -- Deployment-level settings.
+      deployment:
+        # -- Number of replicas. Ignored when hpa.enabled is true.
+        replicas: 1
+        # -- Annotations to add to the Deployment resource.
+        annotations: {}
+        # -- Labels to add to the Deployment resource.
+        labels: {}
+        # -- Resource requests and limits for the pod (pod-level resources).
+        # Applied to all containers in the pod (pause + injected kuma-sidecar).
+        resources: {}
+        # -- Subset of Kubernetes PodSpec fields applied to the pod template
+        # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
+        #  priorityClassName, securityContext, containerSecurityContext).
+        podSpec: {}
+        # -- Resource requests and limits for the pause container.
+        containerResources: {}
       # -- Horizontal Pod Autoscaler settings.
       hpa:
         enabled: false
@@ -886,7 +900,6 @@ meshes:
     egress:
       # -- Deploy a zone egress for this mesh.
       enabled: false
-      replicas: 1
       # -- Per-mesh override for the pause container image. Falls back to
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
@@ -904,15 +917,27 @@ meshes:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
-      # -- Resource requests and limits for the pod (pod-level resources).
-      # Applied to all containers in the pod (pause + injected kuma-sidecar).
-      resources: {}
-      # -- Subset of Kubernetes PodSpec fields applied to the pod template
-      # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-      #  priorityClassName, securityContext, containerSecurityContext).
-      podSpec: {}
-      # -- Resource requests and limits for the pause container.
-      containerResources: {}
+        # -- Annotations to add to the Service resource.
+        annotations: {}
+        # -- Labels to add to the Service resource.
+        labels: {}
+      # -- Deployment-level settings.
+      deployment:
+        # -- Number of replicas. Ignored when hpa.enabled is true.
+        replicas: 1
+        # -- Annotations to add to the Deployment resource.
+        annotations: {}
+        # -- Labels to add to the Deployment resource.
+        labels: {}
+        # -- Resource requests and limits for the pod (pod-level resources).
+        # Applied to all containers in the pod (pause + injected kuma-sidecar).
+        resources: {}
+        # -- Subset of Kubernetes PodSpec fields applied to the pod template
+        # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
+        #  priorityClassName, securityContext, containerSecurityContext).
+        podSpec: {}
+        # -- Resource requests and limits for the pause container.
+        containerResources: {}
       hpa:
         enabled: false
         minReplicas: 2

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.values.yaml
@@ -2,7 +2,9 @@ meshes:
   - name: default
     ingress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1
     egress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
@@ -731,6 +731,10 @@ metadata:
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
+    "team": "platform"
+  annotations:
+    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
+    "custom.io/annotation": "ingress-value"
 spec:
   strategy:
     rollingUpdate:
@@ -790,6 +794,8 @@ metadata:
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
+  annotations:
+    "custom.io/annotation": "egress-value"
 spec:
   strategy:
     rollingUpdate:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
@@ -731,10 +731,10 @@ metadata:
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
-    "team": "platform"
+    team: platform
   annotations:
-    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
-    "custom.io/annotation": "ingress-value"
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    custom.io/annotation: ingress-value
 spec:
   strategy:
     rollingUpdate:
@@ -795,7 +795,7 @@ metadata:
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
   annotations:
-    "custom.io/annotation": "egress-value"
+    custom.io/annotation: egress-value
 spec:
   strategy:
     rollingUpdate:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.values.yaml
@@ -6,18 +6,20 @@ meshes:
         registry: registry.k8s.io
         repository: pause
         tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
-      service:
-        spec:
-          externalIPs:
-            - 192.168.5.2
-          loadBalancerSourceRanges:
-            - 10.0.0.0/8
+      deployment:
+        replicas: 1
+        annotations:
+          custom.io/annotation: "ingress-value"
+          argocd.argoproj.io/hook-delete-policy: "BeforeHookCreation"
+        labels:
+          team: platform
     egress:
       enabled: true
       image:
         registry: registry.k8s.io
         repository: pause
         tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
-      service:
-        spec:
-          publishNotReadyAddresses: true
+      deployment:
+        replicas: 1
+        annotations:
+          custom.io/annotation: "egress-value"

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
@@ -726,7 +726,7 @@ kind: Deployment
 metadata:
   name: kuma-default-ingress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-default-ingress
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma
@@ -785,7 +785,7 @@ kind: Deployment
 metadata:
   name: kuma-default-egress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-default-egress
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.values.yaml
@@ -6,9 +6,11 @@ meshes:
   - name: default
     ingress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1
       image:
         registry: override.example.com
     egress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -792,7 +792,7 @@ kind: Deployment
 metadata:
   name: kuma-mesh-1-ingress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-mesh-1-ingress
     kuma.io/mesh: mesh-1
     app.kubernetes.io/name: kuma
@@ -851,7 +851,7 @@ kind: Deployment
 metadata:
   name: kuma-mesh-1-egress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-mesh-1-egress
     kuma.io/mesh: mesh-1
     app.kubernetes.io/name: kuma
@@ -910,7 +910,7 @@ kind: Deployment
 metadata:
   name: kuma-mesh-2-ingress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-mesh-2-ingress
     kuma.io/mesh: mesh-2
     app.kubernetes.io/name: kuma
@@ -969,7 +969,7 @@ kind: Deployment
 metadata:
   name: kuma-mesh-2-egress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-mesh-2-egress
     kuma.io/mesh: mesh-2
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.values.yaml
@@ -2,14 +2,16 @@ meshes:
   - name: mesh-1
     ingress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1
       image:
         registry: registry.k8s.io
         repository: pause
         tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
     egress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1
       image:
         registry: registry.k8s.io
         repository: pause
@@ -17,14 +19,16 @@ meshes:
   - name: mesh-2
     ingress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1
       image:
         registry: registry.k8s.io
         repository: pause
         tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
     egress:
       enabled: true
-      replicas: 1
+      deployment:
+        replicas: 1
       image:
         registry: registry.k8s.io
         repository: pause

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
@@ -475,6 +475,9 @@ metadata:
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
     k8s.kuma.io/zone-proxy-type: ingress
+    "environment": "production"
+  annotations:
+    "service.beta.kubernetes.io/aws-load-balancer-type": "external"
 spec:
   type: LoadBalancer
   ports:
@@ -497,6 +500,9 @@ metadata:
     app.kubernetes.io/name: kuma
     app.kubernetes.io/instance: kuma
     k8s.kuma.io/zone-proxy-type: egress
+    "environment": "production"
+  annotations:
+    "custom.io/egress": "true"
 spec:
   type: ClusterIP
   ports:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.values.yaml
@@ -7,11 +7,10 @@ meshes:
         repository: pause
         tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
       service:
-        spec:
-          externalIPs:
-            - 192.168.5.2
-          loadBalancerSourceRanges:
-            - 10.0.0.0/8
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: "external"
+        labels:
+          environment: production
     egress:
       enabled: true
       image:
@@ -19,5 +18,7 @@ meshes:
         repository: pause
         tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
       service:
-        spec:
-          publishNotReadyAddresses: true
+        annotations:
+          custom.io/egress: "true"
+        labels:
+          environment: production

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
@@ -731,7 +731,7 @@ kind: Deployment
 metadata:
   name: kuma-default-ingress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-default-ingress
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma
@@ -790,7 +790,7 @@ kind: Deployment
 metadata:
   name: kuma-default-egress
   namespace: kuma-system
-  labels: 
+  labels:
     app: kuma-default-egress
     kuma.io/mesh: default
     app.kubernetes.io/name: kuma

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyDeploymentAnnotations.golden.yaml
@@ -1,0 +1,1376 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-system
+  labels:
+    kuma.io/sidecar-injection: "false"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuma-control-plane-config
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+data:
+  config.yaml: |
+    # use this file to override default configuration of `kuma-cp`
+    #
+    # see conf/kuma-cp.conf.yml for available settings
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuma-control-plane
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  # Kubernetes resources
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: # Gateway API
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - referencegrants
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses # ClusterScope
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses/status # ClusterScope
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - kuma.io
+    resources:
+      - dataplanes
+      - dataplaneinsights
+      - meshes
+      - zones
+      - zoneinsights
+      - zoneingresses
+      - zoneingressinsights
+      - zoneegresses
+      - zoneegressinsights
+      - meshinsights
+      - serviceinsights
+      - proxytemplates
+      - ratelimits
+      - trafficpermissions
+      - trafficroutes
+      - timeouts
+      - retries
+      - circuitbreakers
+      - virtualoutbounds
+      - containerpatches
+      - externalservices
+      - faultinjections
+      - healthchecks
+      - trafficlogs
+      - traffictraces
+      - meshgateways
+      - meshgatewayroutes
+      - meshgatewayinstances
+      - meshgatewayconfigs
+      - meshaccesslogs
+      - meshcircuitbreakers
+      - meshfaultinjections
+      - meshhealthchecks
+      - meshhttproutes
+      - meshloadbalancingstrategies
+      - meshmetrics
+      - meshpassthroughs
+      - meshproxypatches
+      - meshratelimits
+      - meshretries
+      - meshtcproutes
+      - meshtimeouts
+      - meshtlses
+      - meshtraces
+      - meshtrafficpermissions
+      - hostnamegenerators
+      - meshexternalservices
+      - meshidentities
+      - meshmultizoneservices
+      - meshopentelemetrybackends
+      - meshservices
+      - meshtrusts
+      - meshzoneaddresses
+      - workloads
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - kuma.io
+    resources:
+      - meshgatewayinstances/status
+      - meshgatewayinstances/finalizers
+      - meshes/finalizers
+      - dataplanes/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  # validate k8s token before issuing mTLS cert
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuma-control-plane-workloads
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+    # required by MeshGateway
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    # required by MeshGateway
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+    # Gateway API
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - referencegrants
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways/status
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane-workloads
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane-workloads
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  # leader-for-life election deletes Pods in some circumstances
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - referencegrants
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways/status
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kuma-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    prometheus.io/port: "5680"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5680
+      name: diagnostics
+      appProtocol: http
+    - port: 5681
+      name: http-api-server
+      appProtocol: http
+    - port: 5682
+      name: https-api-server
+      appProtocol: https
+    - port: 443
+      name: https-admission-server
+      targetPort: 5443
+      appProtocol: https
+    - port: 5676
+      name: mads-server
+      appProtocol: https
+    - port: 5678
+      name: dp-server
+      appProtocol: https
+  selector:
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 10002
+      protocol: TCP
+      targetPort: 10002
+  selector:
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      protocol: TCP
+      targetPort: 10001
+  selector:
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations: 
+    
+spec:
+  replicas: 1
+  minReadySeconds: 0
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-control-plane
+  template:
+    metadata:
+      annotations:
+        checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
+        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+      labels: 
+        app: kuma-control-plane
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - 'kuma-control-plane'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kuma-control-plane
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+        
+        kubernetes.io/os: linux
+      hostNetwork: false
+      terminationGracePeriodSeconds: 30
+      
+      containers:
+        - name: control-plane
+          image: "docker.io/kumahq/kuma-cp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
+              value: "false"
+            - name: KUMA_API_SERVER_READ_ONLY
+              value: "true"
+            - name: KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET
+              value: "true"
+            - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
+              value: "false"
+            - name: KUMA_DP_SERVER_HDS_ENABLED
+              value: "false"
+            - name: KUMA_ENVIRONMENT
+              value: "kubernetes"
+            - name: KUMA_GENERAL_TLS_CERT_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/tls.crt"
+            - name: KUMA_GENERAL_TLS_KEY_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/tls.key"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_IMAGE
+              value: "docker.io/kumahq/kuma-init:0.0.1"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "50M"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "20m"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "20M"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "512Mi"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "50m"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "64Mi"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "50M"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "20m"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "20M"
+            - name: KUMA_MODE
+              value: "zone"
+            - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
+              value: "true"
+            - name: KUMA_PLUGIN_POLICIES_ENABLED
+              value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
+            - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR
+              value: "/var/run/secrets/kuma.io/tls-cert"
+            - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
+              value: "5443"
+            - name: KUMA_RUNTIME_KUBERNETES_ALLOWED_USERS
+              value: "system:serviceaccount:kuma-system:kuma-control-plane"
+            - name: KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME
+              value: "kuma-control-plane"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CA_CERT_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/ca.crt"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CNI_ENABLED
+              value: "false"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IMAGE
+              value: "docker.io/kumahq/kuma-dp:0.0.1"
+            - name: KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE
+              value: "kuma-system"
+            - name: KUMA_STORE_TYPE
+              value: "kubernetes"
+            - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: control-plane
+                  resource: limits.memory
+                  divisor: "1"
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: control-plane
+                  resource: limits.cpu
+                  divisor: "1"
+          args:
+            - run
+            - --log-level=info
+            - --log-output-path=
+            - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
+          ports:
+            - containerPort: 5680
+              name: diagnostics
+              protocol: TCP
+            - containerPort: 5681
+            - containerPort: 5682
+            - containerPort: 5443
+            - containerPort: 5678
+          livenessProbe:
+            timeoutSeconds: 10
+            httpGet:
+              path: /healthy
+              port: 5680
+          readinessProbe:
+            timeoutSeconds: 10
+            httpGet:
+              path: /ready
+              port: 5680
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          
+          volumeMounts:
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/tls.crt
+              subPath: tls.crt
+              readOnly: true
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/tls.key
+              subPath: tls.key
+              readOnly: true
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              subPath: ca.crt
+              readOnly: true
+            - name: kuma-control-plane-config
+              mountPath: /etc/kuma.io/kuma-control-plane
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: general-tls-cert
+          secret:
+            secretName: general-tls-secret
+        - name: kuma-control-plane-config
+          configMap:
+            name: kuma-control-plane-config
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
+    "custom.io/team": "platform"
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-egress
+  template:
+    metadata:
+      annotations:
+        kuma.io/egress: enabled
+      labels:
+        app: kuma-egress
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - kuma-egress
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsGroup: 5678
+        runAsNonRoot: true
+        runAsUser: 5678
+      serviceAccountName: kuma-egress
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      
+      containers:
+        - name: egress
+          image: "docker.io/kumahq/kuma-dp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUMA_CONTROL_PLANE_URL
+              value: "https://kuma-control-plane.kuma-system:5678"
+            - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
+            - name: KUMA_DATAPLANE_DRAIN_TIME
+              value: 30s
+            - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: KUMA_DATAPLANE_PROXY_TYPE
+              value: "egress"
+            - name: KUMA_READINESS_UNIX_SOCKET_DISABLED
+              value: "true"
+            - name: KUMA_READINESS_PORT
+              value: "9902"
+          args:
+            - run
+            - --log-level=info
+          ports:
+            - containerPort: 10002
+            - containerPort: 9902
+          livenessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 12
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 12
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources: 
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: control-plane-ca
+          secret:
+            secretName: "general-tls-secret"
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    "argocd.argoproj.io/hook-delete-policy": "BeforeHookCreation"
+    "custom.io/team": "platform"
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-ingress
+  template:
+    metadata:
+      annotations:
+        kuma.io/ingress: enabled
+      labels:
+        app: kuma-ingress
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - kuma-ingress
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsGroup: 5678
+        runAsNonRoot: true
+        runAsUser: 5678
+      serviceAccountName: kuma-ingress
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 40
+      
+      containers:
+        - name: ingress
+          image: "docker.io/kumahq/kuma-dp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUMA_CONTROL_PLANE_URL
+              value: "https://kuma-control-plane.kuma-system:5678"
+            - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
+            - name: KUMA_DATAPLANE_DRAIN_TIME
+              value: 30s
+            - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: KUMA_DATAPLANE_PROXY_TYPE
+              value: "ingress"
+            - name: KUMA_READINESS_UNIX_SOCKET_DISABLED
+              value: "true"
+            - name: KUMA_READINESS_PORT
+              value: "9902"
+          args:
+            - run
+            - --log-level=info
+          ports:
+            - containerPort: 10001
+            - containerPort: 9902
+          livenessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 12
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 12
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources: 
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          
+          volumeMounts:
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: control-plane-ca
+          secret:
+            secretName: "general-tls-secret"
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - name: tmp
+          emptyDir: { }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kuma-admission-mutating-webhook-configuration
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+webhooks:
+  - name: mesh.defaulter.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /default-kuma-io-v1alpha1-mesh
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - meshes
+          - dataplanes
+          - dataplaneinsights
+          - meshgateways
+          - zoneingresses
+          - zoneingressinsights
+          - zoneegresses
+          - zoneegressinsights
+          - serviceinsights
+          - zone
+          - zoneinsights
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+    sideEffects: None
+  - name: owner-reference.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /owner-reference-kuma-io-v1alpha1
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - circuitbreakers
+          - externalservices
+          - faultinjections
+          - healthchecks
+          - meshgateways
+          - meshgatewayroutes
+          - proxytemplates
+          - ratelimits
+          - retries
+          - timeouts
+          - trafficlogs
+          - trafficpermissions
+          - trafficroutes
+          - traffictraces
+          - virtualoutbounds
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+  
+      
+    sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: In
+          values:
+          - enabled
+          - "true"
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: mesh-zoneproxy-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - kuma-system
+    objectSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: In
+          values:
+            - enabled
+        - key: kuma.io/mesh
+          operator: Exists
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kuma-validating-webhook-configuration
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+webhooks:
+  - name: validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-kuma-io-v1alpha1
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - circuitbreakers
+          - dataplanes
+          - externalservices
+          - faultinjections
+          - meshgatewayinstances
+          - healthchecks
+          - meshes
+          - meshgateways
+          - meshgatewayroutes
+          - proxytemplates
+          - ratelimits
+          - retries
+          - trafficlogs
+          - trafficpermissions
+          - trafficroutes
+          - traffictraces
+          - virtualoutbounds
+          - zones
+          - containerpatches
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+    
+      
+    sideEffects: None
+  - name: secret.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1-secret
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - secrets
+    sideEffects: None
+  - name: pod.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    failurePolicy: Fail
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1-pod
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+    sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyDeploymentAnnotations.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyDeploymentAnnotations.values.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: true
+  deploymentAnnotations:
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    custom.io/team: platform
+egress:
+  enabled: true
+  deploymentAnnotations:
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    custom.io/team: platform

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -174,6 +174,7 @@ A Helm chart for the Kuma Control Plane
 | ingress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
 | ingress.annotations | object | `{}` | Additional pod annotations (deprecated favor `podAnnotations`) |
 | ingress.podAnnotations | object | `{}` | Additional pod annotations |
+| ingress.deploymentAnnotations | object | `{}` | Annotations to add to the Deployment resource. |
 | ingress.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the Ingress pods |
 | ingress.tolerations | list | `[]` | Tolerations for the Ingress pods |
 | ingress.podDisruptionBudget.enabled | bool | `false` | Whether to create a pod disruption budget |
@@ -212,6 +213,7 @@ A Helm chart for the Kuma Control Plane
 | egress.service.nodePort | string | `nil` | Port on which service is exposed on Node for service of type NodePort |
 | egress.annotations | object | `{}` | Additional pod annotations (deprecated favor `podAnnotations`) |
 | egress.podAnnotations | object | `{}` | Additional pod annotations |
+| egress.deploymentAnnotations | object | `{}` | Annotations to add to the Deployment resource. |
 | egress.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node Selector for the Egress pods |
 | egress.tolerations | list | `[]` | Tolerations for the Egress pods |
 | egress.podDisruptionBudget.enabled | bool | `false` | Whether to create a pod disruption budget |
@@ -239,27 +241,37 @@ A Helm chart for the Kuma Control Plane
 | meshZoneProxyDefaults.egress.service.targetPort | int | `10002` | Container port the zone egress listens on. Do not change unless the zone proxy binary is reconfigured. |
 | meshes[0].name | string | `"default"` | The mesh must already exist or be created separately; this Helm chart will not create it. |
 | meshes[0].ingress.enabled | bool | `false` | Deploy a zone ingress for this mesh. |
-| meshes[0].ingress.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
 | meshes[0].ingress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
 | meshes[0].ingress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride) |
 | meshes[0].ingress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.ingress.service.type when unset. |
 | meshes[0].ingress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.ingress.service.port when unset. |
 | meshes[0].ingress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
-| meshes[0].ingress.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
-| meshes[0].ingress.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
-| meshes[0].ingress.containerResources | object | `{}` | Resource requests and limits for the pause container. |
+| meshes[0].ingress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
+| meshes[0].ingress.service.labels | object | `{}` | Labels to add to the Service resource. |
+| meshes[0].ingress.deployment | object | `{"annotations":{},"containerResources":{},"labels":{},"podSpec":{},"replicas":1,"resources":{}}` | Deployment-level settings. |
+| meshes[0].ingress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
+| meshes[0].ingress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
+| meshes[0].ingress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
+| meshes[0].ingress.deployment.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
+| meshes[0].ingress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
+| meshes[0].ingress.deployment.containerResources | object | `{}` | Resource requests and limits for the pause container. |
 | meshes[0].ingress.hpa | object | `{"enabled":false,"maxReplicas":5,"minReplicas":2,"targetCPUUtilizationPercentage":80}` | Horizontal Pod Autoscaler settings. |
 | meshes[0].ingress.pdb | object | `{"enabled":false,"maxUnavailable":1}` | Pod Disruption Budget settings. |
 | meshes[0].egress.enabled | bool | `false` | Deploy a zone egress for this mesh. |
-| meshes[0].egress.replicas | int | `1` |  |
 | meshes[0].egress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
 | meshes[0].egress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride) |
 | meshes[0].egress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.egress.service.type when unset. |
 | meshes[0].egress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.egress.service.port when unset. |
 | meshes[0].egress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
-| meshes[0].egress.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
-| meshes[0].egress.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
-| meshes[0].egress.containerResources | object | `{}` | Resource requests and limits for the pause container. |
+| meshes[0].egress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
+| meshes[0].egress.service.labels | object | `{}` | Labels to add to the Service resource. |
+| meshes[0].egress.deployment | object | `{"annotations":{},"containerResources":{},"labels":{},"podSpec":{},"replicas":1,"resources":{}}` | Deployment-level settings. |
+| meshes[0].egress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
+| meshes[0].egress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
+| meshes[0].egress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
+| meshes[0].egress.deployment.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
+| meshes[0].egress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
+| meshes[0].egress.deployment.containerResources | object | `{}` | Resource requests and limits for the pause container. |
 | meshes[0].egress.hpa.enabled | bool | `false` |  |
 | meshes[0].egress.hpa.minReplicas | int | `2` |  |
 | meshes[0].egress.hpa.maxReplicas | int | `5` |  |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -252,7 +252,7 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].ingress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
 | meshes[0].ingress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].ingress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
-| meshes[0].ingress.deployment.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
+| meshes[0].ingress.deployment.resources | object | `{}` | Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate). Applied to all containers in the pod (pause + injected kuma-sidecar). |
 | meshes[0].ingress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
 | meshes[0].ingress.deployment.containerResources | object | `{}` | Resource requests and limits for the pause container. |
 | meshes[0].ingress.hpa | object | `{"enabled":false,"maxReplicas":5,"minReplicas":2,"targetCPUUtilizationPercentage":80}` | Horizontal Pod Autoscaler settings. |
@@ -269,7 +269,7 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].egress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
 | meshes[0].egress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].egress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
-| meshes[0].egress.deployment.resources | object | `{}` | Resource requests and limits for the pod (pod-level resources). Applied to all containers in the pod (pause + injected kuma-sidecar). |
+| meshes[0].egress.deployment.resources | object | `{}` | Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate). Applied to all containers in the pod (pause + injected kuma-sidecar). |
 | meshes[0].egress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
 | meshes[0].egress.deployment.containerResources | object | `{}` | Resource requests and limits for the pause container. |
 | meshes[0].egress.hpa.enabled | bool | `false` |  |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -248,13 +248,11 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].ingress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
 | meshes[0].ingress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
 | meshes[0].ingress.service.labels | object | `{}` | Labels to add to the Service resource. |
-| meshes[0].ingress.deployment | object | `{"annotations":{},"containerResources":{},"labels":{},"podSpec":{},"replicas":1,"resources":{}}` | Deployment-level settings. |
+| meshes[0].ingress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":1}` | Deployment-level settings. |
 | meshes[0].ingress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
 | meshes[0].ingress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].ingress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
-| meshes[0].ingress.deployment.resources | object | `{}` | Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate). Applied to all containers in the pod (pause + injected kuma-sidecar). |
-| meshes[0].ingress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
-| meshes[0].ingress.deployment.containerResources | object | `{}` | Resource requests and limits for the pause container. |
+| meshes[0].ingress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext, resources,  containerResources). |
 | meshes[0].ingress.hpa | object | `{"enabled":false,"maxReplicas":5,"minReplicas":2,"targetCPUUtilizationPercentage":80}` | Horizontal Pod Autoscaler settings. |
 | meshes[0].ingress.pdb | object | `{"enabled":false,"maxUnavailable":1}` | Pod Disruption Budget settings. |
 | meshes[0].egress.enabled | bool | `false` | Deploy a zone egress for this mesh. |
@@ -265,13 +263,11 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].egress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
 | meshes[0].egress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
 | meshes[0].egress.service.labels | object | `{}` | Labels to add to the Service resource. |
-| meshes[0].egress.deployment | object | `{"annotations":{},"containerResources":{},"labels":{},"podSpec":{},"replicas":1,"resources":{}}` | Deployment-level settings. |
+| meshes[0].egress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":1}` | Deployment-level settings. |
 | meshes[0].egress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
 | meshes[0].egress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].egress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
-| meshes[0].egress.deployment.resources | object | `{}` | Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate). Applied to all containers in the pod (pause + injected kuma-sidecar). |
-| meshes[0].egress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext). |
-| meshes[0].egress.deployment.containerResources | object | `{}` | Resource requests and limits for the pause container. |
+| meshes[0].egress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext, resources,  containerResources). |
 | meshes[0].egress.hpa.enabled | bool | `false` |  |
 | meshes[0].egress.hpa.minReplicas | int | `2` |  |
 | meshes[0].egress.hpa.maxReplicas | int | `5` |  |

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "kuma.name" . }}-egress
   namespace: {{ .Release.Namespace }}
   labels: {{ include "kuma.egressLabels" . | nindent 4 }}
+  {{- with .Values.egress.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   strategy:
     rollingUpdate:

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "kuma.name" . }}-ingress
   namespace: {{ .Release.Namespace }}
   labels: {{ include "kuma.ingressLabels" . | nindent 4 }}
+  {{- with .Values.ingress.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   strategy:
     rollingUpdate:

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
@@ -23,20 +23,31 @@
 {{- range $roleEntry := $roles }}
 {{- $role := $roleEntry.role }}
 {{- $cfg := $roleEntry.cfg }}
+{{- $dep := and $cfg.deployment | default dict }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kuma.mesh.zoneproxy.name" (dict "root" $ "meshName" $meshName "role" $role) }}
   namespace: {{ $.Release.Namespace }}
-  labels: {{ include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 4 }}
+  labels:
+    {{- include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 4 }}
+    {{- range $key, $value := $dep.labels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- with $dep.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
   {{- if not (and $cfg.hpa $cfg.hpa.enabled) }}
-  replicas: {{ default 1 $cfg.replicas }}
+  replicas: {{ default 1 $dep.replicas }}
   {{- end }}
   selector:
     matchLabels:
@@ -49,21 +60,21 @@ spec:
         {{- include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 8 }}
         kuma.io/sidecar-injection: enabled
     spec:
-      {{- if $cfg.resources }}
-      resources: {{ toYaml $cfg.resources | nindent 8 }}
+      {{- if $dep.resources }}
+      resources: {{ toYaml $dep.resources | nindent 8 }}
       {{- end }}
-      {{- with (and $cfg.podSpec $cfg.podSpec.affinity) }}
+      {{- with (and $dep.podSpec $dep.podSpec.affinity) }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
-      {{- with (and $cfg.podSpec $cfg.podSpec.topologySpreadConstraints) }}
+      {{- with (and $dep.podSpec $dep.podSpec.topologySpreadConstraints) }}
       topologySpreadConstraints: {{ tpl (toYaml . | nindent 8) $ }}
       {{- end }}
-      {{- with (and $cfg.podSpec $cfg.podSpec.priorityClassName) }}
+      {{- with (and $dep.podSpec $dep.podSpec.priorityClassName) }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- if and $cfg.podSpec $cfg.podSpec.securityContext }}
+      {{- if and $dep.podSpec $dep.podSpec.securityContext }}
       securityContext:
-      {{- toYaml $cfg.podSpec.securityContext | trim | nindent 8 }}
+      {{- toYaml $dep.podSpec.securityContext | trim | nindent 8 }}
       {{- else }}
       securityContext:
         runAsUser: 5678
@@ -74,11 +85,11 @@ spec:
       serviceAccountName: {{ include "kuma.mesh.zoneproxy.name" (dict "root" $ "meshName" $meshName "role" $role) }}
       automountServiceAccountToken: {{ default true $cfg.automountServiceAccountToken }}
       restartPolicy: {{ default "Always" $cfg.restartPolicy }}
-      {{- with (and $cfg.podSpec $cfg.podSpec.nodeSelector) }}
+      {{- with (and $dep.podSpec $dep.podSpec.nodeSelector) }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (and $cfg.podSpec $cfg.podSpec.tolerations) }}
+      {{- with (and $dep.podSpec $dep.podSpec.tolerations) }}
       tolerations:
       {{ toYaml . | nindent 8 }}
       {{- end }}
@@ -87,9 +98,9 @@ spec:
         - name: pause
           image: {{ include "kuma.mesh.zoneproxy.image" (dict "root" $ "cfg" $cfg "meshName" $meshName "role" $role) | quote }}
           imagePullPolicy: {{ default "IfNotPresent" $cfg.imagePullPolicy }}
-          {{- if and $cfg.podSpec $cfg.podSpec.containerSecurityContext }}
+          {{- if and $dep.podSpec $dep.podSpec.containerSecurityContext }}
           securityContext:
-          {{- toYaml $cfg.podSpec.containerSecurityContext | trim | nindent 12 }}
+          {{- toYaml $dep.podSpec.containerSecurityContext | trim | nindent 12 }}
           {{- else }}
           securityContext:
             readOnlyRootFilesystem: true
@@ -99,8 +110,8 @@ spec:
               drop:
                 - ALL
           {{- end }}
-          {{- if $cfg.containerResources }}
-          resources: {{ toYaml $cfg.containerResources | nindent 12 }}
+          {{- if $dep.containerResources }}
+          resources: {{ toYaml $dep.containerResources | nindent 12 }}
           {{- else }}
           resources:
             requests:

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
@@ -23,7 +23,7 @@
 {{- range $roleEntry := $roles }}
 {{- $role := $roleEntry.role }}
 {{- $cfg := $roleEntry.cfg }}
-{{- $dep := and $cfg.deployment | default dict }}
+{{- $dep := $cfg.deployment | default dict }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -32,14 +32,12 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 4 }}
-    {{- range $key, $value := $dep.labels }}
-    {{ $key | quote }}: {{ $value | quote }}
+    {{- with $dep.labels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with $dep.annotations }}
   annotations:
-    {{- range $key, $value := . }}
-    {{ $key | quote }}: {{ $value | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   strategy:

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
@@ -58,8 +58,8 @@ spec:
         {{- include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 8 }}
         kuma.io/sidecar-injection: enabled
     spec:
-      {{- if $dep.resources }}
-      resources: {{ toYaml $dep.resources | nindent 8 }}
+      {{- if and $dep.podSpec $dep.podSpec.resources }}
+      resources: {{ toYaml $dep.podSpec.resources | nindent 8 }}
       {{- end }}
       {{- with (and $dep.podSpec $dep.podSpec.affinity) }}
       affinity: {{ tpl (toYaml . | nindent 8) $ }}
@@ -108,8 +108,8 @@ spec:
               drop:
                 - ALL
           {{- end }}
-          {{- if $dep.containerResources }}
-          resources: {{ toYaml $dep.containerResources | nindent 12 }}
+          {{- if and $dep.podSpec $dep.podSpec.containerResources }}
+          resources: {{ toYaml $dep.podSpec.containerResources | nindent 12 }}
           {{- else }}
           resources:
             requests:

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-service.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-service.yaml
@@ -22,10 +22,13 @@ metadata:
   labels:
     {{- include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 4 }}
     k8s.kuma.io/zone-proxy-type: {{ $role }}
-  {{- if and $cfg.service $cfg.service.annotations }}
+    {{- range $key, $value := (and $cfg.service $cfg.service.labels) }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- with (and $cfg.service $cfg.service.annotations) }}
   annotations:
-    {{- range $key, $value := $cfg.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- range $key, $value := . }}
+    {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
 spec:

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -877,15 +877,11 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
-        # Applied to all containers in the pod (pause + injected kuma-sidecar).
-        resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
         # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-        #  priorityClassName, securityContext, containerSecurityContext).
+        #  priorityClassName, securityContext, containerSecurityContext, resources,
+        #  containerResources).
         podSpec: {}
-        # -- Resource requests and limits for the pause container.
-        containerResources: {}
       # -- Horizontal Pod Autoscaler settings.
       hpa:
         enabled: false
@@ -929,15 +925,11 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
-        # Applied to all containers in the pod (pause + injected kuma-sidecar).
-        resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
         # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-        #  priorityClassName, securityContext, containerSecurityContext).
+        #  priorityClassName, securityContext, containerSecurityContext, resources,
+        #  containerResources).
         podSpec: {}
-        # -- Resource requests and limits for the pause container.
-        containerResources: {}
       hpa:
         enabled: false
         minReplicas: 2

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -877,7 +877,7 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Resource requests and limits for the pod (pod-level resources).
+        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
         # Applied to all containers in the pod (pause + injected kuma-sidecar).
         resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
@@ -929,7 +929,7 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Resource requests and limits for the pod (pod-level resources).
+        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
         # Applied to all containers in the pod (pause + injected kuma-sidecar).
         resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -607,6 +607,8 @@ ingress:
   annotations: { }
   # -- Additional pod annotations
   podAnnotations: { }
+  # -- Annotations to add to the Deployment resource.
+  deploymentAnnotations: { }
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -735,6 +737,8 @@ egress:
   annotations: { }
   # -- Additional pod annotations
   podAnnotations: { }
+  # -- Annotations to add to the Deployment resource.
+  deploymentAnnotations: { }
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -844,8 +848,6 @@ meshes:
     ingress:
       # -- Deploy a zone ingress for this mesh.
       enabled: false
-      # -- Number of replicas. Ignored when hpa.enabled is true.
-      replicas: 1
       # -- Per-mesh override for the pause container image. Falls back to
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
@@ -863,15 +865,27 @@ meshes:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
-      # -- Resource requests and limits for the pod (pod-level resources).
-      # Applied to all containers in the pod (pause + injected kuma-sidecar).
-      resources: {}
-      # -- Subset of Kubernetes PodSpec fields applied to the pod template
-      # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-      #  priorityClassName, securityContext, containerSecurityContext).
-      podSpec: {}
-      # -- Resource requests and limits for the pause container.
-      containerResources: {}
+        # -- Annotations to add to the Service resource.
+        annotations: {}
+        # -- Labels to add to the Service resource.
+        labels: {}
+      # -- Deployment-level settings.
+      deployment:
+        # -- Number of replicas. Ignored when hpa.enabled is true.
+        replicas: 1
+        # -- Annotations to add to the Deployment resource.
+        annotations: {}
+        # -- Labels to add to the Deployment resource.
+        labels: {}
+        # -- Resource requests and limits for the pod (pod-level resources).
+        # Applied to all containers in the pod (pause + injected kuma-sidecar).
+        resources: {}
+        # -- Subset of Kubernetes PodSpec fields applied to the pod template
+        # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
+        #  priorityClassName, securityContext, containerSecurityContext).
+        podSpec: {}
+        # -- Resource requests and limits for the pause container.
+        containerResources: {}
       # -- Horizontal Pod Autoscaler settings.
       hpa:
         enabled: false
@@ -886,7 +900,6 @@ meshes:
     egress:
       # -- Deploy a zone egress for this mesh.
       enabled: false
-      replicas: 1
       # -- Per-mesh override for the pause container image. Falls back to
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
@@ -904,15 +917,27 @@ meshes:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
-      # -- Resource requests and limits for the pod (pod-level resources).
-      # Applied to all containers in the pod (pause + injected kuma-sidecar).
-      resources: {}
-      # -- Subset of Kubernetes PodSpec fields applied to the pod template
-      # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-      #  priorityClassName, securityContext, containerSecurityContext).
-      podSpec: {}
-      # -- Resource requests and limits for the pause container.
-      containerResources: {}
+        # -- Annotations to add to the Service resource.
+        annotations: {}
+        # -- Labels to add to the Service resource.
+        labels: {}
+      # -- Deployment-level settings.
+      deployment:
+        # -- Number of replicas. Ignored when hpa.enabled is true.
+        replicas: 1
+        # -- Annotations to add to the Deployment resource.
+        annotations: {}
+        # -- Labels to add to the Deployment resource.
+        labels: {}
+        # -- Resource requests and limits for the pod (pod-level resources).
+        # Applied to all containers in the pod (pause + injected kuma-sidecar).
+        resources: {}
+        # -- Subset of Kubernetes PodSpec fields applied to the pod template
+        # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
+        #  priorityClassName, securityContext, containerSecurityContext).
+        podSpec: {}
+        # -- Resource requests and limits for the pause container.
+        containerResources: {}
       hpa:
         enabled: false
         minReplicas: 2

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -877,15 +877,11 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
-        # Applied to all containers in the pod (pause + injected kuma-sidecar).
-        resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
         # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-        #  priorityClassName, securityContext, containerSecurityContext).
+        #  priorityClassName, securityContext, containerSecurityContext, resources,
+        #  containerResources).
         podSpec: {}
-        # -- Resource requests and limits for the pause container.
-        containerResources: {}
       # -- Horizontal Pod Autoscaler settings.
       hpa:
         enabled: false
@@ -929,15 +925,11 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
-        # Applied to all containers in the pod (pause + injected kuma-sidecar).
-        resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
         # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-        #  priorityClassName, securityContext, containerSecurityContext).
+        #  priorityClassName, securityContext, containerSecurityContext, resources,
+        #  containerResources).
         podSpec: {}
-        # -- Resource requests and limits for the pause container.
-        containerResources: {}
       hpa:
         enabled: false
         minReplicas: 2

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -877,7 +877,7 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Resource requests and limits for the pod (pod-level resources).
+        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
         # Applied to all containers in the pod (pause + injected kuma-sidecar).
         resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template
@@ -929,7 +929,7 @@ meshes:
         annotations: {}
         # -- Labels to add to the Deployment resource.
         labels: {}
-        # -- Resource requests and limits for the pod (pod-level resources).
+        # -- Pod-level resource requests and limits (requires Kubernetes 1.34+ with PodLevelResources feature gate).
         # Applied to all containers in the pod (pause + injected kuma-sidecar).
         resources: {}
         # -- Subset of Kubernetes PodSpec fields applied to the pod template

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -607,6 +607,8 @@ ingress:
   annotations: { }
   # -- Additional pod annotations
   podAnnotations: { }
+  # -- Annotations to add to the Deployment resource.
+  deploymentAnnotations: { }
   # -- Node Selector for the Ingress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -735,6 +737,8 @@ egress:
   annotations: { }
   # -- Additional pod annotations
   podAnnotations: { }
+  # -- Annotations to add to the Deployment resource.
+  deploymentAnnotations: { }
   # -- Node Selector for the Egress pods
   nodeSelector:
     kubernetes.io/os: linux
@@ -844,8 +848,6 @@ meshes:
     ingress:
       # -- Deploy a zone ingress for this mesh.
       enabled: false
-      # -- Number of replicas. Ignored when hpa.enabled is true.
-      replicas: 1
       # -- Per-mesh override for the pause container image. Falls back to
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
@@ -863,15 +865,27 @@ meshes:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
-      # -- Resource requests and limits for the pod (pod-level resources).
-      # Applied to all containers in the pod (pause + injected kuma-sidecar).
-      resources: {}
-      # -- Subset of Kubernetes PodSpec fields applied to the pod template
-      # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-      #  priorityClassName, securityContext, containerSecurityContext).
-      podSpec: {}
-      # -- Resource requests and limits for the pause container.
-      containerResources: {}
+        # -- Annotations to add to the Service resource.
+        annotations: {}
+        # -- Labels to add to the Service resource.
+        labels: {}
+      # -- Deployment-level settings.
+      deployment:
+        # -- Number of replicas. Ignored when hpa.enabled is true.
+        replicas: 1
+        # -- Annotations to add to the Deployment resource.
+        annotations: {}
+        # -- Labels to add to the Deployment resource.
+        labels: {}
+        # -- Resource requests and limits for the pod (pod-level resources).
+        # Applied to all containers in the pod (pause + injected kuma-sidecar).
+        resources: {}
+        # -- Subset of Kubernetes PodSpec fields applied to the pod template
+        # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
+        #  priorityClassName, securityContext, containerSecurityContext).
+        podSpec: {}
+        # -- Resource requests and limits for the pause container.
+        containerResources: {}
       # -- Horizontal Pod Autoscaler settings.
       hpa:
         enabled: false
@@ -886,7 +900,6 @@ meshes:
     egress:
       # -- Deploy a zone egress for this mesh.
       enabled: false
-      replicas: 1
       # -- Per-mesh override for the pause container image. Falls back to
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
@@ -904,15 +917,27 @@ meshes:
         # -- Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.).
         # Merged directly into the Service spec.
         spec: {}
-      # -- Resource requests and limits for the pod (pod-level resources).
-      # Applied to all containers in the pod (pause + injected kuma-sidecar).
-      resources: {}
-      # -- Subset of Kubernetes PodSpec fields applied to the pod template
-      # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
-      #  priorityClassName, securityContext, containerSecurityContext).
-      podSpec: {}
-      # -- Resource requests and limits for the pause container.
-      containerResources: {}
+        # -- Annotations to add to the Service resource.
+        annotations: {}
+        # -- Labels to add to the Service resource.
+        labels: {}
+      # -- Deployment-level settings.
+      deployment:
+        # -- Number of replicas. Ignored when hpa.enabled is true.
+        replicas: 1
+        # -- Annotations to add to the Deployment resource.
+        annotations: {}
+        # -- Labels to add to the Deployment resource.
+        labels: {}
+        # -- Resource requests and limits for the pod (pod-level resources).
+        # Applied to all containers in the pod (pause + injected kuma-sidecar).
+        resources: {}
+        # -- Subset of Kubernetes PodSpec fields applied to the pod template
+        # (nodeSelector, tolerations, affinity, topologySpreadConstraints,
+        #  priorityClassName, securityContext, containerSecurityContext).
+        podSpec: {}
+        # -- Resource requests and limits for the pause container.
+        containerResources: {}
       hpa:
         enabled: false
         minReplicas: 2


### PR DESCRIPTION
## Motivation

There was no way to set annotations on the Deployment resource itself for zone proxies — only pod-level annotations were supported. This matters for tools like ArgoCD (`argocd.argoproj.io/hook-delete-policy`), Karpenter, or any operator that reads Deployment metadata to control lifecycle or scheduling behavior.

## Implementation information

Zone-level ingress/egress (ingress, egress top-level values):
  - Added deploymentAnnotations field rendered onto `Deployment.metadata.annotations`

Mesh-scoped zone proxies (`meshes[].ingress`, `meshes[].egress`):
  - Reorganized scattered fields into a deployment subsection: replicas, resources, podSpec, containerResources moved
   under `deployment.*`
  - Added deployment.annotations and deployment.labels for Deployment metadata
  - Added service.annotations and service.labels for Service metadata (annotations were already wired in the template
   but missing from values)

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/16448

> Changelog: feat(kuma-cp): add mesh-scoped zone proxies
