### PR TITLE
feat(charts): expose CP HPA behavior

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -87,6 +87,9 @@ controlPlane:
             type: Utilization
             averageUtilization: 80
 
+    # -- Scaling behavior for the HPA (https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior). Omit to use Kubernetes defaults.
+    behavior: {}
+
   # -- Node selector for the Kuma Control Plane pods
   nodeSelector:
     kubernetes.io/os: linux

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -36,6 +36,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |
 | controlPlane.autoscaling.maxReplicas | int | `5` | The max CP pods to scale to |
 | controlPlane.autoscaling.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Target metrics for the HPA to scale on |
+| controlPlane.autoscaling.behavior | object | `{}` | Scaling behavior for the HPA (https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior). Omit to use Kubernetes defaults. |
 | controlPlane.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the Kuma Control Plane pods |
 | controlPlane.tolerations | list | `[]` | Tolerations for the Kuma Control Plane pods |
 | controlPlane.podDisruptionBudget.enabled | bool | `false` | Whether to create a pod disruption budget |

--- a/deployments/charts/kuma/templates/cp-hpa.yaml
+++ b/deployments/charts/kuma/templates/cp-hpa.yaml
@@ -13,4 +13,7 @@ spec:
   minReplicas: {{ .Values.controlPlane.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controlPlane.autoscaling.maxReplicas }}
   metrics: {{- toYaml .Values.controlPlane.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.controlPlane.autoscaling.behavior }}
+  behavior: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -87,6 +87,9 @@ controlPlane:
             type: Utilization
             averageUtilization: 80
 
+    # -- Scaling behavior for the HPA (https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior). Omit to use Kubernetes defaults.
+    behavior: {}
+
   # -- Node selector for the Kuma Control Plane pods
   nodeSelector:
     kubernetes.io/os: linux

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -87,6 +87,9 @@ controlPlane:
             type: Utilization
             averageUtilization: 80
 
+    # -- Scaling behavior for the HPA (https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior). Omit to use Kubernetes defaults.
+    behavior: {}
+
   # -- Node selector for the Kuma Control Plane pods
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
## Motivation

The control plane HPA template hardcodes `minReplicas`/`maxReplicas`/`metrics` but doesn't expose [`behavior`][hpa-behavior]. Operators who want longer stabilization windows or per-pod step caps to dampen scale flap have to apply a separate HPA out of band.

In a downstream deployment we saw a 30s HPA scale-down + 30s pod termination grace window driving hundreds of scale events per hour under load, each one a SIGTERM on a CP pod. With this change the same chart can ship `behavior.scaleDown` settings.

## Implementation information

- `templates/cp-hpa.yaml`: emit `behavior:` only when set, via `{{- with ... }}`.
- `values.yaml`: add `controlPlane.autoscaling.behavior: {}` with a doc comment.
- README, `docs/generated/raw/helm-values.yaml`, and the `install-control-plane.dump-values.yaml` golden: regenerated.

Defaults don't change: `behavior: {}` falls through to Kubernetes built-in behavior, so existing deployments aren't affected.

Verified by `helm template` with and without `behavior` set - both produce valid HPA specs, and there's no stray empty `behavior:` key when unset.

[hpa-behavior]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior