### PR TITLE
fix(grafana): success rate stat shows red when no errors

### DIFF
--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -354,7 +354,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "1 - (sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])), 1))",
+          "expr": "1 - ((sum(rate(envoy_http_downstream_rq_xx{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) or vector(0), 1))",
           "legendFormat": "",
           "refId": "A"
         }


### PR DESCRIPTION
## Motivation

When no 5xx errors exist, the PromQL expression returns an empty vector, causing the Grafana stat panel to fall back to the null/red threshold instead of showing 100% success rate.

## Implementation information

Added `or vector(0)` fallback to both the 5xx numerator and total denominator expressions in `kuma-mesh.json` so the panel evaluates to 1.0 (100% success) when there is no error traffic.

> Changelog: fix(grafana): success rate stat shows red when no errors