### PR TITLE
fix(xds): enable reuse_port on inbound:passthrough listener

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-permissive-mtls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-permissive-mtls.listeners.golden.yaml
@@ -166,6 +166,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -183,6 +184,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-strict-mtls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-strict-mtls.listeners.golden.yaml
@@ -156,6 +156,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -173,6 +174,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-workload-identity-custom-functions.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-workload-identity-custom-functions.listeners.golden.yaml
@@ -148,6 +148,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -165,6 +166,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-external-validator.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-external-validator.listeners.golden.yaml
@@ -96,6 +96,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -123,6 +124,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-feature-strict-inbound-ports.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-feature-strict-inbound-ports.listeners.golden.yaml
@@ -104,6 +104,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -131,6 +132,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -104,6 +104,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -131,6 +132,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust.listeners.golden.yaml
@@ -96,6 +96,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -123,6 +124,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-permissive-mtls-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-permissive-mtls-meshservice.listeners.golden.yaml
@@ -124,6 +124,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -151,6 +152,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-permissive-mtls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-permissive-mtls.listeners.golden.yaml
@@ -124,6 +124,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -151,6 +152,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-strict-mtls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-strict-mtls.listeners.golden.yaml
@@ -104,6 +104,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -131,6 +132,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-workload-identity-no-ca.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-workload-identity-no-ca.listeners.golden.yaml
@@ -96,6 +96,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -123,6 +124,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-workload-identity.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-workload-identity.listeners.golden.yaml
@@ -96,6 +96,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777
@@ -123,6 +124,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15001
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 17777

--- a/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/2-envoy-config.golden.yaml
@@ -248,6 +248,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/profile-source/4-envoy-config.golden.yaml
@@ -296,6 +296,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/1-envoy-config.golden.yaml
@@ -118,6 +118,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/template-proxy/2-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/template-proxy/2-envoy-config.golden.yaml
@@ -102,6 +102,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/02.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/02.envoy.golden.yaml
@@ -53,6 +53,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -70,6 +71,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/03.envoy.golden.yaml
@@ -53,6 +53,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -70,6 +71,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/04.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/04.envoy.golden.yaml
@@ -33,6 +33,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/05.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/05.envoy.golden.yaml
@@ -49,6 +49,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -67,6 +68,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/06.envoy.golden.yaml
@@ -49,6 +49,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 8080
@@ -69,6 +70,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 8080

--- a/pkg/xds/generator/testdata/transparent-proxy/07.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/07.envoy.golden.yaml
@@ -49,6 +49,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -67,6 +68,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/08.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/08.envoy.golden.yaml
@@ -49,6 +49,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -67,6 +68,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/09.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/09.envoy.golden.yaml
@@ -49,6 +49,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy
@@ -67,6 +68,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/generator/testdata/transparent-proxy/10.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/transparent-proxy/10.envoy.golden.yaml
@@ -49,6 +49,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 8080
@@ -69,6 +70,7 @@ resources:
       socketAddress:
         address: '::'
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filterChainMatch:
         destinationPort: 8080

--- a/pkg/xds/generator/transparent_proxy_generator.go
+++ b/pkg/xds/generator/transparent_proxy_generator.go
@@ -136,7 +136,9 @@ func CreateInboundPassthroughListener(
 	inboundListenerBuilder := envoy_listeners.NewInboundListenerBuilder(proxy.APIVersion, allIP, inboundPort, model.SocketAddressProtocolTCP).
 		WithOverwriteName(listenerName).
 		Configure(envoy_listeners.StatPrefix(statPrefix)).
-		Configure(envoy_listeners.OriginalDstForwarder())
+		Configure(envoy_listeners.OriginalDstForwarder()).
+		// SO_REUSEPORT so each worker owns its own LISTEN socket; a shared fd can wedge if one worker loses its epoll registration.
+		Configure(envoy_listeners.EnableReusePort(true))
 
 	if useStrictInboundPorts && len(proxy.Dataplane.Spec.Networking.Inbound) > 0 {
 		seenPorts := map[uint32]bool{}

--- a/pkg/xds/server/v3/testdata/hook-before-pt.golden.yaml
+++ b/pkg/xds/server/v3/testdata/hook-before-pt.golden.yaml
@@ -269,6 +269,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/pkg/xds/server/v3/testdata/stable-es.golden.yaml
+++ b/pkg/xds/server/v3/testdata/stable-es.golden.yaml
@@ -433,6 +433,7 @@ resources:
       socketAddress:
         address: 0.0.0.0
         portValue: 15006
+    enableReusePort: true
     filterChains:
     - filters:
       - name: envoy.filters.network.tcp_proxy

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -558,6 +558,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -586,6 +587,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -481,6 +481,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -509,6 +510,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -558,6 +558,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -586,6 +587,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
@@ -481,6 +481,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -509,6 +510,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
@@ -558,6 +558,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -586,6 +587,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
@@ -640,6 +640,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -668,6 +669,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
@@ -717,6 +717,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -745,6 +746,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
@@ -563,6 +563,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -591,6 +592,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
@@ -640,6 +640,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -668,6 +669,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -488,6 +488,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -516,6 +517,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -565,6 +565,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -593,6 +594,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -554,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -582,6 +583,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -477,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -505,6 +506,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -554,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -582,6 +583,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -477,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -505,6 +506,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -554,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -582,6 +583,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
@@ -507,6 +507,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -535,6 +536,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
@@ -584,6 +584,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -612,6 +613,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -511,6 +511,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -539,6 +540,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -588,6 +588,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -616,6 +617,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
@@ -834,6 +834,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -862,6 +863,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
@@ -612,6 +612,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -640,6 +641,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
@@ -525,6 +525,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -553,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
@@ -479,6 +479,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -507,6 +508,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
@@ -556,6 +556,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -584,6 +585,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
@@ -476,6 +476,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -504,6 +505,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
@@ -553,6 +553,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -581,6 +582,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
@@ -476,6 +476,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -504,6 +505,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
@@ -553,6 +553,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -581,6 +582,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
@@ -544,6 +544,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -572,6 +573,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
@@ -621,6 +621,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -649,6 +650,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
@@ -544,6 +544,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -572,6 +573,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
@@ -621,6 +621,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -649,6 +650,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -707,6 +707,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -735,6 +736,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -784,6 +784,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -812,6 +813,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -681,6 +681,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -709,6 +710,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -758,6 +758,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -786,6 +787,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -618,6 +618,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -646,6 +647,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -618,6 +618,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -646,6 +647,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -618,6 +618,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -646,6 +647,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
@@ -525,6 +525,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -553,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -535,6 +535,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -563,6 +564,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -612,6 +612,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -640,6 +641,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
@@ -547,6 +547,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -575,6 +576,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
@@ -624,6 +624,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -652,6 +653,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
@@ -461,6 +461,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -489,6 +490,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
@@ -538,6 +538,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -566,6 +567,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -586,6 +586,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -614,6 +615,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -469,6 +469,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -497,6 +498,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -586,6 +586,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -614,6 +615,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -469,6 +469,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -497,6 +498,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -586,6 +586,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -614,6 +615,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -525,6 +525,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -553,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -539,6 +539,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -567,6 +568,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -616,6 +616,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -644,6 +645,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
@@ -539,6 +539,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -567,6 +568,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
@@ -616,6 +616,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -644,6 +645,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -509,6 +509,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -537,6 +538,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -586,6 +586,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -614,6 +615,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -699,6 +699,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [
@@ -724,6 +725,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -1022,6 +1022,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [
@@ -1047,6 +1048,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -699,6 +699,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [
@@ -724,6 +725,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -1022,6 +1022,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [
@@ -1047,6 +1048,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filters": [

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -503,6 +503,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -531,6 +532,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -580,6 +580,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -608,6 +609,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -503,6 +503,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -531,6 +532,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -580,6 +580,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -608,6 +609,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
@@ -2198,6 +2198,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -2226,6 +2227,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
@@ -539,6 +539,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -567,6 +568,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
@@ -788,6 +788,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -816,6 +817,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
@@ -813,6 +813,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -841,6 +842,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
@@ -890,6 +890,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -918,6 +919,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
@@ -448,6 +448,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -476,6 +477,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
@@ -525,6 +525,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {
@@ -553,6 +554,7 @@
             "portValue": 15006
           }
         },
+        "enableReusePort": true,
         "filterChains": [
           {
             "filterChainMatch": {


### PR DESCRIPTION
The :15006 inbound passthrough listener was running with
enable_reuse_port=false, so a single kernel LISTEN socket was dup'd
across each worker's epoll instance. We've seen long-running pods
wedge in this configuration: the fd stays in LISTEN (ss confirms)
and iptables packet counters keep advancing, but no Envoy worker
calls accept(). The wire signature is SYN -> SYN-ACK -> immediate
RST (kernel accept-queue overflow with tcp_abort_on_overflow=1)
while every in-Envoy reject counter (downstream_listener_filter_*,
no_filter_chain_match, *extension_config_missing,
downstream_cx_overload_reject) stays at zero. Recovery requires a
pod restart.

Setting enable_reuse_port=true makes each worker bind its own
SO_REUSEPORT socket - the same shape the outbound passthrough
listener already uses - removing the shared-fd state where one or
both workers can lose their epoll registration without anyone
re-attaching.

Scoped to CreateInboundPassthroughListener. Other inbound listeners
are unaffected because they have bind_to_port=false and the flag
has no effect on them.

Signed-off-by: Charly Molter <charly.molter@konghq.com>