### PR TITLE
fix(kuma-init): properly validate ip family condition

### DIFF
--- a/app/kumactl/cmd/install/install_transparent_proxy_validator.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_validator.go
@@ -22,6 +22,13 @@ import (
 
 const defaultLogName = "transparentproxy.validator"
 
+// shouldSkipValidation returns true when the given IP version should not be
+// validated. IPv6 is skipped when the node has no local IPv6 address or the
+// mode is IPv4-only. IPv4 is never skipped.
+func shouldSkipValidation(ipv6, hasLocalIPv6Addr, validateOnlyIPv4 bool) bool {
+	return ipv6 && (!hasLocalIPv6Addr || validateOnlyIPv4)
+}
+
 func newInstallTransparentProxyValidator() *cobra.Command {
 	ipFamilyMode := tproxy_config.IPFamilyModeDualStack
 	serverPort := tproxy_validate.ServerPort
@@ -62,7 +69,7 @@ The result will be shown as text in stdout as well as the exit code.
 			validateOnlyIPv4 := ipFamilyMode == tproxy_config.IPFamilyModeIPv4
 
 			validate := func(ipv6 bool) error {
-				if ipv6 && (!hasLocalIPv6Addr || validateOnlyIPv4) {
+				if shouldSkipValidation(ipv6, hasLocalIPv6Addr, validateOnlyIPv4) {
 					return nil
 				}
 

--- a/app/kumactl/cmd/install/install_transparent_proxy_validator.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_validator.go
@@ -62,7 +62,7 @@ The result will be shown as text in stdout as well as the exit code.
 			validateOnlyIPv4 := ipFamilyMode == tproxy_config.IPFamilyModeIPv4
 
 			validate := func(ipv6 bool) error {
-				if ipv6 && !hasLocalIPv6Addr || validateOnlyIPv4 {
+				if ipv6 && (!hasLocalIPv6Addr || validateOnlyIPv4) {
 					return nil
 				}
 

--- a/app/kumactl/cmd/install/install_transparent_proxy_validator_test.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy_validator_test.go
@@ -1,0 +1,23 @@
+package install
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("shouldSkipValidation",
+	func(ipv6, hasLocalIPv6Addr, validateOnlyIPv4, expected bool) {
+		Expect(shouldSkipValidation(ipv6, hasLocalIPv6Addr, validateOnlyIPv4)).To(Equal(expected))
+	},
+	// IPv4 validation (ipv6=false) must never be skipped regardless of mode or IPv6 availability
+	Entry("ipv4 call, dualstack mode, no IPv6 addr", false, false, false, false),
+	Entry("ipv4 call, ipv4-only mode, no IPv6 addr", false, false, true, false),
+	Entry("ipv4 call, dualstack mode, has IPv6 addr", false, true, false, false),
+	Entry("ipv4 call, ipv4-only mode, has IPv6 addr", false, true, true, false),
+	// IPv6 validation (ipv6=true) is skipped when no local IPv6 address or ipv4-only mode
+	Entry("ipv6 call, dualstack mode, no IPv6 addr", true, false, false, true),
+	Entry("ipv6 call, ipv4-only mode, no IPv6 addr", true, false, true, true),
+	Entry("ipv6 call, ipv4-only mode, has IPv6 addr", true, true, true, true),
+	// IPv6 validation runs only in dualstack mode with a local IPv6 address present
+	Entry("ipv6 call, dualstack mode, has IPv6 addr", true, true, false, false),
+)


### PR DESCRIPTION
## Motivation

When deploying Kuma with CNI in IPv4-only mode (ipFamilyMode=ipv4), the `kuma-validation` init container always exits successfully, even when CNI has not applied any iptables rules to the pod. Pods start up with broken traffic routing and no warning. The root cause is a Go operator precedence bug in `install_transparent_proxy_validator.go`. The condition on line 65:

  ```golang
if ipv6 && !hasLocalIPv6Addr || validateOnlyIPv4 {
      return nil
  }
```
Go evaluates `&&` before `||`, so this reads as `(ipv6 && !hasLocalIPv6Addr) || validateOnlyIPv4`. When validateOnlyIPv4 is true (set whenever ipFamilyMode=ipv4), the entire condition is true regardless of the ipv6 argument, and both validate(false) and validate(true) skip immediately. No TCP socket is opened, no iptables rules are tested, the function returns nil, and the command exits 0.

## Implementation information

Added parentheses to fix the precedence:
```golang
  if ipv6 && (!hasLocalIPv6Addr || validateOnlyIPv4) {
      return nil
  }
```
  The ipv6 guard now controls the skip: the early return fires only when inside the IPv6 validation call AND either
  there is no local IPv6 address or the mode is IPv4-only. IPv4 validation (ipv6=false) always runs regardless of mode.

  Behavior after the fix:
  - ipFamilyMode=ipv4: IPv4 validates, IPv6 skips
  - ipFamilyMode=dualstack, no IPv6 on node: IPv4 validates, IPv6 skips
  - ipFamilyMode=dualstack, IPv6 present: both validate

Tested with `ipv4` mode and indeed was starting, but after fix it validates

## Supporting documentation

 Fixes #16809