### PR TITLE
chore(log): unify field keys, fix antipatterns

### DIFF
--- a/pkg/core/bootstrap/autoconfig.go
+++ b/pkg/core/bootstrap/autoconfig.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -121,8 +120,7 @@ func autoconfigureTLS(cfg *kuma_cp.Config) error {
 	if cfg.General.TlsCertFile != "" {
 		return nil
 	}
-	autoconfigureLog.Info(fmt.Sprintf("directory %v will be used as a working directory, "+
-		"it could be changed using KUMA_GENERAL_WORK_DIR environment variable", cfg.General.WorkDir))
+	autoconfigureLog.Info("directory will be used as a working directory, it could be changed using KUMA_GENERAL_WORK_DIR environment variable", "workDir", cfg.General.WorkDir)
 
 	if crtFile, keyFile, err := tryReadKeyPair(workDir(cfg.General.WorkDir)); err == nil {
 		cfg.General.TlsCertFile = crtFile

--- a/pkg/core/resources/apis/meshopentelemetrybackend/status_updater.go
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/status_updater.go
@@ -437,9 +437,9 @@ func (s *StatusUpdater) updateResourceCondition(
 	log := s.logger.WithValues(logKey, resource.GetMeta().GetName(), "mesh", resource.GetMeta().GetMesh())
 	if err := s.resManager.Update(ctx, resource); err != nil {
 		if store.IsConflict(err) {
-			log.Info(fmt.Sprintf("couldn't update %s, will retry next interval", typeName), "interval", s.interval)
+			log.Info("couldn't update status, will retry next interval", "resourceType", typeName, "interval", s.interval)
 		} else {
-			log.Error(err, fmt.Sprintf("could not update %s status", typeName))
+			log.Error(err, "could not update status", "resourceType", typeName)
 		}
 	}
 }

--- a/pkg/core/runtime/reports/reports.go
+++ b/pkg/core/runtime/reports/reports.go
@@ -252,12 +252,12 @@ func startReportTicker(rt core_runtime.Runtime, buffer *reportsBuffer, extraFn c
 	go func() {
 		err := buffer.dispatch(rt, pingHost, pingPort, "start", extraFn)
 		if err != nil {
-			log.V(2).Info("failed sending usage info", "cause", err.Error())
+			log.V(1).Info("failed sending usage info", "cause", err.Error())
 		}
 		for range time.Tick(time.Second * pingInterval) {
 			err := buffer.dispatch(rt, pingHost, pingPort, "ping", extraFn)
 			if err != nil {
-				log.V(2).Info("failed sending usage info", "cause", err.Error())
+				log.V(1).Info("failed sending usage info", "cause", err.Error())
 			}
 		}
 	}()

--- a/pkg/gc/collector.go
+++ b/pkg/gc/collector.go
@@ -106,7 +106,7 @@ func (d *collector) cleanup(ctx context.Context, now time.Time, insightType Insi
 		}
 	}
 	for rk, age := range onDelete {
-		d.log.Info(fmt.Sprintf("deleting %s which is offline for %v", resourceType, age), "name", rk.Name, "mesh", rk.Mesh)
+		d.log.Info("deleting resource which is offline", "resourceType", resourceType, "offlineFor", age, "name", rk.Name, "mesh", rk.Mesh)
 		resource := registry.Global().MustNewObject(core_model.ResourceType(resourceType))
 		if err := d.rm.Delete(ctx, resource, store.DeleteBy(rk)); err != nil {
 			d.log.Error(err, "unable to delete", "resourceType", resourceType, "name", rk.Name, "mesh", rk.Mesh)

--- a/pkg/plugins/runtime/gateway/generator.go
+++ b/pkg/plugins/runtime/gateway/generator.go
@@ -156,8 +156,7 @@ func gatewayListenerInfoFromProxy(
 		return nil
 	}
 
-	log.V(1).Info(fmt.Sprintf("matched gateway %q to dataplane %q",
-		gateway.Meta.GetName(), proxy.Dataplane.Meta.GetName()))
+	log.V(1).Info("matched gateway to dataplane", "gateway", gateway.Meta.GetName(), "dataplane", proxy.Dataplane.Meta.GetName())
 
 	// Canonicalize the tags on each listener to be the merged resources
 	// of dataplane, gateway and listener tags.

--- a/pkg/plugins/runtime/k8s/probes/pod_probe_overrider.go
+++ b/pkg/plugins/runtime/k8s/probes/pod_probe_overrider.go
@@ -110,7 +110,7 @@ func overrideProbe(probe *kube_core.Probe, virtualPort uint32,
 		return nil
 	}
 
-	log.V(1).Info(fmt.Sprintf("overriding %s probe", probeName), "container", containerName)
+	log.V(1).Info("overriding probe", "probe", probeName, "container", containerName)
 
 	namedPortResolver(probe.ProbeHandler)
 

--- a/pkg/transparentproxy/kubernetes/kubernetes_config.go
+++ b/pkg/transparentproxy/kubernetes/kubernetes_config.go
@@ -174,7 +174,7 @@ func (c configurer) redirectExcludePorts(kind trafficKind) (tproxy_config.Ports,
 		source string,
 		value tproxy_config.Ports,
 	) (tproxy_config.Ports, error) {
-		l.V(1).Info(fmt.Sprintf("using exclude %s ports from the %s", kind, source))
+		l.V(1).Info("using exclude ports", "kind", kind, "source", source)
 		return value, nil
 	}
 
@@ -228,7 +228,7 @@ func (c configurer) redirectExcludePortsForIPs(kind trafficKind) []string {
 	)
 
 	logDebugUsageAndReturn := func(source string, value []string) []string {
-		l.V(1).Info(fmt.Sprintf("using exclude %s IPs from the %s", kind, source))
+		l.V(1).Info("using exclude IPs", "kind", kind, "source", source)
 		return value
 	}
 
@@ -289,7 +289,7 @@ func (c configurer) ipFamilyMode() (tproxy_config.IPFamilyMode, error) {
 		source string,
 		value tproxy_config.IPFamilyMode,
 	) (tproxy_config.IPFamilyMode, error) {
-		l.V(1).Info(fmt.Sprintf("using IP Family Mode from the %s", source))
+		l.V(1).Info("using IP family mode", "source", source)
 		return value, nil
 	}
 

--- a/pkg/transparentproxy/validate/validator.go
+++ b/pkg/transparentproxy/validate/validator.go
@@ -154,7 +154,7 @@ func (v *Validator) RunClient(
 		retry.WithMaxRetries(retries, retry.NewConstant(v.ClientRetryInterval)), // backoff
 		func(context.Context) error {
 			if err := runLocalClient(v.ClientConnectIP, serverPort); err != nil {
-				v.Logger.Info("failed to connect to the server, retrying...", "error", err)
+				v.Logger.Info("failed to connect to the server, retrying", "error", err)
 				return retry.RetryableError(err)
 			}
 			v.Logger.Info("client successfully connected to the server")

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -79,28 +78,28 @@ func (k *kubeAuthenticator) authResource(ctx context.Context, resource model.Res
 	serviceAccountAuthErr := errors.Errorf("invalid service account token")
 	userInfo := strings.Split(tokenReview.Status.User.Username, ":")
 	if len(userInfo) != 4 {
-		log.Info(fmt.Sprintf("[WARNING] invalid service account token: username inside TokenReview response has unexpected format: %q",
-			tokenReview.Status.User.Username), "proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Info("[WARNING] invalid service account token: username inside TokenReview response has unexpected format",
+			"username", tokenReview.Status.User.Username, "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return serviceAccountAuthErr
 	}
 
 	if userInfo[0] != "system" || userInfo[1] != "serviceaccount" {
-		log.Info(fmt.Sprintf("[WARNING] invalid service account token: user %q is not a service account", tokenReview.Status.User.Username),
-			"proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Info("[WARNING] invalid service account token: user is not a service account",
+			"username", tokenReview.Status.User.Username, "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return serviceAccountAuthErr
 	}
 
 	tokenSANamespace := userInfo[2]
 	if tokenSANamespace != podNamespace {
-		log.Info(fmt.Sprintf("[WARNING] invalid service account token: token belongs to a namespace %q different from proxyId %q", tokenSANamespace, podNamespace),
-			"proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Info("[WARNING] invalid service account token: token namespace does not match proxyId",
+			"tokenNamespace", tokenSANamespace, "proxyId", podNamespace, "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return serviceAccountAuthErr
 	}
 
 	tokenSAName := userInfo[3]
 	if tokenSAName != serviceAccountName {
-		log.Info(fmt.Sprintf("[WARNING] invalid service account token: service account name in token %q does not match pod service account", tokenSAName),
-			"proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Info("[WARNING] invalid service account token: service account name in token does not match pod service account",
+			"tokenServiceAccount", tokenSAName, "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return serviceAccountAuthErr
 	}
 

--- a/pkg/xds/auth/k8s/authenticator.go
+++ b/pkg/xds/auth/k8s/authenticator.go
@@ -91,8 +91,8 @@ func (k *kubeAuthenticator) authResource(ctx context.Context, resource model.Res
 
 	tokenSANamespace := userInfo[2]
 	if tokenSANamespace != podNamespace {
-		log.Info("[WARNING] invalid service account token: token namespace does not match proxyId",
-			"tokenNamespace", tokenSANamespace, "proxyId", podNamespace, "proxy", resourceName, "serviceAccountName", serviceAccountName)
+		log.Info("[WARNING] invalid service account token: token namespace does not match proxy namespace",
+			"tokenNamespace", tokenSANamespace, "proxyNamespace", podNamespace, "proxy", resourceName, "serviceAccountName", serviceAccountName)
 		return serviceAccountAuthErr
 	}
 

--- a/pkg/xds/template/proxy_template_resolver.go
+++ b/pkg/xds/template/proxy_template_resolver.go
@@ -34,11 +34,11 @@ func (r *SimpleProxyTemplateResolver) GetTemplate(proxy *model.Proxy) *mesh_prot
 	}
 
 	if bestMatchTemplate := SelectProxyTemplate(proxy.Dataplane, templateList.Items); bestMatchTemplate != nil {
-		log.V(2).Info("found the best matching ProxyTemplate", "proxytemplate", core_model.MetaToResourceKey(bestMatchTemplate.GetMeta()))
+		log.V(1).Info("found the best matching ProxyTemplate", "proxytemplate", core_model.MetaToResourceKey(bestMatchTemplate.GetMeta()))
 		return bestMatchTemplate.Spec
 	}
 
-	log.V(2).Info("no matching ProxyTemplate")
+	log.V(1).Info("no matching ProxyTemplate")
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

The log search experience for on-call is degraded by `fmt.Sprintf` in front of structured loggers (grep can't match on field values), useful debug logs sitting behind `V(2)` instead of the more commonly enabled `V(1)`, and trailing `...` in messages that add noise. None individually is a bug - together they make logs harder to act on.

## Implementation information

Mechanical sweep across the tree (excluding files owned by sibling PRs in this series):

- `V(2)` demoted to `V(1)` (4 call sites: `reports.go` x2, `proxy_template_resolver.go` x2). These remain debug logs and do not change default info-level logging.
- `fmt.Sprintf` message templating replaced with structured fields (8 call sites: `gc/collector.go`, `gateway/generator.go`, `k8s/probes/pod_probe_overrider.go`, `meshopentelemetrybackend/status_updater.go`, `transparentproxy/kubernetes/kubernetes_config.go` x3, `core/bootstrap/autoconfig.go`).
- `xds/auth/k8s/authenticator.go` warning messages moved to structured fields (4 call sites); unused `fmt` import removed.
- Trailing `...` dropped from `transparentproxy/validate/validator.go` retry message.

Skipped (intentional): `mesh`/`Mesh` collision is in `pod_controller.go` (sibling PR); `zoneID`/`hostedZoneId` is in enterprise fork only; all `Info("...", "err", err)` instances are intentional retry-loop demotions; `KumaPqLockLogger` fmt.Sprintf wraps a printf-style interface; `webhooks/` files are owned by a sibling PR.
