### PR TITLE
feat(dataplane): add computed labels for zone proxy listeners

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -96,6 +96,12 @@ const (
 	// DeletionGracePeriodStartedLabel is used when generating MeshServices on
 	// universal, it's here to avoid import cycles
 	DeletionGracePeriodStartedLabel string = "kuma.io/deletion-grace-period-started-at"
+
+	// ListenerZoneIngressLabel is auto-computed when a Dataplane has at least one ZoneIngress listener.
+	ListenerZoneIngressLabel = "kuma.io/listener-zoneingress"
+
+	// ListenerZoneEgressLabel is auto-computed when a Dataplane has at least one ZoneEgress listener.
+	ListenerZoneEgressLabel = "kuma.io/listener-zoneegress"
 )
 
 type ResourceOrigin string

--- a/pkg/core/resources/labels/compute.go
+++ b/pkg/core/resources/labels/compute.go
@@ -168,6 +168,27 @@ func Compute(
 		if ok {
 			set(mesh_proto.ProxyTypeLabel, strings.ToLower(string(proxy.GetProxyType())))
 		}
+		if dp, ok := spec.(*mesh_proto.Dataplane); ok {
+			hasIngress, hasEgress := false, false
+			for _, l := range dp.GetNetworking().GetListeners() {
+				switch l.Type {
+				case mesh_proto.Dataplane_Networking_Listener_ZoneIngress:
+					hasIngress = true
+				case mesh_proto.Dataplane_Networking_Listener_ZoneEgress:
+					hasEgress = true
+				}
+			}
+			if hasIngress {
+				set(mesh_proto.ListenerZoneIngressLabel, "enabled")
+			} else {
+				delete(labels, mesh_proto.ListenerZoneIngressLabel)
+			}
+			if hasEgress {
+				set(mesh_proto.ListenerZoneEgressLabel, "enabled")
+			} else {
+				delete(labels, mesh_proto.ListenerZoneEgressLabel)
+			}
+		}
 	}
 
 	if labelsOpts.IsK8s {

--- a/pkg/core/resources/labels/compute_test.go
+++ b/pkg/core/resources/labels/compute_test.go
@@ -379,5 +379,25 @@ var _ = Describe("Compute", func() {
 				"kuma.io/listener-zoneegress":  "enabled",
 			},
 		}),
+		Entry("stale listener labels are removed when listeners are absent", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: builders.Dataplane().
+				WithMesh("mesh-1").
+				WithServices("backend").
+				WithLabels(map[string]string{
+					"kuma.io/listener-zoneingress": "enabled",
+					"kuma.io/listener-zoneegress":  "enabled",
+				}).
+				Build(),
+			expectedLabels: map[string]string{
+				"kuma.io/mesh":       "mesh-1",
+				"kuma.io/origin":     "zone",
+				"kuma.io/zone":       "zone-1",
+				"kuma.io/env":        "kubernetes",
+				"kuma.io/proxy-type": "sidecar",
+			},
+		}),
 	)
 })

--- a/pkg/core/resources/labels/compute_test.go
+++ b/pkg/core/resources/labels/compute_test.go
@@ -298,5 +298,86 @@ var _ = Describe("Compute", func() {
 				"kuma.io/proxy-type": "zoneegress",
 			},
 		}),
+		Entry("dataplane with ZoneIngress listener", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: builders.Dataplane().
+				WithMesh("mesh-1").
+				With(func(dp *mesh.DataplaneResource) {
+					dp.Spec.Networking.Listeners = []*mesh_proto.Dataplane_Networking_Listener{
+						{
+							Type:    mesh_proto.Dataplane_Networking_Listener_ZoneIngress,
+							Address: "127.0.0.1",
+							Port:    10001,
+						},
+					}
+				}).
+				Build(),
+			expectedLabels: map[string]string{
+				"kuma.io/mesh":                 "mesh-1",
+				"kuma.io/origin":               "zone",
+				"kuma.io/zone":                 "zone-1",
+				"kuma.io/env":                  "kubernetes",
+				"kuma.io/proxy-type":           "sidecar",
+				"kuma.io/listener-zoneingress": "enabled",
+			},
+		}),
+		Entry("dataplane with ZoneEgress listener", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: builders.Dataplane().
+				WithMesh("mesh-1").
+				With(func(dp *mesh.DataplaneResource) {
+					dp.Spec.Networking.Listeners = []*mesh_proto.Dataplane_Networking_Listener{
+						{
+							Type:    mesh_proto.Dataplane_Networking_Listener_ZoneEgress,
+							Address: "127.0.0.1",
+							Port:    10001,
+						},
+					}
+				}).
+				Build(),
+			expectedLabels: map[string]string{
+				"kuma.io/mesh":                "mesh-1",
+				"kuma.io/origin":              "zone",
+				"kuma.io/zone":                "zone-1",
+				"kuma.io/env":                 "kubernetes",
+				"kuma.io/proxy-type":          "sidecar",
+				"kuma.io/listener-zoneegress": "enabled",
+			},
+		}),
+		Entry("dataplane with both ZoneIngress and ZoneEgress listeners", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			r: builders.Dataplane().
+				WithMesh("mesh-1").
+				With(func(dp *mesh.DataplaneResource) {
+					dp.Spec.Networking.Listeners = []*mesh_proto.Dataplane_Networking_Listener{
+						{
+							Type:    mesh_proto.Dataplane_Networking_Listener_ZoneIngress,
+							Address: "127.0.0.1",
+							Port:    10001,
+						},
+						{
+							Type:    mesh_proto.Dataplane_Networking_Listener_ZoneEgress,
+							Address: "127.0.0.1",
+							Port:    10002,
+						},
+					}
+				}).
+				Build(),
+			expectedLabels: map[string]string{
+				"kuma.io/mesh":                 "mesh-1",
+				"kuma.io/origin":               "zone",
+				"kuma.io/zone":                 "zone-1",
+				"kuma.io/env":                  "kubernetes",
+				"kuma.io/proxy-type":           "sidecar",
+				"kuma.io/listener-zoneingress": "enabled",
+				"kuma.io/listener-zoneegress":  "enabled",
+			},
+		}),
 	)
 })

--- a/pkg/core/resources/labels/registry.go
+++ b/pkg/core/resources/labels/registry.go
@@ -8,13 +8,15 @@ import (
 // if changed sync with:
 // https://github.com/Kong/shared-speakeasy/blob/b3ddd3ef1f31e42bfe71b96ea473493072f9742c/customtypes/kumalabels/kumalabels.go#L15
 var AllComputedLabels = map[string]struct{}{
-	metadata.KumaMeshLabel:         {},
-	mesh_proto.ResourceOriginLabel: {},
-	mesh_proto.ZoneTag:             {},
-	mesh_proto.EnvTag:              {},
-	mesh_proto.KubeNamespaceTag:    {},
-	mesh_proto.PolicyRoleLabel:     {},
-	mesh_proto.ProxyTypeLabel:      {},
-	metadata.KumaServiceAccount:    {},
-	metadata.KumaWorkload:          {},
+	metadata.KumaMeshLabel:              {},
+	mesh_proto.ResourceOriginLabel:      {},
+	mesh_proto.ZoneTag:                  {},
+	mesh_proto.EnvTag:                   {},
+	mesh_proto.KubeNamespaceTag:         {},
+	mesh_proto.PolicyRoleLabel:          {},
+	mesh_proto.ProxyTypeLabel:           {},
+	metadata.KumaServiceAccount:         {},
+	metadata.KumaWorkload:               {},
+	mesh_proto.ListenerZoneIngressLabel: {},
+	mesh_proto.ListenerZoneEgressLabel:  {},
 }


### PR DESCRIPTION
## Motivation

Auto-compute `kuma.io/listener-zoneingress` and `kuma.io/listener-zoneegress` labels on Dataplanes based on listener presence, as specified in [MADR-102](https://github.com/kumahq/kuma/blob/c2ecbd802cfd6944b8ace64991ac1c93f8162b5d/docs/madr/decisions/102-zone-proxy-listener-computed-labels.md).

## Implementation information

Extend `resource_labels.Compute` method to automatically add new labels to Dataplane resources.

## Supporting documentation

Fix #16556

> Changelog: feat(kuma-cp): add mesh-scoped zone proxies
