### PR TITLE
test(framework): wait for app restart

### DIFF
--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -229,8 +230,6 @@ func (s *UniversalApp) ReStart() error {
 	if err := s.KillMainApp(); err != nil {
 		return err
 	}
-	// No needed but this just in case kill -9 is not instant
-	time.Sleep(1 * time.Second)
 	return s.StartMainApp()
 }
 
@@ -240,7 +239,15 @@ func (s *UniversalApp) KillMainApp() error {
 	if err != nil {
 		return err
 	}
-	return nil
+
+	pattern := s.mainAppProcessPattern()
+	if pattern == "" {
+		return nil
+	}
+	if err := s.killMainAppProcess(pattern); err != nil {
+		return err
+	}
+	return s.waitMainAppProcessStopped(pattern)
 }
 
 func (s *UniversalApp) StartMainApp() error {
@@ -257,6 +264,51 @@ func (s *UniversalApp) CreateMainApp(cmd string) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func (s *UniversalApp) mainAppProcessPattern() string {
+	lines := strings.Split(s.mainAppCmd, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		return line
+	}
+	return strings.TrimSpace(s.mainAppCmd)
+}
+
+func (s *UniversalApp) killMainAppProcess(pattern string) error {
+	_, _, err := s.universalNetworking.RunCommand(fmt.Sprintf("pkill -9 -f %q", s.mainAppProcessRegex(pattern)))
+	if isExitStatus(err, 1) {
+		return nil
+	}
+	return err
+}
+
+func (s *UniversalApp) waitMainAppProcessStopped(pattern string) error {
+	cmd := fmt.Sprintf("pgrep -f %q", s.mainAppProcessRegex(pattern))
+	for range 20 {
+		out, _, err := s.universalNetworking.RunCommand(cmd)
+		if isExitStatus(err, 1) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		Logf("App:%q process still running: %q", s.appName, strings.TrimSpace(out))
+		time.Sleep(500 * time.Millisecond)
+	}
+	return errors.Errorf("timed out waiting for app:%q process to stop", s.appName)
+}
+
+func (s *UniversalApp) mainAppProcessRegex(pattern string) string {
+	return "^" + regexp.QuoteMeta(pattern)
+}
+
+func isExitStatus(err error, status int) bool {
+	var exitError *ssh.ExitError
+	return errors.As(err, &exitError) && exitError.ExitStatus() == status
 }
 
 func (s *UniversalApp) CreateSpireAgent(


### PR DESCRIPTION
## Motivation

App restart helpers in the e2e framework return before the new pods are
actually ready. Tests that restart an app then immediately assert on it
race the rollout and flake.

> Changelog: skip

## Implementation information

Wait for fresh ready pods after an app restart before returning, so
callers observe a settled deployment.

## Supporting documentation

Split out of #16624 (one fix per PR).