### PR TITLE
fix(kuma-cp): allow zoneproxy injection before mesh exists

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -688,7 +688,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1101,6 +1101,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -12395,7 +12395,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -12802,6 +12802,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -12395,7 +12395,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -12809,6 +12809,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -876,6 +876,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 154c47a95fc93687dd1e825cea7f843d0fe8c450f82014d27cd7eb1a49f3bd35
-        checksum/tls-secrets: e89d26010d35fe840d1d25797c72b5a89d520dec24a8e9ce5ab9ff7c60b67193
+        checksum/tls-secrets: 89f763d2b27e31d39f08410650331a8e49d955fafa9576a23e459a187b0660fe
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -909,6 +909,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -876,6 +876,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -886,6 +886,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -500,7 +500,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1039,6 +1039,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -12457,7 +12457,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -13134,6 +13134,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -876,6 +876,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -500,7 +500,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1045,6 +1045,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -880,6 +880,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: b81e1b37e2b17fe3c61bef0167ccfe3f0a262ad43734a49a9e73d4fe8efd1593
+        checksum/tls-secrets: 5965b4d559aeb401b8dcbdd94fad68e9e4d9be168439c878a8d7bbc0721fdf7e
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -878,6 +878,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: b81e1b37e2b17fe3c61bef0167ccfe3f0a262ad43734a49a9e73d4fe8efd1593
+        checksum/tls-secrets: 5965b4d559aeb401b8dcbdd94fad68e9e4d9be168439c878a8d7bbc0721fdf7e
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -878,6 +878,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: b81e1b37e2b17fe3c61bef0167ccfe3f0a262ad43734a49a9e73d4fe8efd1593
+        checksum/tls-secrets: 5965b4d559aeb401b8dcbdd94fad68e9e4d9be168439c878a8d7bbc0721fdf7e
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -878,6 +878,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
@@ -192,7 +192,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -599,6 +599,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -876,6 +876,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -531,7 +531,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1217,6 +1217,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -876,6 +876,8 @@ webhooks:
             - enabled
         - key: kuma.io/mesh
           operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
+          operator: Exists
     clientConfig:
       caBundle: XYZ
       service:

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -876,6 +876,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -880,6 +880,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -690,7 +690,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1103,6 +1103,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -708,7 +708,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1121,6 +1121,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -493,7 +493,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3a137bbfcbbe6ba5a3997b30b1b047b2b080a9f912520a5fa683f11c4c6b6f3c
-        checksum/tls-secrets: 17cc83c6da6ba7f3e2dfc73221800aadb333ead12495e0bc051f7fcddb84151b
+        checksum/tls-secrets: 7b3fbcc00b79d18122d34a8cf32a29c0f7ba9cdfb7845a5f1a63b5d99fda3d7f
       labels: 
         app: kuma-control-plane
         "foo": "baz"
@@ -908,6 +908,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -512,7 +512,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 2f553eadd8f68661f4b1fd0b3ccbbc562943d89fa76f2f2ba2975541290fda71
-        checksum/tls-secrets: 7bcd8bc99086e6b161ed4605c7158fb435eecb21deac5bf32b57ed8fd59d4848
+        checksum/tls-secrets: d84e3b01b758326b244821d9ebc9c3fd094263dfd3c369dbb97779763da83e3d
       labels: 
         app: kuma-control-plane
         "foo": "bar"
@@ -1085,6 +1085,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -758,7 +758,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
         bim: "bam"
         foo: "{\"bar\": \"baz\"}"
       labels: 
@@ -1475,6 +1475,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -531,7 +531,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1211,6 +1211,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -472,7 +472,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -879,6 +879,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -546,7 +546,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1286,6 +1286,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/ingressLbService.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/ingressLbService.golden.yaml
@@ -504,7 +504,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1045,6 +1045,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
@@ -535,7 +535,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -754,6 +754,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -813,6 +814,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -1060,6 +1062,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
@@ -535,7 +535,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -758,6 +758,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -819,6 +820,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -1066,6 +1068,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
@@ -535,7 +535,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -754,6 +754,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -813,6 +814,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -1060,6 +1062,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -601,7 +601,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -820,6 +820,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -879,6 +880,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -938,6 +940,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -997,6 +1000,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -1244,6 +1248,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
@@ -541,7 +541,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -760,6 +760,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -819,6 +820,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -1066,6 +1068,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
@@ -540,7 +540,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -759,6 +759,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
     spec:
       securityContext:
         runAsUser: 5678
@@ -818,6 +819,7 @@ spec:
         app.kubernetes.io/name: kuma
         app.kubernetes.io/instance: kuma
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
     spec:
       securityContext:
         runAsUser: 5678
@@ -1065,6 +1067,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -876,6 +876,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -488,7 +488,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: 3436c44681aed5e14160899aa0e5054d756d2c803237a49e18d69c231c05cf5e
+        checksum/tls-secrets: cd1c50ca02a7fa50784dd969a5ca09913b6711e397de6261f4066691000b64dc
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -917,6 +917,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -469,7 +469,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -877,6 +877,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
@@ -100,7 +100,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -507,6 +507,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyDeploymentAnnotations.golden.yaml
@@ -531,7 +531,7 @@ spec:
     metadata:
       annotations:
         checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
-        checksum/tls-secrets: f682bf0be13a5363a8fe433d046be85b64bbd62026cabcead33f236e51de8fa0
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1210,6 +1210,8 @@ webhooks:
           values:
             - enabled
         - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
           operator: Exists
     clientConfig:
       caBundle: XYZ

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -286,6 +286,8 @@ webhooks:
             - enabled
         - key: kuma.io/mesh
           operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
+          operator: Exists
     clientConfig:
       {{- include "kuma.webhook.caBundle" (dict "Values" .Values "caBundle" $caBundle) | nindent 6 }}
       service:

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
@@ -57,6 +57,7 @@ spec:
       labels:
         {{- include "kuma.mesh.zoneproxy.labels" (dict "root" $ "meshName" $meshName "role" $role) | nindent 8 }}
         kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: {{ $role }}
     spec:
       {{- if and $dep.podSpec $dep.podSpec.resources }}
       resources: {{ toYaml $dep.podSpec.resources | nindent 8 }}

--- a/pkg/plugins/runtime/k8s/metadata/labels.go
+++ b/pkg/plugins/runtime/k8s/metadata/labels.go
@@ -6,8 +6,10 @@ const (
 	// Label value must be the name of a Mesh resource.
 	KumaMeshLabel = "kuma.io/mesh"
 
-	// KumaZoneProxyTypeLabel is a Service label that drives zone proxy
-	// listener generation on the Dataplane of a matching pod.
+	// KumaZoneProxyTypeLabel marks mesh-scoped zone proxy resources.
+	// On Services it drives zone proxy listener generation on the Dataplane of a
+	// matching pod, and on Pods it acts as an injector hint for mesh-scoped zone
+	// proxies.
 	// Allowed values: ingress or egress.
 	KumaZoneProxyTypeLabel = "k8s.kuma.io/zone-proxy-type"
 )

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -18,6 +18,7 @@ import (
 	conf "github.com/kumahq/kuma/v2/pkg/config/plugins/runtime/k8s"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
 	k8s_util "github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/util"
 	inject "github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/webhooks/injector"
 	"github.com/kumahq/kuma/v2/pkg/test/matchers"
@@ -1064,6 +1065,83 @@ spec:
 			cfgFile: "inject.config.yaml",
 		}),
 	)
+
+	Describe("mesh existence precheck", func() {
+		newInjector := func() *inject.KumaInjector {
+			var cfg conf.Injector
+			ExpectWithOffset(1, config.Load(filepath.Join("testdata", "inject.config.yaml"), &cfg)).To(Succeed())
+			cfg.CaCertFile = caCertPath
+
+			inj, err := inject.New(
+				cfg,
+				"http://kuma-control-plane.kuma-system:5681",
+				k8sClient,
+				false,
+				k8s.NewSimpleConverter(),
+				9901,
+				9902,
+				false,
+				systemNamespace,
+				nil,
+				false,
+			)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			return inj
+		}
+
+		newPod := func(namespace string, explicitMesh bool) *kube_core.Pod {
+			labels := map[string]string{
+				metadata.KumaSidecarInjectionAnnotation: "enabled",
+			}
+			if explicitMesh {
+				labels[metadata.KumaMeshLabel] = "default"
+			}
+
+			return &kube_core.Pod{
+				ObjectMeta: kube_meta.ObjectMeta{
+					Name:      "zone-proxy",
+					Namespace: namespace,
+					Labels:    labels,
+				},
+				Spec: kube_core.PodSpec{
+					Containers: []kube_core.Container{
+						{Name: "pause", Image: "registry.k8s.io/pause:3.10"},
+					},
+				},
+			}
+		}
+
+		It("allows system namespace pods to inject before the mesh exists", func() {
+			pod := newPod(systemNamespace, true)
+
+			Expect(newInjector().InjectKuma(context.Background(), pod)).To(Succeed())
+			Expect(pod.Spec.Containers).To(ContainElement(
+				WithTransform(func(c kube_core.Container) string { return c.Name }, Equal(k8s_util.KumaSidecarContainerName)),
+			))
+		})
+
+		It("still rejects system namespace pods without an explicit mesh label when the mesh does not exist", func() {
+			pod := newPod(systemNamespace, false)
+
+			err := newInjector().InjectKuma(context.Background(), pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`"default" not found`))
+			Expect(pod.Spec.Containers).ToNot(ContainElement(
+				WithTransform(func(c kube_core.Container) string { return c.Name }, Equal(k8s_util.KumaSidecarContainerName)),
+			))
+		})
+
+		It("still rejects non-system namespace pods when the mesh does not exist", func() {
+			pod := newPod("default", true)
+
+			err := newInjector().InjectKuma(context.Background(), pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`"default" not found`))
+			Expect(pod.Spec.Containers).ToNot(ContainElement(
+				WithTransform(func(c kube_core.Container) string { return c.Name }, Equal(k8s_util.KumaSidecarContainerName)),
+			))
+		})
+	})
 
 	Describe("delta xDS injection", func() {
 		const (

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -75,6 +75,15 @@ spec:
 	BeforeEach(func() {
 		err := k8sClient.DeleteAllOf(context.Background(), &v1alpha1.Mesh{})
 		Expect(err).ToNot(HaveOccurred())
+		err = k8sClient.DeleteAllOf(context.Background(), &kube_core.Service{}, kube_client.InNamespace("default"))
+		Expect(err).ToNot(HaveOccurred())
+		ns := &kube_core.Namespace{}
+		err = k8sClient.Get(context.Background(), kube_client.ObjectKey{Name: "default"}, ns)
+		Expect(err).ToNot(HaveOccurred())
+		delete(ns.Labels, metadata.KumaMeshLabel)
+		delete(ns.Annotations, metadata.KumaMeshLabel)
+		err = k8sClient.Update(context.Background(), ns)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	DescribeTableSubtree("should inject Kuma into a Pod",
@@ -1089,8 +1098,9 @@ spec:
 			return inj
 		}
 
-		newPod := func(namespace string, explicitMesh bool, zoneProxyType string) *kube_core.Pod {
+		newPod := func(explicitMesh bool, zoneProxyType string) *kube_core.Pod {
 			labels := map[string]string{
+				"app":                                   "zone-proxy",
 				metadata.KumaSidecarInjectionAnnotation: "enabled",
 			}
 			if explicitMesh {
@@ -1103,7 +1113,7 @@ spec:
 			return &kube_core.Pod{
 				ObjectMeta: kube_meta.ObjectMeta{
 					Name:      "zone-proxy",
-					Namespace: namespace,
+					Namespace: "default",
 					Labels:    labels,
 				},
 				Spec: kube_core.PodSpec{
@@ -1114,8 +1124,31 @@ spec:
 			}
 		}
 
+		createZoneProxyService := func(namespace string) {
+			svc := &kube_core.Service{
+				ObjectMeta: kube_meta.ObjectMeta{
+					Name:      "zone-proxy-svc",
+					Namespace: namespace,
+					Labels: map[string]string{
+						metadata.KumaZoneProxyTypeLabel: "ingress",
+					},
+				},
+				Spec: kube_core.ServiceSpec{
+					Selector: map[string]string{
+						"app": "zone-proxy",
+					},
+					Ports: []kube_core.ServicePort{
+						{
+							Port: 10001,
+						},
+					},
+				},
+			}
+			ExpectWithOffset(1, k8sClient.Create(context.Background(), svc)).To(Succeed())
+		}
+
 		It("allows zone proxy pods to inject before the mesh exists", func() {
-			pod := newPod("default", true, "ingress")
+			pod := newPod(true, "ingress")
 
 			Expect(newInjector().InjectKuma(context.Background(), pod)).To(Succeed())
 			Expect(pod.Spec.Containers).To(ContainElement(
@@ -1124,7 +1157,7 @@ spec:
 		})
 
 		It("still rejects zone proxy pods without an explicit mesh label when the mesh does not exist", func() {
-			pod := newPod("default", false, "ingress")
+			pod := newPod(false, "ingress")
 
 			err := newInjector().InjectKuma(context.Background(), pod)
 			Expect(err).To(HaveOccurred())
@@ -1135,7 +1168,39 @@ spec:
 		})
 
 		It("still rejects non-zone-proxy pods when the mesh does not exist", func() {
-			pod := newPod("default", true, "")
+			pod := newPod(true, "")
+
+			err := newInjector().InjectKuma(context.Background(), pod)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`"default" not found`))
+			Expect(pod.Spec.Containers).ToNot(ContainElement(
+				WithTransform(func(c kube_core.Container) string { return c.Name }, Equal(k8s_util.KumaSidecarContainerName)),
+			))
+		})
+
+		It("allows zone proxy pods selected by a Service before the mesh exists when the mesh is on the namespace", func() {
+			createZoneProxyService("default")
+
+			ns := &kube_core.Namespace{}
+			Expect(k8sClient.Get(context.Background(), kube_client.ObjectKey{Name: "default"}, ns)).To(Succeed())
+			if ns.Labels == nil {
+				ns.Labels = map[string]string{}
+			}
+			ns.Labels[metadata.KumaMeshLabel] = "default"
+			Expect(k8sClient.Update(context.Background(), ns)).To(Succeed())
+
+			pod := newPod(false, "")
+
+			Expect(newInjector().InjectKuma(context.Background(), pod)).To(Succeed())
+			Expect(pod.Spec.Containers).To(ContainElement(
+				WithTransform(func(c kube_core.Container) string { return c.Name }, Equal(k8s_util.KumaSidecarContainerName)),
+			))
+		})
+
+		It("still rejects service-selected zone proxy pods when the mesh is not set on the pod or namespace", func() {
+			createZoneProxyService("default")
+
+			pod := newPod(false, "")
 
 			err := newInjector().InjectKuma(context.Background(), pod)
 			Expect(err).To(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -1089,12 +1089,15 @@ spec:
 			return inj
 		}
 
-		newPod := func(namespace string, explicitMesh bool) *kube_core.Pod {
+		newPod := func(namespace string, explicitMesh bool, zoneProxyType string) *kube_core.Pod {
 			labels := map[string]string{
 				metadata.KumaSidecarInjectionAnnotation: "enabled",
 			}
 			if explicitMesh {
 				labels[metadata.KumaMeshLabel] = "default"
+			}
+			if zoneProxyType != "" {
+				labels[metadata.KumaZoneProxyTypeLabel] = zoneProxyType
 			}
 
 			return &kube_core.Pod{
@@ -1111,8 +1114,8 @@ spec:
 			}
 		}
 
-		It("allows system namespace pods to inject before the mesh exists", func() {
-			pod := newPod(systemNamespace, true)
+		It("allows zone proxy pods to inject before the mesh exists", func() {
+			pod := newPod("default", true, "ingress")
 
 			Expect(newInjector().InjectKuma(context.Background(), pod)).To(Succeed())
 			Expect(pod.Spec.Containers).To(ContainElement(
@@ -1120,8 +1123,8 @@ spec:
 			))
 		})
 
-		It("still rejects system namespace pods without an explicit mesh label when the mesh does not exist", func() {
-			pod := newPod(systemNamespace, false)
+		It("still rejects zone proxy pods without an explicit mesh label when the mesh does not exist", func() {
+			pod := newPod("default", false, "ingress")
 
 			err := newInjector().InjectKuma(context.Background(), pod)
 			Expect(err).To(HaveOccurred())
@@ -1131,8 +1134,8 @@ spec:
 			))
 		})
 
-		It("still rejects non-system namespace pods when the mesh does not exist", func() {
-			pod := newPod("default", true)
+		It("still rejects non-zone-proxy pods when the mesh does not exist", func() {
+			pod := newPod("default", true, "")
 
 			err := newInjector().InjectKuma(context.Background(), pod)
 			Expect(err).To(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -1169,6 +1169,7 @@ spec:
 
 		It("still rejects non-zone-proxy pods when the mesh does not exist", func() {
 			pod := newPod(true, "")
+			pod.Labels["app"] = "regular"
 
 			err := newInjector().InjectKuma(context.Background(), pod)
 			Expect(err).To(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
+	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,22 +41,30 @@ func (i *KumaInjector) preCheck(ctx context.Context, pod *kube_core.Pod, logger 
 
 	meshName := k8s_util.MeshOfByLabelOrAnnotation(logger, pod, ns)
 	logger = logger.WithValues("mesh", meshName)
-	// Mesh zone proxy pods rely on the Pod/Dataplane reconciliation path to
-	// retry until the target mesh exists, so admission must not block them
-	// here. Prefer the pod-local zone-proxy-type hint when present, but also
-	// fall back to matching Services so the regular injector path keeps working
-	// when zone proxy is not in the default release namespace.
-	isZoneProxyPod := pod.GetLabels()[metadata.KumaZoneProxyTypeLabel] != ""
-	if !isZoneProxyPod {
-		isZoneProxyPod, err = i.hasZoneProxyService(ctx, pod)
-		if err != nil {
-			return "", errors.Wrap(err, "could not determine if pod is a zone proxy")
+	if meshErr := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); meshErr != nil {
+		if !kube_errors.IsNotFound(meshErr) {
+			return "", meshErr
 		}
-	}
-	skipMeshExistenceCheck := hasExplicitMesh(pod, ns) && isZoneProxyPod
-	if !skipMeshExistenceCheck {
-		if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {
-			return "", err
+
+		// Mesh zone proxy pods rely on the Pod/Dataplane reconciliation path to
+		// retry until the target mesh exists, so admission must not block them
+		// here. Prefer the pod-local zone-proxy-type hint when present, but only
+		// fall back to matching Services after a Mesh NotFound so the regular
+		// injector path keeps its fast path.
+		if !hasExplicitMesh(pod, ns) {
+			return "", meshErr
+		}
+
+		isZoneProxyPod := pod.GetLabels()[metadata.KumaZoneProxyTypeLabel] != ""
+		if !isZoneProxyPod {
+			var serviceErr error
+			isZoneProxyPod, serviceErr = i.hasZoneProxyService(ctx, pod)
+			if serviceErr != nil {
+				return "", errors.Wrap(serviceErr, "could not determine if pod is a zone proxy")
+			}
+		}
+		if !isZoneProxyPod {
+			return "", meshErr
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
@@ -39,12 +39,11 @@ func (i *KumaInjector) preCheck(ctx context.Context, pod *kube_core.Pod, logger 
 
 	meshName := k8s_util.MeshOfByLabelOrAnnotation(logger, pod, ns)
 	logger = logger.WithValues("mesh", meshName)
-	// Mesh zone proxy pods are selected by a dedicated webhook in the system
-	// namespace and carry an explicit mesh label. They rely on the Pod/Dataplane
-	// reconciliation path to retry until the target mesh exists, so admission
-	// must not block them here.
-	skipMeshExistenceCheck := ns.GetName() == i.systemNamespace &&
-		pod.GetLabels()[metadata.KumaMeshLabel] != ""
+	// Mesh zone proxy pods carry explicit mesh and zone-proxy-type labels. They
+	// rely on the Pod/Dataplane reconciliation path to retry until the target
+	// mesh exists, so admission must not block them here.
+	skipMeshExistenceCheck := pod.GetLabels()[metadata.KumaMeshLabel] != "" &&
+		pod.GetLabels()[metadata.KumaZoneProxyTypeLabel] != ""
 	if !skipMeshExistenceCheck {
 		if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {
 			return "", err

--- a/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
@@ -39,9 +39,16 @@ func (i *KumaInjector) preCheck(ctx context.Context, pod *kube_core.Pod, logger 
 
 	meshName := k8s_util.MeshOfByLabelOrAnnotation(logger, pod, ns)
 	logger = logger.WithValues("mesh", meshName)
-	// Check mesh exists
-	if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {
-		return "", err
+	// Mesh zone proxy pods are selected by a dedicated webhook in the system
+	// namespace and carry an explicit mesh label. They rely on the Pod/Dataplane
+	// reconciliation path to retry until the target mesh exists, so admission
+	// must not block them here.
+	skipMeshExistenceCheck := ns.GetName() == i.systemNamespace &&
+		pod.GetLabels()[metadata.KumaMeshLabel] != ""
+	if !skipMeshExistenceCheck {
+		if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {
+			return "", err
+		}
 	}
 
 	// Warn if an init container in the pod is using the same UID as the sidecar. This traffic will be exempt from

--- a/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/precheck.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	mesh_k8s "github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
@@ -39,11 +40,19 @@ func (i *KumaInjector) preCheck(ctx context.Context, pod *kube_core.Pod, logger 
 
 	meshName := k8s_util.MeshOfByLabelOrAnnotation(logger, pod, ns)
 	logger = logger.WithValues("mesh", meshName)
-	// Mesh zone proxy pods carry explicit mesh and zone-proxy-type labels. They
-	// rely on the Pod/Dataplane reconciliation path to retry until the target
-	// mesh exists, so admission must not block them here.
-	skipMeshExistenceCheck := pod.GetLabels()[metadata.KumaMeshLabel] != "" &&
-		pod.GetLabels()[metadata.KumaZoneProxyTypeLabel] != ""
+	// Mesh zone proxy pods rely on the Pod/Dataplane reconciliation path to
+	// retry until the target mesh exists, so admission must not block them
+	// here. Prefer the pod-local zone-proxy-type hint when present, but also
+	// fall back to matching Services so the regular injector path keeps working
+	// when zone proxy is not in the default release namespace.
+	isZoneProxyPod := pod.GetLabels()[metadata.KumaZoneProxyTypeLabel] != ""
+	if !isZoneProxyPod {
+		isZoneProxyPod, err = i.hasZoneProxyService(ctx, pod)
+		if err != nil {
+			return "", errors.Wrap(err, "could not determine if pod is a zone proxy")
+		}
+	}
+	skipMeshExistenceCheck := hasExplicitMesh(pod, ns) && isZoneProxyPod
 	if !skipMeshExistenceCheck {
 		if err := i.client.Get(ctx, kube_types.NamespacedName{Name: meshName}, &mesh_k8s.Mesh{}); err != nil {
 			return "", err
@@ -87,6 +96,40 @@ func (i *KumaInjector) preCheck(ctx context.Context, pod *kube_core.Pod, logger 
 		return "", err
 	}
 	return meshName, nil
+}
+
+func (i *KumaInjector) hasZoneProxyService(ctx context.Context, pod *kube_core.Pod) (bool, error) {
+	services := &kube_core.ServiceList{}
+	if err := i.client.List(ctx, services, kube_client.InNamespace(pod.Namespace)); err != nil {
+		return false, err
+	}
+	for idx := range services.Items {
+		svc := &services.Items[idx]
+		if k8s_util.MatchService(svc,
+			k8s_util.AnySelector(),
+			k8s_util.Not(k8s_util.Ignored()),
+			k8s_util.MatchServiceThatSelectsPod(pod, nil),
+		) && svc.Labels[metadata.KumaZoneProxyTypeLabel] != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func hasExplicitMesh(pod *kube_core.Pod, ns *kube_core.Namespace) bool {
+	if mesh, exists := metadata.Annotations(pod.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
+		return true
+	}
+	if mesh, exists := metadata.Annotations(pod.GetAnnotations()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
+		return true
+	}
+	if mesh, exists := metadata.Annotations(ns.GetLabels()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
+		return true
+	}
+	if mesh, exists := metadata.Annotations(ns.GetAnnotations()).GetString(metadata.KumaMeshLabel); exists && mesh != "" {
+		return true
+	}
+	return false
 }
 
 func (i *KumaInjector) needToInject(pod *kube_core.Pod, ns *kube_core.Namespace) (bool, error) {


### PR DESCRIPTION
## Motivation
When installing zone scoped proxies with `controlPlane.defaults.skipMeshCreation=true`, the rollout job completed but the restarted zone proxy Deployment created a new ReplicaSet that could not create Pods because the injector rejected them while the Mesh was still absent.

```text
$ kubectl -n kuma-system get rs
NAME                              DESIRED   CURRENT   READY   AGE    CONTAINERS      IMAGES
kuma-default-ingress-5489bf997d   1         0         0       99s    pause           registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a
kuma-default-ingress-5775669d6f   1         1         1       2m1s   pause           registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a
```

```text
$ kubectl -n kuma-system describe deployment kuma-default-ingress
Replicas:               1 desired | 0 updated | 1 total | 1 available | 1 unavailable
Conditions:
  Type             Status  Reason
  Available        True    MinimumReplicasAvailable
  Progressing      True    NewReplicaSetCreated
  ReplicaFailure   True    FailedCreate
OldReplicaSets:    kuma-default-ingress-5775669d6f (1/1 replicas created)
NewReplicaSet:     kuma-default-ingress-5489bf997d (0/1 replicas created)
```

```text
$ kubectl -n kuma-system get events
Warning   FailedCreate   replicaset/kuma-default-ingress-5489bf997d   Error creating: admission webhook "mesh-zoneproxy-kuma-injector.kuma.io" denied the request: Mesh.kuma.io "default" not found
```

This change follows the eventual-consistency behavior documented in MADR 094:
- https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/094-zone-proxy-deployment-model.md#L109-L109
- "Zone proxies can be deployed before their target mesh exists. Bootstrap already validates mesh existence for Dataplanes ... The zone proxy logs the error and retries until the mesh is created."

The reproduction uses the Helm-installed Deployment in `kuma-system`, but mesh-scoped zone proxies are not limited to the system namespace.

## Implementation details
- add `k8s.kuma.io/zone-proxy-type` to the zone proxy Pod template as an injector hint
- require that label in the dedicated `mesh-zoneproxy-kuma-injector.kuma.io` webhook selector
- allow Pods with both `kuma.io/mesh` and `k8s.kuma.io/zone-proxy-type` to bypass the mesh-existence precheck until the reconciliation retry path catches up
- add injector tests for zone-proxy and non-zone-proxy cases

## Additional information

Fixes #16406

> Changelog: feat(kuma-cp): add mesh-scoped zone proxies