### PR TITLE
test(meshaccesslog): wait for test-server-2 readiness

### DIFF
--- a/test/e2e_env/multizone/meshaccesslog/meshaccesslog.go
+++ b/test/e2e_env/multizone/meshaccesslog/meshaccesslog.go
@@ -230,6 +230,13 @@ spec:
 			g.Expect(log).To(Equal(fmt.Sprintf("sni=%s", testServer1SNI)))
 		}, "60s", "1s").Should(Succeed())
 
+		By("traffic to test-server-2 becomes routable before checking that it is not logged")
+		Eventually(func(g Gomega) {
+			response, err := client.CollectEchoResponse(multizone.UniZone2, demoClient, urlFor(testServer2))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(response.Instance).To(Equal(testServer2))
+		}, "60s", "1s").Should(Succeed())
+
 		By("traffic to test-server-2 does not match the rule and is not logged")
 		Consistently(func(g Gomega) {
 			_, err := client.CollectEchoResponse(multizone.UniZone2, demoClient, urlFor(testServer2))


### PR DESCRIPTION
## Motivation

`MeshAccessLog on Zone Ingress should log only traffic whose SNI matches the rule` can flake in multizone before it reaches the real assertion. The failure we investigated was a readiness race: traffic to `test-server-2` sometimes hit DNS or routing propagation before the path was fully converged, so the test failed for environment reasons rather than because `test-server-2` was being logged.

## Implementation information

This change adds an `Eventually(...)` warm-up for `test-server-2` before the negative assertion.

Step by step, this helps because:
1. the old test validated `test-server-1` and then immediately started a negative `Consistently(...)` check against `test-server-2`;
2. in multizone, `test-server-2` can still be converging across DNS, xDS, and routing at that moment;
3. the new `Eventually(...)` waits until traffic to `test-server-2` succeeds and confirms `response.Instance == testServer2`;
4. once that succeeds, the request path is ready, so the next check is testing access-log behavior rather than environment readiness;
5. the existing `Consistently(...)` remains in place, so if `test-server-2` traffic is incorrectly logged after readiness, the test still fails.

## Supporting documentation

- Flake investigation: https://github.com/kumahq/kuma/actions/runs/26564907389/job/78258426693#step:3:5377

> Changelog: skip
