### PR TITLE
feat(meshtrace): support zone proxy Dataplanes

### DIFF
--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -11,6 +11,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	"github.com/kumahq/kuma/v2/pkg/core/naming"
 	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/destinationname"
@@ -60,6 +61,9 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 		return err
 	}
 	if err := applyToOutbounds(ctx, policies.SingleItemRules, listeners.Outbound, proxy); err != nil {
+		return err
+	}
+	if err := applyToZoneProxyListeners(ctx, policies.SingleItemRules, rs, proxy); err != nil {
 		return err
 	}
 	if err := applyToClusters(ctx, policies.SingleItemRules, rs, proxy); err != nil {
@@ -143,6 +147,36 @@ func applyToOutbounds(ctx xds_context.Context, rules core_rules.SingleItemRules,
 	return nil
 }
 
+func applyToZoneProxyListeners(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {
+	if !proxy.Dataplane.Spec.GetNetworking().HasZoneProxyListeners() {
+		return nil
+	}
+	listenerRes := rs.Resources(envoy_resource.ListenerType)
+	for _, l := range proxy.Dataplane.Spec.GetNetworking().GetListeners() {
+		var name string
+		switch l.GetType() {
+		case mesh_proto.Dataplane_Networking_Listener_ZoneIngress:
+			name = naming.ContextualZoneIngressListenerName(l.GetSectionName())
+		case mesh_proto.Dataplane_Networking_Listener_ZoneEgress:
+			name = naming.ContextualZoneEgressListenerName(l.GetSectionName())
+		default:
+			continue
+		}
+		res, ok := listenerRes[name]
+		if !ok {
+			continue
+		}
+		listener, ok := res.Resource.(*envoy_listener.Listener)
+		if !ok {
+			continue
+		}
+		if err := configureListener(ctx, rules, proxy, listener, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {
 	for uri, resType := range rs.IndexByOrigin(xds.NonMeshExternalService) {
 		service, port, found := meshroute.DestinationPortFromRef(ctx.Mesh, &resolve.RealResourceBackendRef{
@@ -166,6 +200,11 @@ func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRu
 
 func configureListener(ctx xds_context.Context, rules core_rules.SingleItemRules, proxy *xds.Proxy, listener *envoy_listener.Listener, destination string) error {
 	serviceName := proxy.Dataplane.IdentifyingName(ctx.ControlPlane != nil && ctx.ControlPlane.InboundTagsDisabled)
+	// A zone-proxy-only Dataplane has no service tag, so IdentifyingName falls back to "unknown".
+	// Use the Dataplane name instead so tracing span service names are stable (MADR-103 group 4).
+	if serviceName == mesh_proto.ServiceUnknown && proxy.Dataplane.Spec.GetNetworking().IsZoneProxyOnly() {
+		serviceName = proxy.Dataplane.GetMeta().GetName()
+	}
 	rawConf := rules.Rules[0].Conf
 	conf := rawConf.(api.Conf)
 

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -25,6 +25,7 @@ import (
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	core_rules "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/subsetutils"
+	plugins_xds "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrace/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrace/plugin/v1alpha1"
 	gateway_plugin "github.com/kumahq/kuma/v2/pkg/plugins/runtime/gateway"
@@ -772,3 +773,318 @@ func getResourceYaml(list core_xds.ResourceList) []byte {
 	Expect(err).ToNot(HaveOccurred())
 	return actualResource
 }
+
+func zoneEgressOnlyDataplane(name string) *builders.DataplaneBuilder {
+	return builders.Dataplane().
+		WithName(name).
+		WithAddress("192.168.0.10").
+		WithoutInbounds().
+		With(func(d *core_mesh.DataplaneResource) {
+			d.Spec.Networking.Listeners = []*mesh_proto.Dataplane_Networking_Listener{
+				{
+					Type:    mesh_proto.Dataplane_Networking_Listener_ZoneEgress,
+					Address: "192.168.0.10",
+					Port:    10002,
+					Name:    "ze-port",
+				},
+			}
+		})
+}
+
+func zoneIngressOnlyDataplane(name string) *builders.DataplaneBuilder {
+	return builders.Dataplane().
+		WithName(name).
+		WithAddress("192.168.0.11").
+		WithoutInbounds().
+		With(func(d *core_mesh.DataplaneResource) {
+			d.Spec.Networking.Listeners = []*mesh_proto.Dataplane_Networking_Listener{
+				{
+					Type:    mesh_proto.Dataplane_Networking_Listener_ZoneIngress,
+					Address: "192.168.0.11",
+					Port:    10001,
+					Name:    "zi-port",
+				},
+			}
+		})
+}
+
+func mixedInboundAndZoneEgressDataplane(name string) *builders.DataplaneBuilder {
+	return builders.Dataplane().
+		WithName(name).
+		WithAddress("192.168.0.1").
+		AddInbound(builders.Inbound().
+			WithService("backend").
+			WithAddress("192.168.0.1").
+			WithPort(17777)).
+		With(func(d *core_mesh.DataplaneResource) {
+			d.Spec.Networking.Listeners = []*mesh_proto.Dataplane_Networking_Listener{
+				{
+					Type:    mesh_proto.Dataplane_Networking_Listener_ZoneEgress,
+					Address: "192.168.0.1",
+					Port:    10002,
+					Name:    "ze-port",
+				},
+			}
+		})
+}
+
+func zoneEgressListenerResource() core_xds.Resource {
+	name := naming.ContextualZoneEgressListenerName("ze-port")
+	return core_xds.Resource{
+		Name:   name,
+		Origin: metadata.OriginEgress,
+		Resource: NewListenerBuilder(envoy_common.APIV3, name).
+			Configure(InboundListener("192.168.0.10", 10002, core_xds.SocketAddressProtocolTCP)).
+			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mes-http").
+				Configure(MatchTransportProtocol("tls")).
+				Configure(MatchServerNames("sni.extsvc.default.zone-1.aws-aurora.8443")).
+				Configure(HttpConnectionManager("mes-http", false, nil, true)),
+			)).
+			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mes-tcp").
+				Configure(MatchTransportProtocol("tls")).
+				Configure(MatchServerNames("sni.extsvc.default.zone-1.redis.6379")).
+				Configure(TCPProxy("mes-tcp", plugins_xds.NewSplitBuilder().WithClusterName("mes-tcp").WithWeight(1).Build())),
+			)).MustBuild(),
+	}
+}
+
+func zoneIngressListenerResource() core_xds.Resource {
+	name := naming.ContextualZoneIngressListenerName("zi-port")
+	return core_xds.Resource{
+		Name:   name,
+		Origin: metadata.OriginIngress,
+		Resource: NewListenerBuilder(envoy_common.APIV3, name).
+			Configure(InboundListener("192.168.0.11", 10001, core_xds.SocketAddressProtocolTCP)).
+			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
+				Configure(MatchTransportProtocol("tls")).
+				Configure(MatchServerNames("backend{mesh=default}")).
+				Configure(TCPProxy("backend", plugins_xds.NewSplitBuilder().WithClusterName("backend").WithWeight(1).Build())),
+			)).MustBuild(),
+	}
+}
+
+func mixedInboundAndZoneEgressResources() []core_xds.Resource {
+	inbound := core_xds.Resource{
+		Name:   "inbound:192.168.0.1:17777",
+		Origin: metadata.OriginInbound,
+		Resource: NewInboundListenerBuilder(envoy_common.APIV3, "192.168.0.1", 17777, core_xds.SocketAddressProtocolTCP).
+			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, envoy_common.AnonymousResource).
+				Configure(HttpConnectionManager("192.168.0.1:17777", false, nil, true)),
+			)).MustBuild(),
+	}
+	egressName := naming.ContextualZoneEgressListenerName("ze-port")
+	egress := core_xds.Resource{
+		Name:   egressName,
+		Origin: metadata.OriginEgress,
+		Resource: NewListenerBuilder(envoy_common.APIV3, egressName).
+			Configure(InboundListener("192.168.0.1", 10002, core_xds.SocketAddressProtocolTCP)).
+			Configure(FilterChain(NewFilterChainBuilder(envoy_common.APIV3, "mes-http").
+				Configure(MatchTransportProtocol("tls")).
+				Configure(MatchServerNames("sni.extsvc.default.zone-1.aws-aurora.8443")).
+				Configure(HttpConnectionManager("mes-http", false, nil, true)),
+			)).MustBuild(),
+	}
+	return []core_xds.Resource{inbound, egress}
+}
+
+var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
+	type testCase struct {
+		dp              *builders.DataplaneBuilder
+		resources       []core_xds.Resource
+		singleItemRules core_rules.SingleItemRules
+		goldenFile      string
+	}
+	DescribeTable("should generate proper Envoy config",
+		func(given testCase) {
+			rs := core_xds.NewResourceSet()
+			for _, res := range given.resources {
+				r := res
+				rs.Add(&r)
+			}
+
+			xdsCtx := *xds_samples.SampleContextWith(xds_context.NewResources()).
+				WithMeshBuilder(samples.MeshDefaultBuilder()).Build()
+
+			proxy := xds_builders.Proxy().
+				WithDataplane(given.dp).
+				WithMetadata(&core_xds.DataplaneMetadata{}).
+				WithPolicies(xds_builders.MatchedPolicies().
+					WithSingleItemPolicy(api.MeshTraceType, given.singleItemRules)).
+				WithZone("zone-1").
+				Build()
+
+			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
+			Expect(plugin.Apply(rs, xdsCtx, proxy)).To(Succeed())
+
+			listenerYaml, err := util_yaml.GetResourcesToYaml(rs, envoy_resource.ListenerType)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listenerYaml).To(matchers.MatchGoldenYAML(fmt.Sprintf("testdata/%s.listener.golden.yaml", given.goldenFile)))
+
+			clusterYaml, err := util_yaml.GetResourcesToYaml(rs, envoy_resource.ClusterType)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterYaml).To(matchers.MatchGoldenYAML(fmt.Sprintf("testdata/%s.cluster.golden.yaml", given.goldenFile)))
+		},
+		Entry("zone-egress-only zipkin", testCase{
+			dp:        zoneEgressOnlyDataplane("zone-egress-1"),
+			resources: []core_xds.Resource{zoneEgressListenerResource()},
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							Zipkin: &api.ZipkinBackend{
+								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+								SharedSpanContext: true,
+								TraceId128Bit:     true,
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "zone-egress-only-zipkin",
+		}),
+		Entry("zone-egress-only datadog", testCase{
+			dp:        zoneEgressOnlyDataplane("zone-egress-1"),
+			resources: []core_xds.Resource{zoneEgressListenerResource()},
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							Datadog: &api.DatadogBackend{
+								Url:          "http://ingest.datadog.eu:8126",
+								SplitService: true,
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "zone-egress-only-datadog",
+		}),
+		Entry("zone-egress-only opentelemetry", testCase{
+			dp:        zoneEgressOnlyDataplane("zone-egress-1"),
+			resources: []core_xds.Resource{zoneEgressListenerResource()},
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							OpenTelemetry: &api.OpenTelemetryBackend{
+								Endpoint: "jaeger-collector.mesh-observability:4317",
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "zone-egress-only-otel",
+		}),
+		Entry("zone-ingress-only zipkin", testCase{
+			dp:        zoneIngressOnlyDataplane("zone-ingress-1"),
+			resources: []core_xds.Resource{zoneIngressListenerResource()},
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							Zipkin: &api.ZipkinBackend{
+								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+								SharedSpanContext: true,
+								TraceId128Bit:     true,
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "zone-ingress-only-zipkin",
+		}),
+		Entry("zone-ingress-only datadog", testCase{
+			dp:        zoneIngressOnlyDataplane("zone-ingress-1"),
+			resources: []core_xds.Resource{zoneIngressListenerResource()},
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							Datadog: &api.DatadogBackend{
+								Url:          "http://ingest.datadog.eu:8126",
+								SplitService: true,
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "zone-ingress-only-datadog",
+		}),
+		Entry("zone-ingress-only opentelemetry", testCase{
+			dp:        zoneIngressOnlyDataplane("zone-ingress-1"),
+			resources: []core_xds.Resource{zoneIngressListenerResource()},
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							OpenTelemetry: &api.OpenTelemetryBackend{
+								Endpoint: "jaeger-collector.mesh-observability:4317",
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "zone-ingress-only-otel",
+		}),
+		Entry("mixed inbound and zone egress zipkin", testCase{
+			dp:        mixedInboundAndZoneEgressDataplane("backend"),
+			resources: mixedInboundAndZoneEgressResources(),
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							Zipkin: &api.ZipkinBackend{
+								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+								SharedSpanContext: true,
+								TraceId128Bit:     true,
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "mixed-inbound-and-zone-egress-zipkin",
+		}),
+		Entry("mixed inbound and zone egress datadog", testCase{
+			dp:        mixedInboundAndZoneEgressDataplane("backend"),
+			resources: mixedInboundAndZoneEgressResources(),
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							Datadog: &api.DatadogBackend{
+								Url:          "http://ingest.datadog.eu:8126",
+								SplitService: true,
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "mixed-inbound-and-zone-egress-datadog",
+		}),
+		Entry("mixed inbound and zone egress opentelemetry", testCase{
+			dp:        mixedInboundAndZoneEgressDataplane("backend"),
+			resources: mixedInboundAndZoneEgressResources(),
+			singleItemRules: core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{{
+					Subset: []subsetutils.Tag{},
+					Conf: api.Conf{
+						Backends: &[]api.Backend{{
+							OpenTelemetry: &api.OpenTelemetryBackend{
+								Endpoint: "jaeger-collector.mesh-observability:4317",
+							},
+						}},
+					},
+				}},
+			},
+			goldenFile: "mixed-inbound-and-zone-egress-otel",
+		}),
+	)
+})

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-datadog.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-datadog.cluster.golden.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: meshtrace:datadog
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_datadog
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:datadog
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: ingest.datadog.eu
+                portValue: 8126
+    name: meshtrace:datadog
+    type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-datadog.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-datadog.listener.golden.yaml
@@ -1,0 +1,88 @@
+resources:
+- name: inbound:192.168.0.1:17777
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 17777
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: "192_168_0_1_17777"
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.datadog
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.DatadogConfig
+                collectorCluster: meshtrace:datadog
+                serviceName: backend_INBOUND
+            spawnUpstreamSpan: false
+    name: inbound:192.168.0.1:17777
+    trafficDirection: INBOUND
+- name: self_zoneegress_dp_ze-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.aws-aurora.8443
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: mes-http
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.datadog
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.DatadogConfig
+                collectorCluster: meshtrace:datadog
+                serviceName: backend_INBOUND
+            spawnUpstreamSpan: false
+      name: mes-http
+    name: self_zoneegress_dp_ze-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-otel.cluster.golden.yaml
@@ -1,0 +1,23 @@
+resources:
+- name: meshtrace:opentelemetry
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_opentelemetry
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:opentelemetry
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: jaeger-collector.mesh-observability
+                portValue: 4317
+    name: meshtrace:opentelemetry
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-otel.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-otel.listener.golden.yaml
@@ -1,0 +1,92 @@
+resources:
+- name: inbound:192.168.0.1:17777
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 17777
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: "192_168_0_1_17777"
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.opentelemetry
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpcService:
+                  envoyGrpc:
+                    clusterName: meshtrace:opentelemetry
+                serviceName: backend
+            spawnUpstreamSpan: false
+    name: inbound:192.168.0.1:17777
+    trafficDirection: INBOUND
+- name: self_zoneegress_dp_ze-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.aws-aurora.8443
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: mes-http
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.opentelemetry
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpcService:
+                  envoyGrpc:
+                    clusterName: meshtrace:opentelemetry
+                serviceName: backend
+            spawnUpstreamSpan: false
+      name: mes-http
+    name: self_zoneegress_dp_ze-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-zipkin.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-zipkin.cluster.golden.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: meshtrace:zipkin
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_zipkin
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:zipkin
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: jaeger-collector.mesh-observability
+                portValue: 9411
+    name: meshtrace:zipkin
+    type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-zipkin.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-zipkin.listener.golden.yaml
@@ -1,0 +1,96 @@
+resources:
+- name: inbound:192.168.0.1:17777
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 17777
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: "192_168_0_1_17777"
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.zipkin
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+                collectorCluster: meshtrace:zipkin
+                collectorEndpoint: /api/v2/spans
+                collectorEndpointVersion: HTTP_JSON
+                collectorHostname: jaeger-collector.mesh-observability:9411
+                sharedSpanContext: true
+                traceId128bit: true
+            spawnUpstreamSpan: false
+    name: inbound:192.168.0.1:17777
+    trafficDirection: INBOUND
+- name: self_zoneegress_dp_ze-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.aws-aurora.8443
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: mes-http
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.zipkin
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+                collectorCluster: meshtrace:zipkin
+                collectorEndpoint: /api/v2/spans
+                collectorEndpointVersion: HTTP_JSON
+                collectorHostname: jaeger-collector.mesh-observability:9411
+                sharedSpanContext: true
+                traceId128bit: true
+            spawnUpstreamSpan: false
+      name: mes-http
+    name: self_zoneegress_dp_ze-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-datadog.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-datadog.cluster.golden.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: meshtrace:datadog
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_datadog
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:datadog
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: ingest.datadog.eu
+                portValue: 8126
+    name: meshtrace:datadog
+    type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-datadog.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-datadog.listener.golden.yaml
@@ -1,0 +1,58 @@
+resources:
+- name: self_zoneegress_dp_ze-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.10
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.aws-aurora.8443
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: mes-http
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.datadog
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.DatadogConfig
+                collectorCluster: meshtrace:datadog
+                serviceName: zone-egress-1_INBOUND
+            spawnUpstreamSpan: false
+      name: mes-http
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.redis.6379
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mes-tcp
+          statPrefix: mes-tcp
+      name: mes-tcp
+    name: self_zoneegress_dp_ze-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-otel.cluster.golden.yaml
@@ -1,0 +1,23 @@
+resources:
+- name: meshtrace:opentelemetry
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_opentelemetry
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:opentelemetry
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: jaeger-collector.mesh-observability
+                portValue: 4317
+    name: meshtrace:opentelemetry
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-otel.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-otel.listener.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: self_zoneegress_dp_ze-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.10
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.aws-aurora.8443
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: mes-http
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.opentelemetry
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                grpcService:
+                  envoyGrpc:
+                    clusterName: meshtrace:opentelemetry
+                serviceName: zone-egress-1
+            spawnUpstreamSpan: false
+      name: mes-http
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.redis.6379
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mes-tcp
+          statPrefix: mes-tcp
+      name: mes-tcp
+    name: self_zoneegress_dp_ze-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-zipkin.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-zipkin.cluster.golden.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: meshtrace:zipkin
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_zipkin
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:zipkin
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: jaeger-collector.mesh-observability
+                portValue: 9411
+    name: meshtrace:zipkin
+    type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-zipkin.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-zipkin.listener.golden.yaml
@@ -1,0 +1,62 @@
+resources:
+- name: self_zoneegress_dp_ze-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.10
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.aws-aurora.8443
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: mes-http
+          tracing:
+            customTags:
+            - literal:
+                value: default
+              tag: kuma.mesh
+            - literal:
+                value: zone-1
+              tag: kuma.zone
+            provider:
+              name: envoy.tracers.zipkin
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
+                collectorCluster: meshtrace:zipkin
+                collectorEndpoint: /api/v2/spans
+                collectorEndpointVersion: HTTP_JSON
+                collectorHostname: jaeger-collector.mesh-observability:9411
+                sharedSpanContext: true
+                traceId128bit: true
+            spawnUpstreamSpan: false
+      name: mes-http
+    - filterChainMatch:
+        serverNames:
+        - sni.extsvc.default.zone-1.redis.6379
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mes-tcp
+          statPrefix: mes-tcp
+      name: mes-tcp
+    name: self_zoneegress_dp_ze-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-datadog.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-datadog.cluster.golden.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: meshtrace:datadog
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_datadog
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:datadog
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: ingest.datadog.eu
+                portValue: 8126
+    name: meshtrace:datadog
+    type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-datadog.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-datadog.listener.golden.yaml
@@ -1,0 +1,22 @@
+resources:
+- name: self_zoneingress_dp_zi-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.11
+        portValue: 10001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - backend{mesh=default}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+          statPrefix: backend
+    name: self_zoneingress_dp_zi-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-otel.cluster.golden.yaml
@@ -1,0 +1,23 @@
+resources:
+- name: meshtrace:opentelemetry
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_opentelemetry
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:opentelemetry
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: jaeger-collector.mesh-observability
+                portValue: 4317
+    name: meshtrace:opentelemetry
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-otel.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-otel.listener.golden.yaml
@@ -1,0 +1,22 @@
+resources:
+- name: self_zoneingress_dp_zi-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.11
+        portValue: 10001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - backend{mesh=default}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+          statPrefix: backend
+    name: self_zoneingress_dp_zi-port
+    trafficDirection: INBOUND

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-zipkin.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-zipkin.cluster.golden.yaml
@@ -1,0 +1,18 @@
+resources:
+- name: meshtrace:zipkin
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: meshtrace_zipkin
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: meshtrace:zipkin
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: jaeger-collector.mesh-observability
+                portValue: 9411
+    name: meshtrace:zipkin
+    type: STRICT_DNS

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-zipkin.listener.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-zipkin.listener.golden.yaml
@@ -1,0 +1,22 @@
+resources:
+- name: self_zoneingress_dp_zi-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.11
+        portValue: 10001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - backend{mesh=default}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: backend
+          statPrefix: backend
+    name: self_zoneingress_dp_zi-port
+    trafficDirection: INBOUND


### PR DESCRIPTION
## Motivation

Implements [MADR-103](https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/103-policy-matching-mesh-scoped-zone-proxy.md)
group (4): `MeshTrace` generation on mesh-scoped zone proxy Dataplanes
(Dataplanes carrying `networking.listeners[]`).

Closes #16596.

## Implementation information

* `applyToZoneProxyListeners` walks embedded zone proxy listeners by
  contextual name (`self_zoneingress_dp_<port>` /
  `self_zoneegress_dp_<port>` from `naming.ContextualZone...ListenerName`)
  and feeds each filter chain to the existing `configureListener` path.
  HCM filter chains (HTTP-based MeshExternalService on zone egress) get
  the tracing provider injected; TCP-only filter chains (zone ingress,
  TCP MES on zone egress) are a silent no-op via the configurer's
  `UpdateHTTPConnectionManager` (it returns early when the HCM filter
  is absent).
* On a zone-proxy-only DPP, `IdentifyingName` falls back to `unknown`;
  use `Dataplane.Name` instead so Datadog `service` tag and OTel
  `service.name` carry a stable identifier. Mirrors the same fallback
  used by `MeshMetric`.

Unbroken paths:
- Regular Dataplanes (no embedded listeners) are unaffected — the new
  function short-circuits via `HasZoneProxyListeners()`.
- Legacy global-scoped ZoneEgressProxy is unchanged; that path runs
  through `proxy.ZoneEgressProxy`, not `proxy.Dataplane`.

Test coverage: nine new entries (zone-egress-only, zone-ingress-only,
mixed inbound+zone-egress × Zipkin/Datadog/OTel) with 18 new golden
files. The mixed entry confirms that both regular inbound HCM and zone
egress HCM get tracing on the same DPP.

## Supporting documentation

- MADR-103: `docs/madr/decisions/103-policy-matching-mesh-scoped-zone-proxy.md`
- MADR-095 (zone proxy as Dataplane): `docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md`
- Matchers wiring (`feat(matchers): include zone proxy listeners when matching DPP policies`, #16584)

> Changelog: feat(meshtrace): support zone proxy Dataplanes