### PR TITLE
ci(mise): pin to v2026.5.7

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -56,6 +56,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
       - run: |
           make build
       - id: annotate-image-tag
@@ -112,6 +115,9 @@ jobs:
         run: |
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
       - id: image_meta
         env:
           REGISTRY: ${{ inputs.REGISTRY }}
@@ -228,6 +234,9 @@ jobs:
         run: |
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
       - name: package-helm-chart
         id: package-helm
         env:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -25,6 +25,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - run: |

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -99,6 +99,9 @@ jobs:
           restore-keys: |
             go-build-${{ runner.os }}-
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -23,6 +23,9 @@ jobs:
       - id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Initialize CodeQL

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -33,6 +33,9 @@ jobs:
             exit 1
           fi
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - run: |

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -99,6 +99,9 @@ jobs:
           ref: ${{ env.BRANCH_NAME }}
           token: ${{ steps.github-app-token.outputs.token }}
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         if: steps.parse-commands.outputs.has_command == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,9 @@ jobs:
         with:
           ref: "master"
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: install-kuma-ci-tools

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -18,6 +18,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: "Enable IPv6 for Docker and enable necessary kernel modules for ip6tables"

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -31,6 +31,9 @@ jobs:
           ref: master
           path: repo
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: "sync docs" # loop over all the branches and generate the docs

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: "Install tools"


### PR DESCRIPTION
## Motivation

mise v2026.5.8 swapped its sigstore backend to sigstore-rust, which doesn't yet handle cosign public-key bundle verification. Any workflow that hits a mise-action cache miss now fails installing kube-linter@0.8.x (and any other aqua tool signed the same way) with `public key verification not yet supported`.

We've already seen this take down kong-mesh's upgrade-kuma workflow. Cached runs in this repo work for now, but the moment a cache key shifts (mise.toml change, runner cycle, eviction) any of these workflows would fail the same way.

## Implementation information

Inline `version: 2026.5.7` on every `jdx/mise-action` call so we get deterministic behavior regardless of what latest mise ships.

Drop the pin once upstream restores public-key support.

## Supporting documentation

Upstream: https://github.com/jdx/mise/discussions/9889