### PR TITLE
fix(motb): align env defaults with documentation

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -4649,16 +4649,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -4667,8 +4683,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -4649,16 +4649,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -4667,8 +4683,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -4669,16 +4669,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -4687,8 +4703,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -6848,16 +6848,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -6866,8 +6882,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/deployments/charts/kuma/crds/kuma.io_meshopentelemetrybackends.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshopentelemetrybackends.yaml
@@ -74,16 +74,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -92,8 +108,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -19351,20 +19351,60 @@ components:
                 in the
 
                 final exporter config for this backend.
+
+                Defaults to mode: Optional, precedence: EnvFirst,
+                allowSignalOverrides: true
+
+                when omitted.
               properties:
                 allowSignalOverrides:
                   description: >-
-                    AllowSignalOverrides controls whether signal-specific OTEL
-                    env vars such
+                    AllowSignalOverrides controls whether per-signal OTEL env
+                    vars
 
-                    as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared
-                    config.
+                    (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+
+                    OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+
+                    OTEL_EXPORTER_OTLP_* values.
+
+                    true (default): per-signal vars override the shared values
+                    for that
+
+                    signal.
+
+                    false: per-signal vars are ignored; the shared values apply
+                    to all
+
+                    signals. When per-signal overrides are dropped this way,
+
+                    SignalOverridesDisallowed appears in blockedReasons (a soft
+                    block -
+
+                    export still works via the shared config).
                   type: boolean
                 mode:
                   default: Optional
                   description: >-
-                    Mode controls whether OTEL env vars are ignored, allowed, or
-                    required.
+                    Mode controls whether OTEL env vars participate in the
+                    merge.
+
+                    Disabled: env vars are skipped entirely; only explicit
+                    backend fields and
+
+                    built-in defaults apply.
+
+                    Optional (default): env vars are used when present; absence
+                    is fine.
+
+                    Required: env vars must supply the missing fields - if any
+                    required field
+
+                    is missing the signal is blocked (state: missing,
+                    RequiredEnvMissing in
+
+                    blockedReasons) even when an explicit value or default could
+                    fill it.
                   enum:
                     - Disabled
                     - Optional
@@ -19373,10 +19413,18 @@ components:
                 precedence:
                   default: EnvFirst
                   description: >-
-                    Precedence controls whether explicit backend fields or env
-                    vars win when
+                    Precedence controls which source wins when both an explicit
+                    backend field
 
-                    both are present for the same field.
+                    and an env var are present for the same field.
+
+                    EnvFirst (default): env vars win; explicit backend fields
+                    fill gaps.
+
+                    ExplicitFirst: explicit backend fields win; env vars fill
+                    gaps.
+
+                    In either case, built-in defaults are the last fallback.
                   enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/docs/generated/raw/crds/kuma.io_meshopentelemetrybackends.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshopentelemetrybackends.yaml
@@ -74,16 +74,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -92,8 +108,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/meshopentelemetrybackend.go
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/meshopentelemetrybackend.go
@@ -26,6 +26,8 @@ type MeshOpenTelemetryBackend struct {
 	Protocol *Protocol `json:"protocol,omitempty"`
 	// Env controls whether standard OTEL exporter env vars participate in the
 	// final exporter config for this backend.
+	// Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+	// when omitted.
 	// +kubebuilder:validation:Optional
 	Env *EnvPolicy `json:"env,omitempty"`
 }
@@ -62,17 +64,34 @@ const (
 )
 
 type EnvPolicy struct {
-	// Mode controls whether OTEL env vars are ignored, allowed, or required.
+	// Mode controls whether OTEL env vars participate in the merge.
+	// Disabled: env vars are skipped entirely; only explicit backend fields and
+	// built-in defaults apply.
+	// Optional (default): env vars are used when present; absence is fine.
+	// Required: env vars must supply the missing fields - if any required field
+	// is missing the signal is blocked (state: missing, RequiredEnvMissing in
+	// blockedReasons) even when an explicit value or default could fill it.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=Optional
 	Mode EnvMode `json:"mode"`
-	// Precedence controls whether explicit backend fields or env vars win when
-	// both are present for the same field.
+	// Precedence controls which source wins when both an explicit backend field
+	// and an env var are present for the same field.
+	// EnvFirst (default): env vars win; explicit backend fields fill gaps.
+	// ExplicitFirst: explicit backend fields win; env vars fill gaps.
+	// In either case, built-in defaults are the last fallback.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=EnvFirst
 	Precedence EnvPrecedence `json:"precedence"`
-	// AllowSignalOverrides controls whether signal-specific OTEL env vars such
-	// as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+	// AllowSignalOverrides controls whether per-signal OTEL env vars
+	// (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+	// OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+	// OTEL_EXPORTER_OTLP_* values.
+	// true (default): per-signal vars override the shared values for that
+	// signal.
+	// false: per-signal vars are ignored; the shared values apply to all
+	// signals. When per-signal overrides are dropped this way,
+	// SignalOverridesDisallowed appears in blockedReasons (a soft block -
+	// export still works via the shared config).
 	AllowSignalOverrides *bool `json:"allowSignalOverrides,omitempty"`
 }
 

--- a/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/rest.yaml
@@ -180,15 +180,32 @@ components:
               description: |-
                 Env controls whether standard OTEL exporter env vars participate in the
                 final exporter config for this backend.
+                Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                when omitted.
               properties:
                 allowSignalOverrides:
                   description: |-
-                    AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                    as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                    AllowSignalOverrides controls whether per-signal OTEL env vars
+                    (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                    OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                    OTEL_EXPORTER_OTLP_* values.
+                    true (default): per-signal vars override the shared values for that
+                    signal.
+                    false: per-signal vars are ignored; the shared values apply to all
+                    signals. When per-signal overrides are dropped this way,
+                    SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                    export still works via the shared config).
                   type: boolean
                 mode:
                   default: Optional
-                  description: Mode controls whether OTEL env vars are ignored, allowed, or required.
+                  description: |-
+                    Mode controls whether OTEL env vars participate in the merge.
+                    Disabled: env vars are skipped entirely; only explicit backend fields and
+                    built-in defaults apply.
+                    Optional (default): env vars are used when present; absence is fine.
+                    Required: env vars must supply the missing fields - if any required field
+                    is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                    blockedReasons) even when an explicit value or default could fill it.
                   enum:
                     - Disabled
                     - Optional
@@ -197,8 +214,11 @@ components:
                 precedence:
                   default: EnvFirst
                   description: |-
-                    Precedence controls whether explicit backend fields or env vars win when
-                    both are present for the same field.
+                    Precedence controls which source wins when both an explicit backend field
+                    and an env var are present for the same field.
+                    EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                    ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                    In either case, built-in defaults are the last fallback.
                   enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/pkg/core/resources/apis/meshopentelemetrybackend/k8s/crd/kuma.io_meshopentelemetrybackends.yaml
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/k8s/crd/kuma.io_meshopentelemetrybackends.yaml
@@ -74,16 +74,32 @@ spec:
                 description: |-
                   Env controls whether standard OTEL exporter env vars participate in the
                   final exporter config for this backend.
+                  Defaults to mode: Optional, precedence: EnvFirst, allowSignalOverrides: true
+                  when omitted.
                 properties:
                   allowSignalOverrides:
                     description: |-
-                      AllowSignalOverrides controls whether signal-specific OTEL env vars such
-                      as `OTEL_EXPORTER_OTLP_TRACES_*` may diverge from the shared config.
+                      AllowSignalOverrides controls whether per-signal OTEL env vars
+                      (OTEL_EXPORTER_OTLP_TRACES_*, OTEL_EXPORTER_OTLP_METRICS_*,
+                      OTEL_EXPORTER_OTLP_LOGS_*) may diverge from the shared
+                      OTEL_EXPORTER_OTLP_* values.
+                      true (default): per-signal vars override the shared values for that
+                      signal.
+                      false: per-signal vars are ignored; the shared values apply to all
+                      signals. When per-signal overrides are dropped this way,
+                      SignalOverridesDisallowed appears in blockedReasons (a soft block -
+                      export still works via the shared config).
                     type: boolean
                   mode:
                     default: Optional
-                    description: Mode controls whether OTEL env vars are ignored,
-                      allowed, or required.
+                    description: |-
+                      Mode controls whether OTEL env vars participate in the merge.
+                      Disabled: env vars are skipped entirely; only explicit backend fields and
+                      built-in defaults apply.
+                      Optional (default): env vars are used when present; absence is fine.
+                      Required: env vars must supply the missing fields - if any required field
+                      is missing the signal is blocked (state: missing, RequiredEnvMissing in
+                      blockedReasons) even when an explicit value or default could fill it.
                     enum:
                     - Disabled
                     - Optional
@@ -92,8 +108,11 @@ spec:
                   precedence:
                     default: EnvFirst
                     description: |-
-                      Precedence controls whether explicit backend fields or env vars win when
-                      both are present for the same field.
+                      Precedence controls which source wins when both an explicit backend field
+                      and an env var are present for the same field.
+                      EnvFirst (default): env vars win; explicit backend fields fill gaps.
+                      ExplicitFirst: explicit backend fields win; env vars fill gaps.
+                      In either case, built-in defaults are the last fallback.
                     enum:
                     - ExplicitFirst
                     - EnvFirst

--- a/pkg/plugins/policies/core/xds/otel.go
+++ b/pkg/plugins/policies/core/xds/otel.go
@@ -201,8 +201,8 @@ func BuildSignalRuntimePlan(
 	signal core_xds.OtelSignal,
 	options AddResolvedBackendOptions,
 ) core_xds.OtelSignalRuntimePlan {
-	mode := motb_api.EnvModeOptional
-	allowOverrides := false
+	mode := motb_api.DefaultEnvMode
+	allowOverrides := motb_api.DefaultAllowSignalOverrides
 	if envPolicy != nil {
 		mode = envPolicy.Mode
 		allowOverrides = envPolicy.AllowSignalOverrides

--- a/pkg/plugins/policies/core/xds/otel_test.go
+++ b/pkg/plugins/policies/core/xds/otel_test.go
@@ -455,6 +455,27 @@ var _ = Describe("BuildSignalRuntimePlan", func() {
 		Expect(plan.BlockedReasons).To(BeEmpty())
 	})
 
+	It("should allow per-signal overrides when env block is omitted", func() {
+		plan := policies_xds.BuildSignalRuntimePlan(
+			&core_xds.OtelBootstrapInventory{
+				Shared: &core_xds.OtelSignalEnvInventory{
+					EndpointPresent: true,
+				},
+				Traces: &core_xds.OtelSignalEnvInventory{
+					OverrideKinds: []string{"endpoint"},
+				},
+			},
+			nil,
+			core_xds.OtelSignalTraces,
+			policies_xds.AddResolvedBackendOptions{},
+		)
+
+		Expect(plan.Enabled).To(BeTrue())
+		Expect(plan.EnvInputPresent).To(BeTrue())
+		Expect(plan.OverrideKinds).To(ConsistOf("endpoint"))
+		Expect(plan.BlockedReasons).NotTo(ContainElement(core_xds.OtelBlockedReasonSignalOverridesBlocked))
+	})
+
 	It("should mark disabled env mode with env input as blocked by policy", func() {
 		plan := policies_xds.BuildSignalRuntimePlan(
 			&core_xds.OtelBootstrapInventory{


### PR DESCRIPTION
## Motivation

The `MeshOpenTelemetryBackend.spec.env` block has a documented default of `mode: Optional`, `precedence: EnvFirst`, `allowSignalOverrides: true` - encoded in the `DefaultAllowSignalOverrides` constant and the `EffectiveAllowSignalOverrides()` helper. Two gaps came up while reviewing the companion website PR:

1. The proto field comments only said what each field controls, not how the values behave - so the autogenerated CRD/OpenAPI descriptions were too thin to replace the manual website table.
2. `BuildSignalRuntimePlan` defaulted `allowOverrides = false` when the whole `env:` block was omitted (resolved policy nil), contradicting the documented default. This caused `SignalOverridesDisallowed` to spuriously appear in `blockedReasons` for backends with no `env:` block whenever the sidecar carried per-signal `OTEL_EXPORTER_OTLP_*_*` env vars.

## Implementation information

- Expanded Godoc comments on `EnvPolicy.Mode`, `EnvPolicy.Precedence`, `EnvPolicy.AllowSignalOverrides`, and the parent `Env` field to spell out per-value behaviour and the relevant `blockedReasons`. Regenerated CRDs and `rest.yaml`.
- Fixed `BuildSignalRuntimePlan` to default `mode` and `allowOverrides` from the named API constants (`DefaultEnvMode`, `DefaultAllowSignalOverrides`) instead of inline `EnvModeOptional` / `false`, so the nil-env-block path matches the documented default. Added a regression test for the omitted-env-block case.

## Supporting documentation

Companion website PR: kumahq/kuma-website#2694. The default-mismatch was caught by an automated reviewer comment on this PR's earlier doc-only revision.

<!--
-->

> Changelog: feat(kuma-cp): add MeshOpenTelemetryBackend for shared policy-based OpenTelemetry backends
