### PR TITLE
fix(helm): catch placeholder (backport of #16589)

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -52,6 +52,7 @@ function update_version {
 }
 
 function package {
+  local dev=${1}
   # First package all the charts
   for dir in "${CHARTS_DIR}"/*; do
     if [ ! -d "${dir}" ]; then
@@ -88,6 +89,31 @@ function package {
 
     # Restore files removed above
     git checkout -- "${dir}"
+  done
+
+  # In release mode (no --dev), every Chart.yaml inside the packaged tgz must
+  # carry a real version. A leftover 0.0.0-preview means helm dep update did
+  # not replace the embedded subchart - the chart would ship with a bogus
+  # helm.sh/chart label.
+  if [ -z "${dev}" ]; then
+    verify_packaged
+  fi
+}
+
+function verify_packaged {
+  local f p v
+  local -a bad
+  for f in "${CHARTS_PACKAGE_PATH}"/*.tgz; do
+    bad=()
+    while read -r p; do
+      v=$(tar -zxOf "${f}" "${p}" | yq .version)
+      if [[ ${v} == 0.0.0-preview* ]]; then
+        bad+=("${p}")
+      fi
+    done < <(tar -tzf "${f}" | grep -E 'Chart\.yaml$')
+    if (( ${#bad[@]} > 0 )); then
+      msg_err "packaged chart ${f} ships placeholder version in: ${bad[*]}. helm dep update did not replace the embedded subchart."
+    fi
   done
 }
 
@@ -188,7 +214,7 @@ function main {
 
   case $op in
     package)
-      package
+      package "${dev}"
       ;;
     update-version)
       update_version "${dev}"


### PR DESCRIPTION
## Motivation

Backport of #16589 to this release line. Future patches on this branch (and the downstream chart that pins this kuma version via `go.mod`) need the same release-pipeline guard.

Without this check, a future `helm dep update` failure inside `cr package` would silently ship the embedded subchart with `version: 0.0.0-preview.vlocal-build`, producing a bogus `helm.sh/chart` label on every kuma resource - the same bug that hit 5 of the last 10 downstream chart releases.

## Implementation information

Cherry-picked verbatim from #16589 (master commit `677d18a593`). One file changed: `tools/releases/helm.sh`. The hunk applied via 3-way merge with no conflicts.

> Changelog: skip
