### PR TITLE
feat(xds): delta xDS Helm + injection (bp 16392)

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -940,6 +940,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW).
+  deltaXds: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -290,6 +290,7 @@ A Helm chart for the Kuma Control Plane
 | experimental.ebpf.tcAttachIface | string | `""` | Name of the network interface which TC programs should be attached to, we'll try to automatically determine it if empty |
 | experimental.ebpf.programsSourcePath | string | `"/tmp/kuma-ebpf"` | Path where compiled eBPF programs which will be installed can be found |
 | experimental.sidecarContainers | bool | `false` | If true, enable native Kubernetes sidecars. This requires at least Kubernetes v1.29 |
+| experimental.deltaXds | bool | `false` | If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW). |
 | postgres.port | string | `"5432"` | Postgres port, password should be provided as a secret reference in "controlPlane.secrets" with the Env value "KUMA_STORE_POSTGRES_PASSWORD". Example: controlPlane:   secrets:     - Secret: postgres-postgresql       Key: postgresql-password       Env: KUMA_STORE_POSTGRES_PASSWORD |
 | postgres.tls.mode | string | `"disable"` | Mode of TLS connection. Available values are: "disable", "verifyNone", "verifyCa", "verifyFull" |
 | postgres.tls.disableSSLSNI | bool | `false` | Whether to disable SNI the postgres `sslsni` option. |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -307,6 +307,10 @@ env:
 - name: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
   value: "true"
 {{- end }}
+{{- if .Values.experimental.deltaXds }}
+- name: KUMA_EXPERIMENTAL_DELTA_XDS
+  value: "true"
+{{- end }}
 {{- if and .Values.cni.enabled .Values.cni.taintController.enabled }}
 - name: KUMA_RUNTIME_KUBERNETES_NODE_TAINT_CONTROLLER_ENABLED
   value: "true"

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -940,6 +940,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW).
+  deltaXds: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -940,6 +940,8 @@ experimental:
   # -- If true, enable native Kubernetes sidecars. This requires at least
   # Kubernetes v1.29
   sidecarContainers: false
+  # -- If true, uses Delta xDS (incremental) protocol to deliver changes to sidecars instead of State of the World (SOTW).
+  deltaXds: false
 
 # Postgres' settings for universal control plane on k8s
 postgres:

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -38,6 +38,7 @@ type DataplaneProxyFactory struct {
 	applicationProbeProxyPort    uint32
 	unifiedResourceNamingEnabled bool
 	spireEnabled                 bool
+	deltaXdsEnabled              bool
 }
 
 func NewDataplaneProxyFactory(
@@ -52,6 +53,7 @@ func NewDataplaneProxyFactory(
 	applicationProbeProxyPort uint32,
 	unifiedResourceNamingEnabled bool,
 	spireEnabled bool,
+	deltaXdsEnabled bool,
 ) *DataplaneProxyFactory {
 	return &DataplaneProxyFactory{
 		ControlPlaneURL:              controlPlaneURL,
@@ -65,6 +67,7 @@ func NewDataplaneProxyFactory(
 		applicationProbeProxyPort:    applicationProbeProxyPort,
 		unifiedResourceNamingEnabled: unifiedResourceNamingEnabled,
 		spireEnabled:                 spireEnabled,
+		deltaXdsEnabled:              deltaXdsEnabled,
 	}
 }
 
@@ -276,6 +279,12 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 			Name:  "KUMA_CONTROL_PLANE_CA_CERT",
 			Value: i.ControlPlaneCACert,
 		},
+	}
+	if i.deltaXdsEnabled {
+		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT"] = kube_core.EnvVar{
+			Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+			Value: "DELTA_GRPC",
+		}
 	}
 	if xdsTransportProtocol, exist := metadata.Annotations(podAnnotations).GetString(metadata.KumaXdsTransportProtocolVariant); exist {
 		envVars["KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT"] = kube_core.EnvVar{

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -383,6 +383,7 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 			converter,
 			rt.Config().GetEnvoyAdminPort(),
 			rt.Config().Store.Kubernetes.SystemNamespace,
+			rt.Config().Experimental.DeltaXds,
 		)
 		if err != nil {
 			return err

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -94,7 +94,7 @@ func addGatewayReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime, conve
 
 	proxyFactory := containers.NewDataplaneProxyFactory(
 		cpURL, caCert, rt.Config().GetEnvoyAdminPort(), cfg.SidecarContainer.DataplaneContainer, cfg.BuiltinDNS,
-		false, false, false, 0, cfg.UnifiedResourceNamingEnabled, cfg.Spire.Enabled,
+		false, false, false, 0, cfg.UnifiedResourceNamingEnabled, cfg.Spire.Enabled, rt.Config().Experimental.DeltaXds,
 	)
 
 	kubeConfig := mgr.GetConfig()

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -102,6 +102,7 @@ func New(
 	converter k8s_common.Converter,
 	envoyAdminPort uint32,
 	systemNamespace string,
+	deltaXdsEnabled bool,
 ) (*KumaInjector, error) {
 	var caCert string
 	if cfg.CaCertFile != "" {
@@ -121,7 +122,7 @@ func New(
 			controlPlaneURL, caCert, envoyAdminPort, cfg.SidecarContainer.DataplaneContainer,
 			cfg.BuiltinDNS, cfg.SidecarContainer.WaitForDataplaneReady, sidecarContainersEnabled,
 			cfg.VirtualProbesEnabled, cfg.ApplicationProbeProxyPort, cfg.UnifiedResourceNamingEnabled,
-			cfg.Spire.Enabled,
+			cfg.Spire.Enabled, deltaXdsEnabled,
 		),
 		systemNamespace: systemNamespace,
 	}, nil

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -92,7 +92,7 @@ spec:
 				var cfg conf.Injector
 				Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 				cfg.CaCertFile = caCertPath
-				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, sidecarsEnabled, k8s.NewSimpleConverter(), 9901, systemNamespace)
+				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, sidecarsEnabled, k8s.NewSimpleConverter(), 9901, systemNamespace, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				// and create mesh
@@ -887,7 +887,7 @@ spec:
 			var cfg conf.Injector
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, systemNamespace)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, systemNamespace, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -993,7 +993,7 @@ spec:
 			var cfg conf.Injector
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, systemNamespace)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, systemNamespace, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1064,4 +1064,119 @@ spec:
 			cfgFile: "inject.config.yaml",
 		}),
 	)
+
+	Describe("delta xDS injection", func() {
+		const (
+			defaultMesh = `
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default`
+			defaultNamespace = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kuma.io/sidecar-injection: enabled`
+		)
+
+		newInjector := func(deltaXdsEnabled bool) *inject.KumaInjector {
+			var cfg conf.Injector
+			ExpectWithOffset(1, config.Load(filepath.Join("testdata", "inject.config.yaml"), &cfg)).To(Succeed())
+			cfg.CaCertFile = caCertPath
+			inj, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, false, k8s.NewSimpleConverter(), 9901, systemNamespace, deltaXdsEnabled)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			return inj
+		}
+
+		injectPod := func(injector *inject.KumaInjector, podYAML string) *kube_core.Pod {
+			decoder := serializer.NewCodecFactory(k8sClientScheme).UniversalDeserializer()
+
+			obj, _, err := decoder.Decode([]byte(defaultMesh), nil, nil)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, k8sClient.Create(context.Background(), obj.(kube_client.Object))).To(Succeed())
+
+			ns, _, err := decoder.Decode([]byte(defaultNamespace), nil, nil)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, k8sClient.Update(context.Background(), ns.(kube_client.Object))).To(Succeed())
+
+			pod := &kube_core.Pod{}
+			ExpectWithOffset(1, yaml.Unmarshal([]byte(podYAML), pod)).To(Succeed())
+			ExpectWithOffset(1, injector.InjectKuma(context.Background(), pod)).To(Succeed())
+			return pod
+		}
+
+		sidecarEnv := func(pod *kube_core.Pod) []kube_core.EnvVar {
+			for _, c := range pod.Spec.Containers {
+				if c.Name == k8s_util.KumaSidecarContainerName {
+					return c.Env
+				}
+			}
+			return nil
+		}
+
+		It("sets DELTA_GRPC transport on the injected sidecar", func() {
+			pod := injectPod(newInjector(true), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox`)
+
+			Expect(sidecarEnv(pod)).To(ContainElement(kube_core.EnvVar{
+				Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+				Value: "DELTA_GRPC",
+			}))
+		})
+
+		It("allows per-pod xds-transport-protocol-variant annotation to override deltaXds", func() {
+			// The per-pod annotation is applied after deltaXdsEnabled, so it takes precedence.
+			pod := injectPod(newInjector(true), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  annotations:
+    kuma.io/xds-transport-protocol-variant: "GRPC"
+  labels:
+    run: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox`)
+
+			Expect(sidecarEnv(pod)).To(ContainElement(kube_core.EnvVar{
+				Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+				Value: "GRPC",
+			}))
+		})
+
+		It("allows kuma.io/sidecar-env-vars to override the transport variant", func() {
+			// sidecar-env-vars runs after deltaXdsEnabled, so the annotation wins.
+			pod := injectPod(newInjector(true), `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  annotations:
+    kuma.io/sidecar-env-vars: "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT=GRPC"
+  labels:
+    run: busybox
+spec:
+  containers:
+  - name: busybox
+    image: busybox`)
+
+			Expect(sidecarEnv(pod)).To(ContainElement(kube_core.EnvVar{
+				Name:  "KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT",
+				Value: "GRPC",
+			}))
+		})
+	})
 }, Ordered)


### PR DESCRIPTION
## Motivation

Backports #16392 to `release-2.13`.

The `KUMA_EXPERIMENTAL_DELTA_XDS` env var is a no-op on 2.13.x because the k8s injector never propagates `KUMA_DATAPLANE_RUNTIME_ENVOY_XDS_TRANSPORT_PROTOCOL_VARIANT=DELTA_GRPC` to injected sidecars. Today the only workaround is per-deployment `kuma.io/xds-transport-protocol-variant: DELTA_GRPC`. This lets operators flip delta xDS at the CP level via the standard chart value.

## Implementation information

Cherry-pick of 585975b80 with conflict resolution against 2.13:

- `experimental.inboundTagsDisabled` and `experimental.envoyAdminUnixSocket` blocks were dropped from `values.yaml`, `_helpers.tpl`, `README.md`, `install-control-plane.dump-values.yaml`, and `helm-values.yaml` (they don't exist on 2.13). Only `experimental.deltaXds` is added.
- In `containers/factory.go`, the `if i.envoyAdminUnixSocket` env-var block was dropped for the same reason.
- `injector.New()` on 2.13 ends at `systemNamespace string`, so the new `deltaXdsEnabled bool` is appended directly (without master's `envoyReadinessPort`, `envoyAdminUnixSocket`, and `metrics` params).
- `NewDataplaneProxyFactory()` calls in `injector.go` and `plugin_gateway.go` append `deltaXdsEnabled` after `cfg.Spire.Enabled` (master's `OtelPipeEnabled` slot doesn't exist on 2.13).
- Same shape adjustment in `injector_test.go`.

## Supporting documentation

- Original PR: #16392
- Fixes: #16405