### PR TITLE
fix(helm): verify packaged chart has real version

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -52,6 +52,7 @@ function update_version {
 }
 
 function package {
+  local dev=${1}
   # First package all the charts
   for dir in "${CHARTS_DIR}"/*; do
     if [ ! -d "${dir}" ]; then
@@ -88,6 +89,31 @@ function package {
 
     # Restore files removed above
     git checkout -- "${dir}"
+  done
+
+  # In release mode (no --dev), every Chart.yaml inside the packaged tgz must
+  # carry a real version. A leftover 0.0.0-preview means helm dep update did
+  # not replace the embedded subchart - the chart would ship with a bogus
+  # helm.sh/chart label.
+  if [ -z "${dev}" ]; then
+    verify_packaged
+  fi
+}
+
+function verify_packaged {
+  local f p v
+  local -a bad
+  for f in "${CHARTS_PACKAGE_PATH}"/*.tgz; do
+    bad=()
+    while read -r p; do
+      v=$(tar -zxOf "${f}" "${p}" | yq .version)
+      if [[ ${v} == 0.0.0-preview* ]]; then
+        bad+=("${p}")
+      fi
+    done < <(tar -tzf "${f}" | grep -E 'Chart\.yaml$')
+    if (( ${#bad[@]} > 0 )); then
+      msg_err "packaged chart ${f} ships placeholder version in: ${bad[*]}. helm dep update did not replace the embedded subchart."
+    fi
   done
 }
 
@@ -188,7 +214,7 @@ function main {
 
   case $op in
     package)
-      package
+      package "${dev}"
       ;;
     update-version)
       update_version "${dev}"


### PR DESCRIPTION
## Motivation

5 of the last 10 downstream chart releases shipped with the embedded kuma subchart still at `version: 0.0.0-preview.vlocal-build`. That version flows into the `helm.sh/chart` label on every kuma resource, so installs of those charts produced `helm.sh/chart: kuma-0.0.0-preview.vlocal-build`. Reported by a customer in Slack.

Inside each broken tarball, `Chart.lock` recorded the proper resolved version (e.g. `2.11.13`), but `helm dep update` (run by `cr package`) had not replaced the embedded `charts/kuma/` directory. The release pipeline had no check for this and shipped the chart anyway.

## Implementation information

Add `verify_packaged` to `tools/releases/helm.sh`. After `cr package`, read every `Chart.yaml` inside the produced `.tgz` with `yq` (matching the existing pattern in `release()` further down the same file) and fail with the offending path if `.version` starts with `0.0.0-preview`. Skipped under `--dev` because the placeholder is intentional in PR builds (the dependency is removed and the embedded chart ships as-is).

I verified by hand against the real broken tarballs - the check fires on each one, names the bad subchart, and exits non-zero. It passes on the working ones.

> Changelog: skip