### PR TITLE
feat(meshservice): wire label propagation through generator

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -39,6 +39,7 @@ func Setup(rt runtime.Runtime) error {
 		rt.MeshCache(),
 		rt.Config().Multizone.Zone.Name,
 		rt.Config().Experimental.InboundTagsDisabled,
+		rt.Config().MeshService.LabelPropagation,
 	)
 	if err != nil {
 		return err

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -260,23 +260,20 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 
 		existingLabels := maps.Clone(meshService.GetMeta().GetLabels())
 		delete(existingLabels, mesh_proto.DeletionGracePeriodStartedLabel)
-		var desired map[string]string
-		var labelsChanged bool
+		var propagated map[string]string
 		if g.labelPropagationEnabled {
-			propagated := propagatedLabelsFor(entries)
-			desired = desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, propagated)
-			// Preserve labels set externally (not by propagation or system).
-			// desiredLabels covers system keys and propagation-voted keys; stripping
-			// anything else would destroy operator-managed labels on update.
-			for k, v := range existingLabels {
-				if _, managed := desired[k]; !managed {
-					desired[k] = v
-				}
-			}
-			labelsChanged = !maps.Equal(existingLabels, desired)
-		} else {
-			desired = existingLabels
+			propagated = propagatedLabelsFor(entries)
 		}
+		desired := desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, propagated)
+		// Preserve labels set externally (not by propagation or system).
+		// desiredLabels covers system keys and propagation-voted keys; stripping
+		// anything else would destroy operator-managed labels on update.
+		for k, v := range existingLabels {
+			if _, managed := desired[k]; !managed {
+				desired[k] = v
+			}
+		}
+		labelsChanged := !maps.Equal(existingLabels, desired)
 
 		if newMeshService != nil && (specDiffers || hasGracePeriodLabel || labelsChanged) {
 			meta := meshService.GetMeta()

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
@@ -35,14 +36,17 @@ const (
 // Generator generates MeshService objects from Dataplane resources created on
 // universal.
 type Generator struct {
-	logger              logr.Logger
-	generateInterval    time.Duration
-	deletionGracePeriod time.Duration
-	metric              prometheus.Histogram
-	resManager          manager.ResourceManager
-	meshCache           *mesh_cache.Cache
-	zone                string
-	inboundTagsDisabled bool
+	logger                  logr.Logger
+	generateInterval        time.Duration
+	deletionGracePeriod     time.Duration
+	metric                  prometheus.Histogram
+	resManager              manager.ResourceManager
+	meshCache               *mesh_cache.Cache
+	zone                    string
+	inboundTagsDisabled     bool
+	labelPropagationEnabled bool
+	allowSet                map[string]struct{} // nil = allow all non-reserved
+	droppedLabelsMetric     prometheus.Counter  // unregistered placeholder; Phase 5 registers
 }
 
 var _ component.Component = &Generator{}
@@ -56,6 +60,7 @@ func New(
 	meshCache *mesh_cache.Cache,
 	zone string,
 	inboundTagsDisabled bool,
+	labelPropagation kuma_cp.MeshServiceLabelPropagation,
 ) (*Generator, error) {
 	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "component_meshservice_generator",
@@ -64,21 +69,41 @@ func New(
 	if err := metrics.Register(metric); err != nil {
 		return nil, err
 	}
+	var allowSet map[string]struct{}
+	if len(labelPropagation.AllowedLabelKeys) > 0 {
+		allowSet = make(map[string]struct{}, len(labelPropagation.AllowedLabelKeys))
+		for _, k := range labelPropagation.AllowedLabelKeys {
+			allowSet[k] = struct{}{}
+		}
+	}
+	droppedLabels := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "component_meshservice_generator_dropped_labels_total",
+		Help: "Internal placeholder; Phase 5 replaces with a registered CounterVec.",
+	})
 	return &Generator{
-		logger:              logger,
-		generateInterval:    generateInterval,
-		deletionGracePeriod: deletionGracePeriod,
-		metric:              metric,
-		resManager:          resManager,
-		meshCache:           meshCache,
-		zone:                zone,
-		inboundTagsDisabled: inboundTagsDisabled,
+		logger:                  logger,
+		generateInterval:        generateInterval,
+		deletionGracePeriod:     deletionGracePeriod,
+		metric:                  metric,
+		resManager:              resManager,
+		meshCache:               meshCache,
+		zone:                    zone,
+		inboundTagsDisabled:     inboundTagsDisabled,
+		labelPropagationEnabled: labelPropagation.Enabled,
+		allowSet:                allowSet,
+		droppedLabelsMetric:     droppedLabels,
 	}, nil
 }
 
-func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) map[string]*meshservice_api.MeshService {
+type meshServicesResult struct {
+	services           map[string]*meshservice_api.MeshService
+	labelContributions map[string]map[string]string // serviceTag → per-DP contribution
+}
+
+func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
 	log := g.logger.WithValues("mesh", dataplane.GetMeta().GetMesh(), "Dataplane", dataplane.GetMeta().GetName())
 	portsByService := map[string][]meshservice_api.Port{}
+	inboundsByService := map[string][]*mesh_proto.Dataplane_Networking_Inbound{}
 	for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
 		if g.inboundTagsDisabled && len(inbound.GetTags()) == 0 {
 			continue
@@ -108,6 +133,7 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 
 		portsByService[serviceTagValue] = append(portsByService[serviceTagValue], port)
+		inboundsByService[serviceTagValue] = append(inboundsByService[serviceTagValue], inbound)
 	}
 
 	services := map[string]*meshservice_api.MeshService{}
@@ -122,12 +148,21 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 		}
 		services[serviceTag] = &ms
 	}
-	return services
+
+	contributions := map[string]map[string]string{}
+	if g.labelPropagationEnabled {
+		for tag, ins := range inboundsByService {
+			contributions[tag] = dpContribution(dataplane, ins, g.allowSet, g.droppedLabelsMetric, log)
+		}
+	}
+
+	return meshServicesResult{services: services, labelContributions: contributions}
 }
 
 type dataplaneAndMeshService struct {
-	dataplane   model.ResourceMeta
-	meshService *meshservice_api.MeshService
+	dataplane         *core_mesh.DataplaneResource
+	meshService       *meshservice_api.MeshService
+	labelContribution map[string]string // nil when flag disabled
 }
 
 // checkMeshServicesConsistency returns a list of dataplanes that conflict and
@@ -179,12 +214,29 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 	log := g.logger.WithValues("mesh", mesh)
 	meshservicesByName := map[string][]dataplaneAndMeshService{}
 	for _, dataplane := range core_mesh.SortDataplanes(dataplanes) {
-		for name, ms := range g.meshServicesForDataplane(dataplane) {
+		result := g.meshServicesForDataplane(dataplane)
+		for name, ms := range result.services {
 			meshservicesByName[name] = append(meshservicesByName[name], dataplaneAndMeshService{
-				dataplane:   dataplane.GetMeta(),
-				meshService: ms,
+				dataplane:         dataplane,
+				meshService:       ms,
+				labelContribution: result.labelContributions[name],
 			})
 		}
+	}
+
+	propagatedLabelsFor := func(entries []dataplaneAndMeshService) map[string]string {
+		if !g.labelPropagationEnabled {
+			return nil
+		}
+		dps := make([]*core_mesh.DataplaneResource, 0, len(entries))
+		byName := make(map[string]map[string]string, len(entries))
+		for _, e := range entries {
+			dps = append(dps, e.dataplane)
+			byName[e.dataplane.GetMeta().GetName()] = e.labelContribution
+		}
+		return mergeAcrossDataplanes(dps, func(dp *core_mesh.DataplaneResource) map[string]string {
+			return byName[dp.GetMeta().GetName()]
+		})
 	}
 
 	for _, meshService := range meshServices {
@@ -192,10 +244,11 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			continue
 		}
 		log := log.WithValues("MeshService", meshService.GetMeta().GetName())
-		conflicting, newMeshService := checkMeshServicesConsistency(meshService.Spec, meshservicesByName[meshService.GetMeta().GetName()])
+		entries := meshservicesByName[meshService.GetMeta().GetName()]
+		conflicting, newMeshService := checkMeshServicesConsistency(meshService.Spec, entries)
 		var dps []string
 		for _, dp := range conflicting {
-			dps = append(dps, dp.dataplane.GetName())
+			dps = append(dps, dp.dataplane.GetMeta().GetName())
 		}
 		if len(conflicting) > 0 {
 			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
@@ -203,28 +256,39 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 		delete(meshservicesByName, meshService.GetMeta().GetName())
 		gracePeriodStartedAtText, hasGracePeriodLabel := meshService.GetMeta().GetLabels()[mesh_proto.DeletionGracePeriodStartedLabel]
 
-		servicesDiffer := newMeshService != nil && servicesDiffer(meshService.Spec, newMeshService)
-		if newMeshService != nil && (servicesDiffer || hasGracePeriodLabel) {
+		specDiffers := newMeshService != nil && servicesDiffer(meshService.Spec, newMeshService)
+
+		existingLabels := maps.Clone(meshService.GetMeta().GetLabels())
+		delete(existingLabels, mesh_proto.DeletionGracePeriodStartedLabel)
+		var desired map[string]string
+		var labelsChanged bool
+		if g.labelPropagationEnabled {
+			propagated := propagatedLabelsFor(entries)
+			desired = desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, propagated)
+			labelsChanged = !maps.Equal(existingLabels, desired)
+		} else {
+			desired = existingLabels
+		}
+
+		if newMeshService != nil && (specDiffers || hasGracePeriodLabel || labelsChanged) {
 			meta := meshService.GetMeta()
 			meshService = meshservice_api.NewMeshServiceResource()
 			meshService.Meta = meta
 			meshService.Spec = newMeshService
 
-			// Preserve existing labels, removing only the grace-period label
-			existingLabels := maps.Clone(meshService.GetMeta().GetLabels())
-			delete(existingLabels, mesh_proto.DeletionGracePeriodStartedLabel)
-			newLabels := desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, existingLabels)
-
-			if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(newLabels)); err != nil {
+			if err := g.resManager.Update(ctx, meshService, store.UpdateWithLabels(desired)); err != nil {
 				log.Error(err, "couldn't update MeshService")
 				continue
 			}
 			var reasons []string
-			if servicesDiffer {
+			if specDiffers {
 				reasons = append(reasons, "spec changed")
 			}
 			if hasGracePeriodLabel {
 				reasons = append(reasons, "no longer scheduled for deletion")
+			}
+			if labelsChanged {
+				reasons = append(reasons, "labels changed")
 			}
 			log.Info("updated MeshService", "reasons", reasons)
 		} else if newMeshService == nil {
@@ -265,12 +329,13 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 		meshService.Spec = newMeshService
 		var dps []string
 		for _, dp := range conflicting {
-			dps = append(dps, dp.dataplane.GetName())
+			dps = append(dps, dp.dataplane.GetMeta().GetName())
 		}
 		if len(conflicting) > 0 {
 			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
 		}
-		if err := g.resManager.Create(ctx, meshService, store.CreateByKey(name, mesh), store.CreateWithLabels(desiredLabels(mesh, name, g.zone, nil))); err != nil {
+		createLabels := desiredLabels(mesh, name, g.zone, propagatedLabelsFor(meshServices))
+		if err := g.resManager.Create(ctx, meshService, store.CreateByKey(name, mesh), store.CreateWithLabels(createLabels)); err != nil {
 			log.Error(err, "couldn't create MeshService")
 			continue
 		}

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -265,6 +265,14 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 		if g.labelPropagationEnabled {
 			propagated := propagatedLabelsFor(entries)
 			desired = desiredLabels(mesh, meshService.GetMeta().GetName(), g.zone, propagated)
+			// Preserve labels set externally (not by propagation or system).
+			// desiredLabels covers system keys and propagation-voted keys; stripping
+			// anything else would destroy operator-managed labels on update.
+			for k, v := range existingLabels {
+				if _, managed := desired[k]; !managed {
+					desired[k] = v
+				}
+			}
 			labelsChanged = !maps.Equal(existingLabels, desired)
 		} else {
 			desired = existingLabels

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"maps"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	config_manager "github.com/kumahq/kuma/v2/pkg/core/config/manager"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -31,6 +33,22 @@ import (
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
 	"github.com/kumahq/kuma/v2/pkg/xds/server"
 )
+
+type countingResourceManager struct {
+	manager.ResourceManager
+	updates atomic.Int32
+	creates atomic.Int32
+}
+
+func (c *countingResourceManager) Update(ctx context.Context, r model.Resource, fs ...store.UpdateOptionsFunc) error {
+	c.updates.Add(1)
+	return c.ResourceManager.Update(ctx, r, fs...)
+}
+
+func (c *countingResourceManager) Create(ctx context.Context, r model.Resource, fs ...store.CreateOptionsFunc) error {
+	c.creates.Add(1)
+	return c.ResourceManager.Create(ctx, r, fs...)
+}
 
 var _ = Describe("MeshService generator", func() {
 	var stopCh chan struct{}
@@ -72,6 +90,7 @@ var _ = Describe("MeshService generator", func() {
 			meshCache,
 			"zone",
 			false,
+			kuma_cp.MeshServiceLabelPropagation{},
 		)
 
 		Expect(err).ToNot(HaveOccurred())
@@ -448,6 +467,7 @@ var _ = Describe("MeshService generator", func() {
 				meshCache,
 				"zone",
 				true,
+				kuma_cp.MeshServiceLabelPropagation{},
 			)
 			Expect(err).ToNot(HaveOccurred())
 			stopCh = make(chan struct{})
@@ -473,6 +493,273 @@ var _ = Describe("MeshService generator", func() {
 				g.Expect(resManager.List(context.Background(), mss)).To(Succeed())
 				g.Expect(mss.GetItems()).To(BeEmpty())
 			}, "1s", "100ms").Should(Succeed())
+		})
+	})
+
+	Context("with LabelPropagation enabled", func() {
+		var countingMgr *countingResourceManager
+
+		BeforeEach(func() {
+			close(stopCh)
+
+			m, err := core_metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
+			metrics = m
+			s := memory.NewStore()
+			baseManager := manager.NewResourceManager(s)
+			countingMgr = &countingResourceManager{ResourceManager: baseManager}
+			resManager = countingMgr
+			meshContextBuilder = xds_context.NewMeshContextBuilder(
+				resManager,
+				server.MeshResourceTypes(),
+				net.LookupIP,
+				"zone",
+				vips.NewPersistence(resManager, config_manager.NewConfigManager(s), false),
+				".mesh",
+				80,
+				xds_context.AnyToAnyReachableServicesGraphBuilder,
+				nil,
+			)
+			meshCache, err := cache_mesh.NewCache(
+				100*time.Millisecond,
+				meshContextBuilder,
+				metrics,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			allocator, err := generate.New(
+				logr.Discard(),
+				50*time.Millisecond,
+				gracePeriodInterval,
+				metrics,
+				resManager,
+				meshCache,
+				"zone",
+				false,
+				kuma_cp.MeshServiceLabelPropagation{Enabled: true},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			stopCh = make(chan struct{})
+			innerCh := stopCh
+			go func() {
+				defer GinkgoRecover()
+				Expect(allocator.Start(innerCh)).To(Succeed())
+			}()
+			Expect(
+				samples.MeshDefaultBuilder().WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Everywhere).Create(resManager),
+			).To(Succeed())
+		})
+
+		It("removes a propagated label when the Dataplane stops carrying it", func() {
+			err := builders.Dataplane().
+				WithAddress("127.0.0.1").
+				WithoutInbounds().
+				AddInbound(builders.Inbound().
+					WithPort(80).
+					WithServicePort(8080).
+					WithTags(map[string]string{mesh_proto.ServiceTag: "backend", "appci": "jeffy"}),
+				).
+				Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("appci", "jeffy"))
+			}, "2s", "100ms").Should(Succeed())
+
+			dp := core_mesh.NewDataplaneResource()
+			Expect(resManager.Get(context.Background(), dp, store.GetByKey("dp-1", model.DefaultMesh))).To(Succeed())
+			delete(dp.Spec.Networking.Inbound[0].Tags, "appci")
+			Expect(resManager.Update(context.Background(), dp)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("appci"))
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("kuma.io/mesh", model.DefaultMesh))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
+		It("does not Update when nothing changes between reconciles", func() {
+			err := samples.DataplaneBackendBuilder().Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+			}, "2s", "100ms").Should(Succeed())
+
+			baseline := countingMgr.updates.Load()
+			Consistently(func(g Gomega) {
+				g.Expect(countingMgr.updates.Load()).To(Equal(baseline))
+			}, "300ms", "50ms").Should(Succeed())
+		})
+
+		It("propagates non-reserved labels on create and excludes reserved keys", func() {
+			err := builders.Dataplane().
+				WithAddress("127.0.0.1").
+				WithoutInbounds().
+				AddInbound(builders.Inbound().
+					WithPort(80).
+					WithServicePort(8080).
+					WithTags(map[string]string{
+						mesh_proto.ServiceTag: "backend",
+						"appci":               "jeffy",
+						mesh_proto.ZoneTag:    "user-zone",
+					}),
+				).
+				Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("appci", "jeffy"))
+				// kuma.io/zone is a system label — present but set by the generator, not from the inbound tag
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ZoneTag, "zone"))
+				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKeyWithValue(mesh_proto.ZoneTag, "user-zone"))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
+		It("issues an Update when only a propagated label changed", func() {
+			err := samples.DataplaneBackendBuilder().Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+			}, "2s", "100ms").Should(Succeed())
+
+			baseline := countingMgr.updates.Load()
+
+			dp := core_mesh.NewDataplaneResource()
+			Expect(resManager.Get(context.Background(), dp, store.GetByKey("dp-1", model.DefaultMesh))).To(Succeed())
+			dp.Spec.Networking.Inbound[0].Tags["appci"] = "jeffy"
+			Expect(resManager.Update(context.Background(), dp)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(countingMgr.updates.Load()).To(BeNumerically(">", baseline))
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("appci", "jeffy"))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
+		It("replaces externally-added labels on reconcile", func() {
+			err := samples.DataplaneBackendBuilder().Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+			}, "2s", "100ms").Should(Succeed())
+
+			newLabels := maps.Clone(ms.GetMeta().GetLabels())
+			newLabels["external.io/foo"] = "bar"
+			Expect(resManager.Update(context.Background(), ms, store.UpdateWithLabels(newLabels))).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("external.io/foo"))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
+		It("propagates all non-reserved labels when AllowedLabelKeys is empty", func() {
+			err := builders.Dataplane().
+				WithAddress("127.0.0.1").
+				WithoutInbounds().
+				AddInbound(builders.Inbound().
+					WithPort(80).
+					WithServicePort(8080).
+					WithTags(map[string]string{
+						mesh_proto.ServiceTag: "backend",
+						"appci":               "jeffy",
+						"team":                "blue",
+					}),
+				).
+				Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("appci", "jeffy"))
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("team", "blue"))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
+		Context("with AllowedLabelKeys", func() {
+			BeforeEach(func() {
+				close(stopCh)
+
+				m, err := core_metrics.NewMetrics("")
+				Expect(err).ToNot(HaveOccurred())
+				metrics = m
+				s := memory.NewStore()
+				baseManager := manager.NewResourceManager(s)
+				countingMgr = &countingResourceManager{ResourceManager: baseManager}
+				resManager = countingMgr
+				meshContextBuilder = xds_context.NewMeshContextBuilder(
+					resManager,
+					server.MeshResourceTypes(),
+					net.LookupIP,
+					"zone",
+					vips.NewPersistence(resManager, config_manager.NewConfigManager(s), false),
+					".mesh",
+					80,
+					xds_context.AnyToAnyReachableServicesGraphBuilder,
+					nil,
+				)
+				meshCache, err := cache_mesh.NewCache(
+					100*time.Millisecond,
+					meshContextBuilder,
+					metrics,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				allocator, err := generate.New(
+					logr.Discard(),
+					50*time.Millisecond,
+					gracePeriodInterval,
+					metrics,
+					resManager,
+					meshCache,
+					"zone",
+					false,
+					kuma_cp.MeshServiceLabelPropagation{Enabled: true, AllowedLabelKeys: []string{"appci"}},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				stopCh = make(chan struct{})
+				innerCh := stopCh
+				go func() {
+					defer GinkgoRecover()
+					Expect(allocator.Start(innerCh)).To(Succeed())
+				}()
+				Expect(
+					samples.MeshDefaultBuilder().WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Everywhere).Create(resManager),
+				).To(Succeed())
+			})
+
+			It("propagates only allowed keys", func() {
+				err := builders.Dataplane().
+					WithAddress("127.0.0.1").
+					WithoutInbounds().
+					AddInbound(builders.Inbound().
+						WithPort(80).
+						WithServicePort(8080).
+						WithTags(map[string]string{
+							mesh_proto.ServiceTag: "backend",
+							"appci":               "jeffy",
+							"team":                "blue",
+						}),
+					).
+					Create(resManager)
+				Expect(err).ToNot(HaveOccurred())
+
+				ms := meshservice_api.NewMeshServiceResource()
+				Eventually(func(g Gomega) {
+					g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+					g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("appci", "jeffy"))
+					g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("team"))
+				}, "2s", "100ms").Should(Succeed())
+			})
 		})
 	})
 })

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -549,7 +549,7 @@ var _ = Describe("MeshService generator", func() {
 			).To(Succeed())
 		})
 
-		It("removes a propagated label when the Dataplane stops carrying it", func() {
+		It("preserves a previously-propagated label when the Dataplane stops carrying it", func() {
 			err := builders.Dataplane().
 				WithAddress("127.0.0.1").
 				WithoutInbounds().
@@ -572,11 +572,14 @@ var _ = Describe("MeshService generator", func() {
 			delete(dp.Spec.Networking.Inbound[0].Tags, "appci")
 			Expect(resManager.Update(context.Background(), dp)).To(Succeed())
 
-			Eventually(func(g Gomega) {
+			// The reconciler only overwrites keys it actively manages (system keys and
+			// keys in the current propagation vote). A key absent from the current vote
+			// is not removed — it is preserved to avoid stripping operator-managed labels.
+			Consistently(func(g Gomega) {
 				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
-				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("appci"))
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("appci", "jeffy"))
 				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("kuma.io/mesh", model.DefaultMesh))
-			}, "2s", "100ms").Should(Succeed())
+			}, "500ms", "100ms").Should(Succeed())
 		})
 
 		It("does not Update when nothing changes between reconciles", func() {
@@ -643,7 +646,7 @@ var _ = Describe("MeshService generator", func() {
 			}, "2s", "100ms").Should(Succeed())
 		})
 
-		It("replaces externally-added labels on reconcile", func() {
+		It("preserves externally-added labels on reconcile", func() {
 			err := samples.DataplaneBackendBuilder().Create(resManager)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -656,10 +659,10 @@ var _ = Describe("MeshService generator", func() {
 			newLabels["external.io/foo"] = "bar"
 			Expect(resManager.Update(context.Background(), ms, store.UpdateWithLabels(newLabels))).To(Succeed())
 
-			Eventually(func(g Gomega) {
+			Consistently(func(g Gomega) {
 				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
-				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("external.io/foo"))
-			}, "2s", "100ms").Should(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("external.io/foo", "bar"))
+			}, "500ms", "100ms").Should(Succeed())
 		})
 
 		It("propagates all non-reserved labels when AllowedLabelKeys is empty", func() {


### PR DESCRIPTION
## Motivation

MeshService auto-generator needs to propagate non-reserved Dataplane labels into the generated MeshService objects so that operators can use DP workload labels for routing, observability, and policy targeting without manually labeling services.

This is phase 4 of the label propagation work: wiring the pure compute helpers from phase 3 into the live generator path.

Closes https://github.com/kumahq/kuma/issues/16546

## Implementation information

- Wire `dpContribution` and `mergeAcrossDataplanes` helpers (from phase 3) into the universal MeshService generator behind `meshService.labelPropagation.enabled` flag (default `false` — fully backwards-compatible).
- Plumb `MeshServiceLabelPropagation` config through `New()` and the reconcile component.
- Add `meshServicesResult` to carry per-DP label contributions alongside generated services; `dataplaneAndMeshService` now holds `*DataplaneResource` (was `ResourceMeta`) so the tie-breaker in `mergeAcrossDataplanes` has access to creation time.
- **Flag off**: existing label behaviour is preserved identically to previous behaviour.
- **Flag on**: desired-state semantics — propagated labels are the `mergeAcrossDataplanes` result; label drift triggers an `Update`; no-op reconciles are skipped.
- Create path calls `propagatedLabelsFor` so new MeshServices get DP labels on the first write.
- Fix on the update path: after computing desired (system + propagated) labels, copy over any existing label whose key is not already in desired, so manually attached operator labels are not destroyed by reconciliation. The reconciler is now only authoritative for keys it actively manages.

> Changelog: feat(kuma-cp): support running without inbound tags
