### PR TITLE
feat(api-server): introduce SNIs to resources of MS/MES/MMZS

### DIFF
--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18496,9 +18496,9 @@ components:
         snis:
           description: >-
             List of SNIs (Server Name Indication) advertised by xDS for this
-            destination, one entry per port, sorted by port ascending. Always
-            set for MeshService, MeshMultiZoneService and MeshExternalService;
-            absent for other resource types.
+            destination, one entry per port, sorted by port ascending. Present
+            for MeshService, MeshMultiZoneService and MeshExternalService when
+            the destination has SNI sections/ports; absent otherwise.
           type: array
           readOnly: true
           items:
@@ -18522,8 +18522,8 @@ components:
                 description: The SNI string advertised by xDS for this port.
           example:
             - port: 8080
-              sectionName: http
-              sni: sni.extsvc.default.zone-east.kuma-system.myresource1.http
+              sectionName: '8080'
+              sni: sni.extsvc.default.zone-east.kuma-system.myresource1.8080
         name:
           description: Name of the Kuma resource
           type: string
@@ -19217,9 +19217,9 @@ components:
         snis:
           description: >-
             List of SNIs (Server Name Indication) advertised by xDS for this
-            destination, one entry per port, sorted by port ascending. Always
-            set for MeshService, MeshMultiZoneService and MeshExternalService;
-            absent for other resource types.
+            destination, one entry per port, sorted by port ascending. Present
+            for MeshService, MeshMultiZoneService and MeshExternalService when
+            the destination has SNI sections/ports; absent otherwise.
           type: array
           readOnly: true
           items:
@@ -19243,8 +19243,8 @@ components:
                 description: The SNI string advertised by xDS for this port.
           example:
             - port: 8080
-              sectionName: http
-              sni: sni.mzsvc.default.zone-east.kuma-demo.myresource1.http
+              sectionName: '8080'
+              sni: sni.mzsvc.default.zone-east.kuma-demo.myresource1.8080
         name:
           description: Name of the Kuma resource
           type: string
@@ -19758,9 +19758,9 @@ components:
         snis:
           description: >-
             List of SNIs (Server Name Indication) advertised by xDS for this
-            destination, one entry per port, sorted by port ascending. Always
-            set for MeshService, MeshMultiZoneService and MeshExternalService;
-            absent for other resource types.
+            destination, one entry per port, sorted by port ascending. Present
+            for MeshService, MeshMultiZoneService and MeshExternalService when
+            the destination has SNI sections/ports; absent otherwise.
           type: array
           readOnly: true
           items:
@@ -19784,8 +19784,8 @@ components:
                 description: The SNI string advertised by xDS for this port.
           example:
             - port: 8080
-              sectionName: http
-              sni: sni.msvc.default.zone-east.kuma-demo.myresource1.http
+              sectionName: '8080'
+              sni: sni.msvc.default.zone-east.kuma-demo.myresource1.8080
         name:
           description: Name of the Kuma resource
           type: string

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18497,15 +18497,13 @@ components:
           description: >-
             List of SNIs (Server Name Indication) advertised by xDS for this
             destination, one entry per port, sorted by port ascending. Present
-            for MeshService, MeshMultiZoneService and MeshExternalService when
-            the destination has SNI sections/ports; absent otherwise.
+            for MeshService, MeshMultiZoneService and MeshExternalService.
           type: array
           readOnly: true
           items:
             type: object
             required:
               - port
-              - sectionName
               - sni
             properties:
               port:
@@ -19212,15 +19210,13 @@ components:
           description: >-
             List of SNIs (Server Name Indication) advertised by xDS for this
             destination, one entry per port, sorted by port ascending. Present
-            for MeshService, MeshMultiZoneService and MeshExternalService when
-            the destination has SNI sections/ports; absent otherwise.
+            for MeshService, MeshMultiZoneService and MeshExternalService.
           type: array
           readOnly: true
           items:
             type: object
             required:
               - port
-              - sectionName
               - sni
             properties:
               port:
@@ -19747,15 +19743,13 @@ components:
           description: >-
             List of SNIs (Server Name Indication) advertised by xDS for this
             destination, one entry per port, sorted by port ascending. Present
-            for MeshService, MeshMultiZoneService and MeshExternalService when
-            the destination has SNI sections/ports; absent otherwise.
+            for MeshService, MeshMultiZoneService and MeshExternalService.
           type: array
           readOnly: true
           items:
             type: object
             required:
               - port
-              - sectionName
               - sni
             properties:
               port:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18512,17 +18512,11 @@ components:
                 type: integer
                 format: int32
                 description: The destination port this SNI corresponds to.
-              sectionName:
-                type: string
-                description: >-
-                  The section name placed in the trailing segment of the SNI:
-                  the port name when set, otherwise the stringified port number.
               sni:
                 type: string
                 description: The SNI string advertised by xDS for this port.
           example:
             - port: 8080
-              sectionName: '8080'
               sni: sni.extsvc.default.zone-east.kuma-system.myresource1.8080
         name:
           description: Name of the Kuma resource
@@ -19233,17 +19227,11 @@ components:
                 type: integer
                 format: int32
                 description: The destination port this SNI corresponds to.
-              sectionName:
-                type: string
-                description: >-
-                  The section name placed in the trailing segment of the SNI:
-                  the port name when set, otherwise the stringified port number.
               sni:
                 type: string
                 description: The SNI string advertised by xDS for this port.
           example:
             - port: 8080
-              sectionName: '8080'
               sni: sni.mzsvc.default.zone-east.kuma-demo.myresource1.8080
         name:
           description: Name of the Kuma resource
@@ -19774,17 +19762,11 @@ components:
                 type: integer
                 format: int32
                 description: The destination port this SNI corresponds to.
-              sectionName:
-                type: string
-                description: >-
-                  The section name placed in the trailing segment of the SNI:
-                  the port name when set, otherwise the stringified port number.
               sni:
                 type: string
                 description: The SNI string advertised by xDS for this port.
           example:
             - port: 8080
-              sectionName: '8080'
               sni: sni.msvc.default.zone-east.kuma-demo.myresource1.8080
         name:
           description: Name of the Kuma resource

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18493,6 +18493,37 @@ components:
           type: string
           readOnly: true
           example: kri_extsvc_default_zone-east_kuma-system_myresource1_
+        snis:
+          description: >-
+            List of SNIs (Server Name Indication) advertised by xDS for this
+            destination, one entry per port, sorted by port ascending. Always
+            set for MeshService, MeshMultiZoneService and MeshExternalService;
+            absent for other resource types.
+          type: array
+          readOnly: true
+          items:
+            type: object
+            required:
+              - port
+              - sectionName
+              - sni
+            properties:
+              port:
+                type: integer
+                format: int32
+                description: The destination port this SNI corresponds to.
+              sectionName:
+                type: string
+                description: >-
+                  The section name placed in the trailing segment of the SNI:
+                  the port name when set, otherwise the stringified port number.
+              sni:
+                type: string
+                description: The SNI string advertised by xDS for this port.
+          example:
+            - port: 8080
+              sectionName: http
+              sni: sni.extsvc.default.zone-east.kuma-system.myresource1.http
         name:
           description: Name of the Kuma resource
           type: string
@@ -19183,6 +19214,37 @@ components:
           type: string
           readOnly: true
           example: kri_mzsvc_default_zone-east_kuma-demo_myresource1_
+        snis:
+          description: >-
+            List of SNIs (Server Name Indication) advertised by xDS for this
+            destination, one entry per port, sorted by port ascending. Always
+            set for MeshService, MeshMultiZoneService and MeshExternalService;
+            absent for other resource types.
+          type: array
+          readOnly: true
+          items:
+            type: object
+            required:
+              - port
+              - sectionName
+              - sni
+            properties:
+              port:
+                type: integer
+                format: int32
+                description: The destination port this SNI corresponds to.
+              sectionName:
+                type: string
+                description: >-
+                  The section name placed in the trailing segment of the SNI:
+                  the port name when set, otherwise the stringified port number.
+              sni:
+                type: string
+                description: The SNI string advertised by xDS for this port.
+          example:
+            - port: 8080
+              sectionName: http
+              sni: sni.mzsvc.default.zone-east.kuma-demo.myresource1.http
         name:
           description: Name of the Kuma resource
           type: string
@@ -19693,6 +19755,37 @@ components:
           type: string
           readOnly: true
           example: kri_msvc_default_zone-east_kuma-demo_myresource1_
+        snis:
+          description: >-
+            List of SNIs (Server Name Indication) advertised by xDS for this
+            destination, one entry per port, sorted by port ascending. Always
+            set for MeshService, MeshMultiZoneService and MeshExternalService;
+            absent for other resource types.
+          type: array
+          readOnly: true
+          items:
+            type: object
+            required:
+              - port
+              - sectionName
+              - sni
+            properties:
+              port:
+                type: integer
+                format: int32
+                description: The destination port this SNI corresponds to.
+              sectionName:
+                type: string
+                description: >-
+                  The section name placed in the trailing segment of the SNI:
+                  the port name when set, otherwise the stringified port number.
+              sni:
+                type: string
+                description: The SNI string advertised by xDS for this port.
+          example:
+            - port: 8080
+              sectionName: http
+              sni: sni.msvc.default.zone-east.kuma-demo.myresource1.http
         name:
           description: Name of the Kuma resource
           type: string

--- a/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
@@ -8,6 +8,13 @@
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
    "kri": "kri_msvc_default___redis-1_",
+   "snis": [
+    {
+     "port": 6379,
+     "sectionName": "6379",
+     "sni": "sni.msvc.default.redis-1.6379"
+    }
+   ],
    "spec": {
     "state": "Unavailable",
     "selector": {
@@ -40,6 +47,13 @@
    "creationTime": "0001-01-01T00:00:00Z",
    "modificationTime": "0001-01-01T00:00:00Z",
    "kri": "kri_msvc_default___redis-2_",
+   "snis": [
+    {
+     "port": 6379,
+     "sectionName": "6379",
+     "sni": "sni.msvc.default.redis-2.6379"
+    }
+   ],
    "spec": {
     "state": "Unavailable",
     "selector": {

--- a/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_meshservices.golden.json
@@ -11,7 +11,6 @@
    "snis": [
     {
      "port": 6379,
-     "sectionName": "6379",
      "sni": "sni.msvc.default.redis-1.6379"
     }
    ],
@@ -50,7 +49,6 @@
    "snis": [
     {
      "port": 6379,
-     "sectionName": "6379",
      "sni": "sni.msvc.default.redis-2.6379"
     }
    ],

--- a/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
@@ -14,7 +14,6 @@
  "snis": [
   {
    "port": 4242,
-   "sectionName": "4242",
    "sni": "sni.extsvc.default.default.mes-tcp.4242"
   }
  ],

--- a/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshexternalservice_01.golden.json
@@ -11,6 +11,13 @@
   "kuma.io/zone": "default"
  },
  "kri": "kri_extsvc_default_default__mes-tcp_",
+ "snis": [
+  {
+   "port": 4242,
+   "sectionName": "4242",
+   "sni": "sni.extsvc.default.default.mes-tcp.4242"
+  }
+ ],
  "spec": {
   "match": {
    "type": "HostnameGenerator",

--- a/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
@@ -8,6 +8,13 @@
   "kuma.io/mesh": "default"
  },
  "kri": "kri_mzsvc_default___redis_",
+ "snis": [
+  {
+   "port": 6379,
+   "sectionName": "6379",
+   "sni": "sni.mzsvc.default.redis.6379"
+  }
+ ],
  "spec": {
   "selector": {
    "meshService": {

--- a/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshmultizoneservice_01.golden.json
@@ -11,7 +11,6 @@
  "snis": [
   {
    "port": 6379,
-   "sectionName": "6379",
    "sni": "sni.mzsvc.default.redis.6379"
   }
  ],

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
@@ -11,6 +11,13 @@
   "kuma.io/zone": "default"
  },
  "kri": "kri_msvc_default_default__redis_",
+ "snis": [
+  {
+   "port": 6379,
+   "sectionName": "6379",
+   "sni": "sni.msvc.default.default.redis.6379"
+  }
+ ],
  "spec": {
   "state": "Unavailable",
   "selector": {

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_01.golden.json
@@ -14,7 +14,6 @@
  "snis": [
   {
    "port": 6379,
-   "sectionName": "6379",
    "sni": "sni.msvc.default.default.redis.6379"
   }
  ],

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_01.golden.json
@@ -14,7 +14,6 @@
  "snis": [
   {
    "port": 8081,
-   "sectionName": "8081",
    "sni": "sni.msvc.default.default.with-status.8081"
   }
  ],

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_01.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_01.golden.json
@@ -11,6 +11,13 @@
   "kuma.io/zone": "default"
  },
  "kri": "kri_msvc_default_default__with-status_",
+ "snis": [
+  {
+   "port": 8081,
+   "sectionName": "8081",
+   "sni": "sni.msvc.default.default.with-status.8081"
+  }
+ ],
  "spec": {
   "state": "Unavailable",
   "selector": {

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_03.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_03.golden.json
@@ -14,7 +14,6 @@
  "snis": [
   {
    "port": 8082,
-   "sectionName": "8082",
    "sni": "sni.msvc.default.default.with-status.8082"
   }
  ],

--- a/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_03.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_meshservice_with_status_03.golden.json
@@ -11,6 +11,13 @@
   "kuma.io/zone": "default"
  },
  "kri": "kri_msvc_default_default__with-status_",
+ "snis": [
+  {
+   "port": 8082,
+   "sectionName": "8082",
+   "sni": "sni.msvc.default.default.with-status.8082"
+  }
+ ],
  "spec": {
   "state": "Unavailable",
   "selector": {

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/helpers.go
@@ -8,6 +8,7 @@ import (
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/vip"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/sni"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 )
 
@@ -73,6 +74,13 @@ func (m Match) GetValue() int32 {
 
 func (m Match) GetProtocol() core_meta.Protocol {
 	return m.Protocol
+}
+
+func (s *MeshExternalService) SNIs() []sni.Section {
+	if s == nil {
+		return nil
+	}
+	return []sni.Section{{Port: s.Match.Port, SectionName: s.Match.GetName()}}
 }
 
 func (l *MeshExternalServiceResourceList) GetDestinations() []core.Destination {

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -144,7 +144,7 @@ components:
           readOnly: true
           example: 'kri_extsvc_default_zone-east_kuma-system_myresource1_'
         snis:
-          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Always set for MeshService, MeshMultiZoneService and MeshExternalService; absent for other resource types.'
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService when the destination has SNI sections/ports; absent otherwise.'
           type: array
           readOnly: true
           items:
@@ -163,8 +163,8 @@ components:
                 description: 'The SNI string advertised by xDS for this port.'
           example:
             - port: 8080
-              sectionName: 'http'
-              sni: 'sni.extsvc.default.zone-east.kuma-system.myresource1.http'
+              sectionName: '8080'
+              sni: 'sni.extsvc.default.zone-east.kuma-system.myresource1.8080'
         name:
           description: 'Name of the Kuma resource'
           type: string

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -155,15 +155,11 @@ components:
                 type: integer
                 format: int32
                 description: 'The destination port this SNI corresponds to.'
-              sectionName:
-                type: string
-                description: 'The section name placed in the trailing segment of the SNI: the port name when set, otherwise the stringified port number.'
               sni:
                 type: string
                 description: 'The SNI string advertised by xDS for this port.'
           example:
             - port: 8080
-              sectionName: '8080'
               sni: 'sni.extsvc.default.zone-east.kuma-system.myresource1.8080'
         name:
           description: 'Name of the Kuma resource'

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -143,6 +143,28 @@ components:
           type: string
           readOnly: true
           example: 'kri_extsvc_default_zone-east_kuma-system_myresource1_'
+        snis:
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Always set for MeshService, MeshMultiZoneService and MeshExternalService; absent for other resource types.'
+          type: array
+          readOnly: true
+          items:
+            type: object
+            required: [port, sectionName, sni]
+            properties:
+              port:
+                type: integer
+                format: int32
+                description: 'The destination port this SNI corresponds to.'
+              sectionName:
+                type: string
+                description: 'The section name placed in the trailing segment of the SNI: the port name when set, otherwise the stringified port number.'
+              sni:
+                type: string
+                description: 'The SNI string advertised by xDS for this port.'
+          example:
+            - port: 8080
+              sectionName: 'http'
+              sni: 'sni.extsvc.default.zone-east.kuma-system.myresource1.http'
         name:
           description: 'Name of the Kuma resource'
           type: string

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -144,12 +144,12 @@ components:
           readOnly: true
           example: 'kri_extsvc_default_zone-east_kuma-system_myresource1_'
         snis:
-          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService when the destination has SNI sections/ports; absent otherwise.'
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService.'
           type: array
           readOnly: true
           items:
             type: object
-            required: [port, sectionName, sni]
+            required: [port, sni]
             properties:
               port:
                 type: integer

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core"
 	core_vip "github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/vip"
 	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/sni"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
@@ -89,6 +90,17 @@ func (p Port) GetValue() int32 {
 
 func (p Port) GetProtocol() core_meta.Protocol {
 	return p.AppProtocol
+}
+
+func (s *MeshMultiZoneService) SNIs() []sni.Section {
+	if s == nil {
+		return nil
+	}
+	out := make([]sni.Section, 0, len(s.Ports))
+	for _, p := range s.Ports {
+		out = append(out, sni.Section{Port: p.Port, SectionName: p.GetName()})
+	}
+	return out
 }
 
 func (l *MeshMultiZoneServiceResourceList) GetDestinations() []core.Destination {

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -155,15 +155,11 @@ components:
                 type: integer
                 format: int32
                 description: 'The destination port this SNI corresponds to.'
-              sectionName:
-                type: string
-                description: 'The section name placed in the trailing segment of the SNI: the port name when set, otherwise the stringified port number.'
               sni:
                 type: string
                 description: 'The SNI string advertised by xDS for this port.'
           example:
             - port: 8080
-              sectionName: '8080'
               sni: 'sni.mzsvc.default.zone-east.kuma-demo.myresource1.8080'
         name:
           description: 'Name of the Kuma resource'

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -144,12 +144,12 @@ components:
           readOnly: true
           example: 'kri_mzsvc_default_zone-east_kuma-demo_myresource1_'
         snis:
-          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService when the destination has SNI sections/ports; absent otherwise.'
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService.'
           type: array
           readOnly: true
           items:
             type: object
-            required: [port, sectionName, sni]
+            required: [port, sni]
             properties:
               port:
                 type: integer

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -144,7 +144,7 @@ components:
           readOnly: true
           example: 'kri_mzsvc_default_zone-east_kuma-demo_myresource1_'
         snis:
-          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Always set for MeshService, MeshMultiZoneService and MeshExternalService; absent for other resource types.'
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService when the destination has SNI sections/ports; absent otherwise.'
           type: array
           readOnly: true
           items:
@@ -163,8 +163,8 @@ components:
                 description: 'The SNI string advertised by xDS for this port.'
           example:
             - port: 8080
-              sectionName: 'http'
-              sni: 'sni.mzsvc.default.zone-east.kuma-demo.myresource1.http'
+              sectionName: '8080'
+              sni: 'sni.mzsvc.default.zone-east.kuma-demo.myresource1.8080'
         name:
           description: 'Name of the Kuma resource'
           type: string

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -143,6 +143,28 @@ components:
           type: string
           readOnly: true
           example: 'kri_mzsvc_default_zone-east_kuma-demo_myresource1_'
+        snis:
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Always set for MeshService, MeshMultiZoneService and MeshExternalService; absent for other resource types.'
+          type: array
+          readOnly: true
+          items:
+            type: object
+            required: [port, sectionName, sni]
+            properties:
+              port:
+                type: integer
+                format: int32
+                description: 'The destination port this SNI corresponds to.'
+              sectionName:
+                type: string
+                description: 'The section name placed in the trailing segment of the SNI: the port name when set, otherwise the stringified port number.'
+              sni:
+                type: string
+                description: 'The SNI string advertised by xDS for this port.'
+          example:
+            - port: 8080
+              sectionName: 'http'
+              sni: 'sni.mzsvc.default.zone-east.kuma-demo.myresource1.http'
         name:
           description: 'Name of the Kuma resource'
           type: string

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/helpers.go
@@ -8,6 +8,7 @@ import (
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core"
 	core_vip "github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/vip"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/sni"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
@@ -124,6 +125,17 @@ func (p Port) GetValue() int32 {
 
 func (p Port) GetProtocol() core_meta.Protocol {
 	return p.AppProtocol
+}
+
+func (s *MeshService) SNIs() []sni.Section {
+	if s == nil {
+		return nil
+	}
+	out := make([]sni.Section, 0, len(s.Ports))
+	for _, p := range s.Ports {
+		out = append(out, sni.Section{Port: p.Port, SectionName: p.GetName()})
+	}
+	return out
 }
 
 func (l *MeshServiceResourceList) GetDestinations() []core.Destination {

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -155,15 +155,11 @@ components:
                 type: integer
                 format: int32
                 description: 'The destination port this SNI corresponds to.'
-              sectionName:
-                type: string
-                description: 'The section name placed in the trailing segment of the SNI: the port name when set, otherwise the stringified port number.'
               sni:
                 type: string
                 description: 'The SNI string advertised by xDS for this port.'
           example:
             - port: 8080
-              sectionName: '8080'
               sni: 'sni.msvc.default.zone-east.kuma-demo.myresource1.8080'
         name:
           description: 'Name of the Kuma resource'

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -144,7 +144,7 @@ components:
           readOnly: true
           example: 'kri_msvc_default_zone-east_kuma-demo_myresource1_'
         snis:
-          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Always set for MeshService, MeshMultiZoneService and MeshExternalService; absent for other resource types.'
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService when the destination has SNI sections/ports; absent otherwise.'
           type: array
           readOnly: true
           items:
@@ -163,8 +163,8 @@ components:
                 description: 'The SNI string advertised by xDS for this port.'
           example:
             - port: 8080
-              sectionName: 'http'
-              sni: 'sni.msvc.default.zone-east.kuma-demo.myresource1.http'
+              sectionName: '8080'
+              sni: 'sni.msvc.default.zone-east.kuma-demo.myresource1.8080'
         name:
           description: 'Name of the Kuma resource'
           type: string

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -144,12 +144,12 @@ components:
           readOnly: true
           example: 'kri_msvc_default_zone-east_kuma-demo_myresource1_'
         snis:
-          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService when the destination has SNI sections/ports; absent otherwise.'
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Present for MeshService, MeshMultiZoneService and MeshExternalService.'
           type: array
           readOnly: true
           items:
             type: object
-            required: [port, sectionName, sni]
+            required: [port, sni]
             properties:
               port:
                 type: integer

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -143,6 +143,28 @@ components:
           type: string
           readOnly: true
           example: 'kri_msvc_default_zone-east_kuma-demo_myresource1_'
+        snis:
+          description: 'List of SNIs (Server Name Indication) advertised by xDS for this destination, one entry per port, sorted by port ascending. Always set for MeshService, MeshMultiZoneService and MeshExternalService; absent for other resource types.'
+          type: array
+          readOnly: true
+          items:
+            type: object
+            required: [port, sectionName, sni]
+            properties:
+              port:
+                type: integer
+                format: int32
+                description: 'The destination port this SNI corresponds to.'
+              sectionName:
+                type: string
+                description: 'The section name placed in the trailing segment of the SNI: the port name when set, otherwise the stringified port number.'
+              sni:
+                type: string
+                description: 'The SNI string advertised by xDS for this port.'
+          example:
+            - port: 8080
+              sectionName: 'http'
+              sni: 'sni.msvc.default.zone-east.kuma-demo.myresource1.http'
         name:
           description: 'Name of the Kuma resource'
           type: string

--- a/pkg/core/resources/model/rest/v1alpha1/resource.go
+++ b/pkg/core/resources/model/rest/v1alpha1/resource.go
@@ -2,10 +2,13 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"sort"
 	"time"
 
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/sni"
 )
 
 type Resource struct {
@@ -36,8 +39,10 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 	}
 
 	var kriStr string
+	var snis []SNIEntry
 	if id, _ := kri.FromResourceMetaE(r.ResourceMeta, r.Type); !id.IsEmpty() {
 		kriStr = id.String()
+		snis = computeSNIs(id, r.Spec)
 	}
 
 	// Explicit struct with all fields in desired order
@@ -50,6 +55,7 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 		ModificationTime time.Time         `json:"modificationTime"`
 		Labels           map[string]string `json:"labels,omitempty"`
 		KRI              string            `json:"kri,omitempty"`
+		SNIs             []SNIEntry        `json:"snis,omitempty"`
 		Spec             json.RawMessage   `json:"spec,omitempty"`
 		Status           json.RawMessage   `json:"status,omitempty"`
 	}{
@@ -60,11 +66,53 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 		ModificationTime: r.ModificationTime,
 		Labels:           r.Labels,
 		KRI:              kriStr,
+		SNIs:             snis,
 		Spec:             specJSON,
 		Status:           statusJSON,
 	}
 
 	return json.Marshal(aux)
+}
+
+// SNIEntry pairs a destination port with the SNI advertised by xDS for that
+// port. Section is the section name fed into the trailing segment of the
+// SNI (typically the port name, falling back to the stringified port).
+type SNIEntry struct {
+	Port    int32  `json:"port"`
+	Section string `json:"sectionName"`
+	SNI     string `json:"sni"`
+}
+
+// computeSNIs returns the list of SNIs for the resource identified by id,
+// derived from the sections contributed by spec. Entries are sorted by port
+// ascending so the output is deterministic. Returns nil for resources that
+// are not destinations or whose spec does not implement sni.SectionLister.
+func computeSNIs(id kri.Identifier, spec core_model.ResourceSpec) []SNIEntry {
+	desc, err := registry.Global().DescriptorFor(id.ResourceType)
+	if err != nil || !desc.IsDestination {
+		return nil
+	}
+	lister, ok := spec.(sni.SectionLister)
+	if !ok {
+		return nil
+	}
+	sections := lister.SNIs()
+	if len(sections) == 0 {
+		return nil
+	}
+	out := make([]SNIEntry, 0, len(sections))
+	for _, s := range sections {
+		v, err := sni.FromKRIE(kri.WithSectionName(id, s.SectionName))
+		if err != nil {
+			continue
+		}
+		out = append(out, SNIEntry{Port: s.Port, Section: s.SectionName, SNI: v})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Port < out[j].Port })
+	return out
 }
 
 func (r *Resource) GetMeta() ResourceMeta {

--- a/pkg/core/resources/model/rest/v1alpha1/resource.go
+++ b/pkg/core/resources/model/rest/v1alpha1/resource.go
@@ -78,9 +78,8 @@ func (r *Resource) MarshalJSON() ([]byte, error) {
 // port. Section is the section name fed into the trailing segment of the
 // SNI (typically the port name, falling back to the stringified port).
 type SNIEntry struct {
-	Port    int32  `json:"port"`
-	Section string `json:"sectionName"`
-	SNI     string `json:"sni"`
+	Port int32  `json:"port"`
+	SNI  string `json:"sni"`
 }
 
 // computeSNIs returns the list of SNIs for the resource identified by id,
@@ -106,7 +105,7 @@ func computeSNIs(id kri.Identifier, spec core_model.ResourceSpec) []SNIEntry {
 		if err != nil {
 			continue
 		}
-		out = append(out, SNIEntry{Port: s.Port, Section: s.SectionName, SNI: v})
+		out = append(out, SNIEntry{Port: s.Port, SNI: v})
 	}
 	if len(out) == 0 {
 		return nil

--- a/pkg/core/resources/model/rest/v1alpha1/resource_test.go
+++ b/pkg/core/resources/model/rest/v1alpha1/resource_test.go
@@ -105,8 +105,8 @@ var _ = Describe("Rest Resource", func() {
 				Expect(json.Unmarshal(bytes, &got)).To(Succeed())
 				Expect(got.KRI).To(Equal("kri_msvc_default_east_demo_backend_"))
 				Expect(got.SNIs).To(Equal([]v1alpha1.SNIEntry{
-					{Port: 6379, Section: "6379", SNI: "sni.msvc.default.east.demo.backend.6379"},
-					{Port: 8080, Section: "http", SNI: "sni.msvc.default.east.demo.backend.http"},
+					{Port: 6379, SNI: "sni.msvc.default.east.demo.backend.6379"},
+					{Port: 8080, SNI: "sni.msvc.default.east.demo.backend.http"},
 				}))
 			})
 
@@ -132,7 +132,7 @@ var _ = Describe("Rest Resource", func() {
 				}
 				Expect(json.Unmarshal(bytes, &got)).To(Succeed())
 				Expect(got.SNIs).To(Equal([]v1alpha1.SNIEntry{
-					{Port: 443, Section: "443", SNI: "sni.extsvc.default.google.443"},
+					{Port: 443, SNI: "sni.extsvc.default.google.443"},
 				}))
 			})
 
@@ -160,7 +160,7 @@ var _ = Describe("Rest Resource", func() {
 				}
 				Expect(json.Unmarshal(bytes, &got)).To(Succeed())
 				Expect(got.SNIs).To(Equal([]v1alpha1.SNIEntry{
-					{Port: 9090, Section: "grpc", SNI: "sni.mzsvc.default.agg.grpc"},
+					{Port: 9090, SNI: "sni.mzsvc.default.agg.grpc"},
 				}))
 			})
 

--- a/pkg/core/resources/model/rest/v1alpha1/resource_test.go
+++ b/pkg/core/resources/model/rest/v1alpha1/resource_test.go
@@ -7,8 +7,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	meshexternalservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshmultizoneservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/model/rest/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/test/kds/samples"
+	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
 
 var _ = Describe("Rest Resource", func() {
@@ -66,6 +71,131 @@ var _ = Describe("Rest Resource", func() {
   }
 }`
 				Expect(string(bytes)).To(MatchJSON(expected))
+			})
+
+			It("should include port-sorted snis for MeshService with multiple ports", func() {
+				res := &v1alpha1.Resource{
+					ResourceMeta: v1alpha1.ResourceMeta{
+						Type:             "MeshService",
+						Mesh:             "default",
+						Name:             "backend",
+						CreationTime:     t1,
+						ModificationTime: t2,
+						Labels: map[string]string{
+							mesh_proto.ZoneTag:             "east",
+							mesh_proto.KubeNamespaceTag:    "demo",
+							mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+						},
+					},
+					Spec: &meshservice_api.MeshService{
+						Ports: []meshservice_api.Port{
+							{Port: 8080, Name: pointer.To("http")},
+							{Port: 6379},
+						},
+					},
+				}
+
+				bytes, err := json.Marshal(res)
+				Expect(err).ToNot(HaveOccurred())
+
+				var got struct {
+					KRI  string              `json:"kri"`
+					SNIs []v1alpha1.SNIEntry `json:"snis"`
+				}
+				Expect(json.Unmarshal(bytes, &got)).To(Succeed())
+				Expect(got.KRI).To(Equal("kri_msvc_default_east_demo_backend_"))
+				Expect(got.SNIs).To(Equal([]v1alpha1.SNIEntry{
+					{Port: 6379, Section: "6379", SNI: "sni.msvc.default.east.demo.backend.6379"},
+					{Port: 8080, Section: "http", SNI: "sni.msvc.default.east.demo.backend.http"},
+				}))
+			})
+
+			It("should include a single sni for MeshExternalService", func() {
+				res := &v1alpha1.Resource{
+					ResourceMeta: v1alpha1.ResourceMeta{
+						Type:             "MeshExternalService",
+						Mesh:             "default",
+						Name:             "google",
+						CreationTime:     t1,
+						ModificationTime: t2,
+					},
+					Spec: &meshexternalservice_api.MeshExternalService{
+						Match: meshexternalservice_api.Match{Port: 443},
+					},
+				}
+
+				bytes, err := json.Marshal(res)
+				Expect(err).ToNot(HaveOccurred())
+
+				var got struct {
+					SNIs []v1alpha1.SNIEntry `json:"snis"`
+				}
+				Expect(json.Unmarshal(bytes, &got)).To(Succeed())
+				Expect(got.SNIs).To(Equal([]v1alpha1.SNIEntry{
+					{Port: 443, Section: "443", SNI: "sni.extsvc.default.google.443"},
+				}))
+			})
+
+			It("should include snis for MeshMultiZoneService", func() {
+				res := &v1alpha1.Resource{
+					ResourceMeta: v1alpha1.ResourceMeta{
+						Type:             "MeshMultiZoneService",
+						Mesh:             "default",
+						Name:             "agg",
+						CreationTime:     t1,
+						ModificationTime: t2,
+					},
+					Spec: &meshmultizoneservice_api.MeshMultiZoneService{
+						Ports: []meshmultizoneservice_api.Port{
+							{Port: 9090, Name: pointer.To("grpc")},
+						},
+					},
+				}
+
+				bytes, err := json.Marshal(res)
+				Expect(err).ToNot(HaveOccurred())
+
+				var got struct {
+					SNIs []v1alpha1.SNIEntry `json:"snis"`
+				}
+				Expect(json.Unmarshal(bytes, &got)).To(Succeed())
+				Expect(got.SNIs).To(Equal([]v1alpha1.SNIEntry{
+					{Port: 9090, Section: "grpc", SNI: "sni.mzsvc.default.agg.grpc"},
+				}))
+			})
+
+			It("should omit snis for MeshService with no ports", func() {
+				res := &v1alpha1.Resource{
+					ResourceMeta: v1alpha1.ResourceMeta{
+						Type:             "MeshService",
+						Mesh:             "default",
+						Name:             "empty",
+						CreationTime:     t1,
+						ModificationTime: t2,
+					},
+					Spec: &meshservice_api.MeshService{},
+				}
+
+				bytes, err := json.Marshal(res)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytes).ToNot(ContainSubstring(`"snis"`))
+			})
+
+			It("should not include snis for non-destination resources", func() {
+				res := &v1alpha1.Resource{
+					ResourceMeta: v1alpha1.ResourceMeta{
+						Type:             "MeshTrafficPermission",
+						Mesh:             "default",
+						Name:             "one",
+						CreationTime:     t1,
+						ModificationTime: t2,
+					},
+					Spec: samples.MeshTrafficPermission,
+				}
+
+				bytes, err := json.Marshal(res)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytes).ToNot(ContainSubstring(`"snis"`))
 			})
 
 			It("should marshal JSON with proper field order and empty spec", func() {

--- a/pkg/core/resources/sni/sni.go
+++ b/pkg/core/resources/sni/sni.go
@@ -7,6 +7,7 @@ import (
 	k8s_validation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/registry"
 )
 
@@ -39,6 +40,35 @@ var sniCapableShortNames = map[string]struct{}{
 // kuma-system on Global.
 func FromKRI(id kri.Identifier) string {
 	return strings.Join(buildSegments(id), ".")
+}
+
+// FromKRIE is the non-panicking variant of FromKRI. It returns an error when
+// the resource type is not SNI-capable or the descriptor cannot be resolved,
+// so callers running in marshaling code paths do not have to defend against
+// programmer errors with recover.
+func FromKRIE(id kri.Identifier) (string, error) {
+	desc, err := registry.Global().DescriptorFor(id.ResourceType)
+	if err != nil {
+		return "", err
+	}
+	if _, ok := sniCapableShortNames[desc.ShortName]; !ok {
+		return "", fmt.Errorf("resource type not supported for SNI: %s", id.ResourceType)
+	}
+	return strings.Join(buildSegmentsFor(desc, id), "."), nil
+}
+
+// Section describes a single (port, sectionName) pair that contributes one
+// SNI for a destination. SectionName is what gets placed into the trailing
+// segment of the SNI and matches kri.Identifier.SectionName.
+type Section struct {
+	Port        int32
+	SectionName string
+}
+
+// SectionLister is implemented by resource spec types that contribute SNI
+// sections.
+type SectionLister interface {
+	SNIs() []Section
 }
 
 // ValidateKRI returns every reason the SNI that FromKRI would produce does
@@ -98,7 +128,10 @@ func buildSegments(id kri.Identifier) []string {
 	if _, ok := sniCapableShortNames[desc.ShortName]; !ok {
 		panic("resource type not supported for SNI: " + string(id.ResourceType))
 	}
+	return buildSegmentsFor(desc, id)
+}
 
+func buildSegmentsFor(desc core_model.ResourceTypeDescriptor, id kri.Identifier) []string {
 	segments := []string{sniFormatPrefix, desc.ShortName, id.Mesh}
 	if id.Zone != "" {
 		segments = append(segments, id.Zone)

--- a/pkg/kds/context/testdata/full_sync/mesh-service/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/global.golden.yaml
@@ -20,10 +20,8 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-1-2v6wfvvcvbc9f55d
 snis:
 - port: 6739
-  sectionName: "6739"
   sni: sni.msvc.default.zone-1.redis-zone-1.6739
 - port: 16739
-  sectionName: some-port
   sni: sni.msvc.default.zone-1.redis-zone-1.some-port
 spec:
   ports:
@@ -64,10 +62,8 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-2-ff29vc4685c6f594
 snis:
 - port: 6739
-  sectionName: "6739"
   sni: sni.msvc.default.zone-2.redis-zone-2.6739
 - port: 16739
-  sectionName: some-port
   sni: sni.msvc.default.zone-2.redis-zone-2.some-port
 spec:
   ports:

--- a/pkg/kds/context/testdata/full_sync/mesh-service/global.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/global.golden.yaml
@@ -18,6 +18,13 @@ labels:
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-1-2v6wfvvcvbc9f55d
+snis:
+- port: 6739
+  sectionName: "6739"
+  sni: sni.msvc.default.zone-1.redis-zone-1.6739
+- port: 16739
+  sectionName: some-port
+  sni: sni.msvc.default.zone-1.redis-zone-1.some-port
 spec:
   ports:
   - appProtocol: tcp
@@ -55,6 +62,13 @@ labels:
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-2-ff29vc4685c6f594
+snis:
+- port: 6739
+  sectionName: "6739"
+  sni: sni.msvc.default.zone-2.redis-zone-2.6739
+- port: 16739
+  sectionName: some-port
+  sni: sni.msvc.default.zone-2.redis-zone-2.some-port
 spec:
   ports:
   - appProtocol: tcp

--- a/pkg/kds/context/testdata/full_sync/mesh-service/zone-1.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/zone-1.golden.yaml
@@ -19,10 +19,8 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-1
 snis:
 - port: 6739
-  sectionName: "6739"
   sni: sni.msvc.default.redis-zone-1.6739
 - port: 16739
-  sectionName: some-port
   sni: sni.msvc.default.redis-zone-1.some-port
 spec:
   ports:
@@ -63,10 +61,8 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-2-ff29vc4685c6f594
 snis:
 - port: 6739
-  sectionName: "6739"
   sni: sni.msvc.default.zone-2.redis-zone-2.6739
 - port: 16739
-  sectionName: some-port
   sni: sni.msvc.default.zone-2.redis-zone-2.some-port
 spec:
   ports:

--- a/pkg/kds/context/testdata/full_sync/mesh-service/zone-1.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/zone-1.golden.yaml
@@ -17,6 +17,13 @@ labels:
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-1
+snis:
+- port: 6739
+  sectionName: "6739"
+  sni: sni.msvc.default.redis-zone-1.6739
+- port: 16739
+  sectionName: some-port
+  sni: sni.msvc.default.redis-zone-1.some-port
 spec:
   ports:
   - appProtocol: tcp
@@ -54,6 +61,13 @@ labels:
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-2-ff29vc4685c6f594
+snis:
+- port: 6739
+  sectionName: "6739"
+  sni: sni.msvc.default.zone-2.redis-zone-2.6739
+- port: 16739
+  sectionName: some-port
+  sni: sni.msvc.default.zone-2.redis-zone-2.some-port
 spec:
   ports:
   - appProtocol: tcp

--- a/pkg/kds/context/testdata/full_sync/mesh-service/zone-2.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/zone-2.golden.yaml
@@ -20,6 +20,13 @@ labels:
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-1-2v6wfvvcvbc9f55d
+snis:
+- port: 6739
+  sectionName: "6739"
+  sni: sni.msvc.default.zone-1.redis-zone-1.6739
+- port: 16739
+  sectionName: some-port
+  sni: sni.msvc.default.zone-1.redis-zone-1.some-port
 spec:
   ports:
   - appProtocol: tcp
@@ -47,6 +54,13 @@ labels:
 mesh: default
 modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-2
+snis:
+- port: 6739
+  sectionName: "6739"
+  sni: sni.msvc.default.redis-zone-2.6739
+- port: 16739
+  sectionName: some-port
+  sni: sni.msvc.default.redis-zone-2.some-port
 spec:
   ports:
   - appProtocol: tcp

--- a/pkg/kds/context/testdata/full_sync/mesh-service/zone-2.golden.yaml
+++ b/pkg/kds/context/testdata/full_sync/mesh-service/zone-2.golden.yaml
@@ -22,10 +22,8 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-1-2v6wfvvcvbc9f55d
 snis:
 - port: 6739
-  sectionName: "6739"
   sni: sni.msvc.default.zone-1.redis-zone-1.6739
 - port: 16739
-  sectionName: some-port
   sni: sni.msvc.default.zone-1.redis-zone-1.some-port
 spec:
   ports:
@@ -56,10 +54,8 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: redis-zone-2
 snis:
 - port: 6739
-  sectionName: "6739"
   sni: sni.msvc.default.redis-zone-2.6739
 - port: 16739
-  sectionName: some-port
   sni: sni.msvc.default.redis-zone-2.some-port
 spec:
   ports:

--- a/tools/openapi/templates/schema.yaml
+++ b/tools/openapi/templates/schema.yaml
@@ -29,8 +29,8 @@ properties:
   snis:
     description: 'List of SNIs (Server Name Indication) advertised by xDS
       for this destination, one entry per port, sorted by port ascending.
-      Always set for MeshService, MeshMultiZoneService and MeshExternalService;
-      absent for other resource types.'
+      Present for MeshService, MeshMultiZoneService and MeshExternalService
+      when the destination has SNI sections/ports; absent otherwise.'
     type: array
     readOnly: true
     items:
@@ -51,8 +51,8 @@ properties:
           description: 'The SNI string advertised by xDS for this port.'
     example:
       - port: 8080
-        sectionName: 'http'
-        sni: 'sni.{{ .ShortName }}.{{ $mesh }}.{{ $zone }}.{{ $ns }}.{{ $name }}.http'
+        sectionName: '8080'
+        sni: 'sni.{{ .ShortName }}.{{ $mesh }}.{{ $zone }}.{{ $ns }}.{{ $name }}.8080'
   {{- end }}
   {{- end }}
   name:

--- a/tools/openapi/templates/schema.yaml
+++ b/tools/openapi/templates/schema.yaml
@@ -29,12 +29,12 @@ properties:
   snis:
     description: 'List of SNIs (Server Name Indication) advertised by xDS
       for this destination, one entry per port, sorted by port ascending.
-      Present for MeshService, MeshMultiZoneService and MeshExternalService.
+      Present for MeshService, MeshMultiZoneService and MeshExternalService.'
     type: array
     readOnly: true
     items:
       type: object
-      required: [port, sectionName, sni]
+      required: [port, sni]
       properties:
         port:
           type: integer

--- a/tools/openapi/templates/schema.yaml
+++ b/tools/openapi/templates/schema.yaml
@@ -25,6 +25,35 @@ properties:
     type: string
     readOnly: true
     example: 'kri_{{ .ShortName }}_{{ $mesh }}_{{ $zone }}_{{ $ns }}_{{ $name }}_'
+  {{- if .IsDestination }}
+  snis:
+    description: 'List of SNIs (Server Name Indication) advertised by xDS
+      for this destination, one entry per port, sorted by port ascending.
+      Always set for MeshService, MeshMultiZoneService and MeshExternalService;
+      absent for other resource types.'
+    type: array
+    readOnly: true
+    items:
+      type: object
+      required: [port, sectionName, sni]
+      properties:
+        port:
+          type: integer
+          format: int32
+          description: 'The destination port this SNI corresponds to.'
+        sectionName:
+          type: string
+          description: 'The section name placed in the trailing segment of
+            the SNI: the port name when set, otherwise the stringified port
+            number.'
+        sni:
+          type: string
+          description: 'The SNI string advertised by xDS for this port.'
+    example:
+      - port: 8080
+        sectionName: 'http'
+        sni: 'sni.{{ .ShortName }}.{{ $mesh }}.{{ $zone }}.{{ $ns }}.{{ $name }}.http'
+  {{- end }}
   {{- end }}
   name:
     description: 'Name of the Kuma resource'

--- a/tools/openapi/templates/schema.yaml
+++ b/tools/openapi/templates/schema.yaml
@@ -29,8 +29,7 @@ properties:
   snis:
     description: 'List of SNIs (Server Name Indication) advertised by xDS
       for this destination, one entry per port, sorted by port ascending.
-      Present for MeshService, MeshMultiZoneService and MeshExternalService
-      when the destination has SNI sections/ports; absent otherwise.'
+      Present for MeshService, MeshMultiZoneService and MeshExternalService.
     type: array
     readOnly: true
     items:
@@ -41,17 +40,11 @@ properties:
           type: integer
           format: int32
           description: 'The destination port this SNI corresponds to.'
-        sectionName:
-          type: string
-          description: 'The section name placed in the trailing segment of
-            the SNI: the port name when set, otherwise the stringified port
-            number.'
         sni:
           type: string
           description: 'The SNI string advertised by xDS for this port.'
     example:
       - port: 8080
-        sectionName: '8080'
         sni: 'sni.{{ .ShortName }}.{{ $mesh }}.{{ $zone }}.{{ $ns }}.{{ $name }}.8080'
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## Motivation

We have introduced matching of SNI for policies, now we need to present users SNI for easier matching creation.

## Implementation information

* Add to response list of SNIs (like we did for KRI) - problem here is that MS/MMZS/MES can have mulitple ports and each port has different SNI (so it's not the same as KRI)
* Added tests
* Added option to introduce SNI field only to resources with `IsDestination` as it should automatically gets for smiliar type in the _future_

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/16555

> Changelog: feat(kuma-cp): add mesh-scoped zone proxies
