### PR TITLE
perf(meshmetric): reduce merge scrape allocs

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/merge.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/merge.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -114,12 +113,13 @@ func renameCluster(clusterName string, metrics []*io_prometheus_client.Metric) {
 }
 
 func mergeDuplicates(typ *io_prometheus_client.MetricType, metrics []*io_prometheus_client.Metric) []*io_prometheus_client.Metric {
-	hashes := map[string][]*io_prometheus_client.Metric{}
+	hashes := make(map[string][]*io_prometheus_client.Metric, len(metrics))
 	for _, metric := range metrics {
-		hashes[hash(metric)] = append(hashes[hash(metric)], metric)
+		h := hash(metric)
+		hashes[h] = append(hashes[h], metric)
 	}
 
-	var result []*io_prometheus_client.Metric
+	result := make([]*io_prometheus_client.Metric, 0, len(hashes))
 
 	for _, dups := range hashes {
 		merged := &io_prometheus_client.Metric{
@@ -164,7 +164,6 @@ func isMeshOrExternalHttpPrefix(metric *io_prometheus_client.Metric) bool {
 }
 
 func markAsMeshTraffic(metrics []*io_prometheus_client.Metric, pred func(*io_prometheus_client.Metric) bool) []*io_prometheus_client.Metric {
-	var markedMetrics []*io_prometheus_client.Metric
 	for _, metric := range metrics {
 		if pred(metric) {
 			name := MeshTrafficLabelName
@@ -174,20 +173,30 @@ func markAsMeshTraffic(metrics []*io_prometheus_client.Metric, pred func(*io_pro
 				Value: &traffic,
 			})
 		}
-
-		markedMetrics = append(markedMetrics, metric)
 	}
 
-	return markedMetrics
+	return metrics
 }
 
 func hash(metric *io_prometheus_client.Metric) string {
-	pairs := []string{}
-	for _, l := range metric.GetLabel() {
-		pairs = append(pairs, fmt.Sprintf("%s=%s", l.GetName(), l.GetValue()))
+	labels := metric.GetLabel()
+	pairs := make([]string, 0, len(labels))
+	var sz int
+	for _, l := range labels {
+		n, v := l.GetName(), l.GetValue()
+		pairs = append(pairs, n+"="+v)
+		sz += len(n) + len(v) + 2 // '=' and ';'
 	}
 	sort.Strings(pairs)
-	return strings.Join(pairs, ";")
+	var b strings.Builder
+	b.Grow(sz)
+	for i, p := range pairs {
+		if i > 0 {
+			b.WriteByte(';')
+		}
+		b.WriteString(p)
+	}
+	return b.String()
 }
 
 func mergeCounter(metrics []*io_prometheus_client.Metric) *io_prometheus_client.Counter {

--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -300,16 +300,22 @@ func (s *Hijacker) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	}
 }
 
+var openMetricsEOFSuffix = []byte("# EOF")
+
 func processMetrics(contents <-chan []byte, contentType expfmt.Format) []byte {
 	buf := new(bytes.Buffer)
 
 	for metrics := range contents {
-		// remove the EOF marker from the metrics, because we are
-		// merging multiple metrics into one response.
-		metrics = bytes.ReplaceAll(metrics, []byte("# EOF"), []byte(""))
+		// OpenMetrics bodies end with "# EOF" (optionally followed by a
+		// newline). Drop the trailing sentinel from each body so the
+		// concatenation stays valid; the final marker is re-added below
+		// when the negotiated content type is OpenMetrics.
+		metrics = bytes.TrimRight(metrics, "\n")
+		metrics = bytes.TrimSuffix(metrics, openMetricsEOFSuffix)
+		metrics = bytes.TrimRight(metrics, "\n")
 
 		buf.Write(metrics)
-		buf.WriteString("\n")
+		buf.WriteByte('\n')
 	}
 
 	processedMetrics := append(processNewlineChars(buf.Bytes()), '\n')
@@ -327,11 +333,10 @@ func processMetrics(contents <-chan []byte, contentType expfmt.Format) []byte {
 // processNewlineChars takes byte data and returns a new byte slice
 // after trimming and deduplicating the newline characters.
 func processNewlineChars(input []byte) []byte {
-	var deduped []byte
-
 	if len(input) == 0 {
 		return nil
 	}
+	deduped := make([]byte, 0, len(input))
 	last := input[0]
 
 	for i := 1; i < len(input); i++ {


### PR DESCRIPTION
## Motivation

After the regex-precompile fix (#16608) the next hottest spots on the
kuma-dp Prometheus scrape path are `MergeClustersForPrometheus`
(registered as the default mutator in `run.go`) and the trailing
buffer post-processing in `Hijacker.ServeHTTP`. Measured on a busy
sidecar (2000 metric families × 8 series ≈ 16k data points) every
15s scrape spends ~16ms in merge and ~1.7ms in newline-dedup, the
latter allocating ~8 MB.

## Implementation information

Six small wins, all in `app/kuma-dp/pkg/dataplane/metrics/{merge,server}.go`:

1. `mergeDuplicates` called `hash(metric)` **twice** per metric
   (line 119 today). Store it in a local.
2. `hash()` built one `fmt.Sprintf("%s=%s", …)` string per label,
   then `sort.Strings` + `strings.Join`. Replace with
   `strings.Builder` pre-sized from the summed label lengths.
3. `mergeDuplicates` returned an unsized result slice and used an
   unsized inner map. Preallocate from `len(metrics)` / `len(hashes)`.
4. `markAsMeshTraffic` copied every metric pointer into a freshly
   appended slice even though it only mutates pointers in place.
   Drop the copy, return the input slice.
5. `processNewlineChars` started from `var deduped []byte` and grew
   by single-byte append. For a 1.6 MB body that amplifies to
   ~8.4 MB allocated (slice doubling, 35 allocations). Preallocate
   to `len(input)`.
6. `processMetrics` ran `bytes.ReplaceAll(body, "# EOF", "")` over
   every app body. `# EOF` is the OpenMetrics terminator and only
   appears at the **end** of a well-formed body. Replace with
   `bytes.TrimSuffix` (and a `TrimRight('\n')` to absorb the
   optional trailing newline before/after the marker).

Behavior: identical end output. Existing `Describe("Merge")` and
`Describe("Profiles")` table tests pass unchanged.

## Supporting documentation

Local benchmark, Apple M4 Max, 20 iterations:

| scenario               | before    | after     | delta              |
|------------------------|-----------|-----------|--------------------|
| Merge small_2k         | 1.80 ms   | 1.60 ms   | -11% / -10k allocs |
| Merge large_16k        | 15.85 ms  | 12.99 ms  | -18% / -76k allocs |
| NewlineDedup large_16k | 1.72 ms   | 1.30 ms   | -24%               |
| NewlineDedup B/op      | 8.40 MB   | 1.44 MB   | -83%               |

> Changelog: perf(meshmetric): reduce per-scrape allocations on the merge and newline-dedup paths