### PR TITLE
chore(deps): align envoy go-control-plane fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containernetworking/plugins v1.9.0
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/envoyproxy/go-control-plane v0.14.0
-	github.com/envoyproxy/go-control-plane/contrib v1.32.4
+	github.com/envoyproxy/go-control-plane/contrib v1.36.0
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/envoyproxy/protoc-gen-validate v1.3.0
 	github.com/evanphx/json-patch/v5 v5.9.11


### PR DESCRIPTION
## Motivation

On release-2.13 the `contrib` require line in go.mod said v1.32.4 but the replace directive already served `kumahq/go-control-plane/contrib v1.36.0-kong-1`. The linked code was v1.36 — the require label was stale metadata.

## Implementation information

Bump `github.com/envoyproxy/go-control-plane/contrib` require from `v1.32.4` to `v1.36.0` so it matches the fork tag the replace already serves. `go mod tidy` runs clean (no go.sum changes).

## Supporting documentation

N/A