### PR TITLE
fix(insights): count mesh-scoped zone proxies in global insight

### DIFF
--- a/pkg/insights/globalinsight/global_insight_service.go
+++ b/pkg/insights/globalinsight/global_insight_service.go
@@ -64,6 +64,10 @@ func (gis *defaultGlobalInsightService) GetGlobalInsight(ctx context.Context) (*
 		return nil, err
 	}
 
+	if err := gis.aggregateMeshScopedZoneProxies(ctx, globalInsights); err != nil {
+		return nil, err
+	}
+
 	return globalInsights, nil
 }
 
@@ -260,4 +264,67 @@ func (gis *defaultGlobalInsightService) aggregateZoneEgresses(
 	}
 
 	return nil
+}
+
+func (gis *defaultGlobalInsightService) aggregateMeshScopedZoneProxies(
+	ctx context.Context,
+	globalInsight *api_types.GlobalInsightBase,
+) error {
+	zoneProxyDataplanes := &mesh.DataplaneResourceList{}
+	if err := gis.resourceStore.List(
+		ctx,
+		zoneProxyDataplanes,
+		core_store.ListByFilterFunc(func(resource core_model.Resource) bool {
+			dataplane, ok := resource.(*mesh.DataplaneResource)
+			return ok && isMeshScopedZoneProxyDataplane(dataplane)
+		}),
+	); err != nil {
+		return err
+	}
+
+	if len(zoneProxyDataplanes.Items) == 0 {
+		return nil
+	}
+
+	resourceKeys := make([]core_model.ResourceKey, 0, len(zoneProxyDataplanes.Items))
+	for _, dataplane := range zoneProxyDataplanes.Items {
+		resourceKeys = append(resourceKeys, core_model.MetaToResourceKey(dataplane.GetMeta()))
+	}
+
+	dataplaneInsights := &mesh.DataplaneInsightResourceList{}
+	if err := gis.resourceStore.List(ctx, dataplaneInsights, core_store.ListByResourceKeys(resourceKeys)); err != nil {
+		return err
+	}
+
+	insightsByKey := map[core_model.ResourceKey]*mesh.DataplaneInsightResource{}
+	for _, dataplaneInsight := range dataplaneInsights.Items {
+		insightsByKey[core_model.MetaToResourceKey(dataplaneInsight.GetMeta())] = dataplaneInsight
+	}
+
+	for _, dataplane := range zoneProxyDataplanes.Items {
+		key := core_model.MetaToResourceKey(dataplane.GetMeta())
+		insight := insightsByKey[key]
+		labels := dataplane.GetMeta().GetLabels()
+
+		if labels[mesh_proto.ListenerZoneIngressLabel] == "enabled" {
+			globalInsight.Zones.ZoneIngresses.Total += 1
+			if insight != nil && insight.GetSpec().(*mesh_proto.DataplaneInsight).IsOnline() {
+				globalInsight.Zones.ZoneIngresses.Online += 1
+			}
+		}
+
+		if labels[mesh_proto.ListenerZoneEgressLabel] == "enabled" {
+			globalInsight.Zones.ZoneEgresses.Total += 1
+			if insight != nil && insight.GetSpec().(*mesh_proto.DataplaneInsight).IsOnline() {
+				globalInsight.Zones.ZoneEgresses.Online += 1
+			}
+		}
+	}
+
+	return nil
+}
+
+func isMeshScopedZoneProxyDataplane(dataplane *mesh.DataplaneResource) bool {
+	labels := dataplane.GetMeta().GetLabels()
+	return labels[mesh_proto.ListenerZoneIngressLabel] == "enabled" || labels[mesh_proto.ListenerZoneEgressLabel] == "enabled"
 }

--- a/pkg/insights/globalinsight/global_insight_service_test.go
+++ b/pkg/insights/globalinsight/global_insight_service_test.go
@@ -74,6 +74,48 @@ var _ = Describe("Global Insight", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(matchers.MatchGoldenJSON(path.Join("testdata", "full_global_insight.golden.json")))
 	})
+
+	It("should include mesh-scoped zone proxy dataplanes in zone stats", func() {
+		// given
+		globalInsightService := globalinsight.NewDefaultGlobalInsightService(rm)
+
+		err := createMeshScopedZoneProxyDataplane("zi-online", "default", []mesh_proto.Dataplane_Networking_Listener_Type{
+			mesh_proto.Dataplane_Networking_Listener_ZoneIngress,
+		}, rs)
+		Expect(err).ToNot(HaveOccurred())
+		err = createDataplaneInsight("zi-online", "default", true, rs)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = createMeshScopedZoneProxyDataplane("zi-ze-offline", "payments", []mesh_proto.Dataplane_Networking_Listener_Type{
+			mesh_proto.Dataplane_Networking_Listener_ZoneIngress,
+			mesh_proto.Dataplane_Networking_Listener_ZoneEgress,
+		}, rs)
+		Expect(err).ToNot(HaveOccurred())
+		err = createDataplaneInsight("zi-ze-offline", "payments", false, rs)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = createMeshScopedZoneProxyDataplane("ze-no-insight", "payments", []mesh_proto.Dataplane_Networking_Listener_Type{
+			mesh_proto.Dataplane_Networking_Listener_ZoneEgress,
+		}, rs)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = builders.Dataplane().
+			WithName("standard-dp").
+			WithMesh("default").
+			WithServices("backend").
+			Create(rs)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		globalInsight, err := globalInsightService.GetGlobalInsight(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		// then
+		Expect(globalInsight.Zones.ZoneIngresses.Total).To(Equal(2))
+		Expect(globalInsight.Zones.ZoneIngresses.Online).To(Equal(1))
+		Expect(globalInsight.Zones.ZoneEgresses.Total).To(Equal(2))
+		Expect(globalInsight.Zones.ZoneEgresses.Online).To(Equal(0))
+	})
 })
 
 func createMeshInsight(name string, rs store.ResourceStore) error {
@@ -174,4 +216,69 @@ func createZoneEgressInsight(name string, mesh string, online bool, rs store.Res
 	}
 
 	return builder.Create(rs)
+}
+
+func createMeshScopedZoneProxyDataplane(
+	name string,
+	mesh string,
+	listenerTypes []mesh_proto.Dataplane_Networking_Listener_Type,
+	rs store.ResourceStore,
+) error {
+	listeners := make([]*mesh_proto.Dataplane_Networking_Listener, 0, len(listenerTypes))
+	for i, listenerType := range listenerTypes {
+		listeners = append(listeners, &mesh_proto.Dataplane_Networking_Listener{
+			Type:    listenerType,
+			Address: "127.0.0.1",
+			Port:    10001 + uint32(i),
+		})
+	}
+
+	dataplane := builders.Dataplane().
+		WithName(name).
+		WithMesh(mesh).
+		With(func(dp *core_mesh.DataplaneResource) {
+			dp.Spec.Networking.Listeners = listeners
+		}).
+		Build()
+
+	return rs.Create(
+		context.Background(),
+		dataplane,
+		store.CreateByKey(name, mesh),
+		store.CreateWithLabels(meshScopedZoneProxyLabels(listenerTypes)),
+	)
+}
+
+func createDataplaneInsight(name string, mesh string, online bool, rs store.ResourceStore) error {
+	builder := builders.DataplaneInsight().WithName(name).WithMesh(mesh)
+
+	if online {
+		builder.AddSubscription(&mesh_proto.DiscoverySubscription{
+			ConnectTime: util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
+		})
+	} else {
+		builder.AddSubscription(&mesh_proto.DiscoverySubscription{
+			ConnectTime:    util_proto.MustTimestampProto(time.Unix(1694779805, 0)),
+			DisconnectTime: util_proto.MustTimestampProto(time.Unix(1694779925, 0)),
+		})
+	}
+
+	return builder.Create(rs)
+}
+
+func meshScopedZoneProxyLabels(
+	listenerTypes []mesh_proto.Dataplane_Networking_Listener_Type,
+) map[string]string {
+	labels := map[string]string{}
+
+	for _, listenerType := range listenerTypes {
+		switch listenerType {
+		case mesh_proto.Dataplane_Networking_Listener_ZoneIngress:
+			labels[mesh_proto.ListenerZoneIngressLabel] = "enabled"
+		case mesh_proto.Dataplane_Networking_Listener_ZoneEgress:
+			labels[mesh_proto.ListenerZoneEgressLabel] = "enabled"
+		}
+	}
+
+	return labels
 }


### PR DESCRIPTION
## Motivation

Count mesh-scoped zone proxies in `/global-insight` so the GUI does not need to walk meshes and dataplanes to derive these numbers.

## Implementation information

- extend global insight aggregation to include dataplanes with `kuma.io/listener-zoneingress` and `kuma.io/listener-zoneegress`
- reuse `DataplaneInsight` to compute online counts for mesh-scoped zone proxies
- keep the existing legacy `ZoneIngressInsight` and `ZoneEgressInsight` aggregation
- add regression coverage for ingress-only, combined ingress+egress, and no-insight cases

## Supporting documentation

Related: https://github.com/kumahq/kuma-gui/issues/4881

Question for reviewers: this PR accumulates mesh-scoped zone proxy counts into the existing `zoneIngresses` and `zoneEgresses` fields. Should these remain the canonical counters, or should we introduce separate fields for mesh-scoped proxies instead?

> Changelog: fix global insight counts for mesh-scoped zone proxies