### PR TITLE
ci(deps): skip deps with unpublished fix ver

### DIFF
--- a/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
+++ b/tools/ci/update-vulnerable-dependencies/update-vulnerable-dependencies.sh
@@ -38,8 +38,14 @@ for dep in $(osv-scanner "${OSV_FLAGS[@]}" | jq -c '.results[].packages[] | .pac
       go mod edit -go="$fixVersion"
     else
       # Always use GOTOOLCHAIN=auto to allow downloading newer Go toolchain
-      # when updating dependencies that require it (e.g., helm requiring Go 1.24+)
-      GOTOOLCHAIN=auto go get "$package"@v"$fixVersion"
+      # when updating dependencies that require it (e.g., helm requiring Go 1.24+).
+      # OSV sometimes reports a fixed version that isn't published to the Go
+      # module proxy (e.g. github.com/docker/docker tags v29.x upstream as
+      # docker-v29.x, so go get fails with "unknown revision"). Don't abort the
+      # whole run in that case — log and move on so other updates still apply.
+      if ! GOTOOLCHAIN=auto go get "$package"@v"$fixVersion"; then
+        echo "WARNING: failed to update $package to v$fixVersion; skipping" >&2
+      fi
     fi
   fi
 done


### PR DESCRIPTION
## Motivation

The nightly `Update insecure dependencies` workflow has been failing on every
active branch (see run for 2026-05-27). Root cause:

- OSV reports GHSA-x744-4wpc-v9h2 fixed in `github.com/docker/docker` v29.3.1.
- moby/moby tags v29 releases as `docker-v29.3.1`, not `v29.3.1`, so the Go
  module proxy has no `v29.x` for that module path.
- `go get github.com/docker/docker@v29.3.1` fails with
  `invalid version: unknown revision v29.3.1`.
- Under `set -Eeuo pipefail` this aborts the whole loop, so no other
  vulnerable deps get bumped either.

## Implementation information

Guard the `go get` with `if !`, log a warning, and continue. Other deps still
get updated; the unfixable one re-surfaces in the "After update" scan output
already shown in the PR body the workflow opens.

Alternative considered: add a per-CVE ignore mechanism for docker. Rejected —
this is a generic problem (any future upstream that publishes a version OSV
knows about before the Go proxy does), so generic skip-on-failure fits better.

## Supporting documentation

> Changelog: skip