### PR TITLE
chore(log): demote chatty events to V(1)

### DIFF
--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -109,7 +109,7 @@ func (t *tracker) OnHealthCheckRequest(streamID xds.StreamID, req *envoy_service
 
 	proxyId, err := xds.ParseProxyIdFromString(req.GetNode().GetId())
 	if err != nil {
-		t.log.Error(err, "failed to parse Dataplane Id out of HealthCheckRequest", "streamid", streamID, "req", req)
+		t.log.Error(err, "failed to parse Dataplane Id out of HealthCheckRequest", "streamID", streamID, "req", req)
 		return nil
 	}
 
@@ -133,7 +133,7 @@ func (t *tracker) OnHealthCheckRequest(streamID xds.StreamID, req *envoy_service
 			defer cancel()
 			watchdog.Start(ctx)
 		}()
-		t.log.V(1).Info("started Watchdog for a Dataplane", "streamid", streamID, "proxyId", proxyId, "dataplaneKey", dataplaneKey)
+		t.log.V(1).Info("started Watchdog for a Dataplane", "streamID", streamID, "proxyId", proxyId, "dataplaneKey", dataplaneKey)
 	}
 	t.dpStreams[dataplaneKey] = streams
 	t.streamsAssociation[streamID] = dataplaneKey

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -312,7 +312,7 @@ func (c *client) startHealthCheck(
 	ticker := time.NewTicker(prevInterval)
 	defer ticker.Stop()
 	for {
-		log.Info("sending health check")
+		log.V(1).Info("sending health check")
 		resp, err := client.HealthCheck(ctx, &mesh_proto.ZoneHealthCheckRequest{})
 		if err != nil && !errors.Is(err, context.Canceled) {
 			if status.Code(err) == codes.Unimplemented {

--- a/pkg/kds/status/status_tracker.go
+++ b/pkg/kds/status/status_tracker.go
@@ -98,7 +98,7 @@ func (c *statusTracker) onStreamOpen(ctx context.Context, streamID int64, typ st
 	// save
 	c.streams[streamID] = state
 
-	c.log.V(1).Info("onStreamOpen", "context", ctx, "streamid", streamID, "type", typ, "subscription", subscription)
+	c.log.V(1).Info("onStreamOpen", "context", ctx, "streamID", streamID, "type", typ, "subscription", subscription)
 	return nil
 }
 
@@ -120,7 +120,7 @@ func (c *statusTracker) onStreamClosed(streamID int64, _ *envoy_core.Node) {
 
 	state := c.streams[streamID]
 	if state == nil {
-		c.log.Info("[WARNING] OnStreamClosed but no state in the status_tracker", "streamid", streamID)
+		c.log.Info("[WARNING] OnStreamClosed but no state in the status_tracker", "streamID", streamID)
 		return
 	}
 
@@ -135,7 +135,7 @@ func (c *statusTracker) onStreamClosed(streamID int64, _ *envoy_core.Node) {
 	// trigger final flush
 	state.Close()
 
-	c.log.V(1).Info("onStreamClosed", "streamid", streamID, "subscription", subscription)
+	c.log.V(1).Info("onStreamClosed", "streamID", streamID, "subscription", subscription)
 }
 
 // OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
@@ -174,7 +174,7 @@ func (c *statusTracker) onStreamRequest(streamID int64, req DiscoveryRequestInfo
 	if state.zone == "" {
 		state.zone = node.Id
 		if err := ReadVersion(node.GetMetadata(), state.subscription.Version); err != nil {
-			c.log.Error(err, "failed to extract version out of the Envoy metadata", "streamid", streamID, "metadata", node.GetMetadata())
+			c.log.Error(err, "failed to extract version out of the Envoy metadata", "streamID", streamID, "metadata", node.GetMetadata())
 		}
 		go c.createStatusSink(state, c.log).Start(state.ctx, state.stop)
 	}
@@ -213,7 +213,7 @@ func (c *statusTracker) onStreamRequest(streamID int64, req DiscoveryRequestInfo
 		}
 	}
 
-	c.log.V(1).Info("OnStreamRequest", "streamid", streamID, "request", req, "subscription", subscription)
+	c.log.V(1).Info("OnStreamRequest", "streamID", streamID, "request", req, "subscription", subscription)
 	return nil
 }
 
@@ -245,7 +245,7 @@ func (c *statusTracker) onStreamResponse(streamID int64, req DiscoveryRequestInf
 	subscription.Status.Total.ResponsesSent++
 	util.StatsOf(subscription.Status, model.ResourceType(req.GetTypeUrl())).ResponsesSent++
 
-	c.log.V(1).Info("OnStreamResponse", "streamid", streamID, "request", req, "response", resp, "subscription", subscription)
+	c.log.V(1).Info("OnStreamResponse", "streamID", streamID, "request", req, "response", resp, "subscription", subscription)
 }
 
 func (c *statusTracker) OnStreamResponse(_ context.Context, streamID int64, req *envoy_sd.DiscoveryRequest, resp *envoy_sd.DiscoveryResponse) {

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -51,37 +51,50 @@ const (
 	ZoneProxyListenersSkippedReason = "ZoneProxyListenersSkipped"
 )
 
+// errSamplerWindow is the dedup window for parse-error log sampling.
+const errSamplerWindow = time.Minute
+
 // parseSampler rate-limits repeated "failed to parse Dataplane" errors so a
 // single malformed resource does not flood the log on every reconcile.
-var parseSampler = newErrSampler(time.Minute)
+var parseSampler = newErrSampler()
 
-// errSampler allows at most one Error log per unique key per window.
+// errSampler allows at most one Error log per unique key per errSamplerWindow.
 // It prevents tight loops from flooding the log when the same parse error
 // repeats for the same resource across reconcile passes.
+// The key should be a stable identifier (e.g. namespace/name), not include
+// variable error text - that avoids cardinality explosions from embedded
+// resource names in error messages.
 type errSampler struct {
-	window time.Duration
-	mu     sync.Mutex
-	last   map[string]time.Time
+	mu         sync.Mutex
+	last       map[string]time.Time
+	suppressed map[string]int
 }
 
-func newErrSampler(window time.Duration) *errSampler {
-	return &errSampler{window: window, last: map[string]time.Time{}}
+func newErrSampler() *errSampler {
+	return &errSampler{
+		last:       map[string]time.Time{},
+		suppressed: map[string]int{},
+	}
 }
 
-func (s *errSampler) allow(key string) bool {
+// allow reports whether the caller should log for key.
+// The second return value is the number of calls suppressed since the last
+// allowed log (zero on first occurrence in a window).
+func (s *errSampler) allow(key string) (bool, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now()
-	for existingKey, t := range s.last {
-		if now.Sub(t) >= s.window {
-			delete(s.last, existingKey)
+	if t, ok := s.last[key]; ok {
+		if now.Sub(t) < errSamplerWindow {
+			s.suppressed[key]++
+			return false, 0
 		}
+		// window expired - fall through and re-allow
 	}
-	if _, ok := s.last[key]; ok {
-		return false
-	}
+	suppressed := s.suppressed[key]
 	s.last[key] = now
-	return true
+	s.suppressed[key] = 0
+	return true, suppressed
 }
 
 // PodReconciler reconciles a Pod object
@@ -206,7 +219,7 @@ func (r *PodReconciler) deleteObjectIfExist(ctx context.Context, object k8s_mode
 		}
 		return errors.Wrapf(err, "could not delete %v %s/%s", object.GetObjectKind(), object.GetName(), object.GetNamespace())
 	}
-	log.V(1).Info("Object deleted")
+	log.Info("Object deleted")
 	return nil
 }
 
@@ -343,8 +356,8 @@ func (r *PodReconciler) findOtherDataplanes(ctx context.Context, pod *kube_core.
 		dp := core_mesh.NewDataplaneResource()
 		if err := r.ResourceConverter.ToCoreResource(&dataplane, dp); err != nil {
 			name := kube_types.NamespacedName{Namespace: dataplane.Namespace, Name: dataplane.Name}
-			if parseSampler.allow(name.String() + ":" + err.Error()) {
-				converterLog.Error(err, "failed to parse Dataplane", "dataplane", name, "spec", dataplane.Spec)
+			if ok, suppressed := parseSampler.allow(name.String()); ok {
+				converterLog.Error(err, "failed to parse Dataplane", "dataplane_ref", name.String(), "suppressed_count", suppressed)
 			}
 			continue // one invalid Dataplane definition should not break the entire mesh
 		}

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -32,6 +34,35 @@ import (
 	util_k8s "github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/util"
 	util_maps "github.com/kumahq/kuma/v2/pkg/util/maps"
 )
+
+// errSampler allows at most one Error log per unique message per window.
+// It prevents tight loops from flooding the log when the same parse error
+// repeats for many resources in a single reconcile pass.
+type errSampler struct {
+	window time.Duration
+	mu     sync.Mutex
+	last   map[string]time.Time
+}
+
+func newErrSampler(window time.Duration) *errSampler {
+	return &errSampler{window: window, last: map[string]time.Time{}}
+}
+
+// allow returns true the first time msg is seen and once per window thereafter.
+func (s *errSampler) allow(msg string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	if t, ok := s.last[msg]; ok && now.Sub(t) < s.window {
+		return false
+	}
+	s.last[msg] = now
+	return true
+}
+
+// parseSampler rate-limits repeated "failed to parse Dataplane" errors so a
+// single malformed resource does not flood the log on every reconcile.
+var parseSampler = newErrSampler(time.Minute)
 
 const (
 	// CreatedKumaDataplaneReason is added to an event when
@@ -171,7 +202,7 @@ func (r *PodReconciler) deleteObjectIfExist(ctx context.Context, object k8s_mode
 		}
 		return errors.Wrapf(err, "could not delete %v %s/%s", object.GetObjectKind(), object.GetName(), object.GetNamespace())
 	}
-	log.Info("Object deleted")
+	log.V(1).Info("Object deleted")
 	return nil
 }
 
@@ -307,7 +338,9 @@ func (r *PodReconciler) findOtherDataplanes(ctx context.Context, pod *kube_core.
 		dataplane := allDataplanes.Items[i]
 		dp := core_mesh.NewDataplaneResource()
 		if err := r.ResourceConverter.ToCoreResource(&dataplane, dp); err != nil {
-			converterLog.Error(err, "failed to parse Dataplane", "dataplane", dataplane.Spec)
+			if parseSampler.allow(err.Error()) {
+				converterLog.Error(err, "failed to parse Dataplane", "dataplane", dataplane.Spec)
+			}
 			continue // one invalid Dataplane definition should not break the entire mesh
 		}
 		if dataplane.Mesh == mesh {
@@ -371,10 +404,10 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	}
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
-		log.Info("Dataplane created")
+		log.V(1).Info("Dataplane created")
 		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Dataplane: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
-		log.Info("Dataplane updated")
+		log.V(1).Info("Dataplane updated")
 		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Dataplane: %s", pod.Name)
 	}
 	return nil

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -48,7 +48,6 @@ func newErrSampler(window time.Duration) *errSampler {
 	return &errSampler{window: window, last: map[string]time.Time{}}
 }
 
-// allow returns true the first time msg is seen and once per window thereafter.
 func (s *errSampler) allow(msg string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -35,34 +35,6 @@ import (
 	util_maps "github.com/kumahq/kuma/v2/pkg/util/maps"
 )
 
-// errSampler allows at most one Error log per unique message per window.
-// It prevents tight loops from flooding the log when the same parse error
-// repeats for many resources in a single reconcile pass.
-type errSampler struct {
-	window time.Duration
-	mu     sync.Mutex
-	last   map[string]time.Time
-}
-
-func newErrSampler(window time.Duration) *errSampler {
-	return &errSampler{window: window, last: map[string]time.Time{}}
-}
-
-func (s *errSampler) allow(msg string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	now := time.Now()
-	if t, ok := s.last[msg]; ok && now.Sub(t) < s.window {
-		return false
-	}
-	s.last[msg] = now
-	return true
-}
-
-// parseSampler rate-limits repeated "failed to parse Dataplane" errors so a
-// single malformed resource does not flood the log on every reconcile.
-var parseSampler = newErrSampler(time.Minute)
-
 const (
 	// CreatedKumaDataplaneReason is added to an event when
 	// a new Dataplane is successfully created.
@@ -78,6 +50,39 @@ const (
 	// so listener generation is skipped.
 	ZoneProxyListenersSkippedReason = "ZoneProxyListenersSkipped"
 )
+
+// parseSampler rate-limits repeated "failed to parse Dataplane" errors so a
+// single malformed resource does not flood the log on every reconcile.
+var parseSampler = newErrSampler(time.Minute)
+
+// errSampler allows at most one Error log per unique key per window.
+// It prevents tight loops from flooding the log when the same parse error
+// repeats for the same resource across reconcile passes.
+type errSampler struct {
+	window time.Duration
+	mu     sync.Mutex
+	last   map[string]time.Time
+}
+
+func newErrSampler(window time.Duration) *errSampler {
+	return &errSampler{window: window, last: map[string]time.Time{}}
+}
+
+func (s *errSampler) allow(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for existingKey, t := range s.last {
+		if now.Sub(t) >= s.window {
+			delete(s.last, existingKey)
+		}
+	}
+	if _, ok := s.last[key]; ok {
+		return false
+	}
+	s.last[key] = now
+	return true
+}
 
 // PodReconciler reconciles a Pod object
 type PodReconciler struct {
@@ -337,8 +342,9 @@ func (r *PodReconciler) findOtherDataplanes(ctx context.Context, pod *kube_core.
 		dataplane := allDataplanes.Items[i]
 		dp := core_mesh.NewDataplaneResource()
 		if err := r.ResourceConverter.ToCoreResource(&dataplane, dp); err != nil {
-			if parseSampler.allow(err.Error()) {
-				converterLog.Error(err, "failed to parse Dataplane", "dataplane", dataplane.Spec)
+			name := kube_types.NamespacedName{Namespace: dataplane.Namespace, Name: dataplane.Name}
+			if parseSampler.allow(name.String() + ":" + err.Error()) {
+				converterLog.Error(err, "failed to parse Dataplane", "dataplane", name, "spec", dataplane.Spec)
 			}
 			continue // one invalid Dataplane definition should not break the entire mesh
 		}

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_internal_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_internal_test.go
@@ -9,20 +9,43 @@ import (
 
 var _ = Describe("errSampler", func() {
 	It("allows each key once per window", func() {
-		sampler := newErrSampler(time.Minute)
+		sampler := newErrSampler()
 
-		Expect(sampler.allow("demo/dp-1:broken spec")).To(BeTrue())
-		Expect(sampler.allow("demo/dp-1:broken spec")).To(BeFalse())
-		Expect(sampler.allow("demo/dp-2:broken spec")).To(BeTrue())
+		ok, suppressed := sampler.allow("demo/dp-1")
+		Expect(ok).To(BeTrue())
+		Expect(suppressed).To(Equal(0))
+
+		ok, _ = sampler.allow("demo/dp-1")
+		Expect(ok).To(BeFalse())
+
+		ok, suppressed = sampler.allow("demo/dp-2")
+		Expect(ok).To(BeTrue())
+		Expect(suppressed).To(Equal(0))
 	})
 
-	It("prunes expired keys", func() {
-		sampler := newErrSampler(time.Minute)
-		sampler.last["demo/stale:broken spec"] = time.Now().Add(-2 * time.Minute)
-		sampler.last["demo/fresh:broken spec"] = time.Now()
+	It("counts suppressed calls", func() {
+		sampler := newErrSampler()
 
-		Expect(sampler.allow("demo/new:broken spec")).To(BeTrue())
-		Expect(sampler.last).NotTo(HaveKey("demo/stale:broken spec"))
-		Expect(sampler.last).To(HaveKey("demo/fresh:broken spec"))
+		ok, _ := sampler.allow("demo/dp-1")
+		Expect(ok).To(BeTrue())
+
+		_, _ = sampler.allow("demo/dp-1")
+		_, _ = sampler.allow("demo/dp-1")
+
+		// expire the window
+		sampler.last["demo/dp-1"] = time.Now().Add(-2 * errSamplerWindow)
+
+		ok, suppressed := sampler.allow("demo/dp-1")
+		Expect(ok).To(BeTrue())
+		Expect(suppressed).To(Equal(2))
+	})
+
+	It("re-allows after window expires", func() {
+		sampler := newErrSampler()
+		sampler.last["demo/dp-1"] = time.Now().Add(-2 * errSamplerWindow)
+
+		ok, suppressed := sampler.allow("demo/dp-1")
+		Expect(ok).To(BeTrue())
+		Expect(suppressed).To(Equal(0))
 	})
 })

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_internal_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_internal_test.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("errSampler", func() {
+	It("allows each key once per window", func() {
+		sampler := newErrSampler(time.Minute)
+
+		Expect(sampler.allow("demo/dp-1:broken spec")).To(BeTrue())
+		Expect(sampler.allow("demo/dp-1:broken spec")).To(BeFalse())
+		Expect(sampler.allow("demo/dp-2:broken spec")).To(BeTrue())
+	})
+
+	It("prunes expired keys", func() {
+		sampler := newErrSampler(time.Minute)
+		sampler.last["demo/stale:broken spec"] = time.Now().Add(-2 * time.Minute)
+		sampler.last["demo/fresh:broken spec"] = time.Now()
+
+		Expect(sampler.allow("demo/new:broken spec")).To(BeTrue())
+		Expect(sampler.last).NotTo(HaveKey("demo/stale:broken spec"))
+		Expect(sampler.last).To(HaveKey("demo/fresh:broken spec"))
+	})
+})

--- a/pkg/util/xds/logging_callbacks.go
+++ b/pkg/util/xds/logging_callbacks.go
@@ -18,37 +18,37 @@ var _ Callbacks = LoggingCallbacks{}
 // OnStreamOpen is called once an xDS stream is open with a stream ID and the type URL (or "" for ADS).
 // Returning an error will end processing and close the stream. OnStreamClosed will still be called.
 func (cb LoggingCallbacks) OnStreamOpen(ctx context.Context, streamID int64, typ string) error {
-	cb.Log.V(1).Info("OnStreamOpen", "context", ctx, "streamid", streamID, "type", typ)
+	cb.Log.V(1).Info("OnStreamOpen", "context", ctx, "streamID", streamID, "type", typ)
 	return nil
 }
 
 // OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
 func (cb LoggingCallbacks) OnStreamClosed(streamID int64) {
-	cb.Log.V(1).Info("OnStreamClosed", "streamid", streamID)
+	cb.Log.V(1).Info("OnStreamClosed", "streamID", streamID)
 }
 
 // OnStreamRequest is called once a request is received on a stream.
 // Returning an error will end processing and close the stream. OnStreamClosed will still be called.
 func (cb LoggingCallbacks) OnStreamRequest(streamID int64, req DiscoveryRequest) error {
-	cb.Log.V(1).Info("OnStreamRequest", "streamid", streamID, "req", req)
+	cb.Log.V(1).Info("OnStreamRequest", "streamID", streamID, "req", req)
 	return nil
 }
 
 // OnStreamResponse is called immediately prior to sending a response on a stream.
 func (cb LoggingCallbacks) OnStreamResponse(streamID int64, req DiscoveryRequest, resp DiscoveryResponse) {
-	cb.Log.V(1).Info("OnStreamResponse", "streamid", streamID, "req", req, "resp", resp)
+	cb.Log.V(1).Info("OnStreamResponse", "streamID", streamID, "req", req, "resp", resp)
 }
 
 // OnDeltaStreamOpen is called once an xDS stream is open with a stream ID and the type URL (or "" for ADS).
 // Returning an error will end processing and close the stream. OnDeltaStreamOpen will still be called.
 func (cb LoggingCallbacks) OnDeltaStreamOpen(ctx context.Context, streamID int64, typ string) error {
-	cb.Log.V(1).Info("OnDeltaStreamOpen", "context", ctx, "streamid", streamID, "type", typ)
+	cb.Log.V(1).Info("OnDeltaStreamOpen", "context", ctx, "streamID", streamID, "type", typ)
 	return nil
 }
 
 // OnDeltaStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
 func (cb LoggingCallbacks) OnDeltaStreamClosed(streamID int64) {
-	cb.Log.V(1).Info("OnDeltaStreamClosed", "streamid", streamID)
+	cb.Log.V(1).Info("OnDeltaStreamClosed", "streamID", streamID)
 }
 
 // OnStreamDeltaRequest is called once a request is received on a stream.
@@ -56,19 +56,19 @@ func (cb LoggingCallbacks) OnDeltaStreamClosed(streamID int64) {
 func (cb LoggingCallbacks) OnStreamDeltaRequest(streamID int64, req DeltaDiscoveryRequest) error {
 	if req.ErrorMsg() != "" {
 		if util.IsUserErrorMessage(req.ErrorMsg()) {
-			cb.Log.Info("OnStreamDeltaRequest: resource was rejected", "err", errors.New(req.ErrorMsg()), "streamid", streamID, "req", req)
+			cb.Log.Info("OnStreamDeltaRequest: resource was rejected", "err", errors.New(req.ErrorMsg()), "streamID", streamID, "req", req)
 		} else {
-			cb.Log.Error(errors.New(req.ErrorMsg()), "OnStreamDeltaRequest: resource was rejected", "streamid", streamID, "req", req)
+			cb.Log.Error(errors.New(req.ErrorMsg()), "OnStreamDeltaRequest: resource was rejected", "streamID", streamID, "req", req)
 		}
 	} else {
-		cb.Log.V(1).Info("OnStreamDeltaRequest", "streamid", streamID, "req", req)
+		cb.Log.V(1).Info("OnStreamDeltaRequest", "streamID", streamID, "req", req)
 	}
 	return nil
 }
 
 // OnStreamDeltaResponse is called immediately prior to sending a response on a stream.
 func (cb LoggingCallbacks) OnStreamDeltaResponse(streamID int64, req DeltaDiscoveryRequest, resp DeltaDiscoveryResponse) {
-	cb.Log.V(1).Info("OnStreamDeltaResponse", "streamid", streamID, "req", req, "resp", resp)
+	cb.Log.V(1).Info("OnStreamDeltaResponse", "streamID", streamID, "req", req, "resp", resp)
 }
 
 // OnFetchRequest is called for each Fetch request. Returning an error will end processing of the

--- a/pkg/xds/server/callbacks/dataplane_status_tracker.go
+++ b/pkg/xds/server/callbacks/dataplane_status_tracker.go
@@ -178,12 +178,12 @@ func (c *dataplaneStatusTracker) onStreamRequest(
 			if md.GetVersion() != nil {
 				state.subscription.Version = md.GetVersion()
 			} else {
-				statusTrackerLog.Error(err, "failed to extract version out of the Envoy metadata", "streamid", streamID, "mode", mode, "metadata", req.Metadata())
+				statusTrackerLog.Error(err, "failed to extract version out of the Envoy metadata", "streamID", streamID, "mode", mode, "metadata", req.Metadata())
 			}
 			// Kick off the async Dataplane status flusher.
 			go c.createStatusSink(req.Metadata(), state).Start(state.stop)
 		} else {
-			statusTrackerLog.Error(err, "failed to parse Dataplane Id out of DiscoveryRequest", "streamid", streamID, "mode", mode, "req", req)
+			statusTrackerLog.Error(err, "failed to parse Dataplane Id out of DiscoveryRequest", "streamID", streamID, "mode", mode, "req", req)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (c *dataplaneStatusTracker) onStreamRequest(
 		if !statusTrackerLog.V(1).Enabled() { // it was already added, no need to add it twice
 			log = log.WithValues("resourceNames", req.GetResourceNames())
 		}
-		log.Info("config requested")
+		log.V(1).Info("config requested")
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

On a busy CP, these log call sites fire on every xDS stream message and every KDS health-check tick. They dominate log volume and crowd out the events on-call actually needs to see. The noise grows linearly with mesh size.

The xDS change (`dataplane_status_tracker.go`) accounts for the bulk of the volume reduction - it fires on every resource request from every connected proxy. The pod controller changes are comparatively minor.

## Implementation information

- `dataplane_status_tracker.go`: demote "config requested" to V(1) - fires on every xDS request, not just first contact. Unify `streamid` -> `streamID` field key consistently across the xDS/KDS/HDS callback family. Keep "proxy connected" and "proxy disconnected" at Info (lifecycle events).
- `kds/mux/client.go`: demote "sending health check" to V(1) - fires every 5 minutes per zone CP, adds nothing on a healthy mesh.
- `pod_controller.go`: keep "Object deleted" at Info (no K8s Event fallback for delete; create/update emit Events so their log can be demoted). Demote "Dataplane created" and "Dataplane updated" to V(1). Rate-sample "failed to parse Dataplane" (1-minute window per resource name) so a single malformed resource cannot flood across repeated reconcile passes; includes `suppressed_count` in the next allowed log. Field renamed `dataplane` -> `dataplane_ref` to make the shape change explicit (was full Spec, now namespace/name string).
- `kds/v2/client/kds_client.go`: no change needed, already demoted in a prior PR