### PR TITLE
test(envoyconfig): drop spurious diff op

### DIFF
--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -38,16 +38,6 @@
       }
     },
     {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/2",
       "value": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -38,16 +38,6 @@
       }
     },
     {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/2",
       "value": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -29,16 +29,6 @@
       }
     },
     {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/2",
       "value": {

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -29,16 +29,6 @@
       }
     },
     {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/2",
       "value": {

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
@@ -29,16 +29,6 @@
       }
     },
     {
-      "op": "remove",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
-      "op": "add",
-      "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/maxDirectResponseBodySizeBytes",
-      "value": 0
-    },
-    {
       "op": "add",
       "path": "/type.googleapis.com~1envoy.config.listener.v3.Listener/_kuma:dynamicconfig/filterChains/0/filters/0/typedConfig/routeConfig/virtualHosts/0/routes/2",
       "value": {

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -57,19 +57,19 @@ func getConfig(mesh, dpp string) string {
 	Expect(json.Unmarshal([]byte(redacted), &response)).To(Succeed())
 	Expect(response.Diff).ToNot(BeNil())
 	response.Diff = pointer.To(slices.DeleteFunc(*response.Diff, func(item api_common.JsonPatchItem) bool {
-		return item.Op == api_common.Test
+		// Drop Test ops (they only assert preconditions) and any standalone
+		// maxDirectResponseBodySizeBytes op. The byte count is just len(body);
+		// the shadow and the running Envoy can briefly disagree on it while
+		// the rest of the route is identical, producing a spurious remove/add
+		// pair that no golden expects. The body content + Etag hash already
+		// pin what's actually sent, so an op about only the byte count is
+		// pure noise.
+		return item.Op == api_common.Test ||
+			strings.HasSuffix(item.Path, "maxDirectResponseBodySizeBytes")
 	}))
-	// Redact maxDirectResponseBodySizeBytes everywhere: as a standalone diff
-	// path (sidecar case where the listener already existed) and nested inside
-	// a wholesale listener add value (zone-proxy case). The body content +
-	// Etag hash already pin what's actually sent; the byte count is just
-	// len(body) and changes whenever any label does, so zeroing it keeps the
-	// golden churn down to the meaningful bits.
+	// Zero maxDirectResponseBodySizeBytes nested inside wholesale listener add
+	// values: the byte count re-derives from the body the golden already pins.
 	for i := range *response.Diff {
-		if strings.HasSuffix((*response.Diff)[i].Path, "maxDirectResponseBodySizeBytes") {
-			(*response.Diff)[i].Value = 0
-			continue
-		}
 		zeroMaxDirectResponseBodySizeBytes((*response.Diff)[i].Value)
 	}
 	slices.SortStableFunc(*response.Diff, func(a, b api_common.JsonPatchItem) int {


### PR DESCRIPTION
## Motivation

The `Envoy Config – Zone Proxies` golden-file e2e test flakes on
`zoneproxies/meshmetric/prometheus.input.yaml`. The captured diff
intermittently carries an extra `remove`+`add` pair of
`maxDirectResponseBodySizeBytes` at the `_kuma:dynamicconfig` route
path that no golden file expects, so `Eventually` never converges and
times out at 90s.

> Changelog: skip

## Implementation information

`getConfig` in the test helper already treats `maxDirectResponseBodySizeBytes`
as meaningless: the byte count is just `len(body)`, and the body content
plus Etag hash already pin what Envoy actually sends. The old code only
*zeroed* the value of standalone diff ops on that path but kept the ops
themselves, so they leaked into the comparison.

The shadow config and the running Envoy briefly disagree on the byte
count while the rest of the route is identical, producing the spurious
pair. No golden file in `testdata/` has a standalone
`maxDirectResponseBodySizeBytes` diff path (verified across all
goldens) — they only appear nested inside wholesale listener `add`
values.

Fix: extend the existing `slices.DeleteFunc` to drop standalone
`maxDirectResponseBodySizeBytes` ops alongside `Test` ops. Nested-value
zeroing for wholesale listener adds is unchanged. No golden files need
updating.

## Supporting documentation

Observed flake: https://github.com/kumahq/kuma/actions/runs/25919666849/job/76186850553