### PR TITLE
fix(k8s): replace deprecated mgr.GetEventRecorderFor()

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/configmap_controller.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
@@ -30,7 +30,7 @@ import (
 // ConfigMapReconciler reconciles a ConfigMap object
 type ConfigMapReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Scheme              *kube_runtime.Scheme
 	Log                 logr.Logger
 	ResourceManager     manager.ResourceManager

--- a/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_converter.go
@@ -33,7 +33,7 @@ func (r *PodReconciler) createOrUpdateBuiltinGatewayDataplane(ctx context.Contex
 
 	if !ok {
 		r.Eventf(
-			pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Missing %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
+			pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Missing %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
 		)
 		return nil
 	}
@@ -41,7 +41,7 @@ func (r *PodReconciler) createOrUpdateBuiltinGatewayDataplane(ctx context.Contex
 	var tags map[string]string
 	if err := json.Unmarshal([]byte(tagsAnnotation), &tags); err != nil || tags == nil {
 		r.Eventf(
-			pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Invalid %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
+			pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Invalid %s annotation on Pod serving a builtin Gateway", metadata.KumaTagsAnnotation,
 		)
 		return nil
 	}
@@ -91,17 +91,17 @@ func (r *PodReconciler) createOrUpdateBuiltinGatewayDataplane(ctx context.Contex
 	})
 	if err != nil {
 		log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
-		r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
+		r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Dataplane: %s", err.Error())
 		return err
 	}
 
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("Dataplane created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Dataplane: %s", dataplane.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Dataplane: %s", dataplane.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("Dataplane updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Dataplane: %s", dataplane.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Dataplane: %s", dataplane.Name)
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller.go
@@ -16,7 +16,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,7 +56,7 @@ const (
 // MeshServiceReconciler reconciles a MeshService object
 type MeshServiceReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Log               logr.Logger
 	Scheme            *kube_runtime.Scheme
 	ResourceConverter k8s_common.Converter
@@ -185,9 +185,9 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 		}
 		switch op {
 		case kube_controllerutil.OperationResultCreated:
-			r.Eventf(svc, kube_core.EventTypeNormal, CreatedMeshServiceReason, "Created Kuma MeshService: %s", name.Name)
+			r.Eventf(svc, nil, kube_core.EventTypeNormal, CreatedMeshServiceReason, "Create", "Created Kuma MeshService: %s", name.Name)
 		case kube_controllerutil.OperationResultUpdated:
-			r.Eventf(svc, kube_core.EventTypeNormal, UpdatedMeshServiceReason, "Updated Kuma MeshService: %s", name.Name)
+			r.Eventf(svc, nil, kube_core.EventTypeNormal, UpdatedMeshServiceReason, "Update", "Updated Kuma MeshService: %s", name.Name)
 		}
 
 		return kube_ctrl.Result{}, nil
@@ -295,10 +295,10 @@ func (r *MeshServiceReconciler) Reconcile(ctx context.Context, req kube_ctrl.Req
 		}
 	}
 	if created > 0 {
-		r.Eventf(svc, kube_core.EventTypeNormal, CreatedMeshServiceReason, "Created %d MeshServices", created)
+		r.Eventf(svc, nil, kube_core.EventTypeNormal, CreatedMeshServiceReason, "Create", "Created %d MeshServices", created)
 	}
 	if updated > 0 {
-		r.Eventf(svc, kube_core.EventTypeNormal, UpdatedMeshServiceReason, "Updated %d MeshServices", updated)
+		r.Eventf(svc, nil, kube_core.EventTypeNormal, UpdatedMeshServiceReason, "Update", "Updated %d MeshServices", updated)
 	}
 
 	return kube_ctrl.Result{}, nil
@@ -355,7 +355,7 @@ func (r *MeshServiceReconciler) setFromClusterIPSvc(_ context.Context, ms *meshs
 	if ms.GetGeneration() != 0 {
 		if owners := ms.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != svc.GetUID() {
 			r.Eventf(
-				svc, kube_core.EventTypeWarning, FailedToGenerateMeshServiceReason, "MeshService already exists and isn't owned by Service",
+				svc, nil, kube_core.EventTypeWarning, FailedToGenerateMeshServiceReason, "FailedToGenerate", "MeshService already exists and isn't owned by Service",
 			)
 			return errors.Errorf("MeshService already exists and isn't owned by Service")
 		}
@@ -387,7 +387,7 @@ func (r *MeshServiceReconciler) setFromPodAndHeadlessSvc(endpoint kube_discovery
 		if ms.GetGeneration() != 0 {
 			if owners := ms.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != endpoint.TargetRef.UID {
 				r.Eventf(
-					svc, kube_core.EventTypeWarning, FailedToGenerateMeshServiceReason, "MeshService already exists and isn't owned by Pod",
+					svc, nil, kube_core.EventTypeWarning, FailedToGenerateMeshServiceReason, "FailedToGenerate", "MeshService already exists and isn't owned by Pod",
 				)
 				return errors.Errorf("MeshService already exists and isn't owned by Pod")
 			}
@@ -500,7 +500,7 @@ func (r *MeshServiceReconciler) manageMeshService(
 
 	if result != kube_controllerutil.OperationResultNone && len(unsupportedPorts) > 0 {
 		ports := strings.Join(unsupportedPorts, ", ")
-		r.Eventf(svc, kube_core.EventTypeNormal, IgnoredUnsupportedPortReason, "Ignored unsupported ports: %s", ports)
+		r.Eventf(svc, nil, kube_core.EventTypeNormal, IgnoredUnsupportedPortReason, "IgnoredPorts", "Ignored unsupported ports: %s", ports)
 	}
 
 	return result, err

--- a/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshservice_controller_test.go
@@ -12,7 +12,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_discovery "k8s.io/api/discovery/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -71,7 +71,7 @@ var _ = Describe("MeshServiceController", func() {
 				Client:            kubeClient,
 				Log:               logr.Discard(),
 				Scheme:            k8sClientScheme,
-				EventRecorder:     kube_record.NewFakeRecorder(10),
+				EventRecorder:     kube_events.NewFakeRecorder(10),
 				ResourceConverter: k8s.NewSimpleConverter(),
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -11,7 +11,7 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +48,7 @@ const (
 // PodReconciler reconciles a Pod object
 type PodReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Scheme                       *kube_runtime.Scheme
 	Log                          logr.Logger
 	PodConverter                 PodConverter
@@ -350,7 +350,7 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Error(err, "unable to create/update Dataplane", "operationResult", operationResult)
-			r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Dataplane: %s", err.Error())
+			r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Dataplane: %s", err.Error())
 		}
 
 		return err
@@ -358,10 +358,10 @@ func (r *PodReconciler) createOrUpdateDataplane(
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("Dataplane created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Dataplane: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Dataplane: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("Dataplane updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Dataplane: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Dataplane: %s", pod.Name)
 	}
 	return nil
 }
@@ -386,16 +386,16 @@ func (r *PodReconciler) createOrUpdateIngress(ctx context.Context, pod *kube_cor
 	log := r.Log.WithValues("pod", kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 	if err != nil {
 		log.Error(err, "unable to create/update Ingress", "operationResult", operationResult)
-		r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Ingress: %s", err.Error())
+		r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Ingress: %s", err.Error())
 		return err
 	}
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("ZoneIngress created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Ingress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Ingress: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("ZoneIngress updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Ingress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Ingress: %s", pod.Name)
 	}
 	return nil
 }
@@ -420,16 +420,16 @@ func (r *PodReconciler) createOrUpdateEgress(ctx context.Context, pod *kube_core
 	log := r.Log.WithValues("pod", kube_types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
 	if err != nil {
 		log.Error(err, "unable to create/update Egress", "operationResult", operationResult)
-		r.Eventf(pod, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "Failed to generate Kuma Egress: %s", err.Error())
+		r.Eventf(pod, nil, kube_core.EventTypeWarning, FailedToGenerateKumaDataplaneReason, "FailedToGenerate", "Failed to generate Kuma Egress: %s", err.Error())
 		return err
 	}
 	switch operationResult {
 	case kube_controllerutil.OperationResultCreated:
 		log.Info("ZoneEgress created")
-		r.Eventf(pod, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Created Kuma Egress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, CreatedKumaDataplaneReason, "Create", "Created Kuma Egress: %s", pod.Name)
 	case kube_controllerutil.OperationResultUpdated:
 		log.Info("ZoneEgress updated")
-		r.Eventf(pod, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Updated Kuma Egress: %s", pod.Name)
+		r.Eventf(pod, nil, kube_core.EventTypeNormal, UpdatedKumaDataplaneReason, "Update", "Updated Kuma Egress: %s", pod.Name)
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -11,7 +11,7 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_intstr "k8s.io/apimachinery/pkg/util/intstr"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -555,7 +555,7 @@ var _ = Describe("PodReconciler", func() {
 
 		reconciler = &PodReconciler{
 			Client:        kubeClient,
-			EventRecorder: kube_record.NewFakeRecorder(10),
+			EventRecorder: kube_events.NewFakeRecorder(10),
 			Scheme:        k8sClientScheme,
 			Log:           core.Log.WithName("test"),
 			PodConverter: PodConverter{

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller.go
@@ -8,7 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +27,7 @@ import (
 // but only when Kuma isn't using the SidecarContainer feature
 type PodStatusReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Scheme            *kube_runtime.Scheme
 	ResourceManager   manager.ResourceManager
 	Log               logr.Logger

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
@@ -8,7 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -173,7 +173,7 @@ var _ = Describe("PodStatusReconciler", func() {
 		postQuitCalled = 0
 		reconciler = &PodStatusReconciler{
 			Client:            kubeClient,
-			EventRecorder:     kube_record.NewFakeRecorder(10),
+			EventRecorder:     kube_events.NewFakeRecorder(10),
 			Scheme:            k8sClientScheme,
 			Log:               core.Log.WithName("test"),
 			ResourceConverter: k8s.NewSimpleConverter(),

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller.go
@@ -9,7 +9,7 @@ import (
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -32,7 +32,7 @@ const (
 // WorkloadReconciler reconciles Workload resources based on Dataplane labels
 type WorkloadReconciler struct {
 	kube_client.Client
-	kube_record.EventRecorder
+	kube_events.EventRecorder
 	Log logr.Logger
 }
 
@@ -103,7 +103,7 @@ func (r *WorkloadReconciler) handleMultipleMeshesDetected(ctx context.Context, n
 	if err := r.Get(ctx, kube_types.NamespacedName{Name: namespace}, ns); err != nil {
 		log.V(1).Info("unable to fetch namespace for event emission", "error", err)
 	} else {
-		r.Eventf(ns, kube_core.EventTypeWarning, MultipleMeshesDetectedReason,
+		r.Eventf(ns, nil, kube_core.EventTypeWarning, MultipleMeshesDetectedReason, "MultipleMeshesDetected",
 			"Skipping Workload generation: namespace %s has pods in multiple meshes (%d meshes) for workload %s. This configuration is not supported.",
 			namespace, meshCount, workloadName)
 	}

--- a/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/workload_controller_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
-	kube_record "k8s.io/client-go/tools/record"
+	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -65,7 +65,7 @@ var _ = Describe("WorkloadController", func() {
 
 			reconciler = &WorkloadReconciler{
 				Client:        kubeClient,
-				EventRecorder: kube_record.NewFakeRecorder(10),
+				EventRecorder: kube_events.NewFakeRecorder(10),
 				Log:           logr.Discard(),
 			}
 

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -158,7 +158,7 @@ func addMeshServiceReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, co
 		Client:            mgr.GetClient(),
 		Log:               core.Log.WithName("controllers").WithName("MeshService"),
 		Scheme:            mgr.GetScheme(),
-		EventRecorder:     mgr.GetEventRecorderFor("k8s.kuma.io/mesh-service-generator"),
+		EventRecorder:     mgr.GetEventRecorder("k8s.kuma.io/mesh-service-generator"),
 		ResourceConverter: converter,
 	}
 	return reconciler.SetupWithManager(mgr)
@@ -189,7 +189,7 @@ func addPodReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter 
 	}
 	reconciler := &k8s_controllers.PodReconciler{
 		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-generator"),
+		EventRecorder: mgr.GetEventRecorder("k8s.kuma.io/dataplane-generator"),
 		Scheme:        mgr.GetScheme(),
 		Log:           core.Log.WithName("controllers").WithName("Pod"),
 		PodConverter: k8s_controllers.PodConverter{
@@ -223,7 +223,7 @@ func addPodStatusReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conv
 	}
 	reconciler := &k8s_controllers.PodStatusReconciler{
 		Client:            mgr.GetClient(),
-		EventRecorder:     mgr.GetEventRecorderFor("k8s.kuma.io/dataplane-jobs-syncer"),
+		EventRecorder:     mgr.GetEventRecorder("k8s.kuma.io/dataplane-jobs-syncer"),
 		Scheme:            mgr.GetScheme(),
 		Log:               core.Log.WithName("controllers").WithName("Pod"),
 		ResourceConverter: converter,
@@ -238,7 +238,7 @@ func addWorkloadReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error
 	}
 	reconciler := &k8s_controllers.WorkloadReconciler{
 		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor("kuma-workload-controller"),
+		EventRecorder: mgr.GetEventRecorder("kuma-workload-controller"),
 		Log:           core.Log.WithName("controllers").WithName("Workload"),
 	}
 	return reconciler.SetupWithManager(mgr)
@@ -265,7 +265,7 @@ func addDNS(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_common
 	}
 	reconciler := &k8s_controllers.ConfigMapReconciler{
 		Client:              mgr.GetClient(),
-		EventRecorder:       mgr.GetEventRecorderFor("k8s.kuma.io/vips-generator"),
+		EventRecorder:       mgr.GetEventRecorder("k8s.kuma.io/vips-generator"),
 		Scheme:              mgr.GetScheme(),
 		Log:                 core.Log.WithName("controllers").WithName("ConfigMap"),
 		ResourceManager:     rt.ResourceManager(),


### PR DESCRIPTION
## Motivation

Backport the controller-runtime event recorder deprecation fix so `make golangci-lint` passes on `release-2.13`.

## Implementation information

- replace `mgr.GetEventRecorderFor()` with `mgr.GetEventRecorder()` in the Kubernetes runtime plugin
- switch the affected controllers and tests to `k8s.io/client-go/tools/events` so the new recorder API compiles cleanly

## Supporting documentation

> Changelog: skip