### PR TITLE
test(e2e): allow to disable preload postgres image

### DIFF
--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -18,6 +18,7 @@ const (
 	DefaultPostgresUser     = "kuma"
 	DefaultPostgresPassword = "kuma"
 	DefaultPostgresDBName   = "kuma"
+	DefaultPreloadImages    = true
 
 	PostgresImage = "postgres:latest@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39"
 
@@ -46,6 +47,7 @@ type deployOptions struct {
 	primaryName      string
 	postgresPassword string
 	initScripts      []string
+	preloadImages    bool
 }
 type DeployOptionsFunc func(*deployOptions)
 
@@ -62,6 +64,7 @@ func Install(name string, optFns ...DeployOptionsFunc) InstallFunc {
 		username:         DefaultPostgresUser,
 		password:         DefaultPostgresPassword,
 		postgresPassword: DefaultPostgresPassword,
+		preloadImages:    DefaultPreloadImages,
 	}
 
 	for _, optFn := range optFns {
@@ -122,5 +125,11 @@ func WithPostgresPassword(postgresPassword string) DeployOptionsFunc {
 func WithInitScript(initScript string) DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.initScripts = append(o.initScripts, initScript)
+	}
+}
+
+func WithoutPreLoadImage() DeployOptionsFunc {
+	return func(o *deployOptions) {
+		o.preloadImages = false
 	}
 }

--- a/test/framework/deployments/postgres/deployment.go
+++ b/test/framework/deployments/postgres/deployment.go
@@ -128,7 +128,7 @@ func WithInitScript(initScript string) DeployOptionsFunc {
 	}
 }
 
-func WithoutPreLoadImage() DeployOptionsFunc {
+func WithoutPreloadImages() DeployOptionsFunc {
 	return func(o *deployOptions) {
 		o.preloadImages = false
 	}

--- a/test/framework/deployments/postgres/kubernetes.go
+++ b/test/framework/deployments/postgres/kubernetes.go
@@ -71,26 +71,28 @@ func (t *k8SDeployment) Deploy(cluster framework.Cluster) error {
 		opts.SetValues[fmt.Sprintf("cluster.initdb.postInitSQL[%d]", i)] = script
 	}
 
-	// Preload chart images into the cluster's container runtime so pod
-	// startup does not hit ghcr.io at test time. The CNPG cluster wait has a
-	// hard 180s budget; transient ghcr.io timeouts during runtime pulls of
-	// the operator and postgres images are the dominant cause of this
-	// BeforeAll flaking on CI.
-	if k8sCluster, ok := cluster.(*framework.K8sCluster); ok {
-		opImages, err := renderChartImages(cluster, nil, cnpgChart, "cnpg")
-		if err != nil {
-			return errors.Wrap(err, "render cnpg operator chart")
-		}
-		clImages, err := renderChartImages(cluster, opts, clusterChart, t.options.primaryName)
-		if err != nil {
-			return errors.Wrap(err, "render cnpg cluster chart")
-		}
-		// postgresImage is consumed by the CNPG operator (via the Cluster
-		// CR) rather than appearing directly in the rendered chart, so add
-		// it explicitly.
-		images := dedupe(append(append(opImages, clImages...), postgresImage))
-		if err := k8sCluster.PreloadImages(images...); err != nil {
-			return errors.Wrap(err, "preload postgres images")
+	if t.options.preloadImages {
+		// Preload chart images into the cluster's container runtime so pod
+		// startup does not hit ghcr.io at test time. The CNPG cluster wait has a
+		// hard 180s budget; transient ghcr.io timeouts during runtime pulls of
+		// the operator and postgres images are the dominant cause of this
+		// BeforeAll flaking on CI.
+		if k8sCluster, ok := cluster.(*framework.K8sCluster); ok {
+			opImages, err := renderChartImages(cluster, nil, cnpgChart, "cnpg")
+			if err != nil {
+				return errors.Wrap(err, "render cnpg operator chart")
+			}
+			clImages, err := renderChartImages(cluster, opts, clusterChart, t.options.primaryName)
+			if err != nil {
+				return errors.Wrap(err, "render cnpg cluster chart")
+			}
+			// postgresImage is consumed by the CNPG operator (via the Cluster
+			// CR) rather than appearing directly in the rendered chart, so add
+			// it explicitly.
+			images := dedupe(append(append(opImages, clImages...), postgresImage))
+			if err := k8sCluster.PreloadImages(images...); err != nil {
+				return errors.Wrap(err, "preload postgres images")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Motivation

We preload images before running but it affects some repos that using this framework on k8s clusters

## Implementation information

Allow to disable preloading images

## Supporting documentation

> Changelog: skip
