### PR TITLE
docs(upgrade): note insecure TLS fallback removal in upcoming patches

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,54 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
+## Upgrade to `2.13.7`, `2.12.11`, `2.11.14`, `2.9.16`, `2.7.26`
+
+Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.
+
+### Insecure TLS fallback removed when no CA cert is provided
+
+Previously, when no CA certificate was configured:
+
+- `kuma-dp` connecting to `kuma-cp` over HTTPS silently set `InsecureSkipVerify=true` and only printed a warning.
+- `kumactl` connecting to the API server silently set `InsecureSkipVerify=true`.
+
+These clients now use the host system's trust store (Go's default) and verify the server certificate. Skipping verification is opt-in.
+
+**Impact**
+
+Connections to a control plane whose certificate cannot be verified against the system trust store (typically self-signed or signed by a private CA that is not installed on the host) will now fail instead of silently succeeding without verification. The inter-CP `grpcs` client returns an error if called without a TLS config.
+
+Deployments that already provide a CA via `--ca-cert-file` / `KUMA_CONTROL_PLANE_CA_CERT[_FILE]`, or that use a publicly trusted certificate, or that run the default Helm-installed setup, are not affected.
+
+**Action required**
+
+If your control plane uses a self-signed certificate or a private CA, provide that CA explicitly.
+
+For `kuma-dp`:
+
+```sh
+kuma-dp run --ca-cert-file=/path/to/ca.pem ...
+# or
+KUMA_CONTROL_PLANE_CA_CERT_FILE=/path/to/ca.pem kuma-dp run ...
+# or pass the PEM directly
+KUMA_CONTROL_PLANE_CA_CERT="$(cat /path/to/ca.pem)" kuma-dp run ...
+```
+
+For `kumactl`:
+
+```sh
+kumactl config control-planes add --ca-cert-file=/path/to/ca.pem ...
+```
+
+**Opt-out (insecure, development/testing only)**
+
+A new explicit flag preserves the previous insecure behavior:
+
+- `kuma-dp run --skip-verify` (env var `KUMA_CONTROL_PLANE_TLS_SKIP_VERIFY=true`)
+- `kumactl config control-planes add --skip-verify`
+
+Do not use this in production.
+
 ## Upgrade to `2.14.x`
 
 ### Inbound listeners now use SO_REUSEPORT by default

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,7 +23,7 @@ These clients now use the host system's trust store (Go's default) and verify th
 
 Connections to a control plane whose certificate cannot be verified against the system trust store (typically self-signed or signed by a private CA that is not installed on the host) will now fail instead of silently succeeding without verification. The inter-CP `grpcs` client returns an error if called without a TLS config.
 
-Deployments that already provide a CA via `--ca-cert-file` / `KUMA_CONTROL_PLANE_CA_CERT[_FILE]`, or that use a publicly trusted certificate, or that run the default Helm-installed setup, are not affected.
+Deployments that already provide a CA via `--ca-cert-file` / `KUMA_CONTROL_PLANE_CA_CERT` / `KUMA_CONTROL_PLANE_CA_CERT_FILE`, or that use a publicly trusted certificate, or that run the default Helm-installed setup, are not affected.
 
 **Action required**
 


### PR DESCRIPTION
## Motivation

PR #16777 changes TLS verification behavior in a way that breaks deployments relying on the silent insecure fallback. Document this for the next patch release on each active branch.

## Supporting documentation

#16777

> Changelog: skip