### PR TITLE
fix(grafana): fix success rate showing as red

### DIFF
--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -354,7 +354,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "1 - ((sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) or vector(0), 1))",
+          "expr": "clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / (sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) > 0), 0) or vector(1)",
           "legendFormat": "",
           "refId": "A"
         }

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) or vector(0), 1), 0)",
+          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / (sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) > 0), 0) or vector(100)",
           "legendFormat": "Success Rate",
           "refId": "A"
         }

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])), 0)",
+          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / clamp_min(sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) or vector(0), 1), 0)",
           "legendFormat": "Success Rate",
           "refId": "A"
         }


### PR DESCRIPTION
## Motivation

Grafana success rate panels showed red (null/0%) in two cases:

1. **No traffic**: when `sum(rate(total))` returns empty, binary division also returns empty, causing the stat panel to display null → red threshold instead of 100%.
2. **Low-traffic services** (<1 req/s): `clamp_min(total, 1)` forced the denominator to 1, distorting the calculated error rate.

Closes https://github.com/kumahq/kuma/issues/16412

## Implementation information

Two-step fix applied to `kuma-service-health.json` and `kuma-mesh.json`:

1. Replace `clamp_min(...or vector(0), 1)` (no-traffic fix) with `(total > 0) or vector(N)` — uses real denominator when traffic exists, returns 100% when total is zero. This avoids the denominator-forced-to-1 distortion for low-traffic services.

> Changelog: fix(grafana): fix success rate showing as red