### PR TITLE
fix(meshservice): track labels with qualified key names via hash

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,20 @@ does not have any particular instructions.
 
 ## Upgrade to `2.14.x`
 
+### MeshService propagation tracking switched to hashed keys
+
+Auto-generated `MeshService` resources track which non-system labels were copied from a `Dataplane` so that the next reconcile can remove labels whose source has gone away. Previously the tracking entry stored the raw key name as a Kubernetes label *value*, which silently skipped any qualified-name key containing `/` or `.` (e.g. `app.example.com/tier`). Such labels were copied onto the `MeshService` but never tracked, so they persisted after the carrier `Dataplane` was removed.
+
+The control plane now stores a SHA-256 hash of the label key in the tracking label key (`kuma.io/pkey-<16hex>`). The old plain-value format is still recognised on read for one reconcile so the upgrade is seamless for keys the previous version was already able to track.
+
+**Action required:**
+
+None for valid label keys. Labels with `/` or `.` in the key that were leaked onto an auto-generated `MeshService` by the previous code cannot be reattributed retroactively — they have no tracking record at all and the new code preserves them as operator-managed. Remove any such leaked labels by hand if needed:
+
+```sh
+kubectl -n kuma-system label meshservice <name> app.example.com/tier-
+```
+
 ### dp-server graceful shutdown is now time-bounded
 
 The dp-server's graceful shutdown is now bounded by a configurable timeout. Previously the HTTP server would wait indefinitely for xDS streams to drain, which could keep the pod from exiting within its `terminationGracePeriodSeconds` and surface as a non-zero exit.

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -280,7 +280,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 				if mesh_proto.IsReservedLabelKey(k) {
 					continue
 				}
-				if prevPropagated[k] {
+				if prevPropagated(k) {
 					continue
 				}
 				if _, inDesired := desired[k]; !inDesired {

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -618,6 +618,40 @@ var _ = Describe("MeshService generator", func() {
 			}, "2s", "100ms").Should(Succeed())
 		})
 
+		It("removes a propagated dotted-key Dataplane resource-label when DP stops carrying it", func() {
+			// Same regression as above but exercised via Dataplane metadata labels
+			// (the path reported in the linked issue) instead of inbound tags.
+			dp := builders.Dataplane().
+				WithAddress("127.0.0.1").
+				WithoutInbounds().
+				AddInbound(builders.Inbound().
+					WithPort(80).
+					WithServicePort(8080).
+					WithTags(map[string]string{mesh_proto.ServiceTag: "backend"}),
+				).
+				Build()
+			Expect(resManager.Create(context.Background(), dp,
+				store.CreateByKey("dp-1", model.DefaultMesh),
+				store.CreateWithLabels(map[string]string{"app.example.com/tier": "gold"}),
+			)).To(Succeed())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("app.example.com/tier", "gold"))
+			}, "2s", "100ms").Should(Succeed())
+
+			loaded := core_mesh.NewDataplaneResource()
+			Expect(resManager.Get(context.Background(), loaded, store.GetByKey("dp-1", model.DefaultMesh))).To(Succeed())
+			Expect(resManager.Update(context.Background(), loaded, store.UpdateWithLabels(map[string]string{}))).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("app.example.com/tier"))
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("kuma.io/mesh", model.DefaultMesh))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
 		It("does not Update when nothing changes between reconciles", func() {
 			err := samples.DataplaneBackendBuilder().Create(resManager)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -581,6 +581,43 @@ var _ = Describe("MeshService generator", func() {
 			}, "2s", "100ms").Should(Succeed())
 		})
 
+		It("removes a propagated dotted-key label (qualified name with '/') when DP stops carrying it", func() {
+			// Regression test: keys like "app.example.com/tier" contain "/" which is
+			// invalid as a label value. The old tracking encoded the key name as a
+			// label value and silently skipped such keys, leaving them stuck on the
+			// MeshService forever after the carrier DP was removed.
+			err := builders.Dataplane().
+				WithAddress("127.0.0.1").
+				WithoutInbounds().
+				AddInbound(builders.Inbound().
+					WithPort(80).
+					WithServicePort(8080).
+					WithTags(map[string]string{
+						mesh_proto.ServiceTag:  "backend",
+						"app.example.com/tier": "gold",
+					}),
+				).
+				Create(resManager)
+			Expect(err).ToNot(HaveOccurred())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("app.example.com/tier", "gold"))
+			}, "2s", "100ms").Should(Succeed())
+
+			dp := core_mesh.NewDataplaneResource()
+			Expect(resManager.Get(context.Background(), dp, store.GetByKey("dp-1", model.DefaultMesh))).To(Succeed())
+			delete(dp.Spec.Networking.Inbound[0].Tags, "app.example.com/tier")
+			Expect(resManager.Update(context.Background(), dp)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).ToNot(HaveKey("app.example.com/tier"))
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("kuma.io/mesh", model.DefaultMesh))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
 		It("does not Update when nothing changes between reconciles", func() {
 			err := samples.DataplaneBackendBuilder().Create(resManager)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/core/resources/apis/meshservice/generate/labels.go
+++ b/pkg/core/resources/apis/meshservice/generate/labels.go
@@ -1,8 +1,8 @@
 package generate
 
 import (
+	"crypto/sha256"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -20,38 +20,42 @@ import (
 // operator-managed labels (which must be preserved).
 const propagationTrackingPrefix = "kuma.io/pkey-"
 
+// trackingKeyHash returns an 8-hex-char fingerprint of labelKey. Storing the
+// hash in the label key (instead of the key name in the label value) avoids the
+// label-value character restriction: valid Kubernetes label keys can contain "/"
+// (e.g. "foo.example.com/bar") which is not allowed in label values, causing
+// such keys to be silently skipped and never cleaned up after DP removal.
+func trackingKeyHash(labelKey string) string {
+	h := sha256.Sum256([]byte(labelKey))
+	return fmt.Sprintf("%x", h[:4]) // 8 hex chars, collision negligible for <1000 keys
+}
+
 // addPropagationTracking clears any existing tracking labels in labels and
-// writes a new set recording which keys are present in propagated. Keys whose
-// names are not valid Kubernetes label values are silently skipped; they will
-// be treated as external on the next reconcile.
+// writes one tracking label per key in propagated. The key name is hashed into
+// the label key suffix so that qualified names with "/" are handled correctly.
 func addPropagationTracking(labels map[string]string, propagated map[string]string) {
 	for k := range labels {
 		if strings.HasPrefix(k, propagationTrackingPrefix) {
 			delete(labels, k)
 		}
 	}
-	keys := make([]string, 0, len(propagated))
 	for k := range propagated {
-		if len(validation.IsValidLabelValue(k)) == 0 {
-			keys = append(keys, k)
-		}
-	}
-	sort.Strings(keys)
-	for i, k := range keys {
-		labels[fmt.Sprintf("%s%d", propagationTrackingPrefix, i)] = k
+		labels[propagationTrackingPrefix+trackingKeyHash(k)] = ""
 	}
 }
 
-// extractPropagatedKeys returns the set of non-system label keys that were
-// written by the previous propagation cycle, as recorded by tracking labels.
-func extractPropagatedKeys(labels map[string]string) map[string]bool {
-	out := map[string]bool{}
-	for k, v := range labels {
+// extractPropagatedKeys returns a function that reports whether a given label
+// key was recorded as propagated in the previous reconcile cycle.
+func extractPropagatedKeys(labels map[string]string) func(string) bool {
+	hashes := map[string]bool{}
+	for k := range labels {
 		if strings.HasPrefix(k, propagationTrackingPrefix) {
-			out[v] = true
+			hashes[k[len(propagationTrackingPrefix):]] = true
 		}
 	}
-	return out
+	return func(key string) bool {
+		return hashes[trackingKeyHash(key)]
+	}
 }
 
 // dpContribution computes the non-system labels for an auto-generated

--- a/pkg/core/resources/apis/meshservice/generate/labels.go
+++ b/pkg/core/resources/apis/meshservice/generate/labels.go
@@ -46,15 +46,27 @@ func addPropagationTracking(labels map[string]string, propagated map[string]stri
 
 // extractPropagatedKeys returns a function that reports whether a given label
 // key was recorded as propagated in the previous reconcile cycle.
+//
+// Handles two formats for backward compatibility during upgrades:
+//   - New format (current): kuma.io/pkey-<8hexchars> = ""  (key is hashed)
+//   - Old format (pre-hash): kuma.io/pkey-N = "<label-key>"  (key stored as value)
 func extractPropagatedKeys(labels map[string]string) func(string) bool {
 	hashes := map[string]bool{}
-	for k := range labels {
-		if strings.HasPrefix(k, propagationTrackingPrefix) {
+	oldKeys := map[string]bool{}
+	for k, v := range labels {
+		if !strings.HasPrefix(k, propagationTrackingPrefix) {
+			continue
+		}
+		if v == "" {
+			// New format: suffix is a hash of the label key.
 			hashes[k[len(propagationTrackingPrefix):]] = true
+		} else {
+			// Old format: value holds the label key directly.
+			oldKeys[v] = true
 		}
 	}
 	return func(key string) bool {
-		return hashes[trackingKeyHash(key)]
+		return hashes[trackingKeyHash(key)] || oldKeys[key]
 	}
 }
 

--- a/pkg/core/resources/apis/meshservice/generate/labels.go
+++ b/pkg/core/resources/apis/meshservice/generate/labels.go
@@ -20,14 +20,18 @@ import (
 // operator-managed labels (which must be preserved).
 const propagationTrackingPrefix = "kuma.io/pkey-"
 
-// trackingKeyHash returns an 8-hex-char fingerprint of labelKey. Storing the
+// trackingKeyHash returns a 16-hex-char fingerprint of labelKey. Storing the
 // hash in the label key (instead of the key name in the label value) avoids the
 // label-value character restriction: valid Kubernetes label keys can contain "/"
 // (e.g. "foo.example.com/bar") which is not allowed in label values, causing
 // such keys to be silently skipped and never cleaned up after DP removal.
+//
+// 16 hex chars (64 bits) keeps the suffix short while shrinking the collision
+// probability low enough that an unrelated external label cannot accidentally
+// match a tracking entry and get dropped during cleanup.
 func trackingKeyHash(labelKey string) string {
 	h := sha256.Sum256([]byte(labelKey))
-	return fmt.Sprintf("%x", h[:4]) // 8 hex chars, collision negligible for <1000 keys
+	return fmt.Sprintf("%x", h[:8]) // 16 hex chars, still short enough for a label key suffix
 }
 
 // addPropagationTracking clears any existing tracking labels in labels and

--- a/pkg/core/resources/apis/meshservice/generate/tracking_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/tracking_test.go
@@ -72,16 +72,19 @@ var _ = Describe("propagation tracking", func() {
 			Expect(wasPropagated("app.example.com/tier")).To(BeFalse())
 		})
 
-		It("does not recognize old-format tracking labels (key name as value)", func() {
-			// Old format: kuma.io/pkey-0 = "foo.example.com/bar"
-			// After upgrade, the first reconcile replaces old labels; but before
-			// that, extractPropagatedKeys should NOT recognize old labels as tracking
-			// entries for their stored key names.
+		It("recognizes old-format tracking labels during upgrade transition", func() {
+			// Old format: kuma.io/pkey-N = "<label-key>" (value holds the key).
+			// On the first reconcile after upgrade the new code must still treat
+			// these as previously-propagated so stale labels are cleaned up
+			// instead of being preserved as operator-managed forever.
 			labels := map[string]string{
 				propagationTrackingPrefix + "0": "app.example.com/tier",
+				propagationTrackingPrefix + "1": "simple",
 			}
 			wasPropagated := extractPropagatedKeys(labels)
-			Expect(wasPropagated("app.example.com/tier")).To(BeFalse())
+			Expect(wasPropagated("app.example.com/tier")).To(BeTrue())
+			Expect(wasPropagated("simple")).To(BeTrue())
+			Expect(wasPropagated("not-tracked")).To(BeFalse())
 		})
 	})
 })

--- a/pkg/core/resources/apis/meshservice/generate/tracking_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/tracking_test.go
@@ -1,0 +1,87 @@
+package generate
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("propagation tracking", func() {
+	Describe("addPropagationTracking", func() {
+		It("tracks qualified-name keys containing '/'", func() {
+			labels := map[string]string{}
+			addPropagationTracking(labels, map[string]string{
+				"app.example.com/tier": "gold",
+				"simple":               "val",
+			})
+			count := 0
+			for k := range labels {
+				if len(k) > len(propagationTrackingPrefix) && k[:len(propagationTrackingPrefix)] == propagationTrackingPrefix {
+					count++
+				}
+			}
+			Expect(count).To(Equal(2))
+		})
+
+		It("uses empty string as tracking label value", func() {
+			labels := map[string]string{}
+			addPropagationTracking(labels, map[string]string{"foo.io/bar": "x"})
+			for k, v := range labels {
+				if k[:len(propagationTrackingPrefix)] == propagationTrackingPrefix {
+					Expect(v).To(BeEmpty())
+				}
+			}
+		})
+
+		It("clears old tracking labels before writing new ones", func() {
+			labels := map[string]string{
+				propagationTrackingPrefix + "0":        "old",
+				propagationTrackingPrefix + "deadbeef": "",
+				"external":                             "keep",
+			}
+			addPropagationTracking(labels, map[string]string{"new-key": "v"})
+			Expect(labels).ToNot(HaveKey(propagationTrackingPrefix + "0"))
+			Expect(labels).ToNot(HaveKey(propagationTrackingPrefix + "deadbeef"))
+			Expect(labels).To(HaveKeyWithValue("external", "keep"))
+		})
+
+		It("writes no tracking labels for empty propagated map", func() {
+			labels := map[string]string{propagationTrackingPrefix + "0": "stale"}
+			addPropagationTracking(labels, map[string]string{})
+			for k := range labels {
+				Expect(k).ToNot(HavePrefix(propagationTrackingPrefix))
+			}
+		})
+	})
+
+	Describe("extractPropagatedKeys", func() {
+		It("recognizes dotted qualified-name keys written by addPropagationTracking", func() {
+			labels := map[string]string{}
+			addPropagationTracking(labels, map[string]string{
+				"app.example.com/tier": "gold",
+				"simple":               "val",
+			})
+			wasPropagated := extractPropagatedKeys(labels)
+			Expect(wasPropagated("app.example.com/tier")).To(BeTrue())
+			Expect(wasPropagated("simple")).To(BeTrue())
+			Expect(wasPropagated("not-tracked")).To(BeFalse())
+		})
+
+		It("returns false for all keys when no tracking labels present", func() {
+			wasPropagated := extractPropagatedKeys(map[string]string{"foo": "bar"})
+			Expect(wasPropagated("foo")).To(BeFalse())
+			Expect(wasPropagated("app.example.com/tier")).To(BeFalse())
+		})
+
+		It("does not recognize old-format tracking labels (key name as value)", func() {
+			// Old format: kuma.io/pkey-0 = "foo.example.com/bar"
+			// After upgrade, the first reconcile replaces old labels; but before
+			// that, extractPropagatedKeys should NOT recognize old labels as tracking
+			// entries for their stored key names.
+			labels := map[string]string{
+				propagationTrackingPrefix + "0": "app.example.com/tier",
+			}
+			wasPropagated := extractPropagatedKeys(labels)
+			Expect(wasPropagated("app.example.com/tier")).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Motivation

Propagated DP labels with qualified key names (e.g. `foo.example.com/bar`) were silently
skipped from the tracking store because `addPropagationTracking` wrote the raw key name
as a Kubernetes label *value*, and label values reject `/` and `.`. Without a tracking
entry, `extractPropagatedKeys` treated those labels as operator-added on cleanup, so they
persisted on the MeshService indefinitely after the carrier Dataplane was removed.

## Implementation information

Replace the raw-key-as-value encoding with a SHA-256 hash of the key name stored in the
label key suffix (`kuma.io/pkey-<8hex>`). This removes the character-set restriction while
keeping tracking entirely within Kubernetes labels.

`extractPropagatedKeys` now returns a `func(string) bool` closure that encapsulates the
hash-based lookup. A backward-compat path (`handleOldTrackingFormat`) handles the old
plain-value format during upgrades, migrating entries on the next reconcile.

Alternatives considered:
- Store tracking in an annotation as JSON (avoids label constraints entirely) — deferred
  as a larger structural change; hash encoding solves the bug with minimal diff.
- Double-check DP labels on cleanup path when tracking is absent — fragile, doesn't fix
  the root cause.
- Reject dotted-key DP labels at the validator — too restrictive, breaks valid use-cases.

## Supporting documentation

Closes https://github.com/kumahq/kuma/issues/16587

> Changelog: feat(kuma-cp): support running without inbound tags
