### PR TITLE
fix(goldenfiles): update meshhttproute gateway

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-builtingateway-with-multiple-listeners.routes.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-builtingateway-with-multiple-listeners.routes.golden.yaml
@@ -13,20 +13,6 @@ resources:
       name: example.kuma.io
       routes:
       - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
-      - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
         route:
@@ -53,20 +39,6 @@ resources:
       - another.kuma.io
       name: another.kuma.io
       routes:
-      - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
       - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
@@ -95,20 +67,6 @@ resources:
       name: app.test.kuma.io
       routes:
       - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
-      - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
         route:
@@ -126,20 +84,6 @@ resources:
       - '*.test.kuma.io'
       name: '*.test.kuma.io'
       routes:
-      - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
       - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
@@ -168,20 +112,6 @@ resources:
       name: another.kuma.io
       routes:
       - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
-      - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
         route:
@@ -200,20 +130,6 @@ resources:
       name: app.test.kuma.io
       routes:
       - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
-      - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
         route:
@@ -231,20 +147,6 @@ resources:
       - '*'
       name: '*'
       routes:
-      - match:
-          path: /
-        name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
-        route:
-          clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          idleTimeout: 5s
-          weightedClusters:
-            clusters:
-            - name: echo-service-f111aabd47affdc4
-              requestHeadersToAdd:
-              - header:
-                  key: x-kuma-tags
-                  value: '&kuma.io/service=sample-gateway&'
-              weight: 100
       - match:
           prefix: /
         name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=


### PR DESCRIPTION
## Motivation

PR #16782 removed redundant exact `/` route matches from gateway virtual hosts but missed updating the `gateway-builtingateway-with-multiple-listeners.routes.golden.yaml` golden file, causing `meshhttproute` plugin tests to fail on master.

## Implementation information

Regenerated the golden file with `UPDATE_GOLDEN_FILES=true`. The diff removes 7 exact `/` match route blocks (one per virtual host) that are now correctly omitted since the prefix `/` match already covers them.

> Changelog: skip