### PR TITLE
test(e2e): increase eventually time

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -529,7 +529,7 @@ spec:
 
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(response.ResponseCode).To(Equal(429))
-			}, "30s", "1s").Should(Succeed())
+			}, "30s", "100ms").Should(Succeed())
 		})
 	})
 

--- a/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/kubernetes/meshexternalservice/meshexternalservice.go
@@ -189,7 +189,7 @@ spec:
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(response.ResponseCode).To(Equal(403))
-			}, "30s", "1s").Should(Succeed())
+			}, "60s", "1s").Should(Succeed())
 		})
 	})
 

--- a/test/e2e_env/multizone/meshproxy/connectivity.go
+++ b/test/e2e_env/multizone/meshproxy/connectivity.go
@@ -213,7 +213,7 @@ spec:
 				r, err := rest.JSON.Unmarshal([]byte(out), meshtrust_api.MeshTrustResourceTypeDescriptor)
 				g.Expect(err).ToNot(HaveOccurred())
 				trust = r.GetSpec().(*meshtrust_api.MeshTrust)
-			}, "30s", "1s").Should(Succeed())
+			}, "60s", "1s").Should(Succeed())
 			return trust
 		}
 


### PR DESCRIPTION
## Motivation

Looks like some tests needs more time, as changes on k8s takes longer time to be processed

## Implementation information

increase eventually from 30 seconds to 60 seconds

## Supporting documentation

> Changelog: skip
