### PR TITLE
fix(kri): populate zone label on policies

### DIFF
--- a/pkg/api-server/kri_endpoint.go
+++ b/pkg/api-server/kri_endpoint.go
@@ -51,10 +51,10 @@ func (k *kriEndpoint) findByKriRoute() restful.RouteFunction {
 			return
 		}
 
-		name := k.getCoreName(identifier, *descriptor)
+		candidates := k.candidateNames(identifier, *descriptor)
 		if err := k.resourceAccess.ValidateGet(
 			request.Request.Context(),
-			core_model.ResourceKey{Mesh: identifier.Mesh, Name: name},
+			core_model.ResourceKey{Mesh: identifier.Mesh, Name: candidates[0]},
 			*descriptor,
 			user.FromCtx(request.Request.Context()),
 		); err != nil {
@@ -63,8 +63,15 @@ func (k *kriEndpoint) findByKriRoute() restful.RouteFunction {
 		}
 
 		resource := descriptor.NewObject()
-		if err := k.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, identifier.Mesh)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
+		var getErr error
+		for _, name := range candidates {
+			getErr = k.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, identifier.Mesh))
+			if getErr == nil || !store.IsNotFound(getErr) {
+				break
+			}
+		}
+		if getErr != nil {
+			rest_errors.HandleError(request.Request.Context(), response, getErr, "Could not retrieve a resource")
 			return
 		}
 
@@ -81,16 +88,24 @@ func (k *kriEndpoint) findByKriRoute() restful.RouteFunction {
 	}
 }
 
-func (k *kriEndpoint) getCoreName(id kri.Identifier, desc core_model.ResourceTypeDescriptor) string {
-	namespace := id.Namespace
-	if id.Namespace == "" {
-		namespace = k.systemNamespace
+// candidateNames returns store names to try when resolving a KRI. Most cases
+// return a single unambiguous name. The empty-zone-on-zone-CP case is
+// ambiguous: the resource may be globally originated and synced down by KDS,
+// or locally admitted with a missing `kuma.io/zone` label (e.g. a policy
+// created on a non-federated zone CP before that label was populated). The
+// hashed-name lookup runs first to preserve existing behavior, with the
+// plain name as fallback.
+func (k *kriEndpoint) candidateNames(id kri.Identifier, desc core_model.ResourceTypeDescriptor) []string {
+	primary := k.getCoreName(id, desc)
+	if k.cpMode != config_core.Global && id.Zone == "" && !id.IsLocallyOriginated(false, k.cpZone) {
+		return []string{primary, k.localName(id, desc)}
 	}
+	return []string{primary}
+}
+
+func (k *kriEndpoint) getCoreName(id kri.Identifier, desc core_model.ResourceTypeDescriptor) string {
 	if id.IsLocallyOriginated(k.cpMode == config_core.Global, k.cpZone) {
-		if k.environment == config_core.UniversalEnvironment || k.isClusterScoped(desc) {
-			return id.Name
-		}
-		return id.Name + "." + namespace
+		return k.localName(id, desc)
 	}
 	// Match HashSuffixMapper in pkg/kds/context/context.go: only include
 	// non-empty label values so the hash is identical to what KDS produces.
@@ -101,11 +116,22 @@ func (k *kriEndpoint) getCoreName(id kri.Identifier, desc core_model.ResourceTyp
 	if id.Namespace != "" {
 		values = append(values, id.Namespace)
 	}
-	hashedName := hash.HashedName(id.Mesh, id.Name, values...)
+	hashed := hash.HashedName(id.Mesh, id.Name, values...)
 	if k.environment == config_core.UniversalEnvironment || k.isClusterScoped(desc) {
-		return hashedName
+		return hashed
 	}
-	return hashedName + "." + k.systemNamespace
+	return hashed + "." + k.systemNamespace
+}
+
+func (k *kriEndpoint) localName(id kri.Identifier, desc core_model.ResourceTypeDescriptor) string {
+	if k.environment == config_core.UniversalEnvironment || k.isClusterScoped(desc) {
+		return id.Name
+	}
+	namespace := id.Namespace
+	if namespace == "" {
+		namespace = k.systemNamespace
+	}
+	return id.Name + "." + namespace
 }
 
 func (k *kriEndpoint) isClusterScoped(desc core_model.ResourceTypeDescriptor) bool {

--- a/pkg/api-server/kri_endpoint_test.go
+++ b/pkg/api-server/kri_endpoint_test.go
@@ -166,6 +166,31 @@ var _ = Describe("KRI endpoint", func() {
 		Expect(coreName).To(Equal("zone-1"))
 	})
 
+	It("should fall back to local name when empty-zone KRI on Zone CP misses hashed lookup", func() {
+		// given: Zone CP (non-federated), policy created locally without
+		// `kuma.io/zone` label populated — KRI emits an empty zone slot
+		// even though the resource was admitted locally. Reproduces #15544.
+		endpoint := kriEndpoint{
+			cpMode:          core.Zone,
+			cpZone:          "default",
+			environment:     core.UniversalEnvironment,
+			systemNamespace: "kuma-system",
+		}
+
+		// when: empty zone is treated as ambiguous on Zone CP — both the
+		// hashed (synced-from-global) and the plain (locally-admitted)
+		// names are returned, with plain second so the global path stays
+		// the default.
+		id := kri.MustFromString("kri_mcb_default___mesh-circuit-breaker-all-default_")
+		candidates := endpoint.candidateNames(id, descriptorFor(id))
+
+		// then
+		Expect(candidates).To(Equal([]string{
+			"mesh-circuit-breaker-all-default-w798xv6xczc42cwb",
+			"mesh-circuit-breaker-all-default",
+		}))
+	})
+
 	It("should resolve Mesh resource on Global CP (cluster-scoped, no namespace in core name)", func() {
 		// given: Global CP, Mesh resource is cluster-scoped in K8s
 		endpoint := kriEndpoint{

--- a/pkg/core/resources/labels/compute.go
+++ b/pkg/core/resources/labels/compute.go
@@ -135,10 +135,14 @@ func Compute(
 		setIfNotExist(metadata.KumaMeshLabel, getMeshOrDefault())
 	}
 
-	if labelsOpts.Mode == config_core.Zone {
+	if labelsOpts.Mode == config_core.Zone && labelsOpts.ZoneName != "" {
 		// If resource can't be created on Zone (like Mesh), there is no point in adding
-		// 'kuma.io/zone', 'kuma.io/origin' and 'kuma.io/env' labels even if the zone is non-federated
-		if rd.KDSFlags.Has(core_model.ProvidedByZoneFlag) {
+		// 'kuma.io/zone', 'kuma.io/origin' and 'kuma.io/env' labels even if the zone is non-federated.
+		// Plugin-originated policies are always admittable on Zone, so they qualify too —
+		// without this, policies whose descriptor lacks ProvidedByZoneFlag (or whose flag
+		// definition changes over time) would be persisted without a zone label, and the
+		// KRI lookup would 404 because the emitted KRI zone slot is empty. Fixes #15544.
+		if rd.KDSFlags.Has(core_model.ProvidedByZoneFlag) || (rd.IsPolicy && rd.IsPluginOriginated) {
 			setIfNotExist(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin))
 			if labels[mesh_proto.ResourceOriginLabel] != string(mesh_proto.GlobalResourceOrigin) {
 				setIfNotExist(mesh_proto.ZoneTag, labelsOpts.ZoneName)


### PR DESCRIPTION
## Motivation

KRI lookup via `/_kri/{kri}` 404s for policies created on a non-federated zone CP (universal or k8s standalone). The emitted KRI has an empty zone slot (e.g. `kri_mcb_default___mesh-circuit-breaker-all-default_`), the lookup routes through `IsLocallyOriginated`, sees `id.Zone == "" != cpZone`, falls into the hashed-name path, and misses the resource stored under its plain name. Manually filling the zone slot (e.g. `kri_mcb_default_default__...`) succeeds.

Root cause in `pkg/core/resources/labels/compute.go`: `kuma.io/zone` / `kuma.io/origin` are only set for resources with `ProvidedByZoneFlag`. For policies whose KDS flags omit it (or whose flag set changes), the resource is persisted without a zone label, the KRI emits an empty slot, and the lookup invariant breaks. PR #15921 papered over this in REST output and was reverted in #16046; #16047 assumed locally-created resources always have `zone==cpZone`, which doesn't hold for these policies.

Fixes #15544

## Implementation information

- `pkg/core/resources/labels/compute.go`: extend the zone-label trigger — plugin-originated policies (`IsPolicy && IsPluginOriginated`) qualify alongside `ProvidedByZoneFlag` resources, and the block is gated on a non-empty `ZoneName` so misconfigured CPs don't write empty labels.
- `pkg/api-server/kri_endpoint.go`: add `candidateNames` — when the KRI zone slot is empty on a zone CP, try the hashed-name lookup first (preserves existing behavior for globally-originated resources synced down) then fall back to the plain name (covers locally-admitted resources whose `kuma.io/zone` label was never populated, including any that already exist from before this fix).
- `pkg/api-server/kri_endpoint_test.go`: regression test for the empty-zone fallback path.

> Changelog: fix(kri): populate zone label on policies

## Supporting documentation

- kumahq/kuma#15544
- kumahq/kuma#15921 (reverted in #16046)
- kumahq/kuma#16047