### PR TITLE
test(gateway): fix connection-limit flake

### DIFF
--- a/test/e2e_env/universal/gateway/resources.go
+++ b/test/e2e_env/universal/gateway/resources.go
@@ -97,21 +97,6 @@ spec:
 		return net.JoinHostPort(universal.Cluster.GetApp(gatewayName).GetIP(), fmt.Sprintf("%d", gatewayPort))
 	}
 
-	keepConnectionOpen := func() {
-		GinkgoHelper()
-		defer GinkgoRecover()
-
-		addr := gatewayAddr()
-		ip, _, _ := net.SplitHostPort(addr)
-		// Send HTTP/1.1 keep-alive requests in a loop to prevent request_headers_timeout
-		// from closing the connection, keeping the TCP slot continuously occupied.
-		cmd := fmt.Sprintf(
-			`bash -c 'while true; do printf "GET / HTTP/1.1\r\nHost: %s\r\nConnection: keep-alive\r\n\r\n"; sleep 0.3; done | ncat %s %d'`,
-			addr, ip, gatewayPort,
-		)
-		_, _, _ = universal.Cluster.Exec("", "", "resources-wait-client", cmd)
-	}
-
 	Specify("connection limit is respected", func() {
 		target := fmt.Sprintf("http://%s/", gatewayAddr())
 
@@ -127,7 +112,7 @@ spec:
 
 		By("allowing more than 1 connection without a limit")
 
-		go keepConnectionOpen()
+		cancelFirstConn := HoldConnection(universal.Cluster, "resources-wait-client", gatewayName, gatewayPort)
 
 		Eventually(func(g Gomega) {
 			response, err := client.CollectEchoResponse(
@@ -141,10 +126,10 @@ spec:
 
 		Expect(universal.Cluster.Install(YamlUniversal(meshGatewayWithLimit))).To(Succeed())
 
-		// Kill existing ncat to close the open connection, then re-occupy the single slot.
-		Expect(universal.Cluster.Kill("resources-wait-client", "ncat")).To(Succeed())
-
-		go keepConnectionOpen()
+		// Close the first keep-alive, then re-occupy the single slot.
+		cancelFirstConn()
+		cancelSecondConn := HoldConnection(universal.Cluster, "resources-wait-client", gatewayName, gatewayPort)
+		defer cancelSecondConn()
 
 		Eventually(func(g Gomega) {
 			response, err := client.CollectFailure(

--- a/test/framework/connection.go
+++ b/test/framework/connection.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"fmt"
 	"net"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,6 +27,7 @@ import (
 func HoldConnection(cluster *UniversalCluster, srcApp, dstApp string, dstPort uint32) func() {
 	GinkgoHelper()
 
+	Expect(cluster.GetApp(srcApp)).ToNot(BeNil(), "source app %q not found", srcApp)
 	dst := cluster.GetApp(dstApp)
 	Expect(dst).ToNot(BeNil(), "destination app %q not found", dstApp)
 	dstIP := dst.GetIP()
@@ -38,15 +40,25 @@ func HoldConnection(cluster *UniversalCluster, srcApp, dstApp string, dstPort ui
 		addr, dstIP, dstPort,
 	)
 
+	// execErr captures a fast-fail from ncat startup (missing binary, ssh
+	// failure, etc.). When non-nil the next Eventually iteration aborts
+	// with the underlying error instead of waiting for the 30s timeout
+	// with a misleading message.
+	var execErr atomic.Value
 	go func() {
 		defer GinkgoRecover()
-		_, _, _ = cluster.Exec("", "", srcApp, cmd)
+		if _, _, err := cluster.Exec("", "", srcApp, cmd); err != nil {
+			execErr.Store(err)
+		}
 	}()
 
 	// Envoy names its listener stats by bound address: listener.<ip>_<port>.*
 	listenerStat := fmt.Sprintf(`listener\..*_%d\.downstream_cx_active`, dstPort)
 	dstAdmin := dst.GetEnvoyAdminTunnel()
 	Eventually(func(g Gomega) {
+		if v := execErr.Load(); v != nil {
+			g.Expect(v.(error)).ToNot(HaveOccurred(), "ncat exec on %q failed", srcApp)
+		}
 		s, err := dstAdmin.GetStats(listenerStat)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(s).To(stats.BeGreaterThanZero())

--- a/test/framework/connection.go
+++ b/test/framework/connection.go
@@ -1,0 +1,59 @@
+package framework
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v2/test/framework/envoy_admin/stats"
+)
+
+// HoldConnection opens a long-lived HTTP/1.1 keep-alive TCP connection from
+// srcApp to dstApp:dstPort inside a UniversalCluster, then blocks until Envoy
+// on dstApp reports the connection on the listener bound to dstPort
+// (downstream_cx_active > 0). It returns a cancel function that terminates the
+// keep-alive by killing ncat on srcApp.
+//
+// Use this primitive when a test needs to "occupy a connection slot" before
+// asserting listener-level connection-limit behavior. It removes the race
+// between a fire-and-forget goroutine that runs ncat and the assertion that
+// follows it — if ncat fails to connect, this fails fast at the call site
+// instead of producing a misleading downstream failure 60s later.
+//
+// The test fails if the connection is not observed within 30s.
+func HoldConnection(cluster *UniversalCluster, srcApp, dstApp string, dstPort uint32) func() {
+	GinkgoHelper()
+
+	dst := cluster.GetApp(dstApp)
+	Expect(dst).ToNot(BeNil(), "destination app %q not found", dstApp)
+	dstIP := dst.GetIP()
+	addr := net.JoinHostPort(dstIP, fmt.Sprintf("%d", dstPort))
+
+	// Send HTTP/1.1 keep-alive requests in a loop to prevent
+	// request_headers_timeout from closing the TCP connection.
+	cmd := fmt.Sprintf(
+		`bash -c 'while true; do printf "GET / HTTP/1.1\r\nHost: %s\r\nConnection: keep-alive\r\n\r\n"; sleep 0.3; done | ncat %s %d'`,
+		addr, dstIP, dstPort,
+	)
+
+	go func() {
+		defer GinkgoRecover()
+		_, _, _ = cluster.Exec("", "", srcApp, cmd)
+	}()
+
+	// Envoy names its listener stats by bound address: listener.<ip>_<port>.*
+	listenerStat := fmt.Sprintf(`listener\..*_%d\.downstream_cx_active`, dstPort)
+	dstAdmin := dst.GetEnvoyAdminTunnel()
+	Eventually(func(g Gomega) {
+		s, err := dstAdmin.GetStats(listenerStat)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(s).To(stats.BeGreaterThanZero())
+	}, "30s", "1s").Should(Succeed(),
+		"ncat from %q did not establish a connection to %s:%d", srcApp, dstIP, dstPort)
+
+	return func() {
+		Expect(cluster.Kill(srcApp, "ncat")).To(Succeed())
+	}
+}


### PR DESCRIPTION
## Motivation

The universal e2e test `Gateway - Resources [It] connection limit is respected` flakes on CI (1× in the last 5 days on master, latent risk on other matrix combos). When it fails the symptom is always the same:

```
[FAILED] Timed out after 60.001s.
Expected <int>: 0 To satisfy [{52} {56}]
```

Root cause: the test fires `go keepConnectionOpen()` and immediately asserts that a second curl is rejected. The goroutine wraps `cluster.Exec(...)` with `_, _, _ = ...`, swallowing any error. If ncat fails to take the slot (silent shell/exec error, slow startup, etc.), nothing occupies the connection-limit slot. curl then succeeds for the full 60s budget and the test fails on a misleading matcher.

Reproduced locally and deterministically by skipping the `go keepConnectionOpen()` call — the same 60s timeout with the same wrong-matcher message appears every time.

## Implementation information

Added a framework primitive `framework.HoldConnection(cluster, srcApp, dstApp, dstPort) func()` that:

1. Spawns the HTTP/1.1 keep-alive ncat from `srcApp` toward `dstApp:dstPort`.
2. **Blocks** until Envoy on `dstApp` reports `downstream_cx_active > 0` on the listener bound to `dstPort` (Envoy keys its listener stats by bound address — `listener.<ip>_<port>.*` — not by the listener name).
3. Returns a `cancel()` that runs `cluster.Kill(srcApp, "ncat")`.

If the connection never establishes within 30s, the test fails at the call site with `ncat from "X" did not establish a connection to Y:Z` instead of producing the downstream "wrong exit code" failure 60s later.

The gateway test now reads:

```go
cancelFirstConn := HoldConnection(universal.Cluster, "resources-wait-client", gatewayName, gatewayPort)
...
cancelFirstConn()
cancelSecondConn := HoldConnection(universal.Cluster, "resources-wait-client", gatewayName, gatewayPort)
defer cancelSecondConn()
```

Local `keepConnectionOpen` helper deleted from `resources.go`; explicit `Kill("resources-wait-client", "ncat")` removed in favor of the returned `cancel()`.

### Alternatives considered

- Inline the `downstream_cx_active` wait inside the gateway test (smaller diff but doesn't deduplicate the fire-and-forget pattern).
- Generic `WaitListenerActiveCx` helper on the `Tunnel` interface (cleaner abstraction but only one call site today; would still leave the racy goroutine pattern in the test).

The framework primitive eliminates the entire race surface and is reusable for any test that needs to occupy a connection slot before asserting on listener behavior.

## Supporting documentation

Verification:

- Reproduced the flake deterministically (skip the goroutine → same 60s wrong-matcher failure).
- 7 consecutive `--until-it-fails` iterations pass with the fix in place (~20s each), zero flakes.
- Negative path (no ncat) now fails fast at 30s with the precondition message instead of 60s+ on the wrong matcher.

> Changelog: skip