### PR TITLE
ci(runners): escape braces in format string

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -157,7 +157,7 @@ jobs:
       #   4. default                    -> the standard self-hosted Kong pool
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{"amd64":"{0}","arm64":"{1}"}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
     secrets: inherit
   build_publish:
     permissions:


### PR DESCRIPTION
## Motivation

PR #16629 left the `RUNNERS_BY_ARCH` format template unescaped:

```
format('{"amd64":"{0}","arm64":"{1}"}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', ...)
```

GHA's `format()` reads literal `{` and `}` as malformed placeholder references. This was masked while the only triggers were fork PRs (the fork-detection branch short-circuits before `format()` evaluates), but blew up on the first push to master:

> Error from function 'format': The following format string is invalid: `{"amd64":"{0}","arm64":"{1}"}`

Broken run: https://github.com/kumahq/kuma/actions/runs/25913918497

## Implementation information

Escape literal braces by doubling them, per the [GitHub Actions expression docs](https://docs.github.com/en/actions/learn-github-actions/expressions#format):

```
format('{{"amd64":"{0}","arm64":"{1}"}}', ...)
```

Same expansion result, just syntactically valid input to `format()`.

> Changelog: skip