### PR TITLE
docs(MADR): auto-generate MeshService on Universal post-tags

### DIFF
--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -8,7 +8,7 @@ Technical Story: https://github.com/Kong/kong-mesh/issues/9443
 
 On Universal, the control plane (CP) auto-generates `MeshService` from `Dataplane` inbound tags (`pkg/core/resources/apis/meshservice/generate/generator.go`). A field report exposed two unmet needs:
 
-- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the auto-generated `MeshService`. MeshMultiZoneService (MMZS) selects on `MeshService.metadata.labels`, so multi-zone selection by team/env is impossible for Universal today.
+- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the auto-generated `MeshService`. MeshMultizoneService selects on `MeshService.metadata.labels`, so multi-zone selection by team/env is impossible for Universal today.
 - Some operators (ECS/Fargate behind restricted networks) cannot reach the zone CP REST API. Their only channel is the `Dataplane` shipped via `kuma-dp run --dataplane-file`.
 
 Inbound tags do two jobs: data plane (DP) grouping (which DPs are one logical service) and per-inbound service membership (which services this port serves). The `kuma.io/workload` label and existing `Workload` generator solve the first job. Many-to-many (M:M) cases (port carve-out: one workload to many MeshServices; workload aggregation: blue/green, canary) need the second.
@@ -24,11 +24,11 @@ Inbound tags do two jobs: data plane (DP) grouping (which DPs are one logical se
 - Removing inbound tags must not regress M:M expressiveness.
 - Restricted-network operators must declare intent and observe its effect through the `Dataplane`/`kuma-dp` channel only. Signals queryable solely via `kumactl inspect` are unreachable for them.
 - Auto-generation has a single writer (CP). Distributed N-writer designs on a shared resource reintroduce CP-side coordination.
-- Silent MMZS misses are unacceptable.
+- Silent MeshMultizoneService misses are unacceptable.
 
 ### Release timeline
 
-- Kuma 2.14: tag-free operation supported on Kubernetes (K8s) and Universal, opt-in via `inboundTagsDisabled`. The structural replacement (C or D) ships here with a migration tool. The tactical label-propagation patch ships here.
+- Kuma 2.14: tag-free operation supported on Kubernetes (K8s) and Universal, opt-in via `inboundTagsDisabled`. The chosen path (Option D) ships here with a migration tool. The tactical label-propagation patch ships here.
 - Kuma 3.0: tags removed by default. Downstream policies matching `kuma.io/service` break unless migrated.
 
 ## Design
@@ -41,19 +41,7 @@ DP renders MeshService template and submits via bootstrap; CP upserts.
 * Bad. The mitigations (idempotent first-write, ref counting, primary DP) reintroduce CP coordination.
 * Bad. Broadens DP token to write a shared resource; security regression.
 
-### Option B: operator-authored MeshService, no auto-generation
-
-CP no longer generates. Operators run `kumactl apply -f meshservice.yaml`.
-
-* Good. Deletes the polling generator, `checkMeshServicesConsistency`, grace-period delete, and ownership tracking. Smallest CP code.
-* Good. No conflict resolution (single writer). No `WorkloadStatus.Conditions` to maintain.
-* Good. Symmetric with Kubernetes (operator authors the service-identity resource).
-* Good. No new fields on `Dataplane` spec.
-* Bad. Blocks the restricted-network operator entirely.
-* Bad. Universal users must run a parallel CI/GitOps surface for MeshService.
-* Bad. The tactical label-propagation patch cannot ship under it.
-
-### Option C: workload-only auto-generation
+### Option B: workload-only auto-generation
 
 CP generates one MeshService per `kuma.io/workload` value; ports = union of all inbounds.
 
@@ -61,7 +49,7 @@ CP generates one MeshService per `kuma.io/workload` value; ports = union of all 
 * Bad. Cannot express M:M cases. Removing inbound tags silently drops port carve-out and workload aggregation.
 * Bad. Blue/green deployments impossible.
 
-### Option D: structured per-inbound `meshServices` field
+### Option C: structured per-inbound `meshServices` field
 
 Replace the free-form `inbound.tags["kuma.io/service"]` with a typed list:
 
@@ -91,18 +79,17 @@ Migration: `kuma.io/service: <name>` inbound tag becomes `inbound.meshServices: 
 
 * Good. Full M:M expressiveness; the multi-valued list fits port carve-out and aggregation.
 * Good. The channel is the existing `Dataplane`; restricted-network operators are unblocked.
-* Good. Typed and validated; typos fail at registration, not silently at MMZS.
+* Good. Typed and validated; a typo in the `meshServices` field is rejected at Dataplane registration, instead of silently producing a MeshMultizoneService that selects zero MeshServices later.
 * Good. Composes with the existing `kuma.io/workload` label and `Workload` generator.
-* Good. The tactical label-propagation patch ships under it; the field report closes immediately.
-* Bad. Concedes per-inbound service membership is load-bearing; that's a walk-back from "remove inbound tags entirely."
+* Good. The tactical label-propagation patch (see "Tactical patch" section below) is compatible with this option, so the user-reported issue that initiated this MADR can be closed without waiting for the full structural change.
+* Bad. Re-introduces per-inbound service membership under a new name. The original plan was to remove inbound tags entirely; this option keeps the same concept (which inbound serves which logical service) under a typed field instead of a free-form tag. We get a cleaner schema but admit the concept itself cannot be removed.
 * Bad. Adds a hard-to-delete field on `Dataplane`. The polling generator and `inboundTagsDisabled` branching stay.
-* Bad. `meshServices` (plural, on inbound) vs `MeshService` (resource) creates support confusion.
-* Bad. First-DP-wins may not match operator intuition for blue/green (newest-wins).
+* Bad. First-DP-wins conflict policy is wrong for blue/green: when blue and green Dataplanes disagree on a label or port for the same service, the older (blue) one wins because it registered first, but operators usually expect the newer (green) deployment to take precedence.
 * Bad. Largest implementation surface: validator, generator, condition lifecycle, xDS filter, migration tool, downstream policy audits.
 
 #### Migration window behavior
 
-A fleet in transition carries both forms. `checkMeshServicesConsistency` oscillates each tick under split fleets. The chosen option must enforce one of:
+During the migration to the new field, some Dataplanes in a mesh still use the old `kuma.io/service` inbound tag while others already use `inbound.meshServices`. If both forms reference the same service name, the existing `checkMeshServicesConsistency` logic picks a different "winner" on each reconcile pass and the generated `MeshService` spec flips back and forth. To prevent that, the implementation must enforce one of:
 
 - Validator: a Dataplane MUST NOT carry both `inbound.tags["kuma.io/service"]` and the new field.
 - Per-mesh flag: `inboundTagsDisabled` flips per-mesh, exactly one generator path per mesh.
@@ -118,16 +105,30 @@ A fleet in transition carries both forms. `checkMeshServicesConsistency` oscilla
 - `WorkloadStatus.Conditions[PortConflict|LabelConflict]` are set and cleared on every reconcile pass; stale `True` values are unacceptable and must be tested.
 - Conflict signals must mirror to `DataplaneInsight` so `kuma-dp` logs surface them locally for restricted-network operators.
 
+### Option D: operator-authored MeshService, no auto-generation
+
+CP no longer generates. Operators run `kumactl apply -f meshservice.yaml`.
+
+* Good. Deletes the polling generator, `checkMeshServicesConsistency`, grace-period delete, and ownership tracking. Smallest CP code.
+* Good. No conflict resolution (single writer). No `WorkloadStatus.Conditions` to maintain.
+* Good. Symmetric with Kubernetes (operator authors the service-identity resource).
+* Good. No new fields on `Dataplane` spec.
+* Bad. Blocks the restricted-network operator entirely.
+* Bad. Universal users must run a parallel CI/GitOps surface for MeshService.
+* Bad. The tactical label-propagation patch cannot ship under it.
+
 ## Tactical patch (independent, ships in 2.14)
 
-- Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to `MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound tags do not propagate, which signals deprecation. Once shipped, MMZS selectors in the wild depend on it.
-- Silent MMZS-miss is the dominant failure. CP emits a structured warning and metric whenever an MMZS resolves to zero MeshServices in a zone. Lands with the tactical patch.
+The "tactical patch" is a small immediate change that ships ahead of the structural decision and closes the user-reported issue (the field report). It is independent of which option (A-D) is ultimately chosen.
+
+- Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to `MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound tags do not propagate, which signals deprecation. Once shipped, MeshMultizoneService selectors in the wild depend on it.
+- A silent MeshMultizoneService selector miss (the selector resolves to zero MeshServices) is the dominant failure. CP emits a structured warning and metric whenever this happens in a zone. Lands with the tactical patch.
 
 ## Implications for Kong Mesh
 
-Significant in 3.0. Every downstream policy matching on `kuma.io/service` inbound tags breaks at upgrade unless migrated. The downstream project must audit policies, run the migration tool, and document the 2.14-to-3.0 upgrade.
+None specific to the downstream project. The 2.14-to-3.0 migration applies uniformly to all Kuma users; any downstream-specific code that derives MeshServices from inbound tags or matches policies on `kuma.io/service` must be updated alongside Kuma 3.0.
 
 ## Decision
 
 Not generating MeshService on Universal is most clean solution. It removes all the ambiguities that come with MeshService generation.
-It leaves full control over MeshService to mesh operator, they can label it as they need for grouping in MMZS.
+It leaves full control over MeshService to mesh operator, they can label it as they need for grouping in MeshMultizoneService.

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -1,0 +1,208 @@
+# Auto-generated MeshService on Universal post-inbound-tag removal
+
+* Status: proposed
+
+Technical Story: https://github.com/Kong/kong-mesh/issues/9443
+
+## Context and Problem Statement
+
+On Universal, the CP auto-generates `MeshService` from `Dataplane` inbound tags
+(`pkg/core/resources/apis/meshservice/generate/generator.go`). Two in-flight
+changes collide:
+
+1. Remove auto-generation of `MeshService` on Universal.
+2. Remove `Dataplane` inbound tags in favour of `MeshService` as primary identity.
+
+A field report exposed two unmet needs:
+
+- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the
+  auto-generated `MeshService`. MMZS selects on `MeshService.metadata.labels`,
+  so multi-zone selection by team/env is impossible for Universal today.
+- Some operators (ECS/Fargate behind restricted networks) cannot reach the
+  zone CP REST API. Their only channel is the `Dataplane` shipped via
+  `kuma-dp run --dataplane-file`.
+
+Inbound tags do two jobs: DP grouping (which DPs are one logical service) and
+per-inbound service membership (which services this port serves). The
+`kuma.io/workload` label and existing `Workload` generator solve the first
+job. M:M cases (port carve-out: one workload to many MeshServices; workload
+aggregation: blue/green, canary) need the second.
+
+### Use cases
+
+1. Trivial: N tasks for one service, one MeshService, custom labels reach `MeshService.metadata.labels`.
+2. Port carve-out: one workload exposes `http`, `admin`, `metrics` as separate MeshServices.
+3. Workload aggregation: two workloads (blue/green) back the same MeshService.
+4. Restricted-network operator: declares everything via `Dataplane` template at `kuma-dp` startup.
+
+## Decision Drivers
+
+- Removing inbound tags must not regress M:M expressiveness.
+- Restricted-network operators must declare intent and observe its effect through the `Dataplane`/`kuma-dp` channel only. Signals queryable solely via `kumactl inspect` are unreachable for them.
+- Auto-generation has a single writer (CP). Distributed N-writer designs on a shared resource reintroduce CP-side coordination.
+- Silent MMZS misses are unacceptable.
+- Decision-blocking inputs: empirical M:M usage frequency (Options C vs D), and Workload-to-MeshService lifecycle ownership (cascading vs grace-period delete).
+
+### Release timeline (hard)
+
+- Kuma 2.14: tag-free operation supported on K8s and Universal, opt-in via `inboundTagsDisabled`. The structural replacement (C or D) ships here with a migration tool. The tactical label-propagation patch ships here.
+- Kuma 3.0: tags removed by default. Downstream policies matching `kuma.io/service` break unless migrated.
+- Exit criteria below are 2.14-cycle deliverables.
+
+### Path-dependent constraints
+
+- KDS replication: any auto-gen must round-trip zone to global cleanly.
+- MMZS resolution: needs a deterministic label source-of-truth across reconciles.
+- Unified resource naming: validator enforces `inbound.name` stability.
+
+## Design
+
+### Option A: `kuma-dp run --meshservice-template`
+
+DP renders MeshService template and submits via bootstrap; CP upserts.
+
+* Bad. MeshService is N:1 with Dataplane: cold-start race, reconnect flap, rolling-restart skew, last-task orphan, env-var template drift.
+* Bad. The mitigations (idempotent first-write, ref counting, primary DP) reintroduce CP coordination.
+* Bad. Broadens DP token to write a shared resource; security regression.
+
+### Option B: operator-authored MeshService, no auto-generation
+
+CP no longer generates. Operators run `kumactl apply -f meshservice.yaml`.
+
+* Good. Deletes the polling generator, `checkMeshServicesConsistency`, grace-period delete, and ownership tracking. Smallest CP code.
+* Good. No conflict resolution (single writer). No `WorkloadStatus.Conditions` to maintain.
+* Good. Symmetric with Kubernetes (operator authors the service-identity resource).
+* Good. No new fields on `Dataplane` spec.
+* Bad. Blocks the restricted-network operator entirely.
+* Bad. Universal users must run a parallel CI/GitOps surface for MeshService.
+* Bad. The tactical label-propagation patch cannot ship under it.
+
+### Option C: workload-only auto-generation
+
+CP generates one MeshService per `kuma.io/workload` value; ports = union of all inbounds.
+
+* Good. Covers the trivial case with no new spec fields.
+* Bad. Cannot express M:M cases. Removing inbound tags silently drops port carve-out and workload aggregation.
+
+### Option D: structured per-inbound `meshServices` field
+
+Replace the free-form `inbound.tags["kuma.io/service"]` with a typed list:
+
+```yaml
+networking:
+  inbound:
+    - port: 8080
+      name: http
+      meshServices: [checkout]
+    - port: 7000
+      name: metrics
+      meshServices: [checkout-metrics, observability]   # multi-valued, M:M
+```
+
+CP groups inbounds across the mesh by each value in `inbound.meshServices[*]`.
+Per group: `name` is the membership value; `selector` is `kuma.io/workload`
+label match plus per-port-name filter; `ports` is the union by `inbound.name`;
+`labels` is the union of non-`kuma.io/*` keys from member Dataplanes.
+
+Member DPs sorted by `(creation_time, name)` via `SortDataplanes`. On conflict:
+
+| Conflict | Policy |
+|---|---|
+| Same port name, different port/protocol | First-DP-wins; `WorkloadStatus.Conditions[PortConflict]=True` |
+| Same label key, different value | First-DP-wins; `WorkloadStatus.Conditions[LabelConflict]=True` |
+| Divergent port set across DPs | Union; xDS endpoint filter drops DPs missing the port |
+| Missing `kuma.io/workload` or `inbound.name` | Reject at registration |
+
+Migration: `kuma.io/service: <name>` inbound tag becomes `inbound.meshServices: [<name>]`. Mechanical 1:1 lift.
+
+* Good. Full M:M expressiveness; the multi-valued list fits port carve-out and aggregation.
+* Good. The channel is the existing `Dataplane`; restricted-network operators are unblocked.
+* Good. Typed and validated; typos fail at registration, not silently at MMZS.
+* Good. Composes with the existing `kuma.io/workload` label and `Workload` generator.
+* Good. The tactical label-propagation patch ships under it; the field report closes immediately.
+* Bad. Concedes per-inbound service membership is load-bearing; that's a walk-back from "remove inbound tags entirely."
+* Bad. Adds a hard-to-delete field on `Dataplane`. The polling generator and `inboundTagsDisabled` branching stay.
+* Bad. `meshServices` (plural, on inbound) vs `MeshService` (resource) creates support confusion.
+* Bad. First-DP-wins may not match operator intuition for blue/green (newest-wins).
+* Bad. Largest implementation surface: validator, generator, condition lifecycle, xDS filter, migration tool, downstream policy audits.
+
+### Tactical patch (independent, ships in 2.14)
+
+Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to
+`MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound
+tags do not propagate, which signals deprecation. Once shipped, MMZS selectors
+in the wild depend on it; Option B becomes materially harder.
+
+### Migration window behavior
+
+A fleet in transition carries both forms. `checkMeshServicesConsistency`
+oscillates each tick under split fleets. The chosen option must enforce one
+of:
+
+- Validator: a Dataplane MUST NOT carry both `inbound.tags["kuma.io/service"]` and the new field.
+- Per-mesh flag: `inboundTagsDisabled` flips per-mesh, exactly one generator path per mesh.
+
+### Alternatives not considered
+
+- Event-driven generator off `DataplaneLifecycle`: revisit if the performance budget is exceeded.
+- MeshService-as-view (not stock): foreclosed by the current KDS/MMZS replication contract.
+
+## Security implications and review
+
+- DP token scope unchanged; CP remains sole `MeshService` writer.
+- No new privileged DP-to-CP channel. Option A's auth-broadening is avoided.
+- `kuma.io/workload` and `inbound.meshServices` are validated at Dataplane registration.
+
+## Reliability implications
+
+- Silent MMZS-miss is the dominant failure. CP emits a structured warning and
+  metric whenever an MMZS resolves to zero MeshServices in a zone. Lands with
+  the tactical patch.
+- `WorkloadStatus.Conditions[PortConflict|LabelConflict]` are set and cleared
+  on every reconcile pass; stale `True` values are unacceptable and must be
+  tested.
+- Conflict signals must mirror to `DataplaneInsight` so `kuma-dp` logs surface
+  them locally for restricted-network operators.
+- `inboundTagsDisabled` is opt-in in 2.14 and default in 3.0; no follow-up
+  MADR. Migration is forward-only.
+
+### Required failure-mode handling
+
+| Failure | Required behavior |
+|---|---|
+| Cross-operator `kuma.io/workload` collision | Validator checks uniqueness within mesh, or document accepted merge |
+| Auto-gen vs operator-authored MeshService same name | Operator-authored wins via `ManagedByLabel`; generator MUST NOT overwrite |
+| Operator removes `kuma.io/workload` from running DP | Treat as workload departure; grace-period delete only when no DP claims it |
+| Conflict resolved between reconciles | Set conditions to `False` explicitly on clean pass |
+
+### Performance budget
+
+Polling cost at scale is unmeasured. Publish p50/p99 of
+`component_meshservice_generator` at 1k, 5k, and 20k Dataplanes before the
+structural option lands. Option D adds an O(M) factor (mean `meshServices[]`
+cardinality) on top of the existing O(D·I).
+
+## Implications for Kong Mesh
+
+Significant in 3.0. Every downstream policy matching on `kuma.io/service`
+inbound tags breaks at upgrade unless migrated. The downstream project must
+audit policies, run the migration tool, and document the 2.14-to-3.0 upgrade.
+
+## Decision
+
+TBD. The tactical patch and MMZS observability ship in 2.14 ahead of the structural decision.
+
+## Exit criteria (close inside Kuma 2.14)
+
+1. M:M telemetry: count unique `kuma.io/service` values per workload-grouped DP set. Threshold of >=X% with >1 service/workload picks Option D; below picks Option C.
+2. Performance run at 1k, 5k, and 20k Dataplanes.
+3. Operator interviews: 3-5 ECS/Fargate restricted-network operators, ACTA-style.
+4. Lifecycle commitment: Workload-owns-MeshService vs generator-owns-MeshService.
+5. Migration tool ships in 2.14 alongside opt-in.
+6. Conflict policy locked: first-DP-wins vs newest-wins vs explicit priority, decided on data, not aesthetics.
+
+## Notes
+
+- Open: precise selector encoding for "workload labels union per-port filter". May live in xDS endpoint generator; confirm against `pkg/xds/generator/endpoint*`.
+- Open: field naming to avoid `meshServices` (field) vs `MeshService` (resource) confusion.
+- Open: whether to widen the bootstrap channel to accept operator-authored MeshService for the restricted-network cohort, narrowing the gap between Options B and D.

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -1,18 +1,13 @@
 # Auto-generated MeshService on Universal post-inbound-tag removal
 
-* Status: proposed
+* Status: accepted
 
 Technical Story: https://github.com/Kong/kong-mesh/issues/9443
 
 ## Context and Problem Statement
 
 On Universal, the CP auto-generates `MeshService` from `Dataplane` inbound tags
-(`pkg/core/resources/apis/meshservice/generate/generator.go`). Two in-flight
-changes collide:
-
-1. Remove auto-generation of `MeshService` on Universal.
-2. Remove `Dataplane` inbound tags in favour of `MeshService` as primary identity.
-
+(`pkg/core/resources/apis/meshservice/generate/generator.go`). 
 A field report exposed two unmet needs:
 
 - Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the
@@ -32,8 +27,7 @@ aggregation: blue/green, canary) need the second.
 
 1. Trivial: N tasks for one service, one MeshService, custom labels reach `MeshService.metadata.labels`.
 2. Port carve-out: one workload exposes `http`, `admin`, `metrics` as separate MeshServices.
-3. Workload aggregation: two workloads (blue/green) back the same MeshService.
-4. Restricted-network operator: declares everything via `Dataplane` template at `kuma-dp` startup.
+3. Restricted-network operator: declares everything via `Dataplane` template at `kuma-dp` startup.
 
 ## Decision Drivers
 
@@ -43,17 +37,10 @@ aggregation: blue/green, canary) need the second.
 - Silent MMZS misses are unacceptable.
 - Decision-blocking inputs: empirical M:M usage frequency (Options C vs D), and Workload-to-MeshService lifecycle ownership (cascading vs grace-period delete).
 
-### Release timeline (hard)
+### Release timeline
 
 - Kuma 2.14: tag-free operation supported on K8s and Universal, opt-in via `inboundTagsDisabled`. The structural replacement (C or D) ships here with a migration tool. The tactical label-propagation patch ships here.
 - Kuma 3.0: tags removed by default. Downstream policies matching `kuma.io/service` break unless migrated.
-- Exit criteria below are 2.14-cycle deliverables.
-
-### Path-dependent constraints
-
-- KDS replication: any auto-gen must round-trip zone to global cleanly.
-- MMZS resolution: needs a deterministic label source-of-truth across reconciles.
-- Unified resource naming: validator enforces `inbound.name` stability.
 
 ## Design
 
@@ -83,6 +70,7 @@ CP generates one MeshService per `kuma.io/workload` value; ports = union of all 
 
 * Good. Covers the trivial case with no new spec fields.
 * Bad. Cannot express M:M cases. Removing inbound tags silently drops port carve-out and workload aggregation.
+* Bad. Blue/green deployments impossible
 
 ### Option D: structured per-inbound `meshServices` field
 
@@ -106,12 +94,12 @@ label match plus per-port-name filter; `ports` is the union by `inbound.name`;
 
 Member DPs sorted by `(creation_time, name)` via `SortDataplanes`. On conflict:
 
-| Conflict | Policy |
-|---|---|
-| Same port name, different port/protocol | First-DP-wins; `WorkloadStatus.Conditions[PortConflict]=True` |
-| Same label key, different value | First-DP-wins; `WorkloadStatus.Conditions[LabelConflict]=True` |
-| Divergent port set across DPs | Union; xDS endpoint filter drops DPs missing the port |
-| Missing `kuma.io/workload` or `inbound.name` | Reject at registration |
+| Conflict                                     | Policy                                                         |
+|----------------------------------------------|----------------------------------------------------------------|
+| Same port name, different port/protocol      | First-DP-wins; `WorkloadStatus.Conditions[PortConflict]=True`  |
+| Same label key, different value              | First-DP-wins; `WorkloadStatus.Conditions[LabelConflict]=True` |
+| Divergent port set across DPs                | Union; xDS endpoint filter drops DPs missing the port          |
+| Missing `kuma.io/workload` or `inbound.name` | Reject at registration                                         |
 
 Migration: `kuma.io/service: <name>` inbound tag becomes `inbound.meshServices: [<name>]`. Mechanical 1:1 lift.
 
@@ -126,14 +114,7 @@ Migration: `kuma.io/service: <name>` inbound tag becomes `inbound.meshServices: 
 * Bad. First-DP-wins may not match operator intuition for blue/green (newest-wins).
 * Bad. Largest implementation surface: validator, generator, condition lifecycle, xDS filter, migration tool, downstream policy audits.
 
-### Tactical patch (independent, ships in 2.14)
-
-Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to
-`MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound
-tags do not propagate, which signals deprecation. Once shipped, MMZS selectors
-in the wild depend on it; Option B becomes materially harder.
-
-### Migration window behavior
+#### Migration window behavior
 
 A fleet in transition carries both forms. `checkMeshServicesConsistency`
 oscillates each tick under split fleets. The chosen option must enforce one
@@ -142,45 +123,29 @@ of:
 - Validator: a Dataplane MUST NOT carry both `inbound.tags["kuma.io/service"]` and the new field.
 - Per-mesh flag: `inboundTagsDisabled` flips per-mesh, exactly one generator path per mesh.
 
-### Alternatives not considered
-
-- Event-driven generator off `DataplaneLifecycle`: revisit if the performance budget is exceeded.
-- MeshService-as-view (not stock): foreclosed by the current KDS/MMZS replication contract.
-
-## Security implications and review
+#### Security implications and review
 
 - DP token scope unchanged; CP remains sole `MeshService` writer.
 - No new privileged DP-to-CP channel. Option A's auth-broadening is avoided.
 - `kuma.io/workload` and `inbound.meshServices` are validated at Dataplane registration.
 
-## Reliability implications
+#### Reliability implications
 
-- Silent MMZS-miss is the dominant failure. CP emits a structured warning and
-  metric whenever an MMZS resolves to zero MeshServices in a zone. Lands with
-  the tactical patch.
 - `WorkloadStatus.Conditions[PortConflict|LabelConflict]` are set and cleared
   on every reconcile pass; stale `True` values are unacceptable and must be
   tested.
 - Conflict signals must mirror to `DataplaneInsight` so `kuma-dp` logs surface
   them locally for restricted-network operators.
-- `inboundTagsDisabled` is opt-in in 2.14 and default in 3.0; no follow-up
-  MADR. Migration is forward-only.
 
-### Required failure-mode handling
+## Tactical patch (independent, ships in 2.14)
 
-| Failure | Required behavior |
-|---|---|
-| Cross-operator `kuma.io/workload` collision | Validator checks uniqueness within mesh, or document accepted merge |
-| Auto-gen vs operator-authored MeshService same name | Operator-authored wins via `ManagedByLabel`; generator MUST NOT overwrite |
-| Operator removes `kuma.io/workload` from running DP | Treat as workload departure; grace-period delete only when no DP claims it |
-| Conflict resolved between reconciles | Set conditions to `False` explicitly on clean pass |
-
-### Performance budget
-
-Polling cost at scale is unmeasured. Publish p50/p99 of
-`component_meshservice_generator` at 1k, 5k, and 20k Dataplanes before the
-structural option lands. Option D adds an O(M) factor (mean `meshServices[]`
-cardinality) on top of the existing O(D·I).
+- Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to
+`MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound
+tags do not propagate, which signals deprecation. Once shipped, MMZS selectors
+in the wild depend on it.
+- Silent MMZS-miss is the dominant failure. CP emits a structured warning and
+metric whenever an MMZS resolves to zero MeshServices in a zone. Lands with
+the tactical patch.
 
 ## Implications for Kong Mesh
 
@@ -190,19 +155,5 @@ audit policies, run the migration tool, and document the 2.14-to-3.0 upgrade.
 
 ## Decision
 
-TBD. The tactical patch and MMZS observability ship in 2.14 ahead of the structural decision.
-
-## Exit criteria (close inside Kuma 2.14)
-
-1. M:M telemetry: count unique `kuma.io/service` values per workload-grouped DP set. Threshold of >=X% with >1 service/workload picks Option D; below picks Option C.
-2. Performance run at 1k, 5k, and 20k Dataplanes.
-3. Operator interviews: 3-5 ECS/Fargate restricted-network operators, ACTA-style.
-4. Lifecycle commitment: Workload-owns-MeshService vs generator-owns-MeshService.
-5. Migration tool ships in 2.14 alongside opt-in.
-6. Conflict policy locked: first-DP-wins vs newest-wins vs explicit priority, decided on data, not aesthetics.
-
-## Notes
-
-- Open: precise selector encoding for "workload labels union per-port filter". May live in xDS endpoint generator; confirm against `pkg/xds/generator/endpoint*`.
-- Open: field naming to avoid `meshServices` (field) vs `MeshService` (resource) confusion.
-- Open: whether to widen the bootstrap channel to accept operator-authored MeshService for the restricted-network cohort, narrowing the gap between Options B and D.
+Not generating MeshService on univeral is most clean solution. In removes all the ambiguities that comes with MeshService generation. 
+It leaves full controll over Mesh Service to Mesh Operator, they can label it as they need for grouping in MeshMultizoneService.

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -25,7 +25,6 @@ Inbound tags do two jobs: data plane (DP) grouping (which DPs are one logical se
 - Restricted-network operators must declare intent and observe its effect through the `Dataplane`/`kuma-dp` channel only. Signals queryable solely via `kumactl inspect` are unreachable for them.
 - Auto-generation has a single writer (CP). Distributed N-writer designs on a shared resource reintroduce CP-side coordination.
 - Silent MMZS misses are unacceptable.
-- Decision-blocking inputs: empirical M:M usage frequency (Options C vs D), and Workload-to-MeshService lifecycle ownership (cascading vs grace-period delete).
 
 ### Release timeline
 

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -6,12 +6,12 @@ Technical Story: https://github.com/Kong/kong-mesh/issues/9443
 
 ## Context and Problem Statement
 
-On Universal, the CP auto-generates `MeshService` from `Dataplane` inbound tags (`pkg/core/resources/apis/meshservice/generate/generator.go`). A field report exposed two unmet needs:
+On Universal, the control plane (CP) auto-generates `MeshService` from `Dataplane` inbound tags (`pkg/core/resources/apis/meshservice/generate/generator.go`). A field report exposed two unmet needs:
 
-- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the auto-generated `MeshService`. MMZS selects on `MeshService.metadata.labels`, so multi-zone selection by team/env is impossible for Universal today.
+- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the auto-generated `MeshService`. MeshMultiZoneService (MMZS) selects on `MeshService.metadata.labels`, so multi-zone selection by team/env is impossible for Universal today.
 - Some operators (ECS/Fargate behind restricted networks) cannot reach the zone CP REST API. Their only channel is the `Dataplane` shipped via `kuma-dp run --dataplane-file`.
 
-Inbound tags do two jobs: DP grouping (which DPs are one logical service) and per-inbound service membership (which services this port serves). The `kuma.io/workload` label and existing `Workload` generator solve the first job. M:M cases (port carve-out: one workload to many MeshServices; workload aggregation: blue/green, canary) need the second.
+Inbound tags do two jobs: data plane (DP) grouping (which DPs are one logical service) and per-inbound service membership (which services this port serves). The `kuma.io/workload` label and existing `Workload` generator solve the first job. Many-to-many (M:M) cases (port carve-out: one workload to many MeshServices; workload aggregation: blue/green, canary) need the second.
 
 ### Use cases
 
@@ -29,7 +29,7 @@ Inbound tags do two jobs: DP grouping (which DPs are one logical service) and pe
 
 ### Release timeline
 
-- Kuma 2.14: tag-free operation supported on K8s and Universal, opt-in via `inboundTagsDisabled`. The structural replacement (C or D) ships here with a migration tool. The tactical label-propagation patch ships here.
+- Kuma 2.14: tag-free operation supported on Kubernetes (K8s) and Universal, opt-in via `inboundTagsDisabled`. The structural replacement (C or D) ships here with a migration tool. The tactical label-propagation patch ships here.
 - Kuma 3.0: tags removed by default. Downstream policies matching `kuma.io/service` break unless migrated.
 
 ## Design

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -7,7 +7,7 @@ Technical Story: https://github.com/Kong/kong-mesh/issues/9443
 ## Context and Problem Statement
 
 On Universal, the CP auto-generates `MeshService` from `Dataplane` inbound tags
-(`pkg/core/resources/apis/meshservice/generate/generator.go`). 
+(`pkg/core/resources/apis/meshservice/generate/generator.go`).
 A field report exposed two unmet needs:
 
 - Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the
@@ -70,7 +70,7 @@ CP generates one MeshService per `kuma.io/workload` value; ports = union of all 
 
 * Good. Covers the trivial case with no new spec fields.
 * Bad. Cannot express M:M cases. Removing inbound tags silently drops port carve-out and workload aggregation.
-* Bad. Blue/green deployments impossible
+* Bad. Blue/green deployments impossible.
 
 ### Option D: structured per-inbound `meshServices` field
 
@@ -155,5 +155,5 @@ audit policies, run the migration tool, and document the 2.14-to-3.0 upgrade.
 
 ## Decision
 
-Not generating MeshService on univeral is most clean solution. In removes all the ambiguities that comes with MeshService generation. 
-It leaves full controll over Mesh Service to Mesh Operator, they can label it as they need for grouping in MeshMultizoneService.
+Not generating MeshService on Universal is most clean solution. It removes all the ambiguities that come with MeshService generation.
+It leaves full control over MeshService to mesh operator, they can label it as they need for grouping in MMZS.

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -115,14 +115,6 @@ CP no longer generates. Operators run `kumactl apply -f meshservice.yaml`.
 * Good. No new fields on `Dataplane` spec.
 * Bad. Blocks the restricted-network operator entirely.
 * Bad. Universal users must run a parallel CI/GitOps surface for MeshService.
-* Bad. The tactical label-propagation patch cannot ship under it.
-
-## Tactical patch (independent, ships in 2.14)
-
-The "tactical patch" is a small immediate change that ships ahead of the structural decision and closes the user-reported issue (the field report). It is independent of which option (A-D) is ultimately chosen.
-
-- Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to `MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound tags do not propagate, which signals deprecation. Once shipped, MeshMultizoneService selectors in the wild depend on it.
-- A silent MeshMultizoneService selector miss (the selector resolves to zero MeshServices) is the dominant failure. CP emits a structured warning and metric whenever this happens in a zone. Lands with the tactical patch.
 
 ## Implications for Kong Mesh
 
@@ -130,5 +122,5 @@ None specific to the downstream project. The 2.14-to-3.0 migration applies unifo
 
 ## Decision
 
-We go with a combined approach favoring Option B: generate one `MeshService` per `kuma.io/workload` value, giving a one-to-one mapping between `Workload` and `MeshService`. Users needing more complex setups (blue/green, port carve-out, aggregation) author `MeshService` manually. 
+We go with a combined approach favoring Option B + D: generate one `MeshService` per `kuma.io/workload` value, giving a one-to-one mapping between `Workload` and `MeshService`. Users needing more complex setups (blue/green, port carve-out, aggregation) author `MeshService` manually. 
 This keeps the auto-generation path narrow and unambiguous, removes the ambiguities of inbound-tag-driven generation for complex cases, and leaves full control over non-trivial `MeshService` shapes to the mesh operator.

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -6,22 +6,12 @@ Technical Story: https://github.com/Kong/kong-mesh/issues/9443
 
 ## Context and Problem Statement
 
-On Universal, the CP auto-generates `MeshService` from `Dataplane` inbound tags
-(`pkg/core/resources/apis/meshservice/generate/generator.go`).
-A field report exposed two unmet needs:
+On Universal, the CP auto-generates `MeshService` from `Dataplane` inbound tags (`pkg/core/resources/apis/meshservice/generate/generator.go`). A field report exposed two unmet needs:
 
-- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the
-  auto-generated `MeshService`. MMZS selects on `MeshService.metadata.labels`,
-  so multi-zone selection by team/env is impossible for Universal today.
-- Some operators (ECS/Fargate behind restricted networks) cannot reach the
-  zone CP REST API. Their only channel is the `Dataplane` shipped via
-  `kuma-dp run --dataplane-file`.
+- Custom `Dataplane.metadata.labels` and inbound tags do not propagate to the auto-generated `MeshService`. MMZS selects on `MeshService.metadata.labels`, so multi-zone selection by team/env is impossible for Universal today.
+- Some operators (ECS/Fargate behind restricted networks) cannot reach the zone CP REST API. Their only channel is the `Dataplane` shipped via `kuma-dp run --dataplane-file`.
 
-Inbound tags do two jobs: DP grouping (which DPs are one logical service) and
-per-inbound service membership (which services this port serves). The
-`kuma.io/workload` label and existing `Workload` generator solve the first
-job. M:M cases (port carve-out: one workload to many MeshServices; workload
-aggregation: blue/green, canary) need the second.
+Inbound tags do two jobs: DP grouping (which DPs are one logical service) and per-inbound service membership (which services this port serves). The `kuma.io/workload` label and existing `Workload` generator solve the first job. M:M cases (port carve-out: one workload to many MeshServices; workload aggregation: blue/green, canary) need the second.
 
 ### Use cases
 
@@ -87,10 +77,7 @@ networking:
       meshServices: [checkout-metrics, observability]   # multi-valued, M:M
 ```
 
-CP groups inbounds across the mesh by each value in `inbound.meshServices[*]`.
-Per group: `name` is the membership value; `selector` is `kuma.io/workload`
-label match plus per-port-name filter; `ports` is the union by `inbound.name`;
-`labels` is the union of non-`kuma.io/*` keys from member Dataplanes.
+CP groups inbounds across the mesh by each value in `inbound.meshServices[*]`. Per group: `name` is the membership value; `selector` is `kuma.io/workload` label match plus per-port-name filter; `ports` is the union by `inbound.name`; `labels` is the union of non-`kuma.io/*` keys from member Dataplanes.
 
 Member DPs sorted by `(creation_time, name)` via `SortDataplanes`. On conflict:
 
@@ -116,9 +103,7 @@ Migration: `kuma.io/service: <name>` inbound tag becomes `inbound.meshServices: 
 
 #### Migration window behavior
 
-A fleet in transition carries both forms. `checkMeshServicesConsistency`
-oscillates each tick under split fleets. The chosen option must enforce one
-of:
+A fleet in transition carries both forms. `checkMeshServicesConsistency` oscillates each tick under split fleets. The chosen option must enforce one of:
 
 - Validator: a Dataplane MUST NOT carry both `inbound.tags["kuma.io/service"]` and the new field.
 - Per-mesh flag: `inboundTagsDisabled` flips per-mesh, exactly one generator path per mesh.
@@ -131,27 +116,17 @@ of:
 
 #### Reliability implications
 
-- `WorkloadStatus.Conditions[PortConflict|LabelConflict]` are set and cleared
-  on every reconcile pass; stale `True` values are unacceptable and must be
-  tested.
-- Conflict signals must mirror to `DataplaneInsight` so `kuma-dp` logs surface
-  them locally for restricted-network operators.
+- `WorkloadStatus.Conditions[PortConflict|LabelConflict]` are set and cleared on every reconcile pass; stale `True` values are unacceptable and must be tested.
+- Conflict signals must mirror to `DataplaneInsight` so `kuma-dp` logs surface them locally for restricted-network operators.
 
 ## Tactical patch (independent, ships in 2.14)
 
-- Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to
-`MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound
-tags do not propagate, which signals deprecation. Once shipped, MMZS selectors
-in the wild depend on it.
-- Silent MMZS-miss is the dominant failure. CP emits a structured warning and
-metric whenever an MMZS resolves to zero MeshServices in a zone. Lands with
-the tactical patch.
+- Generator propagates non-`kuma.io/*` keys from `Dataplane.metadata.labels` to `MeshService.metadata.labels`, first-DP-wins. Closes the field report. Inbound tags do not propagate, which signals deprecation. Once shipped, MMZS selectors in the wild depend on it.
+- Silent MMZS-miss is the dominant failure. CP emits a structured warning and metric whenever an MMZS resolves to zero MeshServices in a zone. Lands with the tactical patch.
 
 ## Implications for Kong Mesh
 
-Significant in 3.0. Every downstream policy matching on `kuma.io/service`
-inbound tags breaks at upgrade unless migrated. The downstream project must
-audit policies, run the migration tool, and document the 2.14-to-3.0 upgrade.
+Significant in 3.0. Every downstream policy matching on `kuma.io/service` inbound tags breaks at upgrade unless migrated. The downstream project must audit policies, run the migration tool, and document the 2.14-to-3.0 upgrade.
 
 ## Decision
 

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -130,5 +130,5 @@ None specific to the downstream project. The 2.14-to-3.0 migration applies unifo
 
 ## Decision
 
-Not generating MeshService on Universal is most clean solution. It removes all the ambiguities that come with MeshService generation.
-It leaves full control over MeshService to mesh operator, they can label it as they need for grouping in MeshMultizoneService.
+We go with a combined approach favoring Option B: generate one `MeshService` per `kuma.io/workload` value, giving a one-to-one mapping between `Workload` and `MeshService`. Users needing more complex setups (blue/green, port carve-out, aggregation) author `MeshService` manually. 
+This keeps the auto-generation path narrow and unambiguous, removes the ambiguities of inbound-tag-driven generation for complex cases, and leaves full control over non-trivial `MeshService` shapes to the mesh operator.


### PR DESCRIPTION
## Motivation

Capture design discussion for auto-generating `MeshService` on Universal mode
after planned removal of `Dataplane` inbound tags in Kuma 3.0. A field report
on a downstream project surfaced two unmet needs: custom `Dataplane` labels
do not propagate to `MeshService.metadata.labels` (breaking MMZS selection on
team/env), and a subset of operators (ECS/Fargate behind restricted networks)
cannot reach the zone CP REST API at all.

The MADR documents the conflict between two in-flight changes (remove
auto-generation on Universal, remove inbound tags) and the M:M
Workload-to-MeshService cases (port carve-out, blue/green aggregation) that
constrain the design space.

## Implementation information

Documentation only. Presents four options with tradeoffs:

- A: ` kuma-dp run --meshservice-template`
- B: operator-authored MeshService, no auto-generation
- C: workload-only auto-generation
- D: structured per-inbound `meshServices` field

Plus a tactical label-propagation patch that ships independently and closes
the field report. The MADR adds a release timeline (2.14 opt-in via
` inboundTagsDisabled`, 3.0 default), single conflict-resolution policy,
required failure-mode handling table, performance budget, and exit criteria
scoped to the 2.14 cycle.

## Supporting documentation

- Existing Workload generator: ` pkg/core/resources/apis/workload/`
- Existing MeshService generator: ` pkg/core/resources/apis/meshservice/generate/`
- Technical Story link inline in the MADR

> Changelog: skip