### PR TITLE
chore(e2e): pin mise version

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -27,6 +27,9 @@ runs:
         remove_dotnet: true
         remove_haskell: true
     - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+        version: 2026.5.7
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - run: make build


### PR DESCRIPTION
## Motivation

We missed this one

## Implementation information

Pin version for tests

## Supporting documentation

> Changelog: skip