### PR TITLE
fix(kds): default usedonly when fetching stats

### DIFF
--- a/api/mesh/v1alpha1/kds.pb.go
+++ b/api/mesh/v1alpha1/kds.pb.go
@@ -406,7 +406,12 @@ type StatsRequest struct {
 	// Should be empty for ZoneIngress, ZoneEgress.
 	ResourceMesh string `protobuf:"bytes,4,opt,name=resource_mesh,json=resourceMesh,proto3" json:"resource_mesh,omitempty"`
 	// format is the format in which we return the clusters.
-	Format        AdminOutputFormat `protobuf:"varint,5,opt,name=format,proto3,enum=kuma.mesh.v1alpha1.AdminOutputFormat" json:"format,omitempty"`
+	Format AdminOutputFormat `protobuf:"varint,5,opt,name=format,proto3,enum=kuma.mesh.v1alpha1.AdminOutputFormat" json:"format,omitempty"`
+	// used_only filters out stats that have never been written to. Envoy
+	// pre-registers stats for every configured cluster/listener, so for
+	// dataplanes with many unused upstreams this dramatically shrinks the
+	// response and keeps it under the KDS gRPC message size cap.
+	UsedOnly      bool `protobuf:"varint,6,opt,name=used_only,json=usedOnly,proto3" json:"used_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -474,6 +479,13 @@ func (x *StatsRequest) GetFormat() AdminOutputFormat {
 		return x.Format
 	}
 	return AdminOutputFormat_TEXT
+}
+
+func (x *StatsRequest) GetUsedOnly() bool {
+	if x != nil {
+		return x.UsedOnly
+	}
+	return false
 }
 
 // StatsResponse is a response containing result of kuma-dp stats execution on
@@ -855,14 +867,15 @@ const file_api_mesh_v1alpha1_kds_proto_rawDesc = "" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12\x16\n" +
 	"\x05error\x18\x02 \x01(\tH\x00R\x05error\x12\x18\n" +
 	"\x06config\x18\x03 \x01(\fH\x00R\x06configB\b\n" +
-	"\x06result\"\xdb\x01\n" +
+	"\x06result\"\xf8\x01\n" +
 	"\fStatsRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12#\n" +
 	"\rresource_type\x18\x02 \x01(\tR\fresourceType\x12#\n" +
 	"\rresource_name\x18\x03 \x01(\tR\fresourceName\x12#\n" +
 	"\rresource_mesh\x18\x04 \x01(\tR\fresourceMesh\x12=\n" +
-	"\x06format\x18\x05 \x01(\x0e2%.kuma.mesh.v1alpha1.AdminOutputFormatR\x06format\"h\n" +
+	"\x06format\x18\x05 \x01(\x0e2%.kuma.mesh.v1alpha1.AdminOutputFormatR\x06format\x12\x1b\n" +
+	"\tused_only\x18\x06 \x01(\bR\busedOnly\"h\n" +
 	"\rStatsResponse\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12\x16\n" +

--- a/api/mesh/v1alpha1/kds.proto
+++ b/api/mesh/v1alpha1/kds.proto
@@ -109,6 +109,11 @@ message StatsRequest {
   string resource_mesh = 4;
   // format is the format in which we return the clusters.
   AdminOutputFormat format = 5;
+  // used_only filters out stats that have never been written to. Envoy
+  // pre-registers stats for every configured cluster/listener, so for
+  // dataplanes with many unused upstreams this dramatically shrinks the
+  // response and keeps it under the KDS gRPC message size cap.
+  bool used_only = 6;
 }
 
 // StatsResponse is a response containing result of kuma-dp stats execution on

--- a/docs/generated/raw/protos/StatsRequest.json
+++ b/docs/generated/raw/protos/StatsRequest.json
@@ -36,6 +36,10 @@
                         }
                     ],
                     "title": "Admin Output Format"
+                },
+                "used_only": {
+                    "type": "boolean",
+                    "description": "used_only filters out stats that have never been written to. Envoy pre-registers stats for every configured cluster/listener, so for dataplanes with many unused upstreams this dramatically shrinks the response and keeps it under the KDS gRPC message size cap."
                 }
             },
             "additionalProperties": true,

--- a/pkg/api-server/inspect_envoy_admin_endpoints.go
+++ b/pkg/api-server/inspect_envoy_admin_endpoints.go
@@ -190,7 +190,13 @@ func (cl *inspectClient) inspectProxy(request *restful.Request, response *restfu
 			contentType = restful.MIME_JSON
 			format = v1alpha1.AdminOutputFormat_JSON
 		}
-		res, err = cl.adminClient.Stats(ctx, proxy, format)
+		usedOnly := true
+		if v := request.QueryParameter("usedonly"); v != "" {
+			if parsed, perr := strconv.ParseBool(v); perr == nil {
+				usedOnly = parsed
+			}
+		}
+		res, err = cl.adminClient.Stats(ctx, proxy, format, usedOnly)
 	}
 	if err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Could not execute admin operation")

--- a/pkg/envoy/admin/client.go
+++ b/pkg/envoy/admin/client.go
@@ -24,7 +24,7 @@ import (
 type EnvoyAdminClient interface {
 	PostQuit(ctx context.Context, dataplane *core_mesh.DataplaneResource) error
 
-	Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat) ([]byte, error)
+	Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat, usedOnly bool) ([]byte, error)
 	Clusters(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat) ([]byte, error)
 	ConfigDump(ctx context.Context, proxy core_model.ResourceWithAddress, includeEds bool) ([]byte, error)
 }
@@ -133,10 +133,13 @@ func (a *envoyAdminClient) PostQuit(ctx context.Context, dataplane *core_mesh.Da
 	return nil
 }
 
-func (a *envoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat) ([]byte, error) {
+func (a *envoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat, usedOnly bool) ([]byte, error) {
 	query := url.Values{}
 	if format == v1alpha1.AdminOutputFormat_JSON {
 		query.Add("format", "json")
+	}
+	if usedOnly {
+		query.Add("usedonly", "")
 	}
 	return a.executeRequest(ctx, proxy, "stats", query)
 }

--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -114,15 +114,16 @@ func (f *forwardingKdsEnvoyAdminClient) ConfigDump(ctx context.Context, proxy co
 	return forward(f, ctx, proxy, service.ConfigDumpRPC, fallback, doRequest, handleResponse)
 }
 
-func (f *forwardingKdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format mesh_proto.AdminOutputFormat) ([]byte, error) {
+func (f *forwardingKdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format mesh_proto.AdminOutputFormat, usedOnly bool) ([]byte, error) {
 	fallback := func(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
-		return f.fallbackClient.Stats(ctx, proxy, format)
+		return f.fallbackClient.Stats(ctx, proxy, format, usedOnly)
 	}
 	doRequest := func(ctx context.Context, client mesh_proto.InterCPEnvoyAdminForwardServiceClient) (*mesh_proto.StatsResponse, error) {
 		req := &mesh_proto.StatsRequest{
 			ResourceType: string(proxy.Descriptor().Name),
 			ResourceName: proxy.GetMeta().GetName(),
 			ResourceMesh: proxy.GetMeta().GetMesh(),
+			UsedOnly:     usedOnly,
 		}
 		return client.Stats(ctx, req)
 	}

--- a/pkg/intercp/envoyadmin/forwarding_kds_client.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client.go
@@ -123,6 +123,7 @@ func (f *forwardingKdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_mo
 			ResourceType: string(proxy.Descriptor().Name),
 			ResourceName: proxy.GetMeta().GetName(),
 			ResourceMesh: proxy.GetMeta().GetMesh(),
+			Format:       format,
 			UsedOnly:     usedOnly,
 		}
 		return client.Stats(ctx, req)

--- a/pkg/intercp/envoyadmin/forwarding_kds_client_test.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client_test.go
@@ -140,6 +140,20 @@ var _ = Describe("Forwarding KDS Client", func() {
 		}),
 	)
 
+	It("forwarded stats request preserves Format and UsedOnly", func() {
+		// given
+		createZoneInsightConnectedToGlobal("east", otherInstanceID, false)
+
+		// when
+		_, err := forwardingClient.Stats(context.Background(), dp, mesh_proto.AdminOutputFormat_JSON, true)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(forwardClient.lastStatsReq).ToNot(BeNil())
+		Expect(forwardClient.lastStatsReq.Format).To(Equal(mesh_proto.AdminOutputFormat_JSON))
+		Expect(forwardClient.lastStatsReq.UsedOnly).To(BeTrue())
+	})
+
 	DescribeTable("when request for clusters is executed",
 		func(given testCase) {
 			// given
@@ -182,6 +196,7 @@ type countingForwardClient struct {
 	xdsConfigCalled int
 	statsCalled     int
 	clustersCalled  int
+	lastStatsReq    *mesh_proto.StatsRequest
 }
 
 var _ mesh_proto.InterCPEnvoyAdminForwardServiceClient = &countingForwardClient{}
@@ -197,6 +212,7 @@ func (c *countingForwardClient) XDSConfig(ctx context.Context, in *mesh_proto.XD
 
 func (c *countingForwardClient) Stats(ctx context.Context, in *mesh_proto.StatsRequest, opts ...grpc.CallOption) (*mesh_proto.StatsResponse, error) {
 	c.statsCalled++
+	c.lastStatsReq = in
 	return &mesh_proto.StatsResponse{
 		Result: &mesh_proto.StatsResponse_Stats{
 			Stats: []byte("forwarded"),

--- a/pkg/intercp/envoyadmin/forwarding_kds_client_test.go
+++ b/pkg/intercp/envoyadmin/forwarding_kds_client_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Forwarding KDS Client", func() {
 			createZoneInsightConnectedToGlobal("east", given.globalInstanceID, false)
 
 			// when
-			_, err := forwardingClient.Stats(context.Background(), dp, mesh_proto.AdminOutputFormat_TEXT)
+			_, err := forwardingClient.Stats(context.Background(), dp, mesh_proto.AdminOutputFormat_TEXT, false)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/intercp/envoyadmin/server.go
+++ b/pkg/intercp/envoyadmin/server.go
@@ -64,7 +64,7 @@ func (s *server) Stats(ctx context.Context, req *mesh_proto.StatsRequest) (*mesh
 	if err != nil {
 		return nil, err
 	}
-	stats, err := s.adminClient.Stats(ctx, resWithAddr, req.Format)
+	stats, err := s.adminClient.Stats(ctx, resWithAddr, req.Format, req.UsedOnly)
 	if err != nil {
 		if errors.Is(err, &kds_envoyadmin.KDSTransportError{}) {
 			return &mesh_proto.StatsResponse{

--- a/pkg/kds/envoyadmin/kds_client.go
+++ b/pkg/kds/envoyadmin/kds_client.go
@@ -134,7 +134,7 @@ func doRequest[T message]( //nolint:nonamedreturns
 	}
 }
 
-func (k *kdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format mesh_proto.AdminOutputFormat) ([]byte, error) {
+func (k *kdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format mesh_proto.AdminOutputFormat, usedOnly bool) ([]byte, error) {
 	requestType := "StatsRequest"
 	mkMsg := func(reqId, typ, name, mesh string) util_grpc.ReverseUnaryMessage {
 		return &mesh_proto.StatsRequest{
@@ -143,6 +143,7 @@ func (k *kdsEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.Resour
 			ResourceName: name,
 			ResourceMesh: mesh,
 			Format:       format,
+			UsedOnly:     usedOnly,
 		}
 	}
 	resp, err := doRequest[*mesh_proto.StatsResponse](ctx, k.tracer, k.resManager, proxy, requestType, k.rpcs.Stats, mkMsg)

--- a/pkg/kds/service/envoy_admin_processor.go
+++ b/pkg/kds/service/envoy_admin_processor.go
@@ -85,7 +85,7 @@ func (s *envoyAdminProcessor) StartProcessingStats(
 		}
 		go func() { // schedule in the background to be able to quickly process more requests
 			stats, err := s.executeAdminFn(stream.Context(), req.ResourceType, req.ResourceName, req.ResourceMesh, func(ctx context.Context, proxy core_model.ResourceWithAddress) ([]byte, error) {
-				return s.adminClient.Stats(ctx, proxy, req.Format)
+				return s.adminClient.Stats(ctx, proxy, req.Format, req.UsedOnly)
 			})
 
 			resp := &mesh_proto.StatsResponse{

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -202,7 +202,7 @@ type DummyEnvoyAdminClient struct {
 	ClustersCalled   int
 }
 
-func (d *DummyEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat) ([]byte, error) {
+func (d *DummyEnvoyAdminClient) Stats(ctx context.Context, proxy core_model.ResourceWithAddress, format v1alpha1.AdminOutputFormat, usedOnly bool) ([]byte, error) {
 	d.StatsCalled++
 	if format == v1alpha1.AdminOutputFormat_JSON {
 		return []byte("{\"server.live\": 1}\n"), nil


### PR DESCRIPTION
## Motivation

When a user fetches Envoy stats for a busy sidecar via Global CP
(`GET /meshes/{mesh}/dataplanes/{name}/stats`), the request rides the
multiplexed KDS gRPC connection. The Zone CP reads the raw Envoy
`/stats` output and stuffs it into a single `StatsResponse` proto. With
many configured upstreams — typical for meshes that do not use
reachable services — that payload exceeds the 10MiB KDS message size
cap and the request fails with:

```
rpc error: code = ResourceExhausted desc = grpc: received message after
decompression larger than max 10485760
```

Envoy pre-registers ~100 stats per cluster at config load. On a
dataplane that never talks to most of those clusters the long tail of
zero-valued counters dominates the payload. Envoy already exposes
`?usedonly` to drop them at source. Today neither the api-server nor the
KDS request shape forwards it, so the savings are unreachable.

## Implementation information

- `StatsRequest` (`api/mesh/v1alpha1/kds.proto`) gains a `bool
  used_only = 6` field. Additive proto change; older Zone CPs ignore
  the field and behave as today (returns full payload, may still hit
  the cap — wire compat preserved).
- `EnvoyAdminClient.Stats` interface and all implementations (real
  HTTPS client, KDS tunnel client, inter-CP forwarder, test dummy) take
  the new `usedOnly` parameter and append `?usedonly=` to the Envoy
  admin URL when true.
- KDS `envoyAdminProcessor.StartProcessingStats` reads `req.UsedOnly`
  and forwards it through to the admin client.
- The api-server inspect endpoint
  (`pkg/api-server/inspect_envoy_admin_endpoints.go`) **defaults
  `usedonly` to `true`** for stats. Callers can opt out with
  `?usedonly=false`. This is the behavior change that actually unblocks
  affected users.

### Measured savings (local k3d, 211 clusters)

| Format | Baseline | `+usedonly` | Reduction |
|---|---:|---:|---:|
| text | 2.76 MiB | 0.37 MiB | **86.5%** |
| json | 3.77 MiB | 0.49 MiB | 86.9% |
| prometheus | 6.78 MiB | 0.97 MiB | 85.6% |

Per-cluster stat lines drop from 113 to 20. The remaining 20 are the
irreducible "cluster exists" gauges (`membership_*`, `version_text`,
circuit-breaker `remaining_*`).

### Projection by cluster count (text format)

| Clusters | Baseline | `+usedonly` |
|---:|---:|---:|
| 200 | 2.62 MiB | 0.35 MiB |
| 1000 | **13.05 MiB** ⚠ over cap | **1.74 MiB** ✓ |
| 2000 | 26.09 MiB ⚠ | 3.47 MiB ✓ |
| 5000 | 65.22 MiB ⚠ | 8.67 MiB ✓ |

Headroom moves from ~750 clusters to ~5,500 clusters before the cap
becomes a problem again.

### Alternatives considered and discarded

- **Raise `MaxMsgSize`.** Symmetric cap, requires both ends bumped,
  trades wire budget for memory headroom on Global CP. Affected
  customer cannot raise it.
- **Chunked StatsResponse.** Right structural fix long-term but a
  proto and reassembly-protocol change. Out of scope for the
  customer-blocking issue.
- **`filter=` / `type=` defaults.** Filter is highest-reduction but
  highest UX cost (new policy prefixes silently invisible). Type is a
  hard partition that loses gauges or histograms users want. Both are
  better as opt-in user-supplied params on a follow-up.

## Supporting documentation

`StreamStats` over KDS is consumed only by the api-server inspect
endpoint (kumactl `inspect dataplane --type=stats`, Kuma GUI dataplane
stats view). It is **not** a Prometheus federation path — the dp's own
metrics hijacker scrapes Envoy admin directly on each pod. So
`used_only` as the default has no impact on metric storage, alerting,
or any downstream automation.
