### PR TITLE
docs(docs): note multi-instance readiness port

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -64,6 +64,7 @@ The kuma-dp readiness reporter no longer listens on a Unix domain socket. `/read
 **Action required:**
 
 - Universal-mode operators who probed readiness via the Unix socket must switch to TCP loopback: `curl http://localhost:9902/ready`.
+- Universal-mode hosts running more than one `kuma-dp` instance must assign a distinct `KUMA_READINESS_PORT` per instance. Instances previously shared a Unix socket; they now all default to TCP `9902` and will fail to bind on conflict.
 - Custom manifests that still set `KUMA_READINESS_UNIX_SOCKET_DISABLED` can leave the env var in place — it is ignored — or remove it.
 
 ### dp-server graceful shutdown is now time-bounded

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -64,7 +64,12 @@ The kuma-dp readiness reporter no longer listens on a Unix domain socket. `/read
 **Action required:**
 
 - Universal-mode operators who probed readiness via the Unix socket must switch to TCP loopback: `curl http://localhost:9902/ready`.
-- Universal-mode hosts running more than one `kuma-dp` instance must assign a distinct `KUMA_READINESS_PORT` per instance. Instances previously shared a Unix socket; they now all default to TCP `9902` and will fail to bind on conflict.
+- Universal-mode hosts running more than one `kuma-dp` instance must assign a distinct `KUMA_READINESS_PORT` per instance. Each instance previously used its own Unix socket; they now all default to TCP `9902` and will fail to bind on conflict:
+
+  ```sh
+  KUMA_READINESS_PORT=9902 kuma-dp run ...   # instance 1
+  KUMA_READINESS_PORT=9903 kuma-dp run ...   # instance 2
+  ```
 - Custom manifests that still set `KUMA_READINESS_UNIX_SOCKET_DISABLED` can leave the env var in place — it is ignored — or remove it.
 
 ### dp-server graceful shutdown is now time-bounded


### PR DESCRIPTION
## Motivation

#16583 made the kuma-dp readiness reporter TCP-only and added an
`UPGRADE.md` entry, but the entry misses one migration case.

UDS readiness was originally introduced (#13924 / #12001) specifically
to avoid TCP `9902` port conflicts when running multiple `kuma-dp`
instances on a single host in Universal mode. With UDS removed, those
instances all default to TCP `9902` again and fail to bind on conflict
— the exact problem #12001 solved.

> Changelog: skip

## Implementation information

Add one `Action required` bullet to the existing "Readiness reporter is
now TCP-only" section: Universal hosts running multiple `kuma-dp`
instances must assign a distinct `KUMA_READINESS_PORT` per instance.

`KUMA_READINESS_PORT` was kept by #16583, so the fix already exists —
this only documents it.

## Supporting documentation

- Issue: #14039
- Prior PR: #16583
- Origin of UDS readiness: #13924 / #12001
