### PR TITLE
ci(mise): use aqua for setup-envtest

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ node = "24"
 "go:github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema" = "v0.0.0-20230606235304-e35f2ad05c0c"
 "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen" = "v2.7.0"
 "go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "v0.21.0"
-"go:sigs.k8s.io/controller-runtime/tools/setup-envtest" = "v0.24.0"
+"aqua:kubernetes-sigs/controller-runtime/setup-envtest" = "0.24.0"
 "go:github.com/grafana/dashboard-linter" = "v0.0.0-20250428211052-5e22d6dc65a1"
 # === tools excluded from GitHub Actions installs ===
 # ⚠️ If you change any tool name below, update `MISE_DISABLE_TOOLS` in:


### PR DESCRIPTION
## Motivation

`setup-envtest` is a leaf submodule of `sigs.k8s.io/controller-runtime`. `go install` for the leaf path fails on a subset of Kong self-hosted runner pods: the corporate HTTPS proxy intercepts `proxy.golang.org` and 404s the leaf tag, so Go falls back to the parent module which doesn't contain that path.

Switching the source to aqua fetches the prebuilt binary from `kubernetes-sigs/controller-runtime` GitHub releases and bypasses the Go module fetch entirely.

## Implementation information

- `mise.toml`: replace `go:sigs.k8s.io/controller-runtime/tools/setup-envtest = "v0.24.0"` with `aqua:kubernetes-sigs/controller-runtime/setup-envtest = "0.24.0"`.

> Changelog: skip