### PR TITLE
fix(gatewayapi): reconcile classes on startup

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_class_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_class_controller.go
@@ -175,9 +175,21 @@ func gatewayToClassMapper(l logr.Logger, client kube_client.Client) kube_handler
 			return req
 		}
 
+		class, ok := obj.(*gatewayapi.GatewayClass)
+		if ok {
+			if class.Spec.ControllerName != common.ControllerName {
+				return nil
+			}
+
+			return []kube_reconcile.Request{
+				{NamespacedName: kube_client.ObjectKeyFromObject(class)},
+			}
+		}
+
 		gateway, ok := obj.(*gatewayapi.Gateway)
 		if !ok {
 			l.Error(nil, "could not convert to Gateway", "object", obj)
+			return nil
 		}
 
 		return []kube_reconcile.Request{
@@ -220,7 +232,7 @@ func gatewayClassesForConfig(l logr.Logger, client kube_client.Client) kube_hand
 }
 
 func (r *GatewayClassReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
-	startupEvents := make(chan kube_event.GenericEvent, 1)
+	startupEvents := make(chan kube_event.GenericEvent, 16)
 
 	// Add an index to Gateways for use in Reconcile
 	indexLog := r.Log.WithName("gatewayClassNameIndexer")
@@ -261,10 +273,23 @@ func (r *GatewayClassReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 			return nil
 		}
 
-		select {
-		case startupEvents <- kube_event.GenericEvent{}:
-		case <-ctx.Done():
+		classes := &gatewayapi.GatewayClassList{}
+		if err := r.List(ctx, classes); err != nil {
+			r.Log.Error(err, "failed to list GatewayClasses on startup")
 			return nil
+		}
+
+		for i := range classes.Items {
+			class := classes.Items[i]
+			if class.Spec.ControllerName != common.ControllerName {
+				continue
+			}
+
+			select {
+			case startupEvents <- kube_event.GenericEvent{Object: class.DeepCopy()}:
+			case <-ctx.Done():
+				return nil
+			}
 		}
 
 		<-ctx.Done()

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_class_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/gateway_class_controller_test.go
@@ -45,4 +45,32 @@ var _ = Describe("gatewayToClassMapper", func() {
 			NamespacedName: kube_types.NamespacedName{Name: "kuma"},
 		}))
 	})
+
+	It("maps startup GatewayClass events to the class", func() {
+		class := &gatewayapi.GatewayClass{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "kuma"},
+			Spec: gatewayapi.GatewayClassSpec{
+				ControllerName: common.ControllerName,
+			},
+		}
+
+		requests := gatewayToClassMapper(logr.Discard(), nil)(context.Background(), class)
+
+		Expect(requests).To(ConsistOf(kube_reconcile.Request{
+			NamespacedName: kube_types.NamespacedName{Name: "kuma"},
+		}))
+	})
+
+	It("ignores startup GatewayClass events for other controllers", func() {
+		class := &gatewayapi.GatewayClass{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "other"},
+			Spec: gatewayapi.GatewayClassSpec{
+				ControllerName: gatewayapi.GatewayController("other.example/controller"),
+			},
+		}
+
+		requests := gatewayToClassMapper(logr.Discard(), nil)(context.Background(), class)
+
+		Expect(requests).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
## Motivation

Gateway API conformance can start before the `GatewayClass` status is refreshed after control plane startup. CI saw `GatewayClass` `Accepted` stuck on stale `observedGeneration: 0`.

> Changelog: skip

## Implementation information

List Kuma-owned `GatewayClass` resources after manager cache sync and enqueue concrete startup events for each class. Map those startup events directly to their class reconcile request instead of relying on a synthetic nil event to fan out through a list.

Added mapper coverage for startup `GatewayClass` events and non-Kuma classes.

Verified with focused controller tests and full gatewayapi e2e under CPU pressure using k3s v1.35.3-k3s1.

## Supporting documentation

CI failure: Gateway API conformance setup saw stale `GatewayClass` `Accepted` condition.