### PR TITLE
feat(xds): add per-proxy snapshot size histogram

### DIFF
--- a/pkg/xds/metrics/metrics.go
+++ b/pkg/xds/metrics/metrics.go
@@ -13,6 +13,7 @@ type Metrics struct {
 	KubeAuthCache           *prometheus.CounterVec
 	CertExpirationTimestamp *prometheus.GaugeVec
 	SnapshotResources       *prometheus.HistogramVec
+	SnapshotSizeBytes       *prometheus.HistogramVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -37,7 +38,12 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		Help:    "Distribution of resource counts per xDS snapshot by resource type.",
 		Buckets: prometheus.ExponentialBuckets(1, 2, 12),
 	}, []string{"resource_type"})
-	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationTimestamp, snapshotResources); err != nil {
+	snapshotSizeBytes := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "xds_snapshot_size_bytes",
+		Help:    "Total serialized size in bytes of resources in the snapshot computed per proxy, split by xDS resource type.",
+		Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
+	}, []string{"type_url", "proxy_type"})
+	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationTimestamp, snapshotResources, snapshotSizeBytes); err != nil {
 		return nil, err
 	}
 
@@ -47,5 +53,6 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		KubeAuthCache:           kubeAuthCache,
 		CertExpirationTimestamp: certExpirationTimestamp,
 		SnapshotResources:       snapshotResources,
+		SnapshotSizeBytes:       snapshotSizeBytes,
 	}, nil
 }

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -46,8 +46,8 @@ func RegisterXDS(
 	dpLifecycle := xds_callbacks.DataplaneCallbacksToXdsCallbacks(
 		xds_callbacks.NewDataplaneLifecycle(rt.AppContext(), rt.ResourceManager(), authenticator, rt.Config().XdsServer.DataplaneDeregistrationDelay.Duration, rt.GetInstanceId(), rt.Config().Store.Cache.ExpirationTime.Duration))
 	reconciler := DefaultReconciler(rt, xdsContext, statsCallbacks, xdsMetrics)
-	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks)
-	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks)
+	ingressReconciler := DefaultIngressReconciler(rt, xdsContext, statsCallbacks, xdsMetrics)
+	egressReconciler := DefaultEgressReconciler(rt, xdsContext, statsCallbacks, xdsMetrics)
 	otelStatusCache := otelstatus.NewCache()
 	watchdogFactory, err := xds_sync.DefaultDataplaneWatchdogFactory(rt, reconciler, ingressReconciler, egressReconciler, xdsMetrics, envoyCpCtx, otelStatusCache, envoy_common.APIV3)
 	if err != nil {
@@ -127,6 +127,7 @@ func DefaultIngressReconciler(
 	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
+	metrics *xds_metrics.Metrics,
 ) xds_sync.SnapshotReconciler {
 	resolver := &xds_template.StaticProxyTemplateResolver{
 		Template: &mesh_proto.ProxyTemplate{
@@ -145,6 +146,7 @@ func DefaultIngressReconciler(
 		},
 		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
 		statsCallbacks: statsCallbacks,
+		metrics:        metrics,
 	}
 }
 
@@ -152,6 +154,7 @@ func DefaultEgressReconciler(
 	rt core_runtime.Runtime,
 	xdsContext XdsContext,
 	statsCallbacks util_xds.StatsCallbacks,
+	metrics *xds_metrics.Metrics,
 ) xds_sync.SnapshotReconciler {
 	resolver := &xds_template.StaticProxyTemplateResolver{
 		Template: &mesh_proto.ProxyTemplate{
@@ -170,6 +173,7 @@ func DefaultEgressReconciler(
 		},
 		cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
 		statsCallbacks: statsCallbacks,
+		metrics:        metrics,
 	}
 }
 

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core"
 	model "github.com/kumahq/kuma/v2/pkg/core/xds"
 	util_xds "github.com/kumahq/kuma/v2/pkg/util/xds"
@@ -21,6 +22,31 @@ import (
 	xds_sync "github.com/kumahq/kuma/v2/pkg/xds/sync"
 	xds_template "github.com/kumahq/kuma/v2/pkg/xds/template"
 )
+
+var snapshotSizeTypeURLs = []string{
+	envoy_resource.ClusterType,
+	envoy_resource.EndpointType,
+	envoy_resource.ListenerType,
+	envoy_resource.RouteType,
+	envoy_resource.SecretType,
+	envoy_resource.RuntimeType,
+}
+
+// proxyTypeLabel returns the value for the proxy_type histogram label. The
+// reconciler is shared between dataplane, ingress and egress proxies, so we
+// pick the label based on which proxy-specific field is populated.
+func proxyTypeLabel(proxy *model.Proxy) string {
+	switch {
+	case proxy.ZoneIngressProxy != nil:
+		return string(mesh_proto.IngressProxyType)
+	case proxy.ZoneEgressProxy != nil:
+		return string(mesh_proto.EgressProxyType)
+	case proxy.Dataplane != nil && proxy.Dataplane.Spec.IsBuiltinGateway():
+		return string(mesh_proto.GatewayLabel)
+	default:
+		return string(mesh_proto.DataplaneProxyType)
+	}
+}
 
 var reconcileLog = core.Log.WithName("xds").WithName("reconcile")
 
@@ -97,6 +123,21 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 		return false, errors.Wrap(err, "inconsistent snapshot")
 	}
 	log.Info("config has changed", "versions", changed)
+
+	if r.metrics != nil {
+		proxyType := proxyTypeLabel(proxy)
+		for _, typeURL := range snapshotSizeTypeURLs {
+			resources := snapshot.GetResources(typeURL)
+			var total int
+			for _, res := range resources {
+				if res == nil {
+					continue
+				}
+				total += proto.Size(res)
+			}
+			r.metrics.SnapshotSizeBytes.WithLabelValues(typeURL, proxyType).Observe(float64(total))
+		}
+	}
 
 	if err := r.cacher.Cache(ctx, node, snapshot); err != nil {
 		return false, errors.Wrap(err, "failed to store snapshot")

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -21,10 +21,12 @@ import (
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	xds_model "github.com/kumahq/kuma/v2/pkg/core/xds"
 	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
+	test_metrics "github.com/kumahq/kuma/v2/pkg/test/metrics"
 	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/util/proto"
 	util_xds "github.com/kumahq/kuma/v2/pkg/util/xds"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+	xds_metrics "github.com/kumahq/kuma/v2/pkg/xds/metrics"
 )
 
 func hcmForRoute(routeName string) *anypb.Any {
@@ -131,6 +133,8 @@ var _ = Describe("Reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 			statsCallbacks, err := util_xds.NewStatsCallbacks(metrics, "xds", util_xds.NoopVersionExtractor)
 			Expect(err).ToNot(HaveOccurred())
+			xdsMetrics, err := xds_metrics.NewMetrics(metrics)
+			Expect(err).ToNot(HaveOccurred())
 
 			// setup
 			r := &reconciler{
@@ -140,6 +144,7 @@ var _ = Describe("Reconcile", func() {
 				}),
 				cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
 				statsCallbacks: statsCallbacks,
+				metrics:        xdsMetrics,
 			}
 
 			// given
@@ -185,6 +190,23 @@ var _ = Describe("Reconcile", func() {
 			Expect(clusterV1).ToNot(BeEmpty())
 			Expect(endpointV1).ToNot(BeEmpty())
 			Expect(secretV1).ToNot(BeEmpty())
+
+			By("verifying snapshot size histogram was observed for each xDS type")
+			for _, typeURL := range []string{
+				resource.ClusterType,
+				resource.EndpointType,
+				resource.ListenerType,
+				resource.RouteType,
+				resource.SecretType,
+				resource.RuntimeType,
+			} {
+				m := test_metrics.FindMetric(metrics, "xds_snapshot_size_bytes", "type_url", typeURL, "proxy_type", string(mesh_proto.DataplaneProxyType))
+				Expect(m).ToNot(BeNil(), "expected snapshot size histogram for %s", typeURL)
+				Expect(m.GetHistogram().GetSampleCount()).To(BeNumerically(">=", uint64(1)))
+			}
+			// non-empty resource types must have observed a positive byte total
+			listenerMetric := test_metrics.FindMetric(metrics, "xds_snapshot_size_bytes", "type_url", resource.ListenerType, "proxy_type", string(mesh_proto.DataplaneProxyType))
+			Expect(listenerMetric.GetHistogram().GetSampleSum()).To(BeNumerically(">", float64(0)))
 
 			By("simulating discovery event (Dataplane watchdog triggers refresh)")
 			// when


### PR DESCRIPTION
## Motivation

Snapshot size is the load factor that determines whether the control
plane hits the gRPC C-Core 4 MiB receive-window cap (or the proposed
16 MiB cap) on the data plane. Without an explicit metric operators
discover the cap was too small only via secondary symptoms (stream
cancellations, EDS initial-fetch timeouts, warming clusters), making
diagnosis slow. See kumahq/kuma#16355.

## Implementation information

- New histogram `xds_snapshot_size_bytes{type_url, proxy_type}` on
  the existing xDS metrics registry (`pkg/xds/metrics`).
- `type_url`: the standard Envoy resource type URL (Cluster,
  ClusterLoadAssignment, Listener, RouteConfiguration, Secret,
  Runtime), taken from go-control-plane's `envoy_resource` constants.
- `proxy_type`: `dataplane`, `ingress`, `egress`, or `gateway`,
  derived from the `Proxy` struct (`ZoneIngressProxy`,
  `ZoneEgressProxy`, `Dataplane.Spec.IsBuiltinGateway()`).
- Buckets: `prometheus.ExponentialBuckets(1024, 2, 16)` — 1 KiB to
  32 MiB, covers the relevant range around the gRPC caps.
- Observation point: in `pkg/xds/server/v3/reconcile.go::Reconcile`,
  after `GenerateSnapshot` succeeds and the snapshot passes
  `Consistent()`, before `SetSnapshot` is called via the cacher. This
  measures what we are about to ship to that DP per reconcile.
- Per-resource size is computed with `proto.Size`, summed across all
  resources of each type URL in the snapshot.
- The same reconciler is reused for ingress and egress proxies, so
  `xdsMetrics` is now plumbed into `DefaultIngressReconciler` and
  `DefaultEgressReconciler` too.

> Changelog: feat(xds): add per-proxy snapshot size histogram