### PR TITLE
test(e2e): pin postgres image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -153,6 +153,19 @@
       "datasourceTemplate": "docker",
       "packageNameTemplate": "registry.k8s.io/kubectl",
       "depNameTemplate": "kubectl"
+    },
+    {
+      "customType": "regex",
+      "description": [
+        " Update the universal e2e Postgres image digest in the Go deployment helper.",
+        " The Dockerfile manager updates test/dockerfiles/postgres.dockerfile, while this",
+        " keeps the runtime image used by universal e2e deployments on the same pinned tag"
+      ],
+      "managerFilePatterns": ["/test/framework/deployments/postgres/deployment\\.go$/"],
+      "matchStrings": [
+        "PostgresImage\\s*=\\s*\"(?<depName>postgres):(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[0-9a-f]{64}))?\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [

--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -19,7 +19,7 @@ const (
 	DefaultPostgresPassword = "kuma"
 	DefaultPostgresDBName   = "kuma"
 
-	PostgresImage = "postgres"
+	PostgresImage = "postgres:latest@sha256:f7ce845ee6873dd84be93c9828fe0d1fab0f9707dc9ac569694657398b290bce"
 
 	PostgresEnvVarUser     = "POSTGRES_USER"
 	PostgresEnvVarPassword = "POSTGRES_PASSWORD" // #nosec G101 -- Env var not actual password


### PR DESCRIPTION
## Motivation

Universal e2e Postgres setup used the mutable `postgres` image tag. CI failed while resolving `postgres:latest` from Docker Hub during multizone setup.

> Changelog: skip

## Implementation information

Pin the universal Postgres deployment image to the same digest already used by the Postgres test Dockerfile. Add a Renovate custom regex manager so future `postgres:latest` digest bumps update the Go deployment helper too.

Verified with image pull, package build, focused multizone Available services e2e, JSON validation, and regex extraction check.

## Supporting documentation

None.