### PR TITLE
fix(defaults): compute labels on default policies

### DIFF
--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
 	config_store "github.com/kumahq/kuma/v2/pkg/config/core/resources/store"
 	core_ca "github.com/kumahq/kuma/v2/pkg/core/ca"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -36,6 +37,8 @@ func NewMeshManager(
 		unsafeDelete:               config.Store.UnsafeDelete,
 		extensions:                 extensions,
 		createMeshRoutingResources: config.Defaults.CreateMeshRoutingResources,
+		cpMode:                     config.Mode,
+		cpZone:                     config.Multizone.Zone.Name,
 	}
 	if config.Store.Type == config_store.KubernetesStore {
 		meshManager.k8sStore = true
@@ -55,6 +58,8 @@ type meshManager struct {
 	createMeshRoutingResources bool
 	k8sStore                   bool
 	systemNamespace            string
+	cpMode                     config_core.CpMode
+	cpZone                     string
 }
 
 func (m *meshManager) Get(ctx context.Context, resource core_model.Resource, fs ...core_store.GetOptionsFunc) error {
@@ -105,6 +110,9 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 		m.createMeshRoutingResources,
 		m.k8sStore,
 		m.systemNamespace,
+		m.cpMode,
+		m.cpZone,
+		false, // create missing default resources
 	); err != nil {
 		return err
 	}

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -116,7 +116,7 @@ func (m *meshManager) Create(ctx context.Context, resource core_model.Resource, 
 		m.systemNamespace,
 		m.cpMode,
 		m.cpZone,
-		false, // create missing default resources
+		false, // reconcileExistingOnly
 	); err != nil {
 		return err
 	}

--- a/pkg/core/managers/apis/mesh/mesh_manager.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager.go
@@ -28,6 +28,10 @@ func NewMeshManager(
 	extensions context.Context,
 	config kuma_cp.Config,
 ) core_manager.ResourceManager {
+	var cpZone string
+	if config.Multizone != nil {
+		cpZone = config.Multizone.Zone.Name
+	}
 	meshManager := &meshManager{
 		store:                      store,
 		otherManagers:              otherManagers,
@@ -38,7 +42,7 @@ func NewMeshManager(
 		extensions:                 extensions,
 		createMeshRoutingResources: config.Defaults.CreateMeshRoutingResources,
 		cpMode:                     config.Mode,
-		cpZone:                     config.Multizone.Zone.Name,
+		cpZone:                     cpZone,
 	}
 	if config.Store.Type == config_store.KubernetesStore {
 		meshManager.k8sStore = true

--- a/pkg/core/managers/apis/mesh/mesh_manager_test.go
+++ b/pkg/core/managers/apis/mesh/mesh_manager_test.go
@@ -10,6 +10,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	config_store "github.com/kumahq/kuma/v2/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/v2/pkg/config/multizone"
 	core_ca "github.com/kumahq/kuma/v2/pkg/core/ca"
 	"github.com/kumahq/kuma/v2/pkg/core/datasource"
 	"github.com/kumahq/kuma/v2/pkg/core/managers/apis/mesh"
@@ -61,6 +62,7 @@ var _ = Describe("Mesh Manager", func() {
 				Defaults: &kuma_cp.Defaults{
 					CreateMeshRoutingResources: false,
 				},
+				Multizone: multizone.DefaultMultizoneConfig(),
 			})
 		unsafeDeleteResManager = mesh.NewMeshManager(
 			resStore, manager, caManagers, test_resources.Global(),
@@ -72,6 +74,7 @@ var _ = Describe("Mesh Manager", func() {
 				Defaults: &kuma_cp.Defaults{
 					CreateMeshRoutingResources: false,
 				},
+				Multizone: multizone.DefaultMultizoneConfig(),
 			})
 	})
 

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -20,12 +20,13 @@ import (
 
 var log = core.Log.WithName("defaults")
 
-type EnsureDefaultFunc = func(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error
+type EnsureDefaultFunc = func(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config, extensions context.Context) error
 
 var EnsureDefaultFuncs = []EnsureDefaultFunc{
 	EnsureEnvoyAdminCaExists,
 	EnsureOnlyOneZoneExists,
 	EnsureDefaultMeshExists,
+	EnsureDefaultMeshResourcesUpToDate,
 	EnsureZoneTokenSigningKeyExists,
 	EnsureHostnameGeneratorExists,
 }
@@ -61,7 +62,7 @@ func (e *DefaultComponent) Start(stop <-chan struct{}) error {
 	go func() {
 		errChan <- retry.Do(ctx, retry.WithMaxDuration(10*time.Minute, retry.NewConstant(5*time.Second)), func(ctx context.Context) error {
 			for _, fn := range e.Funcs {
-				if err := fn(ctx, e.ResManager, logger, e.CpConfig); err != nil {
+				if err := fn(ctx, e.ResManager, logger, e.CpConfig, e.Extensions); err != nil {
 					logger.V(1).Info("could not ensure default resources. Retrying.", "err", err)
 					return retry.RetryableError(err)
 				}
@@ -81,7 +82,7 @@ func (e DefaultComponent) NeedLeaderElection() bool {
 	return true
 }
 
-func EnsureZoneTokenSigningKeyExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error {
+func EnsureZoneTokenSigningKeyExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config, extensions context.Context) error {
 	if cfg.IsFederatedZoneCP() {
 		return nil
 	}

--- a/pkg/defaults/components.go
+++ b/pkg/defaults/components.go
@@ -20,6 +20,8 @@ import (
 
 var log = core.Log.WithName("defaults")
 
+// EnsureDefaultFunc is invoked at CP boot to ensure default resources exist.
+// `extensions` carries logger fields propagated through the boot pipeline.
 type EnsureDefaultFunc = func(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config, extensions context.Context) error
 
 var EnsureDefaultFuncs = []EnsureDefaultFunc{

--- a/pkg/defaults/envoy_admin_ca.go
+++ b/pkg/defaults/envoy_admin_ca.go
@@ -18,6 +18,7 @@ func EnsureEnvoyAdminCaExists(
 	resManager manager.ResourceManager,
 	logger logr.Logger,
 	cfg kuma_cp.Config,
+	extensions context.Context,
 ) error {
 	if cfg.Mode == config_core.Global {
 		return nil // Envoy Admin CA is not synced in multizone env and not needed in Global CP.

--- a/pkg/defaults/envoy_admin_ca_test.go
+++ b/pkg/defaults/envoy_admin_ca_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Envoy Admin CA defaults", func() {
 		manager := core_manager.NewResourceManager(store)
 
 		// when
-		err := defaults.EnsureEnvoyAdminCaExists(context.Background(), manager, logr.Discard(), kuma_cp.Config{})
+		err := defaults.EnsureEnvoyAdminCaExists(context.Background(), manager, logr.Discard(), kuma_cp.Config{}, context.Background())
 
 		// then
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/defaults/hostname_generator.go
+++ b/pkg/defaults/hostname_generator.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/util/k8s"
 )
 
-func EnsureHostnameGeneratorExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error {
+func EnsureHostnameGeneratorExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config, extensions context.Context) error {
 	if cfg.Defaults.SkipHostnameGenerators {
 		log.V(1).Info("skip ensuring default hostname generators because SkipHostnameGenerators is set to true")
 		return nil

--- a/pkg/defaults/hostname_generator_test.go
+++ b/pkg/defaults/hostname_generator_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Ensure Hostname Generators", func() {
 				resManager,
 				logr.Discard(),
 				given.cpConfig,
+				context.Background(),
 			)
 
 			// then

--- a/pkg/defaults/mesh.go
+++ b/pkg/defaults/mesh.go
@@ -6,10 +6,12 @@ import (
 	"github.com/go-logr/logr"
 
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
+	config_store "github.com/kumahq/kuma/v2/pkg/config/core/resources/store"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/v2/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/v2/pkg/core/resources/store"
+	defaults_mesh "github.com/kumahq/kuma/v2/pkg/defaults/mesh"
 )
 
 var defaultMeshKey = core_model.ResourceKey{
@@ -21,6 +23,7 @@ func EnsureDefaultMeshExists(
 	resManager core_manager.ResourceManager,
 	logger logr.Logger,
 	cfg kuma_cp.Config,
+	extensions context.Context,
 ) error {
 	if cfg.Defaults.SkipMeshCreation {
 		log.V(1).Info("skipping default Mesh creation because KUMA_DEFAULTS_SKIP_MESH_CREATION is set to true")
@@ -43,5 +46,49 @@ func EnsureDefaultMeshExists(
 		return err
 	}
 	logger.Info("default Mesh created")
+	return nil
+}
+
+// EnsureDefaultMeshResourcesUpToDate reconciles the default policies of every
+// Mesh on CP boot. Default policies created by older CP versions predate
+// computed labels — without 'kuma.io/zone' their KRI carries an empty zone
+// slot and /_kri lookups fail. Reconciliation heals such resources in place.
+// Default policies an operator deleted are left absent — only labels of
+// existing resources are reconciled, never recreated.
+func EnsureDefaultMeshResourcesUpToDate(
+	ctx context.Context,
+	resManager core_manager.ResourceManager,
+	logger logr.Logger,
+	cfg kuma_cp.Config,
+	extensions context.Context,
+) error {
+	if cfg.Defaults.SkipMeshCreation {
+		return nil
+	}
+	if cfg.IsFederatedZoneCP() {
+		return nil // default resources are synced from Global CP
+	}
+	meshes := &core_mesh.MeshResourceList{}
+	if err := resManager.List(ctx, meshes); err != nil {
+		return err
+	}
+	zone := cfg.Multizone.Zone.Name
+	for _, mesh := range meshes.Items {
+		if err := defaults_mesh.EnsureDefaultMeshResources(
+			ctx,
+			resManager,
+			mesh,
+			mesh.Spec.GetSkipCreatingInitialPolicies(),
+			extensions,
+			cfg.Defaults.CreateMeshRoutingResources,
+			cfg.Store.Type == config_store.KubernetesStore,
+			cfg.Store.Kubernetes.SystemNamespace,
+			cfg.Mode,
+			zone,
+			true, // reconcile labels of existing resources, never recreate
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -146,9 +146,7 @@ func ensureDefaultResource(
 		if maps.Equal(res.GetMeta().GetLabels(), desired) {
 			return nil, false
 		}
-		// Reconcile labels on a default resource created by an older CP
-		// version that predates computed labels. Without 'kuma.io/zone' the
-		// resource's KRI carries an empty zone slot and /_kri lookups fail.
+		// Older CP versions persisted these without computed labels. Rewrite them in place.
 		if err := resManager.Update(ctx, res, store.UpdateWithLabels(desired)); err != nil {
 			return errors.Wrap(err, "could not reconcile labels of a default resource"), false
 		}

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -3,14 +3,17 @@ package mesh
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
 
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
 	"github.com/kumahq/kuma/v2/pkg/core"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/system"
+	resource_labels "github.com/kumahq/kuma/v2/pkg/core/resources/labels"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/store"
@@ -36,6 +39,9 @@ func EnsureDefaultMeshResources(
 	createMeshDefaultRoutingResources bool,
 	k8sStore bool,
 	systemNamespace string,
+	cpMode config_core.CpMode,
+	cpZone string,
+	reconcileExistingOnly bool,
 ) error {
 	ensureMux.Lock()
 	defer ensureMux.Unlock()
@@ -85,7 +91,7 @@ func EnsureDefaultMeshResources(
 
 		var msg string
 		if !slices.Contains(skippedPolicies, string(resource.Descriptor().Name)) {
-			err, created := ensureDefaultResource(ctx, resManager, resource, key)
+			err, created := ensureDefaultResource(ctx, resManager, resource, key, cpMode, cpZone, k8sStore, systemNamespace, reconcileExistingOnly)
 			if err != nil {
 				return errors.Wrapf(err, "could not create default %s %q", resource.Descriptor().Name, key.Name)
 			}
@@ -103,15 +109,64 @@ func EnsureDefaultMeshResources(
 	return nil
 }
 
-func ensureDefaultResource(ctx context.Context, resManager manager.ResourceManager, res model.Resource, resourceKey model.ResourceKey) (error, bool) {
+func ensureDefaultResource(
+	ctx context.Context,
+	resManager manager.ResourceManager,
+	res model.Resource,
+	resourceKey model.ResourceKey,
+	cpMode config_core.CpMode,
+	cpZone string,
+	k8sStore bool,
+	systemNamespace string,
+	reconcileExistingOnly bool,
+) (error, bool) {
+	computeLabels := func(existing map[string]string) (map[string]string, error) {
+		namespace := resource_labels.UnsetNamespace
+		if k8sStore {
+			namespace = resource_labels.NewNamespace(systemNamespace, true)
+		}
+		return resource_labels.Compute(
+			res.Descriptor(),
+			res.GetSpec(),
+			existing,
+			resourceKey.Mesh,
+			resource_labels.WithMode(cpMode),
+			resource_labels.WithZone(cpZone),
+			resource_labels.WithK8s(k8sStore),
+			resource_labels.WithNamespace(namespace),
+		)
+	}
+
 	err := resManager.Get(ctx, res, store.GetBy(resourceKey), store.GetConsistent())
 	if err == nil {
+		desired, err := computeLabels(res.GetMeta().GetLabels())
+		if err != nil {
+			return errors.Wrap(err, "could not compute labels for a default resource"), false
+		}
+		if maps.Equal(res.GetMeta().GetLabels(), desired) {
+			return nil, false
+		}
+		// Reconcile labels on a default resource created by an older CP
+		// version that predates computed labels. Without 'kuma.io/zone' the
+		// resource's KRI carries an empty zone slot and /_kri lookups fail.
+		if err := resManager.Update(ctx, res, store.UpdateWithLabels(desired)); err != nil {
+			return errors.Wrap(err, "could not reconcile labels of a default resource"), false
+		}
 		return nil, false
 	}
 	if !store.IsNotFound(err) {
 		return errors.Wrap(err, "could not retrieve a resource"), false
 	}
-	if err := resManager.Create(ctx, res, store.CreateBy(resourceKey)); err != nil {
+	if reconcileExistingOnly {
+		// Boot-time reconciliation only heals labels of existing default
+		// resources; it must not recreate ones an operator deleted.
+		return nil, false
+	}
+	desired, err := computeLabels(nil)
+	if err != nil {
+		return errors.Wrap(err, "could not compute labels for a default resource"), false
+	}
+	if err := resManager.Create(ctx, res, store.CreateBy(resourceKey), store.CreateWithLabels(desired)); err != nil {
 		return errors.Wrap(err, "could not create a resource"), false
 	}
 	return nil, true

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/manager"
@@ -34,7 +36,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 	Context("When creating default routing resources is disabled", func() {
 		It("should create default resources in targetRef model", func() {
 			// when
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then Dataplane Token Signing Key for the mesh exists
@@ -68,10 +70,10 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 		It("should ignore subsequent calls to EnsureDefaultMeshResources", func() {
 			// given already ensured default resources
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 			// when ensuring again
-			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "")
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "default", false)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
@@ -90,7 +92,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 		It("should skip creating all default policies", func() {
 			// when
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"*"}, context.Background(), false, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"*"}, context.Background(), false, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then default policies don't exist
@@ -116,7 +118,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 		It("should skip creating selected default policies", func() {
 			// when
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"MeshTimeout", "MeshRetry"}, context.Background(), false, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"MeshTimeout", "MeshRetry"}, context.Background(), false, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then default MeshRetry doesn't exist
@@ -141,10 +143,70 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 		})
 	})
 
+	Context("Computed labels on default policies", func() {
+		It("should set kuma.io/zone and kuma.io/origin on created default policies", func() {
+			// when
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "zone-1", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then a plugin-originated default policy carries zone/origin labels
+			mcb := meshcircuitbreaker.NewMeshCircuitBreakerResource()
+			err = resManager.Get(context.Background(), mcb, core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mcb.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ZoneTag, "zone-1"))
+			Expect(mcb.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin)))
+		})
+
+		It("should heal a default policy stored without labels by an older CP version", func() {
+			// given default resources exist
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "zone-1", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// and a default policy stripped of labels, as an older CP version stored it
+			stale := meshcircuitbreaker.NewMeshCircuitBreakerResource()
+			err = resManager.Get(context.Background(), stale, core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			err = resManager.Update(context.Background(), stale, core_store.UpdateWithLabels(map[string]string{}))
+			Expect(err).ToNot(HaveOccurred())
+
+			// when EnsureDefaultMeshResources runs in reconcile-only mode
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "zone-1", true)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then the stale default policy is reconciled in place
+			healed := meshcircuitbreaker.NewMeshCircuitBreakerResource()
+			err = resManager.Get(context.Background(), healed, core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(healed.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ZoneTag, "zone-1"))
+		})
+
+		It("should not recreate a default policy deleted by an operator", func() {
+			// given default resources exist
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "zone-1", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// and an operator deleted one of them
+			err = resManager.Delete(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.DeleteByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+
+			// when EnsureDefaultMeshResources runs in reconcile-only mode
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, false, "", config_core.Zone, "zone-1", true)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then the deleted policy stays absent
+			err = resManager.Get(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
+			Expect(core_store.IsNotFound(err)).To(BeTrue())
+
+			// and the remaining policies are untouched
+			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("When creating default routing resources is enabled", func() {
 		It("should create default resources", func() {
 			// when
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), true, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), true, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then default TrafficPermission for the mesh exist
@@ -178,10 +240,10 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 		It("should ignore subsequent calls to EnsureDefaultMeshResources", func() {
 			// given already ensured default resources
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), true, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), true, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 			// when ensuring again
-			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), true, false, "")
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), true, false, "", config_core.Zone, "default", false)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
@@ -204,7 +266,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 		It("should skip creating all default policies", func() {
 			// when
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"*"}, context.Background(), true, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"*"}, context.Background(), true, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then default TrafficPermission doesn't exist
@@ -238,7 +300,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 		It("should skip creating selected default policies", func() {
 			// when
-			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"TrafficPermission", "MeshRetry"}, context.Background(), true, false, "")
+			err := mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{"TrafficPermission", "MeshRetry"}, context.Background(), true, false, "", config_core.Zone, "default", false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// then default TrafficPermission doesn't exist

--- a/pkg/defaults/mesh_test.go
+++ b/pkg/defaults/mesh_test.go
@@ -1,0 +1,102 @@
+package defaults_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
+	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	core_manager "github.com/kumahq/kuma/v2/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/v2/pkg/core/resources/store"
+	"github.com/kumahq/kuma/v2/pkg/defaults"
+	defaults_mesh "github.com/kumahq/kuma/v2/pkg/defaults/mesh"
+	meshcircuitbreaker "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/plugins/resources/memory"
+)
+
+var _ = Describe("EnsureDefaultMeshResourcesUpToDate", func() {
+	var resManager core_manager.ResourceManager
+
+	zoneConfig := func() kuma_cp.Config {
+		cfg := kuma_cp.DefaultConfig()
+		cfg.Mode = config_core.Zone
+		cfg.Multizone.Zone.Name = "zone-1"
+		return cfg
+	}
+
+	mcbKey := func(mesh string) core_store.GetOptionsFunc {
+		return core_store.GetByKey("mesh-circuit-breaker-all-"+mesh, mesh)
+	}
+
+	// createMeshWithStaleDefaults persists a Mesh and its default policies as
+	// an older CP version stored them: the MeshCircuitBreaker carries no labels.
+	createMeshWithStaleDefaults := func(name string) {
+		m := core_mesh.NewMeshResource()
+		err := resManager.Create(context.Background(), m, core_store.CreateByKey(name, core_model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+		err = defaults_mesh.EnsureDefaultMeshResources(context.Background(), resManager, m, []string{}, context.Background(), false, false, "", config_core.Zone, "zone-1", false)
+		Expect(err).ToNot(HaveOccurred())
+		mcb := meshcircuitbreaker.NewMeshCircuitBreakerResource()
+		Expect(resManager.Get(context.Background(), mcb, mcbKey(name))).ToNot(HaveOccurred())
+		Expect(resManager.Update(context.Background(), mcb, core_store.UpdateWithLabels(map[string]string{}))).ToNot(HaveOccurred())
+	}
+
+	mcbZoneLabel := func(mesh string) string {
+		mcb := meshcircuitbreaker.NewMeshCircuitBreakerResource()
+		Expect(resManager.Get(context.Background(), mcb, mcbKey(mesh))).ToNot(HaveOccurred())
+		return mcb.GetMeta().GetLabels()[mesh_proto.ZoneTag]
+	}
+
+	BeforeEach(func() {
+		resManager = core_manager.NewResourceManager(memory.NewStore())
+	})
+
+	It("reconciles labels of default policies of every Mesh", func() {
+		// given two Meshes whose default policies predate computed labels
+		createMeshWithStaleDefaults(core_model.DefaultMesh)
+		createMeshWithStaleDefaults("other")
+
+		// when
+		err := defaults.EnsureDefaultMeshResourcesUpToDate(context.Background(), resManager, logr.Discard(), zoneConfig(), context.Background())
+
+		// then every Mesh's default policy carries 'kuma.io/zone'
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mcbZoneLabel(core_model.DefaultMesh)).To(Equal("zone-1"))
+		Expect(mcbZoneLabel("other")).To(Equal("zone-1"))
+	})
+
+	It("does not recreate a default policy deleted by an operator", func() {
+		// given default policies exist and an operator deleted one
+		createMeshWithStaleDefaults(core_model.DefaultMesh)
+		err := resManager.Delete(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.DeleteByKey("mesh-circuit-breaker-all-"+core_model.DefaultMesh, core_model.DefaultMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		err = defaults.EnsureDefaultMeshResourcesUpToDate(context.Background(), resManager, logr.Discard(), zoneConfig(), context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the deleted policy stays absent
+		err = resManager.Get(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), mcbKey(core_model.DefaultMesh))
+		Expect(core_store.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("skips a federated zone CP whose defaults come from Global", func() {
+		// given a stale default policy and a federated zone CP config
+		createMeshWithStaleDefaults(core_model.DefaultMesh)
+		cfg := zoneConfig()
+		cfg.Multizone.Zone.GlobalAddress = "grpcs://localhost:5685"
+
+		// when
+		err := defaults.EnsureDefaultMeshResourcesUpToDate(context.Background(), resManager, logr.Discard(), cfg, context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the stale policy is left untouched — the Global CP owns it
+		Expect(mcbZoneLabel(core_model.DefaultMesh)).To(BeEmpty())
+	})
+})

--- a/pkg/defaults/zone.go
+++ b/pkg/defaults/zone.go
@@ -19,6 +19,7 @@ func EnsureOnlyOneZoneExists(
 	resManager manager.ResourceManager,
 	logger logr.Logger,
 	cfg kuma_cp.Config,
+	extensions context.Context,
 ) error {
 	if cfg.Mode == config_core.Global {
 		return nil // Zone creation on Zone CP is local to the specific zone

--- a/pkg/plugins/authn/api-server/tokens/plugin.go
+++ b/pkg/plugins/authn/api-server/tokens/plugin.go
@@ -103,7 +103,7 @@ func (c *plugin) AfterBootstrap(context *plugins.MutablePluginContext, config pl
 	return nil
 }
 
-func EnsureUserTokenSigningKeyExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config) error {
+func EnsureUserTokenSigningKeyExists(ctx context.Context, resManager core_manager.ResourceManager, logger logr.Logger, cfg kuma_cp.Config, extensions context.Context) error {
 	return core_tokens.EnsureDefaultSigningKeyExist(system.UserTokenSigningKeyPrefix, ctx, resManager, logger)
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 
+	config_core "github.com/kumahq/kuma/v2/pkg/config/core"
 	core_ca "github.com/kumahq/kuma/v2/pkg/core/ca"
 	core_managers "github.com/kumahq/kuma/v2/pkg/core/managers/apis/mesh"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -28,6 +29,8 @@ type MeshReconciler struct {
 	K8sStore                   bool
 	CaManagers                 core_ca.Managers
 	SystemNamespace            string
+	CpMode                     config_core.CpMode
+	CpZone                     string
 }
 
 func (r *MeshReconciler) Reconcile(ctx context.Context, req kube_ctrl.Request) (kube_ctrl.Result, error) {
@@ -68,6 +71,9 @@ func (r *MeshReconciler) ensureDefaultResources(ctx context.Context, mesh *core_
 		r.CreateMeshRoutingResources,
 		r.K8sStore,
 		r.SystemNamespace,
+		r.CpMode,
+		r.CpZone,
+		false, // create missing default resources
 	); err != nil {
 		return errors.Wrap(err, "could not create default mesh resources")
 	}

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller.go
@@ -73,7 +73,7 @@ func (r *MeshReconciler) ensureDefaultResources(ctx context.Context, mesh *core_
 		r.SystemNamespace,
 		r.CpMode,
 		r.CpZone,
-		false, // create missing default resources
+		false, // reconcileExistingOnly
 	); err != nil {
 		return errors.Wrap(err, "could not create default mesh resources")
 	}

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -194,6 +194,8 @@ func addMeshReconciler(mgr kube_ctrl.Manager, rt core_runtime.Runtime) error {
 		K8sStore:                   rt.Config().Store.Type == store.KubernetesStore,
 		SystemNamespace:            rt.Config().Store.Kubernetes.SystemNamespace,
 		CaManagers:                 rt.CaManagers(),
+		CpMode:                     rt.Config().Mode,
+		CpZone:                     rt.Config().Multizone.Zone.Name,
 	}
 	if err := defaultsReconciller.SetupWithManager(mgr); err != nil {
 		return errors.Wrap(err, "could not setup mesh defaults reconciller")


### PR DESCRIPTION
## Motivation

KRI lookup via `/_kri/{kri}` 404s for the auto-created default mesh policies (`mesh-circuit-breaker-all-default`, `mesh-timeout-all-default`, …) on a zone CP.

Root cause: `pkg/defaults/mesh/mesh.go` creates default policies with a bare `resManager.Create(...)` — no label computation, no `CreateWithLabels`. So every default policy is persisted with zero labels. On a zone CP the resource is missing `kuma.io/zone`, its KRI carries an empty zone slot (`kri_mcb_default___mesh-circuit-breaker-all-default_`), and the lookup routes through the hashed-name path and misses the resource stored under its plain name.

User-created resources go through the API server's `createResource` → `labels.Compute`, so they're unaffected. Only the CP-auto-created defaults are broken — on every zone CP, old or new.

Fixes #15544

## Implementation information

**A — compute labels at creation.** `EnsureDefaultMeshResources` now takes the CP mode and zone. `ensureDefaultResource` computes labels via `labels.Compute` and passes `store.CreateWithLabels`, so newly created default policies carry `kuma.io/zone` / `kuma.io/origin` / `kuma.io/mesh`.

**B — heal existing resources.** `ensureDefaultResource` also reconciles labels on an already-existing default resource (recompute, `Update` if they differ — spec untouched). A new boot-time `EnsureDefaultMeshResourcesUpToDate` step iterates every Mesh and runs the reconciliation in reconcile-only mode: it updates labels of existing default policies but never recreates ones an operator deleted. Default policies stored by older CP versions are healed in place on the next CP start — no migration tooling, no manual re-apply.

Federated zone CPs are skipped (defaults come from Global via KDS). Threaded mode/zone through the two existing callers (`mesh_manager.go`, k8s `mesh_controller.go`). The `EnsureDefaultFunc` callback gained an `extensions` context so the boot-time step propagates log fields like every other caller.

> Changelog: fix(defaults): compute labels on default policies

## Supporting documentation

- kumahq/kuma#15544
- Supersedes the earlier symptom-only attempt in #16620