### PR TITLE
feat(meshservice): per-workload MeshService gen

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/component.go
+++ b/pkg/core/resources/apis/meshservice/generate/component.go
@@ -26,10 +26,6 @@ func Setup(rt runtime.Runtime) error {
 		logger.Info("MeshServices are not enabled. Skip starting generator for MeshServices.")
 		return nil
 	}
-	if rt.Config().Experimental.InboundTagsDisabled {
-		logger.Info("Inbound tags are disabled. Skip starting generator for MeshService. Users should create MeshService manually.")
-		return nil
-	}
 	generator, err := New(
 		logger,
 		rt.Config().MeshService.GenerationInterval.Duration,

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -12,6 +12,7 @@ import (
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
@@ -106,13 +107,19 @@ type meshServicesResult struct {
 }
 
 func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
+	if g.inboundTagsDisabled {
+		return g.workloadMeshServiceForDataplane(dataplane)
+	}
+	return g.serviceTagMeshServicesForDataplane(dataplane)
+}
+
+// serviceTagMeshServicesForDataplane generates MeshServices grouped by the
+// kuma.io/service inbound tag. Used when inbound tags are enabled.
+func (g *Generator) serviceTagMeshServicesForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
 	log := g.logger.WithValues("mesh", dataplane.GetMeta().GetMesh(), "Dataplane", dataplane.GetMeta().GetName())
 	portsByService := map[string][]meshservice_api.Port{}
 	inboundsByService := map[string][]*mesh_proto.Dataplane_Networking_Inbound{}
 	for _, inbound := range dataplane.Spec.GetNetworking().GetInbound() {
-		if g.inboundTagsDisabled && len(inbound.GetTags()) == 0 {
-			continue
-		}
 		serviceTagValue := inbound.GetTags()[mesh_proto.ServiceTag]
 		allErrs := apimachineryvalidation.NameIsDNS1035Label(serviceTagValue, false)
 		if len(allErrs) != 0 {
@@ -162,6 +169,67 @@ func (g *Generator) meshServicesForDataplane(dataplane *core_mesh.DataplaneResou
 	}
 
 	return meshServicesResult{services: services, labelContributions: contributions}
+}
+
+// workloadMeshServiceForDataplane generates a single MeshService per
+// kuma.io/workload label value. Used when inbound tags are disabled: inbounds
+// no longer carry tags, so service identity is derived from the workload the
+// Dataplane belongs to, producing a 1:1 workload-to-MeshService mapping.
+func (g *Generator) workloadMeshServiceForDataplane(dataplane *core_mesh.DataplaneResource) meshServicesResult {
+	log := g.logger.WithValues("mesh", dataplane.GetMeta().GetMesh(), "Dataplane", dataplane.GetMeta().GetName())
+
+	workloadName, ok := dataplane.GetMeta().GetLabels()[metadata.KumaWorkload]
+	if !ok || workloadName == "" {
+		return meshServicesResult{}
+	}
+	if allErrs := apimachineryvalidation.NameIsDNS1035Label(workloadName, false); len(allErrs) != 0 {
+		log.Info("couldn't generate MeshService from kuma.io/workload, contains invalid characters", "value", workloadName, "error", allErrs)
+		return meshServicesResult{}
+	}
+
+	var ports []meshservice_api.Port
+	inbounds := dataplane.Spec.GetNetworking().GetInbound()
+	for _, inbound := range inbounds {
+		port := meshservice_api.Port{
+			Name:        &inbound.Name,
+			Port:        int32(inbound.Port),
+			TargetPort:  pointer.To(intstr.FromInt32(int32(inbound.Port))),
+			AppProtocol: core_meta.ProtocolTCP,
+		}
+		if name := pointer.Deref(port.Name); name == "" {
+			port.Name = pointer.To(fmt.Sprintf("%d", port.Port))
+		}
+		if proto := inbound.GetProtocol(); proto != "" {
+			if p := core_meta.ParseProtocol(proto); p != core_meta.ProtocolUnknown {
+				port.AppProtocol = p
+			}
+		}
+		ports = append(ports, port)
+	}
+	if len(ports) == 0 {
+		return meshServicesResult{}
+	}
+
+	ms := meshservice_api.MeshService{
+		Selector: meshservice_api.Selector{
+			DataplaneLabels: &common_api.LabelSelector{
+				MatchLabels: &map[string]string{
+					metadata.KumaWorkload: workloadName,
+				},
+			},
+		},
+		Ports: ports,
+	}
+
+	contributions := map[string]map[string]string{}
+	if g.labelPropagationEnabled {
+		contributions[workloadName] = dpContribution(dataplane, inbounds, g.allowSet, g.droppedLabels, g.logger, workloadName)
+	}
+
+	return meshServicesResult{
+		services:           map[string]*meshservice_api.MeshService{workloadName: &ms},
+		labelContributions: contributions,
+	}
 }
 
 type dataplaneAndMeshService struct {
@@ -256,7 +324,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			dps = append(dps, dp.dataplane.GetMeta().GetName())
 		}
 		if len(conflicting) > 0 {
-			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
+			log.Info("Port conflict, ports must be identical across Dataplane inbounds grouped into a single MeshService", "dps", dps)
 		}
 		delete(meshservicesByName, meshService.GetMeta().GetName())
 		gracePeriodStartedAtText, hasGracePeriodLabel := meshService.GetMeta().GetLabels()[mesh_proto.DeletionGracePeriodStartedLabel]
@@ -359,7 +427,7 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 			dps = append(dps, dp.dataplane.GetMeta().GetName())
 		}
 		if len(conflicting) > 0 {
-			log.Info("Port conflict for a kuma.io/service tag, ports must be identical across Dataplane inbounds for a given kuma.io/service", "dps", dps)
+			log.Info("Port conflict, ports must be identical across Dataplane inbounds grouped into a single MeshService", "dps", dps)
 		}
 		propagated := propagatedLabelsFor(meshServices)
 		createLabels := desiredLabels(mesh, name, g.zone, propagated)

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/v2/pkg/config/app/kuma-cp"
 	config_manager "github.com/kumahq/kuma/v2/pkg/core/config/manager"
@@ -25,6 +26,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/dns/vips"
 	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
 	test_metrics "github.com/kumahq/kuma/v2/pkg/test/metrics"
 	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
 	"github.com/kumahq/kuma/v2/pkg/test/resources/samples"
@@ -481,18 +483,164 @@ var _ = Describe("MeshService generator", func() {
 			).To(Succeed())
 		})
 
-		It("should not generate MeshService for Dataplane with empty inbound tags", func() {
-			err := builders.Dataplane().WithAddress("192.168.0.1").WithoutInbounds().
-				AddInbound(
-					builders.Inbound().WithPort(80).WithServicePort(8080),
-				).Create(resManager)
-			Expect(err).ToNot(HaveOccurred())
+		createDataplane := func(name, workload string, labels map[string]string, inbounds ...*builders.InboundBuilder) {
+			dp := builders.Dataplane().WithAddress("192.168.0.1").WithoutInbounds()
+			for _, inbound := range inbounds {
+				dp.AddInbound(inbound)
+			}
+			allLabels := map[string]string{}
+			maps.Copy(allLabels, labels)
+			if workload != "" {
+				allLabels[metadata.KumaWorkload] = workload
+			}
+			Expect(resManager.Create(
+				context.Background(),
+				dp.Build(),
+				store.CreateByKey(name, model.DefaultMesh),
+				store.CreateWithLabels(allLabels),
+			)).To(Succeed())
+		}
+
+		It("should not generate MeshService for Dataplane without kuma.io/workload label", func() {
+			createDataplane("dp-1", "", nil,
+				builders.Inbound().WithPort(80).WithServicePort(8080).WithName("http"),
+			)
 
 			Consistently(func(g Gomega) {
 				mss := &meshservice_api.MeshServiceResourceList{}
 				g.Expect(resManager.List(context.Background(), mss)).To(Succeed())
 				g.Expect(mss.GetItems()).To(BeEmpty())
 			}, "1s", "100ms").Should(Succeed())
+		})
+
+		It("should not generate MeshService for invalid kuma.io/workload label", func() {
+			createDataplane("dp-1", "Invalid_Workload", nil,
+				builders.Inbound().WithPort(80).WithServicePort(8080).WithName("http"),
+			)
+
+			Consistently(func(g Gomega) {
+				mss := &meshservice_api.MeshServiceResourceList{}
+				g.Expect(resManager.List(context.Background(), mss)).To(Succeed())
+				g.Expect(mss.GetItems()).To(BeEmpty())
+			}, "1s", "100ms").Should(Succeed())
+		})
+
+		It("should generate one MeshService per workload with a port per inbound", func() {
+			createDataplane("dp-1", "backend", nil,
+				builders.Inbound().WithPort(80).WithServicePort(8080).WithName("http"),
+				builders.Inbound().WithPort(90).WithServicePort(9090).WithName("grpc"),
+			)
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.Spec.Selector).To(Equal(meshservice_api.Selector{
+					DataplaneLabels: &common_api.LabelSelector{
+						MatchLabels: &map[string]string{metadata.KumaWorkload: "backend"},
+					},
+				}))
+				g.Expect(ms.Spec.Ports).To(Equal([]meshservice_api.Port{
+					{
+						Name:        pointer.To("http"),
+						Port:        80,
+						TargetPort:  pointer.To(intstr.FromInt32(80)),
+						AppProtocol: core_meta.ProtocolTCP,
+					},
+					{
+						Name:        pointer.To("grpc"),
+						Port:        90,
+						TargetPort:  pointer.To(intstr.FromInt32(90)),
+						AppProtocol: core_meta.ProtocolTCP,
+					},
+				}))
+			}, "2s", "100ms").Should(Succeed())
+		})
+
+		It("should generate a single MeshService for many Dataplanes of one workload", func() {
+			createDataplane("dp-1", "backend", nil,
+				builders.Inbound().WithPort(80).WithServicePort(8080).WithName("http"),
+			)
+			createDataplane("dp-2", "backend", nil,
+				builders.Inbound().WithPort(80).WithServicePort(8080).WithName("http"),
+			)
+
+			Eventually(func(g Gomega) {
+				mss := &meshservice_api.MeshServiceResourceList{}
+				g.Expect(resManager.List(context.Background(), mss)).To(Succeed())
+				g.Expect(mss.GetItems()).To(HaveLen(1))
+				g.Expect(mss.GetItems()[0].GetMeta().GetName()).To(Equal("backend"))
+			}, "2s", "100ms").Should(Succeed())
+		})
+	})
+
+	Context("with InboundTagsDisabled and LabelPropagation enabled", func() {
+		BeforeEach(func() {
+			close(stopCh)
+
+			m, err := core_metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
+			metrics = m
+			s := memory.NewStore()
+			resManager = manager.NewResourceManager(s)
+			meshContextBuilder = xds_context.NewMeshContextBuilder(
+				resManager,
+				server.MeshResourceTypes(),
+				net.LookupIP,
+				"zone",
+				vips.NewPersistence(resManager, config_manager.NewConfigManager(s), false),
+				".mesh",
+				80,
+				xds_context.AnyToAnyReachableServicesGraphBuilder,
+				nil,
+			)
+			meshCache, err := cache_mesh.NewCache(
+				100*time.Millisecond,
+				meshContextBuilder,
+				metrics,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			allocator, err := generate.New(
+				logr.Discard(),
+				50*time.Millisecond,
+				gracePeriodInterval,
+				metrics,
+				resManager,
+				meshCache,
+				"zone",
+				true,
+				kuma_cp.MeshServiceLabelPropagation{Enabled: true},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			stopCh = make(chan struct{})
+			innerCh := stopCh
+			go func() {
+				defer GinkgoRecover()
+				Expect(allocator.Start(innerCh)).To(Succeed())
+			}()
+			Expect(
+				samples.MeshDefaultBuilder().WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Everywhere).Create(resManager),
+			).To(Succeed())
+		})
+
+		It("propagates non-kuma Dataplane labels to the generated MeshService", func() {
+			dp := builders.Dataplane().WithAddress("192.168.0.1").WithoutInbounds().
+				AddInbound(builders.Inbound().WithPort(80).WithServicePort(8080).WithName("http")).
+				Build()
+			Expect(resManager.Create(
+				context.Background(),
+				dp,
+				store.CreateByKey("dp-1", model.DefaultMesh),
+				store.CreateWithLabels(map[string]string{
+					metadata.KumaWorkload: "backend",
+					"team":                "payments",
+				}),
+			)).To(Succeed())
+
+			ms := meshservice_api.NewMeshServiceResource()
+			Eventually(func(g Gomega) {
+				g.Expect(resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+				g.Expect(ms.GetMeta().GetLabels()).To(HaveKeyWithValue("team", "payments"))
+			}, "2s", "100ms").Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Motivation

After the planned removal of `Dataplane` inbound tags, the MeshService
generator currently does nothing on Universal — it bails out early when
inbound tags are disabled, leaving operators to author every `MeshService`
by hand.

Offline decision (see MADR below, Option B): when running without inbound
tags, the control plane should generate one `MeshService` per `Workload`,
i.e. a 1:1 mapping between a `kuma.io/workload` label value and a generated
`MeshService`. This change implements that so the approach can be tested
end to end.


## Implementation information

- `meshservice/generate/component.go`: dropped the `InboundTagsDisabled`
  early-return; the generator now runs in both modes.
- `meshservice/generate/generator.go`: `meshServicesForDataplane` dispatches
  on `inboundTagsDisabled`:
  - disabled → new `workloadMeshServiceForDataplane`: one `MeshService` per
    `kuma.io/workload` value, named after the workload, one `Port` per inbound
    (name/protocol taken from the inbound fields), `Selector.DataplaneLabels`
    matching the workload label.
  - enabled → existing `kuma.io/service`-tag flow, unchanged.
- The reconcile loop, port-consistency check (first-DP-wins), grace-period
  delete and label propagation are keyed by name and reused as-is. Non-`kuma.io/*`
  `Dataplane.metadata.labels` still propagate to the generated `MeshService`.

Replicas of one workload normally have identical inbounds; on a port mismatch
the existing first-DP-wins consistency check applies. A union-of-ports policy
was considered and rejected as a larger change for no real-world gain.

## Supporting documentation

- MADR: docs/madr/decisions/103-universal-meshservice-generation.md

> Changelog: feat(kuma-cp): support running without inbound tags
