### PR TITLE
feat(hostnamegenerator): validate rendered template at creation

### DIFF
--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate.go
@@ -1,9 +1,12 @@
 package v1alpha1
 
 import (
+	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
+	k8s_validation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/kumahq/kuma/v2/pkg/core/validators"
 )
@@ -39,12 +42,36 @@ func validateTemplate(tmpl string) validators.ValidationError {
 	var verr validators.ValidationError
 	if tmpl == "" {
 		verr.AddViolationAt(validators.Root(), validators.MustNotBeEmpty)
+		return verr
 	}
-	_, err := template.New("").
-		Funcs(map[string]any{"label": func(key string) (string, error) { return "", nil }}).
+	parsed, err := template.New("").
+		Funcs(map[string]any{"label": func(string) (string, error) { return "label", nil }}).
 		Parse(tmpl)
 	if err != nil {
 		verr.AddViolationAt(validators.Root(), errors.Wrap(err, "couldn't parse template").Error())
+		return verr
+	}
+	stub := struct {
+		Name        string
+		DisplayName string
+		Namespace   string
+		Mesh        string
+		Zone        string
+	}{
+		Name:        "name",
+		DisplayName: "displayname",
+		Namespace:   "namespace",
+		Mesh:        "mesh",
+		Zone:        "zone",
+	}
+	var sb strings.Builder
+	if err := parsed.Execute(&sb, stub); err != nil {
+		verr.AddViolationAt(validators.Root(), errors.Wrap(err, "couldn't render template with stub values").Error())
+		return verr
+	}
+	rendered := sb.String()
+	if violations := k8s_validation.IsDNS1123Subdomain(rendered); len(violations) > 0 {
+		verr.AddViolationAt(validators.Root(), fmt.Sprintf("template renders to %q which is not a valid DNS name: %s", rendered, strings.Join(violations, ", ")))
 	}
 	return verr
 }

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate_test.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/validate_test.go
@@ -57,6 +57,42 @@ selector:
   meshService: {}
   meshExternalService: {}
 `),
+		ErrorCase("spec.template renders to uppercase",
+			validators.Violation{
+				Field:   `spec.template`,
+				Message: `template renders to "name.MESH" which is not a valid DNS name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			}, `
+template: "{{ .Name }}.MESH"
+selector:
+  meshService: {}
+`),
+		ErrorCase("spec.template renders with leading dot",
+			validators.Violation{
+				Field:   `spec.template`,
+				Message: `template renders to ".name.mesh" which is not a valid DNS name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			}, `
+template: ".{{ .Name }}.mesh"
+selector:
+  meshService: {}
+`),
+		ErrorCase("spec.template renders with consecutive dots",
+			validators.Violation{
+				Field:   `spec.template`,
+				Message: `template renders to "name..mesh" which is not a valid DNS name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			}, `
+template: "{{ .Name }}..mesh"
+selector:
+  meshService: {}
+`),
+		ErrorCase("spec.template renders with underscore",
+			validators.Violation{
+				Field:   `spec.template`,
+				Message: `template renders to "name_svc.mesh" which is not a valid DNS name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			}, `
+template: "{{ .Name }}_svc.mesh"
+selector:
+  meshService: {}
+`),
 	)
 	DescribeValidCases(
 		api.NewHostnameGeneratorResource,
@@ -69,6 +105,16 @@ selector:
 template: "{{ .Name }}.mesh"
 selector:
   meshMultiZoneService: {}
+`),
+		Entry("accepts template using all builtin fields", `
+template: "{{ .Name }}.{{ .DisplayName }}.{{ .Namespace }}.{{ .Mesh }}.{{ .Zone }}.mesh"
+selector:
+  meshService: {}
+`),
+		Entry("accepts template using label function", `
+template: "{{ label \"app\" }}.mesh"
+selector:
+  meshService: {}
 `),
 	)
 })


### PR DESCRIPTION
## Motivation

Until now an invalid template only failed at generation time, surfacing as a status condition on the affected service. Users had no signal at `kubectl apply/kumactl apply` and often noticed the broken hostname much later.

## Implementation information

Render the template at admission time with stub values for the built-in fields (`Name`, `DisplayName`, `Namespace`, `Mesh`, `Zone`) and a fixed `"label"` token for any `label "<key>"` call, then check the result with `IsDNS1123Subdomain`. This doesn't solve all edge cases but with current state where we require each Name/DisplayName/Namespace/Mesh/Zone to be RFC1035 compatible it should verify if generated DNS name is correct.