### PR TITLE
fix(core): fix system name prefix check

### DIFF
--- a/pkg/core/system_names/system_names.go
+++ b/pkg/core/system_names/system_names.go
@@ -16,7 +16,7 @@ const (
 var cleanNameRegex = regexp.MustCompile(`([a-z0-9-]*_?)+`)
 
 func IsSystem(name string) bool {
-	return strings.HasPrefix(SystemPrefix, name)
+	return strings.HasPrefix(name, SystemPrefix)
 }
 
 func CleanName(name string) string {

--- a/pkg/core/system_names/system_names_test.go
+++ b/pkg/core/system_names/system_names_test.go
@@ -1,0 +1,28 @@
+package system_names_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/core/system_names"
+)
+
+func TestIsSystem(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "system_foo", want: true},
+		{name: "system_", want: true},
+		{name: "foo", want: false},
+		{name: "sys", want: false},
+		{name: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := system_names.IsSystem(tt.name); got != tt.want {
+				t.Fatalf("IsSystem(%q) = %t, want %t", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

`IsSystem` had the `HasPrefix` args flipped. Tiny one, but it meant `system_foo` was not seen as system while `sys` and empty string were. oof

## Implementation information

Swap the args and add a small regression test.

Repro before this patch:

```txt
go test ./pkg/core/system_names
IsSystem("system_foo") = false, want true
IsSystem("sys") = true, want false
IsSystem("") = true, want false
```

Checked after:

```txt
go test ./pkg/core/system_names
go test ./pkg/core/...
```

## Supporting documentation

No linked issue.

> Changelog: skip