### PR TITLE
feat(log): resilient component restart logging

### DIFF
--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -37,6 +37,9 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 		lastSuccess    = time.Now()
 		nextSampledAt  time.Time
 		suppressedLogs uint64
+		// attempt counts restarts within the current outage and drives sampling.
+		// generationID stays monotonic across stable-run boundaries for cross-outage tracing.
+		attempt uint64
 	)
 	for generationID := uint64(1); ; generationID++ {
 		lastStart := time.Now()
@@ -74,11 +77,13 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 			lastSuccess = time.Now()
 			nextSampledAt = time.Time{}
 			suppressedLogs = 0
+			attempt = 0
 		}
 		dur, _ := backoff.Next()
-		if generationID <= resilientLogSampleAfterAttempt || !time.Now().Before(nextSampledAt) {
+		attempt++
+		if attempt <= resilientLogSampleAfterAttempt || !time.Now().Before(nextSampledAt) {
 			fields := []any{
-				"attempt", generationID,
+				"attempt", attempt,
 				"sinceLastSuccess", time.Since(lastSuccess),
 				"nextBackoff", dur,
 			}
@@ -90,7 +95,8 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 				suppressedLogs = 0
 			}
 			r.log.Info("scheduling component restart", fields...)
-			if generationID > resilientLogSampleAfterAttempt {
+			// Arm the sampling window once we've hit the burst threshold.
+			if attempt >= resilientLogSampleAfterAttempt {
 				nextSampledAt = time.Now().Add(resilientLogSampleWindow)
 			}
 		} else {

--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -79,16 +79,27 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 			suppressedLogs = 0
 			attempt = 0
 		}
+		// Clean exit: restart immediately without a sampled restart-log line
+		// and without a backoff delay. Operators read "scheduling restart"
+		// as "we hit a failure", so emitting it with no lastError is noise.
+		if lastError == nil {
+			select {
+			case <-stop:
+				r.log.Info("done")
+				return nil
+			default:
+				continue
+			}
+		}
 		dur, _ := backoff.Next()
 		attempt++
 		if attempt <= resilientLogSampleAfterAttempt || !time.Now().Before(nextSampledAt) {
 			fields := []any{
+				"generationID", generationID,
 				"attempt", attempt,
 				"sinceLastSuccess", time.Since(lastSuccess),
 				"nextBackoff", dur,
-			}
-			if lastError != nil {
-				fields = append(fields, "lastError", lastError.Error())
+				"lastError", lastError.Error(),
 			}
 			if suppressedLogs > 0 {
 				fields = append(fields, "suppressed", suppressedLogs)
@@ -102,7 +113,12 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 		} else {
 			suppressedLogs++
 		}
-		<-time.After(dur)
+		select {
+		case <-stop:
+			r.log.Info("done")
+			return nil
+		case <-time.After(dur):
+		}
 	}
 }
 

--- a/pkg/core/runtime/component/resilient.go
+++ b/pkg/core/runtime/component/resilient.go
@@ -8,6 +8,11 @@ import (
 	"github.com/sethvargo/go-retry"
 )
 
+const (
+	resilientLogSampleAfterAttempt = 5
+	resilientLogSampleWindow       = 10 * time.Second
+)
+
 type resilientComponent struct {
 	log             logr.Logger
 	component       Component
@@ -25,14 +30,19 @@ func NewResilientComponent(log logr.Logger, component Component, backoffBaseTime
 }
 
 func (r *resilientComponent) Start(stop <-chan struct{}) error {
-	r.log.Info("starting resilient component ...")
+	r.log.Info("starting resilient component")
 	backoff := r.newBackoff()
+	var (
+		lastError      error
+		lastSuccess    = time.Now()
+		nextSampledAt  time.Time
+		suppressedLogs uint64
+	)
 	for generationID := uint64(1); ; generationID++ {
 		lastStart := time.Now()
 		errCh := make(chan error, 1)
 		go func(errCh chan<- error) {
 			defer close(errCh)
-			// recover from a panic
 			defer func() {
 				if e := recover(); e != nil {
 					if err, ok := e.(error); ok {
@@ -42,7 +52,6 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 					}
 				}
 			}()
-
 			errCh <- r.component.Start(stop)
 		}(errCh)
 		select {
@@ -51,20 +60,42 @@ func (r *resilientComponent) Start(stop <-chan struct{}) error {
 			return nil
 		case err := <-errCh:
 			if err != nil {
-				// TODO: add per-name rate limiting here analogous to panicLogLimiter in runComponent;
-				// resilientComponent logs every restart, so a tight panic loop produces unbounded log volume.
+				lastError = err
 				r.log.WithValues("generationID", generationID).Error(err, "component terminated with an error")
+			} else {
+				// Clean exit: don't carry a prior failure into the next restart log.
+				lastError = nil
 			}
 		}
 		if time.Since(lastStart) > r.backoffMaxTime {
-			// reset backoff so in a case of event with the following steps
-			// 1) Component is unhealthy until max backoff is reached
-			// 2) Component is healthy for at least backoff max time
-			// 3) Component is unhealthy
-			// We start backoff from the beginning
+			// Stable run ended: reset backoff, success baseline, and sampling
+			// state so a new outage starts fresh.
 			backoff = r.newBackoff()
+			lastSuccess = time.Now()
+			nextSampledAt = time.Time{}
+			suppressedLogs = 0
 		}
 		dur, _ := backoff.Next()
+		if generationID <= resilientLogSampleAfterAttempt || !time.Now().Before(nextSampledAt) {
+			fields := []any{
+				"attempt", generationID,
+				"sinceLastSuccess", time.Since(lastSuccess),
+				"nextBackoff", dur,
+			}
+			if lastError != nil {
+				fields = append(fields, "lastError", lastError.Error())
+			}
+			if suppressedLogs > 0 {
+				fields = append(fields, "suppressed", suppressedLogs)
+				suppressedLogs = 0
+			}
+			r.log.Info("scheduling component restart", fields...)
+			if generationID > resilientLogSampleAfterAttempt {
+				nextSampledAt = time.Now().Add(resilientLogSampleWindow)
+			}
+		} else {
+			suppressedLogs++
+		}
 		<-time.After(dur)
 	}
 }

--- a/pkg/core/runtime/component/resilient_test.go
+++ b/pkg/core/runtime/component/resilient_test.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"errors"
+	"fmt"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -9,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 type logEntry struct {
@@ -167,6 +168,7 @@ var _ = Describe("resilientComponent", func() {
 		Expect(len(scheduled)).To(BeNumerically(">=", 3))
 
 		Expect(scheduled[0].tags).To(HaveKeyWithValue("attempt", uint64(1)))
+		Expect(scheduled[0].tags).To(HaveKey("generationID"))
 		Expect(scheduled[0].tags).To(HaveKey("sinceLastSuccess"))
 		Expect(scheduled[0].tags).To(HaveKey("nextBackoff"))
 		Expect(scheduled[0].tags).To(HaveKeyWithValue("lastError", "boom-1"))
@@ -208,7 +210,7 @@ var _ = Describe("resilientComponent", func() {
 		const failures = resilientLogSampleAfterAttempt + 7
 		errs := make([]error, failures)
 		for i := range errs {
-			errs[i] = errors.Errorf("err-%d", i)
+			errs[i] = fmt.Errorf("err-%d", i)
 		}
 		c := &scriptedComponent{script: scriptOfErrors(errs...)}
 		r := NewResilientComponent(log, c, 100*time.Microsecond, 1*time.Millisecond)
@@ -272,7 +274,7 @@ var _ = Describe("resilientComponent", func() {
 		// accumulates suppressed entries inside the same 10s window.
 		preBurst := make([]error, resilientLogSampleAfterAttempt*4)
 		for i := range preBurst {
-			preBurst[i] = errors.Errorf("pre-%d", i)
+			preBurst[i] = fmt.Errorf("pre-%d", i)
 		}
 		script := scriptOfErrors(preBurst...)
 		// Stable run >backoffMaxTime ends one outage and starts a new one.
@@ -285,7 +287,7 @@ var _ = Describe("resilientComponent", func() {
 		// suppressed by leftover nextSampledAt nor carrying suppressed counts.
 		postBurst := make([]error, resilientLogSampleAfterAttempt-1)
 		for i := range postBurst {
-			postBurst[i] = errors.Errorf("post-%d", i)
+			postBurst[i] = fmt.Errorf("post-%d", i)
 		}
 		script = append(script, scriptOfErrors(postBurst...)...)
 
@@ -319,7 +321,7 @@ var _ = Describe("resilientComponent", func() {
 		}
 	})
 
-	It("clears lastError on the restart log after a clean exit", func() {
+	It("skips the restart log on clean exit", func() {
 		log, root := newRecordingLogger()
 		stop := make(chan struct{})
 
@@ -341,9 +343,68 @@ var _ = Describe("resilientComponent", func() {
 		Eventually(done).Should(BeClosed())
 
 		scheduled := root.entriesByMsg("scheduling component restart")
-		Expect(len(scheduled)).To(BeNumerically(">=", 3))
+		// Only the transient-failure restart should emit; the two clean
+		// exits restart silently to avoid "restart with no error" noise.
+		Expect(scheduled).To(HaveLen(1))
 		Expect(scheduled[0].tags).To(HaveKeyWithValue("lastError", "transient"))
-		Expect(scheduled[1].tags).ToNot(HaveKey("lastError"))
-		Expect(scheduled[2].tags).ToNot(HaveKey("lastError"))
+	})
+
+	It("recovers from a panic in the wrapped component", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		c := &scriptedComponent{script: []func() error{
+			func() error { panic(errors.New("synthetic-panic")) },
+			func() error { panic("non-error-panic") },
+			func() error { return errors.New("after-panic") },
+		}}
+		r := NewResilientComponent(log, c, 1*time.Millisecond, 5*time.Millisecond)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(3)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		terminated := root.entriesByMsg("component terminated with an error")
+		Expect(len(terminated)).To(BeNumerically(">=", 3))
+		errStr := func(e logEntry) string {
+			err, _ := e.tags["error"].(error)
+			if err == nil {
+				return ""
+			}
+			return err.Error()
+		}
+		Expect(errStr(terminated[0])).To(ContainSubstring("synthetic-panic"))
+		Expect(errStr(terminated[1])).To(ContainSubstring("non-error-panic"))
+		Expect(errStr(terminated[2])).To(ContainSubstring("after-panic"))
+	})
+
+	It("returns promptly when stop fires during the backoff sleep", func() {
+		log, _ := newRecordingLogger()
+		stop := make(chan struct{})
+
+		// Backoff window large enough to dominate any prompt-shutdown budget.
+		const backoff = 2 * time.Second
+		c := &scriptedComponent{script: scriptOfErrors(errors.New("trigger-backoff"))}
+		r := NewResilientComponent(log, c, backoff, backoff)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(1)))
+		// The component has returned its error; the wrapper is now in the
+		// backoff sleep. Closing stop must unblock it well before backoff fires.
+		closedAt := time.Now()
+		close(stop)
+		Eventually(done, "500ms").Should(BeClosed())
+		Expect(time.Since(closedAt)).To(BeNumerically("<", backoff))
 	})
 })

--- a/pkg/core/runtime/component/resilient_test.go
+++ b/pkg/core/runtime/component/resilient_test.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -112,7 +113,6 @@ func (c *scriptedComponent) NeedLeaderElection() bool { return false }
 func scriptOfErrors(errs ...error) []func() error {
 	out := make([]func() error, len(errs))
 	for i, e := range errs {
-		e := e
 		out[i] = func() error { return e }
 	}
 	return out
@@ -255,31 +255,39 @@ var _ = Describe("resilientComponent", func() {
 		Eventually(done).Should(BeClosed())
 
 		scheduled := root.entriesByMsg("scheduling component restart")
-		Expect(len(scheduled)).To(BeNumerically(">=", 1))
+		Expect(scheduled).ToNot(BeEmpty())
 		sinceLastSuccess, ok := scheduled[0].tags["sinceLastSuccess"].(time.Duration)
 		Expect(ok).To(BeTrue())
 		Expect(sinceLastSuccess).To(BeNumerically("<", stableRun/2))
 	})
 
-	It("starts a fresh sample window after a stable run", func() {
+	It("always-logs the first burst of a new outage after a stable run", func() {
 		log, root := newRecordingLogger()
 		stop := make(chan struct{})
 
 		const stableRun = 30 * time.Millisecond
 		const tinyMax = 1 * time.Millisecond
 
-		// Burst pushes the sampler past the always-log threshold and accumulates
-		// suppressed entries inside the same 10s window.
-		burst := make([]error, resilientLogSampleAfterAttempt*4)
-		for i := range burst {
-			burst[i] = errors.Errorf("burst-%d", i)
+		// Pre-burst pushes the sampler past the always-log threshold and
+		// accumulates suppressed entries inside the same 10s window.
+		preBurst := make([]error, resilientLogSampleAfterAttempt*4)
+		for i := range preBurst {
+			preBurst[i] = errors.Errorf("pre-%d", i)
 		}
-		script := scriptOfErrors(burst...)
+		script := scriptOfErrors(preBurst...)
+		// Stable run >backoffMaxTime ends one outage and starts a new one.
 		script = append(script, func() error {
 			time.Sleep(stableRun)
 			return errors.New("after-stable")
 		})
-		script = append(script, func() error { return errors.New("post-recovery") })
+		// Post-burst: the new outage's first 5 attempts must all log
+		// (post-stable plus 4 quick failures = 5 attempts), neither
+		// suppressed by leftover nextSampledAt nor carrying suppressed counts.
+		postBurst := make([]error, resilientLogSampleAfterAttempt-1)
+		for i := range postBurst {
+			postBurst[i] = errors.Errorf("post-%d", i)
+		}
+		script = append(script, scriptOfErrors(postBurst...)...)
 
 		c := &scriptedComponent{script: script}
 		r := NewResilientComponent(log, c, 100*time.Microsecond, tinyMax)
@@ -295,18 +303,20 @@ var _ = Describe("resilientComponent", func() {
 		Eventually(done).Should(BeClosed())
 
 		scheduled := root.entriesByMsg("scheduling component restart")
-		// The restart log scheduled right after the stable run carries
-		// lastError="after-stable" and must not inherit suppressed state from
-		// the prior burst.
-		var postStable *logEntry
-		for i := range scheduled {
-			if scheduled[i].tags["lastError"] == "after-stable" {
-				postStable = &scheduled[i]
-				break
-			}
+		start := slices.IndexFunc(scheduled, func(e logEntry) bool {
+			return e.tags["lastError"] == "after-stable"
+		})
+		Expect(start).To(BeNumerically(">=", 0))
+
+		// The new outage's first resilientLogSampleAfterAttempt entries must
+		// all be present with outage-local attempt counters 1..N and no
+		// suppressed counts from the prior outage.
+		Expect(len(scheduled)).To(BeNumerically(">=", start+resilientLogSampleAfterAttempt))
+		for i := range resilientLogSampleAfterAttempt {
+			entry := scheduled[start+i]
+			Expect(entry.tags).To(HaveKeyWithValue("attempt", uint64(i+1)))
+			Expect(entry.tags).ToNot(HaveKey("suppressed"))
 		}
-		Expect(postStable).ToNot(BeNil())
-		Expect(postStable.tags).ToNot(HaveKey("suppressed"))
 	})
 
 	It("clears lastError on the restart log after a clean exit", func() {

--- a/pkg/core/runtime/component/resilient_test.go
+++ b/pkg/core/runtime/component/resilient_test.go
@@ -1,0 +1,339 @@
+package component
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+type logEntry struct {
+	msg  string
+	tags map[string]any
+}
+
+type recordingLogSinkRoot struct {
+	mu      sync.Mutex
+	entries []logEntry
+}
+
+func (r *recordingLogSinkRoot) snapshot() []logEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]logEntry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+func (r *recordingLogSinkRoot) entriesByMsg(msg string) []logEntry {
+	var out []logEntry
+	for _, e := range r.snapshot() {
+		if e.msg == msg {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+type recordingLogSink struct {
+	tags []any
+	root *recordingLogSinkRoot
+}
+
+func (s *recordingLogSink) Init(logr.RuntimeInfo) {}
+func (s *recordingLogSink) Enabled(int) bool      { return true }
+
+func (s *recordingLogSink) record(msg string, extra []any) {
+	tags := map[string]any{}
+	all := append(append([]any(nil), s.tags...), extra...)
+	for i := 0; i+1 < len(all); i += 2 {
+		k, ok := all[i].(string)
+		if !ok {
+			continue
+		}
+		tags[k] = all[i+1]
+	}
+	s.root.mu.Lock()
+	defer s.root.mu.Unlock()
+	s.root.entries = append(s.root.entries, logEntry{msg: msg, tags: tags})
+}
+
+func (s *recordingLogSink) Info(_ int, msg string, vals ...any) {
+	s.record(msg, vals)
+}
+
+func (s *recordingLogSink) Error(err error, msg string, vals ...any) {
+	extra := append([]any{"error", err}, vals...)
+	s.record(msg, extra)
+}
+
+func (s *recordingLogSink) WithValues(vals ...any) logr.LogSink {
+	return &recordingLogSink{tags: append(append([]any(nil), s.tags...), vals...), root: s.root}
+}
+
+func (s *recordingLogSink) WithName(string) logr.LogSink {
+	return &recordingLogSink{tags: append([]any(nil), s.tags...), root: s.root}
+}
+
+func newRecordingLogger() (logr.Logger, *recordingLogSinkRoot) {
+	root := &recordingLogSinkRoot{}
+	return logr.New(&recordingLogSink{root: root}), root
+}
+
+// scriptedComponent runs the next scripted behavior per Start call. Once the
+// script is exhausted it blocks until stop closes.
+type scriptedComponent struct {
+	mu     sync.Mutex
+	script []func() error
+	calls  atomic.Int64
+}
+
+func (c *scriptedComponent) Start(stop <-chan struct{}) error {
+	c.calls.Add(1)
+	c.mu.Lock()
+	if len(c.script) == 0 {
+		c.mu.Unlock()
+		<-stop
+		return nil
+	}
+	f := c.script[0]
+	c.script = c.script[1:]
+	c.mu.Unlock()
+	return f()
+}
+
+func (c *scriptedComponent) NeedLeaderElection() bool { return false }
+
+// scriptOfErrors lifts a list of errors into a script that returns one error per Start call.
+func scriptOfErrors(errs ...error) []func() error {
+	out := make([]func() error, len(errs))
+	for i, e := range errs {
+		e := e
+		out[i] = func() error { return e }
+	}
+	return out
+}
+
+var _ = Describe("resilientComponent", func() {
+	const tinyBase = 1 * time.Millisecond
+	const tinyMax = 5 * time.Millisecond
+
+	It("logs an Info on start and an Info on stop", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+		c := &scriptedComponent{}
+		r := NewResilientComponent(log, c, tinyBase, tinyMax)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load).Should(BeNumerically(">=", int64(1)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		Expect(root.entriesByMsg("starting resilient component")).To(HaveLen(1))
+		Expect(root.entriesByMsg("done")).To(HaveLen(1))
+	})
+
+	It("logs scheduling restart with attempt, sinceLastSuccess, nextBackoff and lastError", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		c := &scriptedComponent{script: scriptOfErrors(
+			errors.New("boom-1"),
+			errors.New("boom-2"),
+			errors.New("boom-3"),
+		)}
+		r := NewResilientComponent(log, c, tinyBase, tinyMax)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(4)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		scheduled := root.entriesByMsg("scheduling component restart")
+		Expect(len(scheduled)).To(BeNumerically(">=", 3))
+
+		Expect(scheduled[0].tags).To(HaveKeyWithValue("attempt", uint64(1)))
+		Expect(scheduled[0].tags).To(HaveKey("sinceLastSuccess"))
+		Expect(scheduled[0].tags).To(HaveKey("nextBackoff"))
+		Expect(scheduled[0].tags).To(HaveKeyWithValue("lastError", "boom-1"))
+
+		Expect(scheduled[1].tags).To(HaveKeyWithValue("attempt", uint64(2)))
+		Expect(scheduled[1].tags).To(HaveKeyWithValue("lastError", "boom-2"))
+	})
+
+	It("logs the component-terminated Error per failure", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		c := &scriptedComponent{script: scriptOfErrors(
+			errors.New("kaboom-1"),
+			errors.New("kaboom-2"),
+		)}
+		r := NewResilientComponent(log, c, tinyBase, tinyMax)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(3)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		terminated := root.entriesByMsg("component terminated with an error")
+		Expect(len(terminated)).To(BeNumerically(">=", 2))
+		Expect(terminated[0].tags).To(HaveKey("generationID"))
+		Expect(terminated[0].tags).To(HaveKey("error"))
+	})
+
+	It("samples the restart line after the first burst and reports suppressed", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		const failures = resilientLogSampleAfterAttempt + 7
+		errs := make([]error, failures)
+		for i := range errs {
+			errs[i] = errors.Errorf("err-%d", i)
+		}
+		c := &scriptedComponent{script: scriptOfErrors(errs...)}
+		r := NewResilientComponent(log, c, 100*time.Microsecond, 1*time.Millisecond)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(failures)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		scheduled := root.entriesByMsg("scheduling component restart")
+		Expect(len(scheduled)).To(BeNumerically(">=", resilientLogSampleAfterAttempt))
+		Expect(len(scheduled)).To(BeNumerically("<", failures))
+
+		for i := 0; i < resilientLogSampleAfterAttempt && i < len(scheduled); i++ {
+			Expect(scheduled[i].tags).ToNot(HaveKey("suppressed"))
+		}
+	})
+
+	It("reports sinceLastSuccess relative to the most recent stable-run termination", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		const stableRun = 30 * time.Millisecond
+		const tinyMax = 5 * time.Millisecond
+		c := &scriptedComponent{script: []func() error{
+			func() error { time.Sleep(stableRun); return errors.New("after-stable") },
+			func() error { return errors.New("quick") },
+		}}
+		r := NewResilientComponent(log, c, 1*time.Millisecond, tinyMax)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(2)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		scheduled := root.entriesByMsg("scheduling component restart")
+		Expect(len(scheduled)).To(BeNumerically(">=", 1))
+		sinceLastSuccess, ok := scheduled[0].tags["sinceLastSuccess"].(time.Duration)
+		Expect(ok).To(BeTrue())
+		Expect(sinceLastSuccess).To(BeNumerically("<", stableRun/2))
+	})
+
+	It("starts a fresh sample window after a stable run", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		const stableRun = 30 * time.Millisecond
+		const tinyMax = 1 * time.Millisecond
+
+		// Burst pushes the sampler past the always-log threshold and accumulates
+		// suppressed entries inside the same 10s window.
+		burst := make([]error, resilientLogSampleAfterAttempt*4)
+		for i := range burst {
+			burst[i] = errors.Errorf("burst-%d", i)
+		}
+		script := scriptOfErrors(burst...)
+		script = append(script, func() error {
+			time.Sleep(stableRun)
+			return errors.New("after-stable")
+		})
+		script = append(script, func() error { return errors.New("post-recovery") })
+
+		c := &scriptedComponent{script: script}
+		r := NewResilientComponent(log, c, 100*time.Microsecond, tinyMax)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "5s", "5ms").Should(BeNumerically(">=", int64(len(script))))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		scheduled := root.entriesByMsg("scheduling component restart")
+		// The restart log scheduled right after the stable run carries
+		// lastError="after-stable" and must not inherit suppressed state from
+		// the prior burst.
+		var postStable *logEntry
+		for i := range scheduled {
+			if scheduled[i].tags["lastError"] == "after-stable" {
+				postStable = &scheduled[i]
+				break
+			}
+		}
+		Expect(postStable).ToNot(BeNil())
+		Expect(postStable.tags).ToNot(HaveKey("suppressed"))
+	})
+
+	It("clears lastError on the restart log after a clean exit", func() {
+		log, root := newRecordingLogger()
+		stop := make(chan struct{})
+
+		c := &scriptedComponent{script: []func() error{
+			func() error { return errors.New("transient") },
+			func() error { return nil },
+			func() error { return nil },
+		}}
+		r := NewResilientComponent(log, c, 1*time.Millisecond, 5*time.Millisecond)
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(done)
+			Expect(r.Start(stop)).To(Succeed())
+		}()
+		Eventually(c.calls.Load, "2s", "5ms").Should(BeNumerically(">=", int64(3)))
+		close(stop)
+		Eventually(done).Should(BeClosed())
+
+		scheduled := root.entriesByMsg("scheduling component restart")
+		Expect(len(scheduled)).To(BeNumerically(">=", 3))
+		Expect(scheduled[0].tags).To(HaveKeyWithValue("lastError", "transient"))
+		Expect(scheduled[1].tags).ToNot(HaveKey("lastError"))
+		Expect(scheduled[2].tags).ToNot(HaveKey("lastError"))
+	})
+})

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -58,7 +58,7 @@ func Setup(rt core_runtime.Runtime) error {
 		deltaServer,
 	)
 	return rt.Add(component.NewResilientComponent(
-		kdsZoneLog.WithName("kds-mux-client"),
+		kdsZoneLog.WithName("kds-mux-client").WithValues("peer", rt.Config().Multizone.Zone.GlobalAddress),
 		muxClient,
 		rt.Config().General.ResilientComponentBaseBackoff.Duration,
 		rt.Config().General.ResilientComponentMaxBackoff.Duration,

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -1,6 +1,8 @@
 package zone
 
 import (
+	"net/url"
+
 	"github.com/kumahq/kuma/v2/pkg/core"
 	core_runtime "github.com/kumahq/kuma/v2/pkg/core/runtime"
 	"github.com/kumahq/kuma/v2/pkg/core/runtime/component"
@@ -57,8 +59,12 @@ func Setup(rt core_runtime.Runtime) error {
 		rt,
 		deltaServer,
 	)
+	peer := rt.Config().Multizone.Zone.GlobalAddress
+	if u, err := url.Parse(peer); err == nil {
+		peer = u.Redacted()
+	}
 	return rt.Add(component.NewResilientComponent(
-		kdsZoneLog.WithName("kds-mux-client").WithValues("peer", rt.Config().Multizone.Zone.GlobalAddress),
+		kdsZoneLog.WithName("kds-mux-client").WithValues("peer", peer),
 		muxClient,
 		rt.Config().General.ResilientComponentBaseBackoff.Duration,
 		rt.Config().General.ResilientComponentMaxBackoff.Duration,


### PR DESCRIPTION
## Motivation

When a resilient-wrapped component crashes, the wrapper backs off and retries with nothing in the logs between the original error and the next attempt. On a stuck zone CP this leaves no signal: how many retries so far, how long the outage has been running, what error keeps coming back, which global address is unreachable. Sibling of #16499.

## Implementation information

After each termination, emit `scheduling component restart` at Info with `attempt`, `sinceLastSuccess`, `nextBackoff`, `lastError` (cleared on clean exit), and a `suppressed` counter. The first 5 attempts always log; after that, at most one per 10s, matching the panic limiter window in `runComponent`.

The stable-run boundary (`time.Since(lastStart) > backoffMaxTime`) resets backoff, the success baseline, and the sampling state, so the first restart log of a new outage doesn't carry over suppression or counts from the previous one.

Zone KDS attaches `peer=<global address>` to the resilient logger so every line carries it.

## Sample output

```text
INFO  kds-zone.kds-mux-client  starting resilient component  peer=grpcs://global:5685
ERROR kds-zone.kds-mux-client  component terminated with an error  peer=grpcs://global:5685 generationID=1 error="rpc error: code = Unavailable ..."
INFO  kds-zone.kds-mux-client  scheduling component restart  peer=grpcs://global:5685 attempt=1 sinceLastSuccess=12ms nextBackoff=5s lastError="rpc error: code = Unavailable ..."
INFO  kds-zone.kds-mux-client  scheduling component restart  peer=grpcs://global:5685 attempt=12 sinceLastSuccess=1m4s nextBackoff=1m suppressed=4 lastError="..."
```

## Tests

`resilient_test.go` exercises the public contract end-to-end with tiny backoffs and a scripted inner component. It covers the three correctness invariants that came up in review: `sinceLastSuccess` after a stable run, sampling state reset on the stable-run boundary, and `lastError` cleared on clean exit. Reverting any of those four lines in `resilient.go` fails exactly one test.

> Changelog: feat(kuma-cp): component based logging
