### PR TITLE
ci(lint): backport GOMEMLIMIT arithmetic fixes

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -60,7 +60,7 @@ jobs:
           set -e
           mem_total_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
           mem_total_bytes=$((mem_total_kb * 1024))
-          gomemlimit=$((mem_total_bytes * 9 / 10))
+          gomemlimit=$((mem_total_bytes * 8 / 10))
           echo "GOMEMLIMIT=${gomemlimit}" >> $GITHUB_ENV
           echo "Setting GOMEMLIMIT to $(numfmt --to=iec $gomemlimit)"
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
@@ -68,6 +68,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        env:
+          GOGC: "80" # run GC more aggressively
         with:
           args: --fix=false --verbose
           version: v2.11.3

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -57,9 +57,10 @@ jobs:
         id: set-gomemlimit
         run: |
           # Get total memory in bytes
+          set -e
           mem_total_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
           mem_total_bytes=$((mem_total_kb * 1024))
-          gomemlimit=$((mem_total_bytes * 0.9))
+          gomemlimit=$((mem_total_bytes * 9 / 10))
           echo "GOMEMLIMIT=${gomemlimit}" >> $GITHUB_ENV
           echo "Setting GOMEMLIMIT to $(numfmt --to=iec $gomemlimit)"
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3


### PR DESCRIPTION
## Motivation

`release-2.11` scheduled `build-test-distribute` runs intermittently fail
the `check` job with `golangci-lint exit with code 137` (OOM-killed).

Root cause is already known and fixed on every other release line: the
`Set GOMEMLIMIT` step uses `mem_total_bytes * 0.9`, which is invalid
in bash integer arithmetic. The step throws

```
line 4: mem_total_bytes * 0.9: syntax error: invalid arithmetic operator (error token is ".9")
```

leaves `GOMEMLIMIT` empty, and golangci-lint then runs uncapped — OOM-killed
whenever the runner is tight on memory. Same failure mode hits kong-mesh
`release-2.11`, which inherits the workflow via `sync_ci.sh`.

`release-2.12`, `release-2.13` and `master` all carry the fix; only
`release-2.11` was missed. Backporting closes the gap and lets kong-mesh
`release-2.11` pick up the fix on its next kuma bump — no downstream
workaround needed.

> Changelog: skip

## Implementation information

Two clean cherry-picks from `master`:

- #13747 `ci(lint): fix invalid arithmetic operator in GOMEMLIMIT setter` —
  swap `* 0.9` for integer math (`* 9 / 10`), add `set -e`.
- #14055 `ci(lint): set smaller gomemlimit to combat OOMs` — reduce to
  `* 8 / 10` and add `GOGC=80` (the PR explicitly cites kong-mesh OOMs
  as motivation).

Final state of the step matches `release-2.12`.

## Supporting documentation

- Original master fix: #13747
- Follow-up tightening: #14055
- Observed in scheduled `build-test-distribute` runs on `release-2.11`.