### PR TITLE
feat(log): export log volume counter

### DIFF
--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -1,10 +1,31 @@
 package log
 
 import (
+	"sync/atomic"
+
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+// logLinesCounter holds the registered counter vec, or nil before SetupMetrics is called.
+var logLinesCounter atomic.Pointer[prometheus.CounterVec]
+
+// SetupMetrics registers the kuma_cp_log_lines_total counter with the given
+// Prometheus registerer. Call this once during CP startup, after the metrics
+// registry is ready.
+func SetupMetrics(reg prometheus.Registerer) (*prometheus.CounterVec, error) {
+	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kuma_cp_log_lines_total",
+		Help: "Total number of log lines emitted by the control plane, by logger name and level.",
+	}, []string{"logger", "level"})
+	if err := reg.Register(cv); err != nil {
+		return nil, err
+	}
+	logLinesCounter.Store(cv)
+	return cv, nil
+}
 
 // componentAwareSink wraps a logr.LogSink to add per-component log level
 // control. It intercepts WithName calls to track the hierarchical component
@@ -57,10 +78,20 @@ func (s *componentAwareSink) Enabled(level int) bool {
 }
 
 func (s *componentAwareSink) Info(level int, msg string, keysAndValues ...any) {
+	if cv := logLinesCounter.Load(); cv != nil {
+		lvl := "info"
+		if level > 0 {
+			lvl = "debug"
+		}
+		cv.WithLabelValues(s.name, lvl).Inc()
+	}
 	s.inner.Info(level, msg, keysAndValues...)
 }
 
 func (s *componentAwareSink) Error(err error, msg string, keysAndValues ...any) {
+	if cv := logLinesCounter.Load(); cv != nil {
+		cv.WithLabelValues(s.name, "error").Inc()
+	}
 	s.inner.Error(err, msg, keysAndValues...)
 }
 

--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -12,6 +12,12 @@ import (
 // logLinesCounter is nil until SetupMetrics is called.
 var logLinesCounter atomic.Pointer[prometheus.CounterVec]
 
+// ResetMetrics clears the global log-lines counter. Intended for test teardown
+// to prevent counter state from leaking across packages.
+func ResetMetrics() {
+	logLinesCounter.Store(nil)
+}
+
 // SetupMetrics registers the kuma_cp_log_lines_total counter with the given registerer.
 func SetupMetrics(reg prometheus.Registerer) (*prometheus.CounterVec, error) {
 	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -19,7 +25,11 @@ func SetupMetrics(reg prometheus.Registerer) (*prometheus.CounterVec, error) {
 		Help: "Total number of log lines emitted by the control plane, by logger name and level.",
 	}, []string{"logger", "level"})
 	if err := reg.Register(cv); err != nil {
-		return nil, err
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			cv = are.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			return nil, err
+		}
 	}
 	logLinesCounter.Store(cv)
 	return cv, nil
@@ -38,17 +48,37 @@ type componentAwareSink struct {
 	names     []string // pre-computed hierarchy, most-specific first
 	registry  *ComponentLevelRegistry
 	baseLevel *zap.AtomicLevel // base level for fallback when no override
+	cntInfo   prometheus.Counter
+	cntDebug  prometheus.Counter
+	cntError  prometheus.Counter
 }
 
 // NewComponentAwareSink wraps an existing LogSink with per-component level
 // awareness. The inner sink should be created at max verbosity. baseLevel
 // is used as fallback when no per-component override is set.
 func NewComponentAwareSink(inner logr.LogSink, registry *ComponentLevelRegistry, baseLevel *zap.AtomicLevel) logr.LogSink {
+	cntInfo, cntDebug, cntError := resolveCounters("root")
 	return &componentAwareSink{
 		inner:     inner,
 		registry:  registry,
 		baseLevel: baseLevel,
+		cntInfo:   cntInfo,
+		cntDebug:  cntDebug,
+		cntError:  cntError,
 	}
+}
+
+// resolveCounters pre-resolves the info/debug/error counters for loggerName
+// from the current global CounterVec snapshot. Returns nils if metrics are not
+// set up yet; callers must guard with nil checks.
+func resolveCounters(loggerName string) (prometheus.Counter, prometheus.Counter, prometheus.Counter) {
+	cv := logLinesCounter.Load()
+	if cv == nil {
+		return nil, nil, nil
+	}
+	return cv.WithLabelValues(loggerName, "info"),
+		cv.WithLabelValues(loggerName, "debug"),
+		cv.WithLabelValues(loggerName, "error")
 }
 
 func (s *componentAwareSink) Init(info logr.RuntimeInfo) {
@@ -76,19 +106,23 @@ func (s *componentAwareSink) Enabled(level int) bool {
 }
 
 func (s *componentAwareSink) Info(level int, msg string, keysAndValues ...any) {
-	if cv := logLinesCounter.Load(); cv != nil {
-		lvl := "info"
-		if level > 0 {
-			lvl = "debug"
+	// level == 0 is Info (logr .Info()); level > 0 is a V-level (debug).
+	// Negative values are not produced by zapr but treated as debug defensively.
+	if level == 0 {
+		if s.cntInfo != nil {
+			s.cntInfo.Inc()
 		}
-		cv.WithLabelValues(s.name, lvl).Inc()
+	} else {
+		if s.cntDebug != nil {
+			s.cntDebug.Inc()
+		}
 	}
 	s.inner.Info(level, msg, keysAndValues...)
 }
 
 func (s *componentAwareSink) Error(err error, msg string, keysAndValues ...any) {
-	if cv := logLinesCounter.Load(); cv != nil {
-		cv.WithLabelValues(s.name, "error").Inc()
+	if s.cntError != nil {
+		s.cntError.Inc()
 	}
 	s.inner.Error(err, msg, keysAndValues...)
 }
@@ -100,6 +134,9 @@ func (s *componentAwareSink) WithValues(keysAndValues ...any) logr.LogSink {
 		names:     s.names,
 		registry:  s.registry,
 		baseLevel: s.baseLevel,
+		cntInfo:   s.cntInfo,
+		cntDebug:  s.cntDebug,
+		cntError:  s.cntError,
 	}
 }
 
@@ -108,11 +145,15 @@ func (s *componentAwareSink) WithName(name string) logr.LogSink {
 	if s.name != "" {
 		fullName = s.name + "." + name
 	}
+	cntInfo, cntDebug, cntError := resolveCounters(fullName)
 	return &componentAwareSink{
 		inner:     s.inner.WithName(name),
 		name:      fullName,
 		names:     SplitHierarchy(fullName),
 		registry:  s.registry,
 		baseLevel: s.baseLevel,
+		cntInfo:   cntInfo,
+		cntDebug:  cntDebug,
+		cntError:  cntError,
 	}
 }

--- a/pkg/log/component_sink.go
+++ b/pkg/log/component_sink.go
@@ -9,12 +9,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// logLinesCounter holds the registered counter vec, or nil before SetupMetrics is called.
+// logLinesCounter is nil until SetupMetrics is called.
 var logLinesCounter atomic.Pointer[prometheus.CounterVec]
 
-// SetupMetrics registers the kuma_cp_log_lines_total counter with the given
-// Prometheus registerer. Call this once during CP startup, after the metrics
-// registry is ready.
+// SetupMetrics registers the kuma_cp_log_lines_total counter with the given registerer.
 func SetupMetrics(reg prometheus.Registerer) (*prometheus.CounterVec, error) {
 	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "kuma_cp_log_lines_total",

--- a/pkg/log/component_sink_test.go
+++ b/pkg/log/component_sink_test.go
@@ -136,6 +136,7 @@ var _ = Describe("log volume counter", Serial, func() {
 		Expect(err).NotTo(HaveOccurred())
 		buf = &bytes.Buffer{}
 		clr = kuma_log.NewComponentLevelRegistry()
+		DeferCleanup(kuma_log.ResetMetrics)
 	})
 
 	newLogger := func() logr.Logger {

--- a/pkg/log/component_sink_test.go
+++ b/pkg/log/component_sink_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
 )
@@ -117,5 +119,61 @@ var _ = Describe("ComponentAwareSink", func() {
 		newLogger().WithName("plugins").WithName("authn").WithName("tokens").V(1).Info("deep debug")
 
 		Expect(buf.String()).To(ContainSubstring("deep debug"))
+	})
+})
+
+var _ = Describe("log volume counter", Serial, func() {
+	var (
+		cv  *prometheus.CounterVec
+		buf *bytes.Buffer
+		clr *kuma_log.ComponentLevelRegistry
+	)
+
+	BeforeEach(func() {
+		reg := prometheus.NewRegistry()
+		var err error
+		cv, err = kuma_log.SetupMetrics(reg)
+		Expect(err).NotTo(HaveOccurred())
+		buf = &bytes.Buffer{}
+		clr = kuma_log.NewComponentLevelRegistry()
+	})
+
+	newLogger := func() logr.Logger {
+		return kuma_log.NewLoggerToWithRegistry(buf, kuma_log.InfoLevel, clr)
+	}
+
+	count := func(logger, level string) float64 {
+		return testutil.ToFloat64(cv.WithLabelValues(logger, level))
+	}
+
+	It("increments info counter per logger", func() {
+		newLogger().WithName("xds").Info("hello")
+		Expect(count("xds", "info")).To(Equal(1.0))
+	})
+
+	It("increments error counter per logger", func() {
+		newLogger().WithName("kds").Error(nil, "oops")
+		Expect(count("kds", "error")).To(Equal(1.0))
+	})
+
+	It("increments debug counter for V(1) calls", func() {
+		Expect(clr.SetLevel("xds", kuma_log.DebugLevel)).To(Succeed())
+		newLogger().WithName("xds").V(1).Info("verbose")
+		Expect(count("xds", "debug")).To(Equal(1.0))
+	})
+
+	It("counts multiple calls", func() {
+		l := newLogger().WithName("api")
+		l.Info("one")
+		l.Info("two")
+		l.Info("three")
+		Expect(count("api", "info")).To(Equal(3.0))
+	})
+
+	It("tracks separate loggers independently", func() {
+		newLogger().WithName("xds").Info("from xds")
+		newLogger().WithName("kds").Info("from kds")
+		Expect(count("xds", "info")).To(Equal(1.0))
+		Expect(count("kds", "info")).To(Equal(1.0))
 	})
 })

--- a/pkg/metrics/components/cp_info.go
+++ b/pkg/metrics/components/cp_info.go
@@ -53,7 +53,9 @@ func Setup(rt runtime.Runtime) error {
 	}
 
 	if _, err := kuma_log.SetupMetrics(rt.Metrics()); err != nil {
-		return err
+		if !isDuplicatedError(err) {
+			return err
+		}
 	}
 
 	// We don't want to use cached ResourceManager because the cache is just for a couple of seconds

--- a/pkg/metrics/components/cp_info.go
+++ b/pkg/metrics/components/cp_info.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/kumahq/kuma/v2/pkg/core/runtime"
+	kuma_log "github.com/kumahq/kuma/v2/pkg/log"
 	metrics "github.com/kumahq/kuma/v2/pkg/metrics/store"
 	"github.com/kumahq/kuma/v2/pkg/version"
 )
@@ -49,6 +50,10 @@ func Setup(rt runtime.Runtime) error {
 		if !isDuplicatedError(err) { // can be already registered when K8S registerer is used
 			return err
 		}
+	}
+
+	if _, err := kuma_log.SetupMetrics(rt.Metrics()); err != nil {
+		return err
 	}
 
 	// We don't want to use cached ResourceManager because the cache is just for a couple of seconds


### PR DESCRIPTION
## Motivation

On-call has no way to see which loggers dominate kuma-cp log volume during an incident, so demotion decisions for chatty loggers (next PRs in this series) come from guesswork. Without a meter the standard rots within a year.

## Implementation information

Hook `componentAwareSink.Info` and `.Error` to increment a package-level `atomic.Pointer[prometheus.CounterVec]`. The pointer is nil until `SetupMetrics` is called from `pkg/metrics/components.Setup` during CP startup - no-op before then. Labels are `logger` (dot-separated name from `WithName` calls) and `level` (info/debug/error).

> Changelog: feat(kuma-cp): component based logging
