### PR TITLE
test(e2e): stabilize zone proxy goldens

### DIFF
--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
@@ -61,7 +61,7 @@
           "typedConfig": {
             "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
             "collectorCluster": "meshtrace:datadog",
-            "serviceName": "zone-proxy-demo-client_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server__kuma-3_msvc_80"
+            "serviceName": "zone-proxy-demo-client_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server-no-reusable-ports__kuma-3_msvc_80"
           }
         },
         "spawnUpstreamSpan": false
@@ -99,7 +99,7 @@
           "typedConfig": {
             "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
             "collectorCluster": "meshtrace:datadog",
-            "serviceName": "zone-proxy-demo-client_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server-no-reusable-ports__kuma-3_msvc_80"
+            "serviceName": "zone-proxy-demo-client_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server__kuma-3_msvc_80"
           }
         },
         "spawnUpstreamSpan": false

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -99,7 +99,7 @@
           "typedConfig": {
             "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
             "collectorCluster": "meshtrace:datadog",
-            "serviceName": "zone-proxy-test-server-no-reusable-ports_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server__kuma-3_msvc_80"
+            "serviceName": "zone-proxy-test-server-no-reusable-ports_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server-no-reusable-ports__kuma-3_msvc_80"
           }
         },
         "spawnUpstreamSpan": false
@@ -137,7 +137,7 @@
           "typedConfig": {
             "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
             "collectorCluster": "meshtrace:datadog",
-            "serviceName": "zone-proxy-test-server-no-reusable-ports_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server-no-reusable-ports__kuma-3_msvc_80"
+            "serviceName": "zone-proxy-test-server-no-reusable-ports_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server__kuma-3_msvc_80"
           }
         },
         "spawnUpstreamSpan": false

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
@@ -99,7 +99,7 @@
           "typedConfig": {
             "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
             "collectorCluster": "meshtrace:datadog",
-            "serviceName": "zone-proxy-test-server_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server__kuma-3_msvc_80"
+            "serviceName": "zone-proxy-test-server_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server-no-reusable-ports__kuma-3_msvc_80"
           }
         },
         "spawnUpstreamSpan": false
@@ -137,7 +137,7 @@
           "typedConfig": {
             "@type": "type.googleapis.com/envoy.config.trace.v3.DatadogConfig",
             "collectorCluster": "meshtrace:datadog",
-            "serviceName": "zone-proxy-test-server_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server-no-reusable-ports__kuma-3_msvc_80"
+            "serviceName": "zone-proxy-test-server_OUTBOUND_envoyconfig-zoneproxies_zone-proxy-test-server__kuma-3_msvc_80"
           }
         },
         "spawnUpstreamSpan": false

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -76,7 +76,7 @@ func getConfig(mesh, dpp string) string {
 		if cmp := strings.Compare(a.Path, b.Path); cmp != 0 {
 			return cmp
 		}
-		if cmp := strings.Compare(string(a.Op), string(b.Op)); cmp != 0 {
+		if cmp := strings.Compare(jsonPatchOpKey(a.Op), jsonPatchOpKey(b.Op)); cmp != 0 {
 			return cmp
 		}
 		return strings.Compare(jsonPatchValueKey(a.Value), jsonPatchValueKey(b.Value))
@@ -85,6 +85,16 @@ func getConfig(mesh, dpp string) string {
 	result, err := json.MarshalIndent(response, "", "  ")
 	Expect(err).ToNot(HaveOccurred())
 	return string(result)
+}
+
+func jsonPatchOpKey(op api_common.JsonPatchItemOp) string {
+	if op == api_common.Remove {
+		return "0"
+	}
+	if op == api_common.Add {
+		return "1"
+	}
+	return string(op)
 }
 
 func jsonPatchValueKey(value any) string {

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -76,10 +76,19 @@ func getConfig(mesh, dpp string) string {
 		if cmp := strings.Compare(a.Path, b.Path); cmp != 0 {
 			return cmp
 		}
-		if cmp := strings.Compare(jsonPatchOpKey(a.Op), jsonPatchOpKey(b.Op)); cmp != 0 {
+		if a.Op == api_common.Remove && b.Op == api_common.Add {
+			return -1
+		}
+		if a.Op == api_common.Add && b.Op == api_common.Remove {
+			return 1
+		}
+		if a.Op == api_common.Add && b.Op == api_common.Add && jsonPatchArrayPath(a.Path) {
+			return 0
+		}
+		if cmp := strings.Compare(jsonPatchValueKey(a.Value), jsonPatchValueKey(b.Value)); cmp != 0 {
 			return cmp
 		}
-		return strings.Compare(jsonPatchValueKey(a.Value), jsonPatchValueKey(b.Value))
+		return 0
 	})
 
 	result, err := json.MarshalIndent(response, "", "  ")
@@ -87,14 +96,20 @@ func getConfig(mesh, dpp string) string {
 	return string(result)
 }
 
-func jsonPatchOpKey(op api_common.JsonPatchItemOp) string {
-	if op == api_common.Remove {
-		return "0"
+func jsonPatchArrayPath(path string) bool {
+	idx := strings.LastIndex(path, "/")
+	if idx == -1 || idx == len(path)-1 {
+		return false
 	}
-	if op == api_common.Add {
-		return "1"
+	if path[idx+1:] == "-" {
+		return true
 	}
-	return string(op)
+	for _, r := range path[idx+1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func jsonPatchValueKey(value any) string {

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -73,10 +73,23 @@ func getConfig(mesh, dpp string) string {
 		zeroMaxDirectResponseBodySizeBytes((*response.Diff)[i].Value)
 	}
 	slices.SortStableFunc(*response.Diff, func(a, b api_common.JsonPatchItem) int {
-		return strings.Compare(a.Path, b.Path)
+		if cmp := strings.Compare(a.Path, b.Path); cmp != 0 {
+			return cmp
+		}
+		if cmp := strings.Compare(string(a.Op), string(b.Op)); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(jsonPatchValueKey(a.Value), jsonPatchValueKey(b.Value))
 	})
 
 	result, err := json.MarshalIndent(response, "", "  ")
+	Expect(err).ToNot(HaveOccurred())
+	return string(result)
+}
+
+func jsonPatchValueKey(value any) string {
+	GinkgoHelper()
+	result, err := json.Marshal(value)
 	Expect(err).ToNot(HaveOccurred())
 	return string(result)
 }


### PR DESCRIPTION
## Motivation

Zone proxy envoy config e2e flakes on datadog meshtrace goldens because JSON patch diff entries with same path are ordered nondeterministically.

> Changelog: skip

## Implementation information

Sort JSON patch diff entries by path, op, and value before comparing with goldens. Regenerated affected datadog zone-proxy golden files.

Verified with focused universal e2e datadog zone-proxy spec passing 3x after local repro.

## Supporting documentation

None.