### PR TITLE
fix(e2e): make universal DP compatibility tests actually exercise old DPs

### DIFF
--- a/test/dockerfiles/universal.Dockerfile
+++ b/test/dockerfiles/universal.Dockerfile
@@ -7,6 +7,12 @@ FROM ghcr.io/kumahq/ubuntu-netools:main@sha256:487f66a9386f17fb2ba4cf5271bbf6ce8
 
 ARG ARCH
 
+# ca-certificates is required for curl to validate HTTPS downloads (e.g. older
+# kuma-dp binaries from packages.konghq.com used by compatibility tests).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN useradd -u 5678 -U kuma-dp
 
 RUN mkdir /kuma

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -373,6 +373,15 @@ cp %s/envoy /usr/bin/envoy
 	// create the token file on the app container
 	_, _ = cmd.WriteString("#!/bin/sh\n")
 	_, _ = fmt.Fprintf(cmd, "printf %q > /kuma/token-%s\n", token, name)
+	if envsMap == nil {
+		envsMap = map[string]string{}
+	}
+	// Skip CP cert verification via env var instead of the --skip-verify flag so
+	// that older kuma-dp versions (compatibility tests) silently ignore it
+	// instead of erroring on an unknown flag.
+	if _, ok := envsMap["KUMA_CONTROL_PLANE_TLS_SKIP_VERIFY"]; !ok {
+		envsMap["KUMA_CONTROL_PLANE_TLS_SKIP_VERIFY"] = "true"
+	}
 	for k, v := range envsMap {
 		_, _ = fmt.Fprintf(cmd, "export %s=%s\n", k, utils.ShellEscape(v))
 	}
@@ -399,7 +408,6 @@ cp %s/envoy /usr/bin/envoy
 		"runuser", "-u", "kuma-dp", "--",
 		"/usr/bin/kuma-dp", "run",
 		"--cp-address=" + cpAddress,
-		"--skip-verify",
 		"--dataplane-token-file=/kuma/token-" + name,
 		"--binary-path", "/usr/local/bin/envoy",
 	}

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -350,22 +350,29 @@ func (s *UniversalApp) CreateDP(
 	transparent bool,
 	dpVersion string,
 ) error {
-	cmd := &strings.Builder{}
-	// create the token file on the app container
-	_, _ = cmd.WriteString("#!/bin/sh\n")
-	_, _ = fmt.Fprintf(cmd, "printf %q > /kuma/token-%s\n", token, name)
 	if dpVersion != "" {
 		// It is important to store installation package in /tmp/kuma/, not /tmp/ otherwise root was taking over /tmp/ and Kuma DP could not store /tmp files
 		url := fmt.Sprintf("https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-%[2]s/versions/%[1]s/kuma-%[1]s-linux-%[2]s.tar.gz", dpVersion, Config.Arch)
 		newPathOut := fmt.Sprintf("/tmp/kuma/kuma-%s/bin", dpVersion)
 
-		_, _ = fmt.Fprintf(cmd, `
-mkdir -p /tmp/
-curl --no-progress-bar --fail '%s' | tar xvzf - --directory /tmp/kuma/
+		// Run the install synchronously so a failed download fails the test fast
+		// instead of silently falling through to the image's bundled binaries.
+		installScript := fmt.Sprintf(`set -e
+rm -f /usr/bin/kuma-dp /usr/bin/envoy
+mkdir -p /tmp/kuma/
+curl --no-progress-bar --fail '%s' -o /tmp/kuma/kuma.tar.gz
+tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
 cp %s/kuma-dp /usr/bin/kuma-dp
 cp %s/envoy /usr/bin/envoy
-		`, url, newPathOut, newPathOut)
+`, url, newPathOut, newPathOut)
+		if stdout, stderr, err := s.universalNetworking.RunCommand(installScript); err != nil {
+			return errors.Wrapf(err, "failed to install kuma-dp %s: stdout=%q stderr=%q", dpVersion, stdout, stderr)
+		}
 	}
+	cmd := &strings.Builder{}
+	// create the token file on the app container
+	_, _ = cmd.WriteString("#!/bin/sh\n")
+	_, _ = fmt.Fprintf(cmd, "printf %q > /kuma/token-%s\n", token, name)
 	for k, v := range envsMap {
 		_, _ = fmt.Fprintf(cmd, "export %s=%s\n", k, utils.ShellEscape(v))
 	}


### PR DESCRIPTION
## Motivation

The universal DP compatibility tests silently passed without ever running the old DP binaries — every "old" client/server ran the current build's `kuma-dp`.

Three combined bugs:
1. Download/install ran inside the async DP session with no `set -e`, so `curl`/`cp` failures silently fell through to the image's bundled (current) `kuma-dp`.
2. The test image had no `ca-certificates`, so `curl` failed with `(77) error setting certificate file`.
3. `--skip-verify` is not supported on older `kuma-dp` builds.

## Implementation

- Move the version install out of the long-running DP session into a synchronous `Networking.RunCommand` so download failures fail the test immediately. Add `set -e`, split `curl | tar` (sh has no reliable `pipefail`), and `rm -f` the existing binaries up front so there's nothing to fall back to.
- Install `ca-certificates` in `test/dockerfiles/universal.Dockerfile`.
- Replace `--skip-verify` with `KUMA_CONTROL_PLANE_TLS_SKIP_VERIFY=true` via `envsMap` — unknown env vars are silently ignored by older builds.

> Changelog: skip