### PR TITLE
ci(runners): configurable labels via RUNS_ON

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -45,7 +45,12 @@ env:
 jobs:
   build-binaries:
     timeout-minutes: 70
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     permissions:
       id-token: write
       contents: read
@@ -94,7 +99,12 @@ jobs:
         run: |
           make publish/pulp
   build-images:
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -193,7 +203,12 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -212,7 +227,12 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -45,12 +45,7 @@ env:
 jobs:
   build-binaries:
     timeout-minutes: 70
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -99,12 +94,7 @@ jobs:
         run: |
           make publish/pulp
   build-images:
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -203,12 +193,7 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -227,12 +212,7 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -18,7 +18,12 @@ jobs:
   test_unit:
     timeout-minutes: 25
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -31,7 +36,12 @@ jobs:
           make test
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -18,12 +18,7 @@ jobs:
   test_unit:
     timeout-minutes: 25
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -36,12 +31,7 @@ jobs:
           make test
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,7 +13,12 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,12 +13,7 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,7 +30,12 @@ jobs:
       pr_base_ref: ${{ steps.get-pr-info.outputs.pr_base_ref }}
       pr_merge_commit_sha: ${{ steps.get-pr-info.outputs.pr_merge_commit_sha }}
       branches: ${{ steps.generate-matrix.outputs.branches }}
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-latest'
+      }}
     steps:
       - id: get-pr-info
         name: get-pr-info
@@ -112,7 +117,12 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.collect-info.outputs.branches) }}
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-latest'
+      }}
     env:
       PR_NUMBER: ${{ inputs.PR }}
       PR_TITLE: ${{ needs.collect-info.outputs.pr_title }}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -30,12 +30,7 @@ jobs:
       pr_base_ref: ${{ steps.get-pr-info.outputs.pr_base_ref }}
       pr_merge_commit_sha: ${{ steps.get-pr-info.outputs.pr_merge_commit_sha }}
       branches: ${{ steps.generate-matrix.outputs.branches }}
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-latest'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest' }}
     steps:
       - id: get-pr-info
         name: get-pr-info
@@ -117,12 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.collect-info.outputs.branches) }}
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-latest'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest' }}
     env:
       PR_NUMBER: ${{ inputs.PR }}
       PR_TITLE: ${{ needs.collect-info.outputs.pr_title }}

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,7 +7,12 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,12 +7,7 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -115,16 +115,7 @@ jobs:
       #   4. default                          -> the standard self-hosted Kong pool
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: >-
-        ${{
-          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
-          && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
-          || format(
-              '{"amd64":"{0}","arm64":"{1}"}',
-              vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong',
-              vars.RUNS_ON_RELEASE_2_11_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong'
-            )
-        }}
+      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{"amd64":"{0}","arm64":"{1}"}', vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_RELEASE_2_11_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
     secrets: inherit
   build_publish:
     permissions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -104,13 +104,13 @@ jobs:
           config: .syft.yaml
           upload-sbom-release-assets: true
   resolve_runners:
-    runs-on: ${{ github.event.pull_request.head.repo.fork == true && 'ubuntu-24.04' || fromJSON(vars.RUNS_ON || '{}')[github.event_name == 'pull_request' && github.base_ref || github.ref_name].amd64 || fromJSON(vars.RUNS_ON || '{}').default.amd64 || 'ubuntu-latest-kong' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNS_ON || '{}')[github.event_name == 'pull_request' && github.base_ref || github.ref_name].amd64 || fromJSON(vars.RUNS_ON || '{}').default.amd64 || 'ubuntu-latest-kong' }}
     outputs:
       by_arch: ${{ steps.compute.outputs.by_arch }}
     env:
       RUNS_ON: ${{ vars.RUNS_ON }}
       BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
-      IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
+      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       FORK_FALLBACK: '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
     steps:
       - id: compute

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -115,7 +115,7 @@ jobs:
       #   4. default                          -> the standard self-hosted Kong pool
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{"amd64":"{0}","arm64":"{1}"}', vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_RELEASE_2_11_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_RELEASE_2_11_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
     secrets: inherit
   build_publish:
     permissions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -104,7 +104,7 @@ jobs:
           config: .syft.yaml
           upload-sbom-release-assets: true
   resolve_runners:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.event.pull_request.head.repo.fork == true && 'ubuntu-24.04' || fromJSON(vars.RUNS_ON || '{}')[github.event_name == 'pull_request' && github.base_ref || github.ref_name].amd64 || fromJSON(vars.RUNS_ON || '{}').default.amd64 || 'ubuntu-latest-kong' }}
     outputs:
       by_arch: ${{ steps.compute.outputs.by_arch }}
     env:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -108,16 +108,22 @@ jobs:
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
-      # Pick runners in this order:
-      #   1. fork PR    -> free GitHub-hosted runners (security)
-      #   2. vars.RUNS_ON if set -> overrides (e.g. switch to fastrak pool during a priority release)
-      #   3. default    -> the standard self-hosted Kong pool
+      # Per-arch lookup (each side independent):
+      #   1. fork PR                          -> free GitHub-hosted runners (security)
+      #   2. vars.RUNS_ON_RELEASE_2_11_<ARCH> -> per-branch + per-arch override
+      #   3. vars.RUNS_ON_<ARCH>              -> global per-arch override
+      #   4. default                          -> the standard self-hosted Kong pool
+      # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
+      # and inline expressions can't sanitize `github.ref_name`.
       RUNNERS_BY_ARCH: >-
         ${{
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
           && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
-          || vars.RUNS_ON
-          || '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}'
+          || format(
+              '{"amd64":"{0}","arm64":"{1}"}',
+              vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong',
+              vars.RUNS_ON_RELEASE_2_11_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong'
+            )
         }}
     secrets: inherit
   build_publish:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -23,12 +23,7 @@ jobs:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
     timeout-minutes: 25
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -170,12 +165,7 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -103,12 +103,33 @@ jobs:
           dir: .
           config: .syft.yaml
           upload-sbom-release-assets: true
+  resolve_runners:
+    runs-on: ubuntu-24.04
+    outputs:
+      by_arch: ${{ steps.compute.outputs.by_arch }}
+    env:
+      RUNS_ON: ${{ vars.RUNS_ON }}
+      BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+      IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
+      FORK_FALLBACK: '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
+    steps:
+      - id: compute
+        run: |
+          if [[ "${IS_FORK}" == "true" ]]; then
+            echo "by_arch=${FORK_FALLBACK}" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          by_arch=$(jq -nc --argjson cfg "${RUNS_ON:-null}" --arg b "$BRANCH" '{
+            amd64: ($cfg[$b].amd64 // $cfg.default.amd64 // "ubuntu-latest-kong"),
+            arm64: ($cfg[$b].arm64 // $cfg.default.arm64 // "ubuntu-latest-arm64-kong")
+          }')
+          echo "by_arch=${by_arch}" >>"$GITHUB_OUTPUT"
   test:
-    needs: ["check"]
+    needs: ["check", "resolve_runners"]
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) && '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}' || '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' }}
+      RUNNERS_BY_ARCH: ${{ needs.resolve_runners.outputs.by_arch }}
     secrets: inherit
   build_publish:
     permissions:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -23,7 +23,12 @@ jobs:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
     timeout-minutes: 25
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -165,7 +170,12 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -103,33 +103,22 @@ jobs:
           dir: .
           config: .syft.yaml
           upload-sbom-release-assets: true
-  resolve_runners:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNS_ON || '{}')[github.event_name == 'pull_request' && github.base_ref || github.ref_name].amd64 || fromJSON(vars.RUNS_ON || '{}').default.amd64 || 'ubuntu-latest-kong' }}
-    outputs:
-      by_arch: ${{ steps.compute.outputs.by_arch }}
-    env:
-      RUNS_ON: ${{ vars.RUNS_ON }}
-      BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
-      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-      FORK_FALLBACK: '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
-    steps:
-      - id: compute
-        run: |
-          if [[ "${IS_FORK}" == "true" ]]; then
-            echo "by_arch=${FORK_FALLBACK}" >>"$GITHUB_OUTPUT"
-            exit 0
-          fi
-          by_arch=$(jq -nc --argjson cfg "${RUNS_ON:-null}" --arg b "$BRANCH" '{
-            amd64: ($cfg[$b].amd64 // $cfg.default.amd64 // "ubuntu-latest-kong"),
-            arm64: ($cfg[$b].arm64 // $cfg.default.arm64 // "ubuntu-latest-arm64-kong")
-          }')
-          echo "by_arch=${by_arch}" >>"$GITHUB_OUTPUT"
   test:
-    needs: ["check", "resolve_runners"]
+    needs: ["check"]
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
-      RUNNERS_BY_ARCH: ${{ needs.resolve_runners.outputs.by_arch }}
+      # Pick runners in this order:
+      #   1. fork PR    -> free GitHub-hosted runners (security)
+      #   2. vars.RUNS_ON if set -> overrides (e.g. switch to fastrak pool during a priority release)
+      #   3. default    -> the standard self-hosted Kong pool
+      RUNNERS_BY_ARCH: >-
+        ${{
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+          && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}'
+          || vars.RUNS_ON
+          || '{"amd64":"ubuntu-latest-kong","arm64":"ubuntu-latest-arm64-kong"}'
+        }}
     secrets: inherit
   build_publish:
     permissions:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,12 @@ permissions: {}
 jobs:
   pr-check:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - name: Check PR title
         # Check PR title against the Conventional Commits format using commitlint.

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,12 +6,7 @@ permissions: {}
 jobs:
   pr-check:
     timeout-minutes: 10
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: Check PR title
         # Check PR title against the Conventional Commits format using commitlint.

--- a/.github/workflows/ci-stability-master.yaml
+++ b/.github/workflows/ci-stability-master.yaml
@@ -24,7 +24,12 @@ env:
 
 jobs:
   trigger-build-test-distribute:
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-master.yaml
+++ b/.github/workflows/ci-stability-master.yaml
@@ -24,12 +24,7 @@ env:
 
 jobs:
   trigger-build-test-distribute:
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -16,12 +16,7 @@ env:
 
 jobs:
   get-active-release-branches:
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       contents: read
     outputs:
@@ -48,12 +43,7 @@ jobs:
 
   trigger-build-test-distribute:
     needs: get-active-release-branches
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -16,7 +16,12 @@ env:
 
 jobs:
   get-active-release-branches:
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     permissions:
       contents: read
     outputs:
@@ -43,7 +48,12 @@ jobs:
 
   trigger-build-test-distribute:
     needs: get-active-release-branches
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -19,12 +19,7 @@ env:
 permissions: {}
 jobs:
   trigger-ci:
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: Generate GitHub app token
         id: github-app-token

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -19,7 +19,12 @@ env:
 permissions: {}
 jobs:
   trigger-ci:
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - name: Generate GitHub app token
         id: github-app-token

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,12 +9,7 @@ permissions: {}
 
 jobs:
   analyze:
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,7 +9,12 @@ permissions: {}
 
 jobs:
   analyze:
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -11,12 +11,7 @@ permissions:
   contents: read
 jobs:
   release:
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -11,7 +11,12 @@ permissions:
   contents: read
 jobs:
   release:
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,7 +12,12 @@ jobs:
   pr_comments:
     timeout-minutes: 30
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files'))
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - name: Generate GitHub app token
         id: github-app-token

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,12 +12,7 @@ jobs:
   pr_comments:
     timeout-minutes: 30
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files'))
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: Generate GitHub app token
         id: github-app-token

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,7 +12,12 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,12 +12,7 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -16,12 +16,7 @@ jobs:
     env:
       LOOK_BACK: ${{ github.event.inputs.lookback || '10 minutes' }}
       GH_TOKEN: ${{ github.token }}
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     outputs:
       recent_prs: ${{ steps.get-recent-prs.outputs.out }}
       active_branches: ${{ steps.active-branches.outputs.out }}
@@ -55,12 +50,7 @@ jobs:
 
   pr-comment:
     needs: find-prs
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     if: needs.find-prs.outputs.recent_prs != '[]'
     strategy:
       matrix: 

--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -16,7 +16,12 @@ jobs:
     env:
       LOOK_BACK: ${{ github.event.inputs.lookback || '10 minutes' }}
       GH_TOKEN: ${{ github.token }}
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     outputs:
       recent_prs: ${{ steps.get-recent-prs.outputs.out }}
       active_branches: ${{ steps.active-branches.outputs.out }}
@@ -50,7 +55,12 @@ jobs:
 
   pr-comment:
     needs: find-prs
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     if: needs.find-prs.outputs.recent_prs != '[]'
     strategy:
       matrix: 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,12 @@ permissions:
 jobs:
   release:
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,12 +34,7 @@ permissions:
 jobs:
   release:
     timeout-minutes: 30
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,12 +14,7 @@ jobs:
   analysis:
     timeout-minutes: 10
     name: Scorecard analysis
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,7 +14,12 @@ jobs:
   analysis:
     timeout-minutes: 10
     name: Scorecard analysis
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -11,7 +11,12 @@ permissions:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -11,12 +11,7 @@ permissions:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -20,7 +20,12 @@ permissions:
 jobs:
   generate-docs:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -20,12 +20,7 @@ permissions:
 jobs:
   generate-docs:
     timeout-minutes: 10
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -7,7 +7,12 @@ permissions: read-all
 jobs:
   build-matrix:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     outputs:
       branches: ${{ steps.generate-matrix.outputs.branches }}
     steps:
@@ -28,7 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.build-matrix.outputs.branches) }}
-    runs-on: ubuntu-24.04
+    runs-on: >-
+      ${{
+        vars.RUNS_ON_RELEASE_2_11_AMD64
+        || vars.RUNS_ON_AMD64
+        || 'ubuntu-24.04'
+      }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -7,12 +7,7 @@ permissions: read-all
 jobs:
   build-matrix:
     timeout-minutes: 10
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     outputs:
       branches: ${{ steps.generate-matrix.outputs.branches }}
     steps:
@@ -33,12 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.build-matrix.outputs.branches) }}
-    runs-on: >-
-      ${{
-        vars.RUNS_ON_RELEASE_2_11_AMD64
-        || vars.RUNS_ON_AMD64
-        || 'ubuntu-24.04'
-      }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761


### PR DESCRIPTION
## Motivation

During recent priority release work, kuma's CI jobs were getting starved on the shared self-hosted runner pool. The fix isn't about capacity in general — we just want a switch to dynamically point CI at a different pool whenever priority work needs to land, without editing workflow files.

## Implementation information

Every `runs-on:` across all `.github/workflows/` files now resolves through the same lookup chain (each arch is independent):

```
1. fork PR                              -> free GitHub-hosted runners (security)
2. vars.RUNS_ON_<BRANCH_SLUG>_<ARCH>    -> per-branch + per-arch override
3. vars.RUNS_ON_<ARCH>                  -> global per-arch override
4. <hardcoded fallback>                 -> the original label for the job
```

Variable names per branch (uppercase; `-` and `.` replaced with `_` because GitHub var names can't contain those characters, and inline GHA expressions have no string-replace function):

| Branch | amd64 | arm64 |
| --- | --- | --- |
| master | `RUNS_ON_MASTER_AMD64` | `RUNS_ON_MASTER_ARM64` |
| release-2.13 | `RUNS_ON_RELEASE_2_13_AMD64` | `RUNS_ON_RELEASE_2_13_ARM64` |
| release-2.12 | `RUNS_ON_RELEASE_2_12_AMD64` | `RUNS_ON_RELEASE_2_12_ARM64` |
| release-2.11 | `RUNS_ON_RELEASE_2_11_AMD64` | `RUNS_ON_RELEASE_2_11_ARM64` |
| release-2.9 | `RUNS_ON_RELEASE_2_9_AMD64` | `RUNS_ON_RELEASE_2_9_ARM64` |
| release-2.7 | `RUNS_ON_RELEASE_2_7_AMD64` | `RUNS_ON_RELEASE_2_7_ARM64` |

Empty/unset vars keep the current behaviour for every job (each job's original hardcoded label is preserved as the final fallback). Fork PRs always get free GitHub-hosted runners regardless of var settings.

To switch pools, set the appropriate var in repo settings. To revert, unset it.