### PR TITLE
feat(config): reserved-prefix helper and label propagation config

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -14,6 +14,11 @@ import (
 )
 
 const (
+	KumaIOPrefix    = "kuma.io/"
+	K8sKumaIOPrefix = "k8s.kuma.io/"
+)
+
+const (
 	KubeNamespaceTag = "k8s.kuma.io/namespace"
 	KubeServiceTag   = "k8s.kuma.io/service-name"
 	KubePortTag      = "k8s.kuma.io/service-port"
@@ -21,6 +26,11 @@ const (
 	// currently only disabled/enabled is supported
 	KDSSyncLabel = "kuma.io/kds-sync"
 )
+
+// IsReservedLabelKey reports whether k belongs to a Kuma-reserved label namespace.
+func IsReservedLabelKey(k string) bool {
+	return strings.HasPrefix(k, KumaIOPrefix) || strings.HasPrefix(k, K8sKumaIOPrefix)
+}
 
 const (
 	KubernetesEnvironment = "kubernetes"

--- a/api/mesh/v1alpha1/dataplane_helpers_test.go
+++ b/api/mesh/v1alpha1/dataplane_helpers_test.go
@@ -686,3 +686,24 @@ var _ = Describe("TagSelectorRank", func() {
 		)
 	})
 })
+
+var _ = Describe("IsReservedLabelKey", func() {
+	type testCase struct {
+		key      string
+		expected bool
+	}
+
+	DescribeTable("should identify reserved label keys",
+		func(given testCase) {
+			Expect(IsReservedLabelKey(given.key)).To(Equal(given.expected))
+		},
+		Entry("kuma.io/ prefix", testCase{key: "kuma.io/service", expected: true}),
+		Entry("k8s.kuma.io/ prefix", testCase{key: "k8s.kuma.io/namespace", expected: true}),
+		Entry("bare kuma.io/", testCase{key: "kuma.io/", expected: true}),
+		Entry("bare k8s.kuma.io/", testCase{key: "k8s.kuma.io/", expected: true}),
+		Entry("non-reserved app label", testCase{key: "app", expected: false}),
+		Entry("non-reserved custom domain", testCase{key: "example.com/foo", expected: false}),
+		Entry("empty string", testCase{key: "", expected: false}),
+		Entry("partial prefix kuma.io without slash", testCase{key: "kuma.io", expected: false}),
+	)
+})

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -940,5 +940,5 @@ meshService:
   labelPropagation:
     # If true, propagate allowed user-defined labels from MeshService to generated resources.
     enabled: false # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED
-    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
+    # List of non-reserved label keys eligible for propagation. When empty and enabled is true, all non-reserved labels are propagated. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
     allowedLabelKeys: [] # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -854,14 +854,6 @@ experimental:
   sidecarContainers: true # ENV: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   # If true uses Delta xDS to deliver changes to sidecars.
   deltaXds: false # ENV: KUMA_EXPERIMENTAL_DELTA_XDS
-  # If true, inbound tags are disabled. CP runs without relying on inbound tags.
-  inboundTagsDisabled: false # ENV: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
-  # Controls propagation of user-defined labels from MeshService to generated resources.
-  meshServiceLabelPropagation:
-    # If true, propagate allowed user-defined labels from MeshService to generated resources.
-    enabled: false # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ENABLED
-    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
-    allowedLabelKeys: [] # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS
 proxy:
   gateway:
     # Sets the envoy runtime value to limit maximum number of incoming
@@ -944,3 +936,9 @@ meshService:
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
   # How long we wait before deleting a MeshService if all Dataplanes are gone
   deletionGracePeriod: 1h # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD
+  # Controls propagation of user-defined labels from MeshService to generated resources.
+  labelPropagation:
+    # If true, propagate allowed user-defined labels from MeshService to generated resources.
+    enabled: false # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED
+    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
+    allowedLabelKeys: [] # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -854,6 +854,14 @@ experimental:
   sidecarContainers: true # ENV: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   # If true uses Delta xDS to deliver changes to sidecars.
   deltaXds: false # ENV: KUMA_EXPERIMENTAL_DELTA_XDS
+  # If true, inbound tags are disabled. CP runs without relying on inbound tags.
+  inboundTagsDisabled: false # ENV: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
+  # Controls propagation of user-defined labels from MeshService to generated resources.
+  meshServiceLabelPropagation:
+    # If true, propagate allowed user-defined labels from MeshService to generated resources.
+    enabled: false # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ENABLED
+    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
+    allowedLabelKeys: [] # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS
 proxy:
   gateway:
     # Sets the envoy runtime value to limit maximum number of incoming

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -297,10 +297,6 @@ var DefaultConfig = func() Config {
 			},
 			SidecarContainers: true,
 			DeltaXds:          false,
-			MeshServiceLabelPropagation: ExperimentalMeshServiceLabelPropagation{
-				Enabled:          false,
-				AllowedLabelKeys: []string{},
-			},
 		},
 		Proxy:         xds.DefaultProxyConfig(),
 		InterCp:       intercp.DefaultInterCpConfig(),
@@ -323,6 +319,10 @@ var DefaultConfig = func() Config {
 		MeshService: MeshServiceConfig{
 			GenerationInterval:  config_types.Duration{Duration: 2 * time.Second},
 			DeletionGracePeriod: config_types.Duration{Duration: 1 * time.Hour},
+			LabelPropagation: MeshServiceLabelPropagation{
+				Enabled:          false,
+				AllowedLabelKeys: []string{},
+			},
 		},
 	}
 }
@@ -388,6 +388,9 @@ func (c *Config) Validate() error {
 	}
 	if err := c.IPAM.Validate(); err != nil {
 		return errors.Wrap(err, "IPAM validation failed")
+	}
+	if err := c.MeshService.Validate(); err != nil {
+		return errors.Wrap(err, "MeshService validation failed")
 	}
 	return nil
 }
@@ -488,25 +491,6 @@ type ExperimentalConfig struct {
 	DeltaXds bool `json:"deltaXds" envconfig:"KUMA_EXPERIMENTAL_DELTA_XDS"`
 	// If true, inbound tags are disabled. CP runs without relying on inbound tags.
 	InboundTagsDisabled bool `json:"inboundTagsDisabled" envconfig:"KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED"`
-	// MeshServiceLabelPropagation controls propagation of user-defined labels from MeshService to generated resources.
-	MeshServiceLabelPropagation ExperimentalMeshServiceLabelPropagation `json:"meshServiceLabelPropagation"`
-}
-
-func (e *ExperimentalConfig) Validate() error {
-	for _, k := range e.MeshServiceLabelPropagation.AllowedLabelKeys {
-		if mesh_proto.IsReservedLabelKey(k) {
-			return errors.Errorf("MeshServiceLabelPropagation.AllowedLabelKeys contains reserved key %q", k)
-		}
-	}
-	return nil
-}
-
-type ExperimentalMeshServiceLabelPropagation struct {
-	// If true, propagate allowed user-defined labels from MeshService to generated resources.
-	Enabled bool `json:"enabled" envconfig:"KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ENABLED"`
-	// AllowedLabelKeys is the list of non-reserved label keys eligible for propagation.
-	// Reserved keys (kuma.io/ and k8s.kuma.io/ prefixes) are rejected at validation time.
-	AllowedLabelKeys []string `json:"allowedLabelKeys" envconfig:"KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS"`
 }
 
 type ExperimentalKDSEventBasedWatchdog struct {
@@ -617,8 +601,23 @@ type MeshServiceConfig struct {
 	GenerationInterval config_types.Duration `json:"generationInterval" envconfig:"KUMA_MESH_SERVICE_GENERATION_INTERVAL"`
 	// How long we wait before deleting a MeshService if all Dataplanes are gone
 	DeletionGracePeriod config_types.Duration `json:"deletionGracePeriod" envconfig:"KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD"`
+	// LabelPropagation controls propagation of user-defined labels from MeshService to generated resources.
+	LabelPropagation MeshServiceLabelPropagation `json:"labelPropagation"`
 }
 
 func (i MeshServiceConfig) Validate() error {
+	for _, k := range i.LabelPropagation.AllowedLabelKeys {
+		if mesh_proto.IsReservedLabelKey(k) {
+			return errors.Errorf("LabelPropagation.AllowedLabelKeys contains reserved key %q", k)
+		}
+	}
 	return nil
+}
+
+type MeshServiceLabelPropagation struct {
+	// If true, propagate allowed user-defined labels from MeshService to generated resources.
+	Enabled bool `json:"enabled" envconfig:"KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED"`
+	// AllowedLabelKeys is the list of non-reserved label keys eligible for propagation.
+	// Reserved keys (kuma.io/ and k8s.kuma.io/ prefixes) are rejected at validation time.
+	AllowedLabelKeys []string `json:"allowedLabelKeys" envconfig:"KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS"`
 }

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/config"
 	"github.com/kumahq/kuma/v2/pkg/config/access"
 	api_server "github.com/kumahq/kuma/v2/pkg/config/api-server"
@@ -296,6 +297,10 @@ var DefaultConfig = func() Config {
 			},
 			SidecarContainers: true,
 			DeltaXds:          false,
+			MeshServiceLabelPropagation: ExperimentalMeshServiceLabelPropagation{
+				Enabled:          false,
+				AllowedLabelKeys: []string{},
+			},
 		},
 		Proxy:         xds.DefaultProxyConfig(),
 		InterCp:       intercp.DefaultInterCpConfig(),
@@ -483,6 +488,25 @@ type ExperimentalConfig struct {
 	DeltaXds bool `json:"deltaXds" envconfig:"KUMA_EXPERIMENTAL_DELTA_XDS"`
 	// If true, inbound tags are disabled. CP runs without relying on inbound tags.
 	InboundTagsDisabled bool `json:"inboundTagsDisabled" envconfig:"KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED"`
+	// MeshServiceLabelPropagation controls propagation of user-defined labels from MeshService to generated resources.
+	MeshServiceLabelPropagation ExperimentalMeshServiceLabelPropagation `json:"meshServiceLabelPropagation"`
+}
+
+func (e *ExperimentalConfig) Validate() error {
+	for _, k := range e.MeshServiceLabelPropagation.AllowedLabelKeys {
+		if mesh_proto.IsReservedLabelKey(k) {
+			return errors.Errorf("MeshServiceLabelPropagation.AllowedLabelKeys contains reserved key %q", k)
+		}
+	}
+	return nil
+}
+
+type ExperimentalMeshServiceLabelPropagation struct {
+	// If true, propagate allowed user-defined labels from MeshService to generated resources.
+	Enabled bool `json:"enabled" envconfig:"KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ENABLED"`
+	// AllowedLabelKeys is the list of non-reserved label keys eligible for propagation.
+	// Reserved keys (kuma.io/ and k8s.kuma.io/ prefixes) are rejected at validation time.
+	AllowedLabelKeys []string `json:"allowedLabelKeys" envconfig:"KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS"`
 }
 
 type ExperimentalKDSEventBasedWatchdog struct {

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -608,7 +608,7 @@ type MeshServiceConfig struct {
 func (i MeshServiceConfig) Validate() error {
 	for _, k := range i.LabelPropagation.AllowedLabelKeys {
 		if mesh_proto.IsReservedLabelKey(k) {
-			return errors.Errorf("LabelPropagation.AllowedLabelKeys contains reserved key %q", k)
+			return errors.Errorf(".MeshService.LabelPropagation.AllowedLabelKeys contains reserved key %q", k)
 		}
 	}
 	return nil

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -618,6 +618,7 @@ type MeshServiceLabelPropagation struct {
 	// If true, propagate allowed user-defined labels from MeshService to generated resources.
 	Enabled bool `json:"enabled" envconfig:"KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED"`
 	// AllowedLabelKeys is the list of non-reserved label keys eligible for propagation.
+	// When empty and Enabled is true, all non-reserved labels are propagated.
 	// Reserved keys (kuma.io/ and k8s.kuma.io/ prefixes) are rejected at validation time.
 	AllowedLabelKeys []string `json:"allowedLabelKeys" envconfig:"KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS"`
 }

--- a/pkg/config/app/kuma-cp/experimental_config_test.go
+++ b/pkg/config/app/kuma-cp/experimental_config_test.go
@@ -1,0 +1,62 @@
+package kuma_cp_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
+)
+
+var _ = Describe("ExperimentalConfig Validate", func() {
+	type testCase struct {
+		cfg     kuma_cp.ExperimentalMeshServiceLabelPropagation
+		wantErr string
+	}
+
+	DescribeTable("MeshServiceLabelPropagation validation",
+		func(given testCase) {
+			cfg := kuma_cp.ExperimentalConfig{
+				MeshServiceLabelPropagation: given.cfg,
+			}
+			err := cfg.Validate()
+			if given.wantErr != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(given.wantErr))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+		Entry("disabled with empty allow-list", testCase{
+			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+				Enabled:          false,
+				AllowedLabelKeys: []string{},
+			},
+		}),
+		Entry("enabled with non-reserved keys", testCase{
+			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+				Enabled:          true,
+				AllowedLabelKeys: []string{"app", "version", "team"},
+			},
+		}),
+		Entry("rejects kuma.io/ reserved key", testCase{
+			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+				Enabled:          true,
+				AllowedLabelKeys: []string{"app", "kuma.io/service"},
+			},
+			wantErr: `reserved key "kuma.io/service"`,
+		}),
+		Entry("rejects k8s.kuma.io/ reserved key", testCase{
+			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+				Enabled:          false,
+				AllowedLabelKeys: []string{"k8s.kuma.io/namespace"},
+			},
+			wantErr: `reserved key "k8s.kuma.io/namespace"`,
+		}),
+		Entry("enabled with nil allow-list", testCase{
+			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+				Enabled:          true,
+				AllowedLabelKeys: nil,
+			},
+		}),
+	)
+})

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -940,5 +940,5 @@ meshService:
   labelPropagation:
     # If true, propagate allowed user-defined labels from MeshService to generated resources.
     enabled: false # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED
-    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
+    # List of non-reserved label keys eligible for propagation. When empty and enabled is true, all non-reserved labels are propagated. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
     allowedLabelKeys: [] # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -854,14 +854,6 @@ experimental:
   sidecarContainers: true # ENV: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   # If true uses Delta xDS to deliver changes to sidecars.
   deltaXds: false # ENV: KUMA_EXPERIMENTAL_DELTA_XDS
-  # If true, inbound tags are disabled. CP runs without relying on inbound tags.
-  inboundTagsDisabled: false # ENV: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
-  # Controls propagation of user-defined labels from MeshService to generated resources.
-  meshServiceLabelPropagation:
-    # If true, propagate allowed user-defined labels from MeshService to generated resources.
-    enabled: false # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ENABLED
-    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
-    allowedLabelKeys: [] # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS
 proxy:
   gateway:
     # Sets the envoy runtime value to limit maximum number of incoming
@@ -944,3 +936,9 @@ meshService:
   generationInterval: 2s # ENV: KUMA_MESH_SERVICE_GENERATION_INTERVAL
   # How long we wait before deleting a MeshService if all Dataplanes are gone
   deletionGracePeriod: 1h # ENV: KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD
+  # Controls propagation of user-defined labels from MeshService to generated resources.
+  labelPropagation:
+    # If true, propagate allowed user-defined labels from MeshService to generated resources.
+    enabled: false # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED
+    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
+    allowedLabelKeys: [] # ENV: KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -854,6 +854,14 @@ experimental:
   sidecarContainers: true # ENV: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   # If true uses Delta xDS to deliver changes to sidecars.
   deltaXds: false # ENV: KUMA_EXPERIMENTAL_DELTA_XDS
+  # If true, inbound tags are disabled. CP runs without relying on inbound tags.
+  inboundTagsDisabled: false # ENV: KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED
+  # Controls propagation of user-defined labels from MeshService to generated resources.
+  meshServiceLabelPropagation:
+    # If true, propagate allowed user-defined labels from MeshService to generated resources.
+    enabled: false # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ENABLED
+    # List of non-reserved label keys eligible for propagation. Reserved kuma.io/ and k8s.kuma.io/ keys are rejected.
+    allowedLabelKeys: [] # ENV: KUMA_EXPERIMENTAL_MESHSERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS
 proxy:
   gateway:
     # Sets the envoy runtime value to limit maximum number of incoming

--- a/pkg/config/app/kuma-cp/mesh_service_config_test.go
+++ b/pkg/config/app/kuma-cp/mesh_service_config_test.go
@@ -7,16 +7,16 @@ import (
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 )
 
-var _ = Describe("ExperimentalConfig Validate", func() {
+var _ = Describe("MeshServiceConfig Validate", func() {
 	type testCase struct {
-		cfg     kuma_cp.ExperimentalMeshServiceLabelPropagation
+		cfg     kuma_cp.MeshServiceLabelPropagation
 		wantErr string
 	}
 
-	DescribeTable("MeshServiceLabelPropagation validation",
+	DescribeTable("LabelPropagation validation",
 		func(given testCase) {
-			cfg := kuma_cp.ExperimentalConfig{
-				MeshServiceLabelPropagation: given.cfg,
+			cfg := kuma_cp.MeshServiceConfig{
+				LabelPropagation: given.cfg,
 			}
 			err := cfg.Validate()
 			if given.wantErr != "" {
@@ -27,33 +27,33 @@ var _ = Describe("ExperimentalConfig Validate", func() {
 			}
 		},
 		Entry("disabled with empty allow-list", testCase{
-			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+			cfg: kuma_cp.MeshServiceLabelPropagation{
 				Enabled:          false,
 				AllowedLabelKeys: []string{},
 			},
 		}),
 		Entry("enabled with non-reserved keys", testCase{
-			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+			cfg: kuma_cp.MeshServiceLabelPropagation{
 				Enabled:          true,
 				AllowedLabelKeys: []string{"app", "version", "team"},
 			},
 		}),
 		Entry("rejects kuma.io/ reserved key", testCase{
-			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+			cfg: kuma_cp.MeshServiceLabelPropagation{
 				Enabled:          true,
 				AllowedLabelKeys: []string{"app", "kuma.io/service"},
 			},
 			wantErr: `reserved key "kuma.io/service"`,
 		}),
 		Entry("rejects k8s.kuma.io/ reserved key", testCase{
-			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+			cfg: kuma_cp.MeshServiceLabelPropagation{
 				Enabled:          false,
 				AllowedLabelKeys: []string{"k8s.kuma.io/namespace"},
 			},
 			wantErr: `reserved key "k8s.kuma.io/namespace"`,
 		}),
 		Entry("enabled with nil allow-list", testCase{
-			cfg: kuma_cp.ExperimentalMeshServiceLabelPropagation{
+			cfg: kuma_cp.MeshServiceLabelPropagation{
 				Enabled:          true,
 				AllowedLabelKeys: nil,
 			},

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -401,6 +401,8 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.IPAM.KnownInternalCIDRs).To(Equal([]string{"10.8.0.0/16", "127.0.0.6/32"}))
 			Expect(cfg.MeshService.GenerationInterval.Duration).To(Equal(8 * time.Second))
 			Expect(cfg.MeshService.DeletionGracePeriod.Duration).To(Equal(11 * time.Second))
+			Expect(cfg.MeshService.LabelPropagation.Enabled).To(BeTrue())
+			Expect(cfg.MeshService.LabelPropagation.AllowedLabelKeys).To(Equal([]string{"app", "version"}))
 			Expect(cfg.Runtime.Universal.Workload.GenerationInterval.Duration).To(Equal(9 * time.Second))
 
 			Expect(cfg.CoreResources.Enabled).To(Equal([]string{"meshservice"}))
@@ -855,6 +857,11 @@ ipam:
 meshService:
   generationInterval: 8s
   deletionGracePeriod: 11s
+  labelPropagation:
+    enabled: true
+    allowedLabelKeys:
+    - app
+    - version
 `,
 		}),
 		Entry("from env variables", testCase{
@@ -1179,6 +1186,8 @@ meshService:
 				"KUMA_IPAM_KNOWN_INTERNAL_CIDRS":                                                           "10.8.0.0/16,127.0.0.6/32",
 				"KUMA_MESH_SERVICE_GENERATION_INTERVAL":                                                    "8s",
 				"KUMA_MESH_SERVICE_DELETION_GRACE_PERIOD":                                                  "11s",
+				"KUMA_MESH_SERVICE_LABEL_PROPAGATION_ENABLED":                                              "true",
+				"KUMA_MESH_SERVICE_LABEL_PROPAGATION_ALLOWED_LABEL_KEYS":                                   "app,version",
 				"KUMA_RUNTIME_UNIVERSAL_WORKLOAD_GENERATION_INTERVAL":                                      "9s",
 			},
 			yamlFileConfig: "",


### PR DESCRIPTION
## Motivation

Upcoming MeshService label propagation feature needs a safe way to let operators specify which user-defined labels flow through to generated resources, while ensuring Kuma-reserved labels (`kuma.io/` and `k8s.kuma.io/` prefixes) can never be configured — doing so could cause subtle conflicts or security issues with internal Kuma mechanics.

This is phase 1: the building blocks (prefix constants, `IsReservedLabelKey` helper, config struct with validation) required before implementing the actual propagation logic.

Closes https://github.com/kumahq/kuma/issues/16543

## Implementation information

- Added `KumaIOPrefix`/`K8sKumaIOPrefix` constants and `IsReservedLabelKey` helper to `api/mesh/v1alpha1/dataplane_helpers.go`; placed in dataplane_helpers because that file already owns the canonical label/tag constants for the mesh API
- Added `ExperimentalMeshServiceLabelPropagation` struct (`Enabled bool`, `AllowedLabelKeys []string`) under `ExperimentalConfig` in `pkg/config/app/kuma-cp/config.go`; gated under `Experimental` to allow iteration without a stability commitment
- Added `Validate()` on `ExperimentalConfig` that rejects any `AllowedLabelKeys` entry matching a reserved prefix; wired into the existing config validation chain
- Updated `kuma-cp.defaults.yaml` and generated `docs/generated/raw/kuma-cp.yaml` with the new experimental section (disabled by default, empty allow-list)
- Table-driven Ginkgo tests for both `IsReservedLabelKey` and `ExperimentalConfig.Validate()`

> Changelog: feat(kuma-cp): support running without inbound tags
