### PR TITLE
fix(meshmetric): basic label-selectors typo

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/profiles.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles.go
@@ -253,7 +253,7 @@ func ProfileMutatorGenerator(sidecar *v1alpha1.Sidecar) PrometheusMutator {
 				effectiveSelectors = append(effectiveSelectors, neverSelect)
 			case string(v1alpha1.BasicProfileName):
 				effectiveSelectors = append(effectiveSelectors, basicProfile...)
-				effectiveLabelsSelectors = append(effectiveSelectors, basicProfileLabels...)
+				effectiveLabelsSelectors = append(effectiveLabelsSelectors, basicProfileLabels...)
 			}
 		}
 

--- a/app/kuma-dp/pkg/dataplane/metrics/profiles_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/profiles_test.go
@@ -78,5 +78,10 @@ var _ = Describe("Profiles", func() {
 			expected: "mixed.golden",
 			profiles: "mixed.yaml",
 		}),
+		Entry("Basic must not treat name-selectors as label-value selectors", testCase{
+			input:    "basic_user_labels.in",
+			expected: "basic_user_labels.golden",
+			profiles: "basic_user_labels.yaml",
+		}),
 	)
 })

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_user_labels.golden
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_user_labels.golden
@@ -1,0 +1,5 @@
+# TYPE envoy_cluster_upstream_rq_total counter
+envoy_cluster_upstream_rq_total{envoy_cluster_name="user_rq_time_svc"} 5
+envoy_cluster_upstream_rq_total{envoy_cluster_name="bytes_consumer"} 3
+envoy_cluster_upstream_rq_total{envoy_cluster_name="normal_svc"} 2
+

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_user_labels.in
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_user_labels.in
@@ -1,0 +1,5 @@
+# TYPE envoy_cluster_upstream_rq_total counter
+envoy_cluster_upstream_rq_total{envoy_cluster_name="user_rq_time_svc"} 5
+envoy_cluster_upstream_rq_total{envoy_cluster_name="bytes_consumer"} 3
+envoy_cluster_upstream_rq_total{envoy_cluster_name="ads_cluster"} 7
+envoy_cluster_upstream_rq_total{envoy_cluster_name="normal_svc"} 2

--- a/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_user_labels.yaml
+++ b/app/kuma-dp/pkg/dataplane/metrics/testdata/profiles/basic_user_labels.yaml
@@ -1,0 +1,11 @@
+type: MeshMetric
+mesh: mesh-1
+name: metrics-1
+targetRef:
+  kind: MeshService
+  name: svc-1
+default:
+  sidecar:
+    profiles:
+      appendProfiles:
+        - name: Basic


### PR DESCRIPTION
## Motivation

`ProfileMutatorGenerator` in
`app/kuma-dp/pkg/dataplane/metrics/profiles.go:256` builds
`effectiveLabelsSelectors` from `effectiveSelectors` rather than from
`effectiveLabelsSelectors` itself:

```go
case string(v1alpha1.BasicProfileName):
    effectiveSelectors = append(effectiveSelectors, basicProfile...)
    effectiveLabelsSelectors = append(effectiveSelectors, basicProfileLabels...)
                                       ^^^^^^^^^^^^^^^^^^ typo
```

The Basic profile defines two distinct selector spaces:

- `basicProfile` — selectors over metric **names**
  (`Contains("rq_time")`, `Contains("bytes")`, `Prefix("envoy_server")`, …).
- `basicProfileLabels` — selectors over `EntityLabels` **values**
  (`Prefix(SystemPrefix)`, `Exact(ads_cluster)`, …) used to drop
  metrics whose `envoy_cluster_name` / `envoy_http_conn_manager_prefix`
  / `envoy_listener_address` points at an internal Kuma entity.

The typo concatenates the name-space selectors into the label-value
filter. A real user cluster whose `envoy_cluster_name` happens to
contain any basicProfile substring (e.g. `rq_time`, `bytes`,
`cx_active`, `circuit_breakers`, `ssl_handshake`) is wrongly
classified as an internal entity and the whole metric series is
silently dropped from Basic-profile scrapes.

Example values that trigger the bug today: any cluster name
containing `bytes` (very common in storage / streaming services),
`rq_time`, `cx_active`, etc.

## Implementation information

One-character fix: append to `effectiveLabelsSelectors`, not
`effectiveSelectors`. Behavior change is limited to the Basic profile
label-pass; All / None profiles already skip this block.

Regression covered by new fixture `basic_user_labels.{yaml,in,golden}`:
four series under `envoy_cluster_upstream_rq_total` with cluster
names `user_rq_time_svc`, `bytes_consumer`, `ads_cluster`,
`normal_svc`. Expected output keeps the three user clusters and drops
only `ads_cluster` (legitimate `basicProfileLabels` match).

Verified by stashing the one-line fix locally — the new test entry
fails (44 passed / 1 failed) without the fix and passes with it.

## Supporting documentation

> Changelog: fix(meshmetric): basic profile drops user metrics whose label values contain basicProfile substrings