### PR TITLE
test(server): set secondary listener timeout

### DIFF
--- a/test/server/cmd/echo.go
+++ b/test/server/cmd/echo.go
@@ -133,8 +133,13 @@ func newEchoHTTPCmd() *cobra.Command {
 			}
 			secondInboundMux := http.NewServeMux()
 			secondInboundMux.HandleFunc("/", handleEcho)
+			secondInboundSrv := http.Server{
+				Addr:              net.JoinHostPort(args.ip, strconv.Itoa(secondaryInboundPort)),
+				Handler:           secondInboundMux,
+				ReadHeaderTimeout: time.Second,
+			}
 			go func() {
-				_ = http.ListenAndServe(net.JoinHostPort(args.ip, strconv.Itoa(secondaryInboundPort)), secondInboundMux)
+				_ = secondInboundSrv.ListenAndServe()
 			}()
 			return srv.ListenAndServe()
 		},


### PR DESCRIPTION
## Motivation

`make golangci-lint` reports `G114` for the test echo server secondary inbound listener because it used `http.ListenAndServe` without request-header timeouts.

## Implementation information

- Replace the secondary inbound `http.ListenAndServe` helper with an explicit `http.Server`.
- Set `ReadHeaderTimeout: time.Second`, matching the primary echo server listener.
