### PR TITLE
feat(xds): add DiscoveryResponse size histogram

### DIFF
--- a/pkg/util/xds/callbacks.go
+++ b/pkg/util/xds/callbacks.go
@@ -25,6 +25,10 @@ type Response interface {
 	GetNonce() string
 	VersionInfo() string
 	GetNumberOfResources() int
+	// ByteSize returns the serialized protobuf size in bytes of the
+	// underlying DiscoveryResponse message. Used to expose payload size
+	// observability for xDS responses.
+	ByteSize() int
 }
 
 // DiscoveryRequest defines interface over real Envoy's DiscoveryRequest.

--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -43,6 +43,7 @@ type StatsCallbacks interface {
 type statsCallbacks struct {
 	NoopCallbacks
 	responsesSentMetric    *prometheus.CounterVec
+	responseBytesMetric    *prometheus.HistogramVec
 	requestsReceivedMetric *prometheus.CounterVec
 	versionsMetric         *prometheus.GaugeVec
 	deliveryMetric         prometheus.Histogram
@@ -89,6 +90,15 @@ func NewStatsCallbacks(metrics prometheus.Registerer, dsType string, versionExtr
 		Help: "Number of responses sent by the server to a client",
 	}, []string{"type_url"})
 	if err := metrics.Register(stats.responsesSentMetric); err != nil {
+		return nil, err
+	}
+
+	stats.responseBytesMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    dsType + "_responses_sent_bytes",
+		Help:    "Size in bytes of DiscoveryResponse messages sent by the server",
+		Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
+	}, []string{"type_url"})
+	if err := metrics.Register(stats.responseBytesMetric); err != nil {
 		return nil, err
 	}
 
@@ -185,6 +195,7 @@ func (s *statsCallbacks) OnStreamResponse(streamID int64, request DiscoveryReque
 	}
 
 	s.responsesSentMetric.WithLabelValues(response.GetTypeUrl()).Inc()
+	s.responseBytesMetric.WithLabelValues(response.GetTypeUrl()).Observe(float64(response.ByteSize()))
 }
 
 func (s *statsCallbacks) OnDeltaStreamOpen(context.Context, int64, string) error {
@@ -233,6 +244,7 @@ func (s *statsCallbacks) OnStreamDeltaResponse(streamID int64, request DeltaDisc
 	}
 
 	s.responsesSentMetric.WithLabelValues(response.GetTypeUrl()).Inc()
+	s.responseBytesMetric.WithLabelValues(response.GetTypeUrl()).Observe(float64(response.ByteSize()))
 }
 
 func classifyError(err string) string {

--- a/pkg/util/xds/stats_callbacks_test.go
+++ b/pkg/util/xds/stats_callbacks_test.go
@@ -153,6 +153,20 @@ var _ = Describe("Stats callbacks", func() {
 			Expect(test_metrics.FindMetric(metrics, "xds_responses_sent", "type_url", resource.RouteType).GetCounter().GetValue()).To(Equal(1.0))
 		})
 
+		It("should track response bytes", func() {
+			// when
+			resp := &envoy_discovery.DiscoveryResponse{
+				TypeUrl:     resource.RouteType,
+				VersionInfo: "123",
+			}
+			adaptedCallbacks.OnStreamResponse(context.Background(), streamId, nil, resp)
+
+			// then
+			histogram := test_metrics.FindMetric(metrics, "xds_responses_sent_bytes", "type_url", resource.RouteType).GetHistogram()
+			Expect(histogram.GetSampleCount()).To(Equal(uint64(1)))
+			Expect(histogram.GetSampleSum()).To(BeNumerically(">", 0))
+		})
+
 		It("should track config delivery", func() {
 			// given
 			statsCallbacks.ConfigReadyForDelivery("123")
@@ -322,6 +336,20 @@ var _ = Describe("Stats callbacks", func() {
 
 			// then
 			Expect(test_metrics.FindMetric(metrics, "delta_xds_responses_sent", "type_url", resource.RouteType).GetCounter().GetValue()).To(Equal(1.0))
+		})
+
+		It("should track response bytes", func() {
+			// when
+			resp := &envoy_discovery.DeltaDiscoveryResponse{
+				TypeUrl:           resource.RouteType,
+				SystemVersionInfo: "123",
+			}
+			adaptedCallbacks.OnStreamDeltaResponse(streamId, nil, resp)
+
+			// then
+			histogram := test_metrics.FindMetric(metrics, "delta_xds_responses_sent_bytes", "type_url", resource.RouteType).GetHistogram()
+			Expect(histogram.GetSampleCount()).To(Equal(uint64(1)))
+			Expect(histogram.GetSampleSum()).To(BeNumerically(">", 0))
 		})
 
 		It("should track config delivery", func() {

--- a/pkg/util/xds/v3/callbacks.go
+++ b/pkg/util/xds/v3/callbacks.go
@@ -6,6 +6,7 @@ import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -184,6 +185,12 @@ func (d *discoveryResponse) VersionInfo() string {
 	return d.GetVersionInfo()
 }
 
+func (d *discoveryResponse) ByteSize() int {
+	return proto.Size(d.DiscoveryResponse)
+}
+
+var _ xds.DiscoveryResponse = &discoveryResponse{}
+
 type deltaDiscoveryRequest struct {
 	*envoy_sd.DeltaDiscoveryRequest
 }
@@ -244,6 +251,10 @@ func (d *deltaDiscoveryResponse) GetResources() []*anypb.Any {
 
 func (d *deltaDiscoveryResponse) GetNumberOfResources() int {
 	return len(d.Resources)
+}
+
+func (d *deltaDiscoveryResponse) ByteSize() int {
+	return proto.Size(d.DeltaDiscoveryResponse)
 }
 
 var _ xds.DeltaDiscoveryResponse = &deltaDiscoveryResponse{}


### PR DESCRIPTION
## Motivation

Large xDS responses can deplete the gRPC C-Core 4 MiB receive-window
default in the GoogleGrpc transport (kumahq/kuma#16355), which silently
cancels streams without surfacing a clear error. Today the control
plane has no metric for outgoing DiscoveryResponse payload sizes, so
operators cannot see how close they are to the cap or correlate
regressions with newly-bloated xDS resources.

## Implementation information

- New histogram `<dsType>_responses_sent_bytes` registered alongside the
  existing `<dsType>_responses_sent` counter in
  `pkg/util/xds/stats_callbacks.go`.
- Single label `type_url`, exponential buckets
  `prometheus.ExponentialBuckets(1024, 2, 16)` (1 KiB through 32 MiB)
  to cover the current 4 MiB cap and the 16 MiB cap proposed in
  kumahq/kuma#16429 with headroom.
- Size is computed via `proto.Size` on the underlying envoy
  `DiscoveryResponse` / `DeltaDiscoveryResponse` inside the v3 adapter
  (`pkg/util/xds/v3/callbacks.go`) and exposed through a new
  `ByteSize() int` method added to the `Response` interface in
  `pkg/util/xds/callbacks.go`.
- Both `OnStreamResponse` and `OnStreamDeltaResponse` observe the
  histogram, mirroring the existing counter emission.
- Tests in `stats_callbacks_test.go` assert sample count and a
  non-zero sample sum for both stream and delta callbacks.

> Changelog: feat(kuma-cp): improve control-plane observability with dashboards, histograms, and operational metrics
