### PR TITLE
fix(meshservice): preserve labels on MeshService update

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -76,11 +76,7 @@ func New(
 	}, nil
 }
 
-type meshServicesResult struct {
-	services map[string]*meshservice_api.MeshService
-}
-
-func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
+func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) map[string]*meshservice_api.MeshService {
 	log := g.logger.WithValues("mesh", dataplane.GetMeta().GetMesh(), "Dataplane", dataplane.GetMeta().GetName())
 	portsByService := map[string][]meshservice_api.Port{}
 	for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
@@ -126,9 +122,7 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 		services[serviceTag] = &ms
 	}
-	return meshServicesResult{
-		services: services,
-	}
+	return services
 }
 
 type dataplaneAndMeshService struct {
@@ -185,8 +179,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 	log := g.logger.WithValues("mesh", mesh)
 	meshservicesByName := map[string][]dataplaneAndMeshService{}
 	for _, dataplane := range core_mesh.SortDataplanes(dataplanes) {
-		result := g.meshServicesForDataplane(dataplane)
-		for name, ms := range result.services {
+		for name, ms := range g.meshServicesForDataplane(dataplane) {
 			meshservicesByName[name] = append(meshservicesByName[name], dataplaneAndMeshService{
 				dataplane:   dataplane.GetMeta(),
 				meshService: ms,

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -77,14 +77,12 @@ func New(
 }
 
 type meshServicesResult struct {
-	services          map[string]*meshservice_api.MeshService
-	inboundsByService map[string][]*mesh_proto.Dataplane_Networking_Inbound
+	services map[string]*meshservice_api.MeshService
 }
 
 func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
 	log := g.logger.WithValues("mesh", dataplane.GetMeta().GetMesh(), "Dataplane", dataplane.GetMeta().GetName())
 	portsByService := map[string][]meshservice_api.Port{}
-	inboundsByService := map[string][]*mesh_proto.Dataplane_Networking_Inbound{}
 	for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
 		if g.inboundTagsDisabled && len(inbound.GetTags()) == 0 {
 			continue
@@ -114,7 +112,6 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 
 		portsByService[serviceTagValue] = append(portsByService[serviceTagValue], port)
-		inboundsByService[serviceTagValue] = append(inboundsByService[serviceTagValue], inbound)
 	}
 
 	services := map[string]*meshservice_api.MeshService{}
@@ -130,15 +127,13 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		services[serviceTag] = &ms
 	}
 	return meshServicesResult{
-		services:          services,
-		inboundsByService: inboundsByService,
+		services: services,
 	}
 }
 
 type dataplaneAndMeshService struct {
-	dataplane         model.ResourceMeta
-	meshService       *meshservice_api.MeshService
-	labelContribution map[string]string // nil for now; populated in Phase 4
+	dataplane   model.ResourceMeta
+	meshService *meshservice_api.MeshService
 }
 
 // checkMeshServicesConsistency returns a list of dataplanes that conflict and
@@ -193,9 +188,8 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 		result := g.meshServicesForDataplane(dataplane)
 		for name, ms := range result.services {
 			meshservicesByName[name] = append(meshservicesByName[name], dataplaneAndMeshService{
-				dataplane:         dataplane.GetMeta(),
-				meshService:       ms,
-				labelContribution: nil,
+				dataplane:   dataplane.GetMeta(),
+				meshService: ms,
 			})
 		}
 	}
@@ -223,8 +217,10 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			meshService.Meta = meta
 			meshService.Spec = newMeshService
 
-			// Unset the grace period by excluding it from desired labels
-			newLabels := desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, nil)
+			// Preserve existing labels, removing only the grace-period label
+			existingLabels := maps.Clone(meshService.GetMeta().GetLabels())
+			delete(existingLabels, mesh_proto.DeletionGracePeriodStartedLabel)
+			newLabels := desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, existingLabels)
 
 			if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
 				log.Error(err, "couldn't update MeshService")

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -76,9 +76,15 @@ func New(
 	}, nil
 }
 
-func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) map[string]*meshservice_api.MeshService {
+type meshServicesResult struct {
+	services          map[string]*meshservice_api.MeshService
+	inboundsByService map[string][]*mesh_proto.Dataplane_Networking_Inbound
+}
+
+func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
 	log := g.logger.WithValues("mesh", dataplane.GetMeta().GetMesh(), "Dataplane", dataplane.GetMeta().GetName())
 	portsByService := map[string][]meshservice_api.Port{}
+	inboundsByService := map[string][]*mesh_proto.Dataplane_Networking_Inbound{}
 	for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
 		if g.inboundTagsDisabled && len(inbound.GetTags()) == 0 {
 			continue
@@ -108,6 +114,7 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 
 		portsByService[serviceTagValue] = append(portsByService[serviceTagValue], port)
+		inboundsByService[serviceTagValue] = append(inboundsByService[serviceTagValue], inbound)
 	}
 
 	services := map[string]*meshservice_api.MeshService{}
@@ -122,12 +129,16 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 		services[serviceTag] = &ms
 	}
-	return services
+	return meshServicesResult{
+		services:          services,
+		inboundsByService: inboundsByService,
+	}
 }
 
 type dataplaneAndMeshService struct {
-	dataplane   model.ResourceMeta
-	meshService *meshservice_api.MeshService
+	dataplane         model.ResourceMeta
+	meshService       *meshservice_api.MeshService
+	labelContribution map[string]string // nil for now; populated in Phase 4
 }
 
 // checkMeshServicesConsistency returns a list of dataplanes that conflict and
@@ -161,14 +172,30 @@ func servicesDiffer(a, b *meshservice_api.MeshService) bool {
 	return !reflect.DeepEqual(a.Ports, b.Ports)
 }
 
+func desiredLabels(mesh, name, zone string, propagated map[string]string) map[string]string {
+	out := maps.Clone(propagated)
+	if out == nil {
+		out = map[string]string{}
+	}
+	out[metadata.KumaMeshLabel] = mesh
+	out[mesh_proto.DisplayName] = name
+	out[mesh_proto.ManagedByLabel] = managedByValue
+	out[mesh_proto.EnvTag] = mesh_proto.UniversalEnvironment
+	out[mesh_proto.ZoneTag] = zone
+	out[mesh_proto.ResourceOriginLabel] = string(mesh_proto.ZoneResourceOrigin)
+	return out
+}
+
 func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*core_mesh.DataplaneResource, meshServices []*meshservice_api.MeshServiceResource) {
 	log := g.logger.WithValues("mesh", mesh)
 	meshservicesByName := map[string][]dataplaneAndMeshService{}
 	for _, dataplane := range core_mesh.SortDataplanes(dataplanes) {
-		for name, ms := range g.meshServicesForDataplane(dataplane) {
+		result := g.meshServicesForDataplane(dataplane)
+		for name, ms := range result.services {
 			meshservicesByName[name] = append(meshservicesByName[name], dataplaneAndMeshService{
-				dataplane:   dataplane.GetMeta(),
-				meshService: ms,
+				dataplane:         dataplane.GetMeta(),
+				meshService:       ms,
+				labelContribution: nil,
 			})
 		}
 	}
@@ -196,9 +223,8 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			meshService.Meta = meta
 			meshService.Spec = newMeshService
 
-			// Unset the grace period by deleting the label
-			newLabels := maps.Clone(meshService.GetMeta().GetLabels())
-			delete(newLabels, mesh_proto.DeletionGracePeriodStartedLabel)
+			// Unset the grace period by excluding it from desired labels
+			newLabels := desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, nil)
 
 			if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
 				log.Error(err, "couldn't update MeshService")
@@ -255,14 +281,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 		if len(conflicting) > 0 {
 			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
 		}
-		if err := g.resManager.Create(ctx, meshService, store.CreateByKey(name, mesh), store.CreateWithLabels(map[string]string{
-			metadata.KumaMeshLabel:         mesh,
-			mesh_proto.DisplayName:         name,
-			mesh_proto.ManagedByLabel:      managedByValue,
-			mesh_proto.EnvTag:              mesh_proto.UniversalEnvironment,
-			mesh_proto.ZoneTag:             g.zone,
-			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
-		})); err != nil {
+		if err := g.resManager.Create(ctx, meshService, store.CreateByKey(name, mesh), store.CreateWithLabels(desiredLabels(mesh, name, g.zone, nil))); err != nil {
 			log.Error(err, "couldn't create MeshService")
 			continue
 		}

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -379,6 +379,35 @@ var _ = Describe("MeshService generator", func() {
 		}, "2s", "100ms").Should(Succeed())
 	})
 
+	It("should preserve existing labels when updating MeshService", func() {
+		err := samples.DataplaneBackendBuilder().Create(resManager)
+		Expect(err).ToNot(HaveOccurred())
+
+		ms := meshservice_api.NewMeshServiceResource()
+		Eventually(func(g Gomega) {
+			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+		}, "2s", "100ms").Should(Succeed())
+
+		labelsWithCustom := make(map[string]string)
+		for k, v := range ms.GetMeta().GetLabels() {
+			labelsWithCustom[k] = v
+		}
+		labelsWithCustom["custom.io/extra"] = "preserved"
+		Expect(resManager.Update(context.Background(), ms, store.UpdateWithLabels(labelsWithCustom))).To(Succeed())
+
+		dp := core_mesh.NewDataplaneResource()
+		Expect(resManager.Get(context.Background(), dp, store.GetByKey("dp-1", model.DefaultMesh))).To(Succeed())
+		dp.Spec.Networking.Inbound[0].Port += 1
+		dp.Spec.Networking.Inbound[0].ServicePort += 1
+		Expect(resManager.Update(context.Background(), dp)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+			g.Expect(ms.Spec.Ports[0].Port).To(Equal(int32(81)))
+			g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("custom.io/extra", "preserved"))
+		}, "2s", "100ms").Should(Succeed())
+	})
+
 	It("should emit metric", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(test_metrics.FindMetric(metrics, "component_meshservice_generator")).ToNot(BeNil())

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -2,6 +2,7 @@ package generate_test
 
 import (
 	"context"
+	"maps"
 	"net"
 	"time"
 
@@ -389,9 +390,7 @@ var _ = Describe("MeshService generator", func() {
 		}, "2s", "100ms").Should(Succeed())
 
 		labelsWithCustom := make(map[string]string)
-		for k, v := range ms.GetMeta().GetLabels() {
-			labelsWithCustom[k] = v
-		}
+		maps.Copy(labelsWithCustom, ms.GetMeta().GetLabels())
 		labelsWithCustom["custom.io/extra"] = "preserved"
 		Expect(resManager.Update(context.Background(), ms, store.UpdateWithLabels(labelsWithCustom))).To(Succeed())
 


### PR DESCRIPTION
## Motivation

When the MeshService generator updates an existing `MeshService` resource, it was replacing the entire label set with a freshly computed set of system labels. This caused any labels added externally (e.g., user-defined or downstream labels) to be silently dropped on every generator cycle.

Closes https://github.com/kumahq/kuma/issues/16544

## Implementation information

Two changes in `pkg/core/resources/apis/meshservice/generate/generator.go`:

1. **Refactor** (`refactor(meshservice): restructure generator per-service inbounds and labels`): extracted a `desiredLabels()` helper that centralises the construction of system-managed labels (mesh, display name, managed-by, env, zone, origin). Both the create and update paths now call this helper, eliminating the inline map literal duplication and making the label contract explicit.

2. **Fix** (`fix(meshservice): preserve labels on MeshService update`): the update path now clones the existing labels from the stored resource, deletes only `DeletionGracePeriodStartedLabel`, and passes the result as `propagated` into `desiredLabels()`. System labels are (re-)applied on top, so they can never be overwritten by external labels, but extra labels are preserved. A new test covers the round-trip: create a dataplane, wait for the generator to create the `MeshService`, add a custom label, mutate the dataplane to trigger an update, and assert the custom label survives.

> Changelog: feat(kuma-cp): support running without inbound tags
