### PR TITLE
ci(scorecard): pin runs-on to ubuntu-24.04

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,7 +14,10 @@ jobs:
   analysis:
     timeout-minutes: 10
     name: Scorecard analysis
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    # Must be a literal Ubuntu label; the scorecard-action publish step
+    # rejects expression-based runs-on values during workflow verification.
+    # See https://github.com/ossf/scorecard-action#workflow-restrictions
+    runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
     # Must be a literal Ubuntu label; the scorecard-action publish step
     # rejects expression-based runs-on values during workflow verification.
     # See https://github.com/ossf/scorecard-action#workflow-restrictions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
## Motivation

The daily Scorecard workflow has been failing since 2026-05-16 with:

```
workflow verification failed: scorecard job should have exactly 1 'Ubuntu' virtual environment
```

The scorecard-action publish step fetches the workflow via the GitHub API and runs its own verifier, which requires `runs-on:` to be a literal Ubuntu label (see [workflow-restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)). PR #16629 routed every `runs-on:` through `${{ vars.RUNS_ON_* || ... }}`, and that expression form trips the verifier regardless of what it resolves to.

SARIF upload to code-scanning was unaffected - alerts kept landing daily - but the publish step exits non-zero so the workflow runs red on master.

## Implementation information

- Pin `.github/workflows/scorecard.yml` back to `runs-on: ubuntu-latest`.
- Add a short comment pointing at the workflow-restrictions doc so a future RUNS_ON sweep doesn't reintroduce the expression.

The workflow is cron-only (daily) so it doesn't benefit from runner-pool routing.

> Changelog: skip