### PR TITLE
fix(mesh): reject listeners on gateway dataplanes

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
-
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
@@ -49,6 +48,11 @@ func (d *DataplaneResource) Validate() error {
 				"inbound cannot be defined for delegated gateways")
 		}
 
+		if len(d.Spec.GetNetworking().GetListeners()) > 0 {
+			err.AddViolationAt(net.Field("listeners"),
+				"listeners cannot be defined for delegated gateways")
+		}
+
 		err.AddErrorAt(net.Field("gateway"), validateGateway(d.Spec.GetNetworking().GetGateway()))
 		err.Add(validateNetworking(d.Spec.GetNetworking()))
 		err.Add(validateProbes(d.Spec.GetProbes()))
@@ -60,6 +64,11 @@ func (d *DataplaneResource) Validate() error {
 
 		if len(d.Spec.GetNetworking().GetOutbound()) > 0 {
 			err.AddViolationAt(net.Field("outbound"), "outbound cannot be defined for builtin gateways")
+		}
+
+		if len(d.Spec.GetNetworking().GetListeners()) > 0 {
+			err.AddViolationAt(net.Field("listeners"),
+				"listeners cannot be defined for builtin gateways")
 		}
 
 		if d.Spec.GetProbes() != nil {

--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1,12 +1,11 @@
 package mesh_test
 
 import (
+	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
-
-	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
-	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
 )
 
 var _ = Describe("Dataplane", func() {
@@ -579,6 +578,26 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.inbound
                   message: inbound cannot be defined for delegated gateways`,
 		}),
+		Entry("networking: delegated gateway must not have listeners", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default
+                networking:
+                  address: 192.168.0.1
+                  gateway:
+                    tags:
+                      kuma.io/service: kong
+                  listeners:
+                    - type: ZoneEgress
+                      address: 192.168.0.1
+                      port: 10002
+                      name: ze-port`,
+			expected: `
+                violations:
+                - field: networking.listeners
+                  message: listeners cannot be defined for delegated gateways`,
+		}),
 		Entry("networking: builtin gateway must not have inbounds", testCase{
 			dataplane: `
                 type: Dataplane
@@ -638,6 +657,56 @@ var _ = Describe("Dataplane", func() {
                      path: /8080/healthz`,
 			expected: `
                 violations:
+                - field: networking.probes
+                  message: probes cannot be defined for builtin gateways`,
+		}),
+		Entry("networking: builtin gateway must not have listeners", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default
+                networking:
+                  address: 192.168.0.1
+                  gateway:
+                    type: BUILTIN
+                    tags:
+                      kuma.io/service: kong
+                  listeners:
+                    - type: ZoneEgress
+                      address: 192.168.0.1
+                      port: 10002
+                      name: ze-port`,
+			expected: `
+                violations:
+                - field: networking.listeners
+                  message: listeners cannot be defined for builtin gateways`,
+		}),
+		Entry("networking: builtin gateway listeners and probes both rejected", testCase{
+			dataplane: `
+                type: Dataplane
+                name: dp-1
+                mesh: default
+                networking:
+                  address: 192.168.0.1
+                  gateway:
+                    type: BUILTIN
+                    tags:
+                      kuma.io/service: kong
+                  listeners:
+                    - type: ZoneEgress
+                      address: 192.168.0.1
+                      port: 10002
+                      name: ze-port
+                probes:
+                  port: 0
+                  endpoints:
+                   - inboundPort: 8088
+                     inboundPath: /healthz
+                     path: /8080/healthz`,
+			expected: `
+                violations:
+                - field: networking.listeners
+                  message: listeners cannot be defined for builtin gateways
                 - field: networking.probes
                   message: probes cannot be defined for builtin gateways`,
 		}),

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1,11 +1,12 @@
 package mesh_test
 
 import (
-	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
-	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
+
+	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
 )
 
 var _ = Describe("Dataplane", func() {


### PR DESCRIPTION
## Motivation

Gateway Dataplanes (both delegated and builtin) silently accepted `networking.listeners[]` entries. This created an undefined xDS code path — `applyToGateway` and `applyToZoneProxyListeners` would both walk the same Dataplane, making policy application (meshtrace, MADR-098 matchers) unpredictable. The validator had a gap: `validateListeners` was only called for non-gateway Dataplanes.

Closes https://github.com/kumahq/kuma/issues/16604

## Implementation information

Added explicit validation in both gateway arms of `Validate()`:
- Delegated gateway (`IsDelegatedGateway`): rejects any `networking.listeners[]` with `"listeners cannot be defined for delegated gateways"`
- Builtin gateway (`IsBuiltinGateway`): rejects any `networking.listeners[]` with `"listeners cannot be defined for builtin gateways"`

Tests cover three new cases: delegated gateway with listeners, builtin gateway with listeners, and builtin gateway with both listeners and probes rejected together.

> Changelog: fix(mesh): reject listeners on gateway dataplanes