### PR TITLE
test(e2e): backport stricts inbounds assertion

### DIFF
--- a/test/e2e_env/universal/strictinbounds/strict_inbound.go
+++ b/test/e2e_env/universal/strictinbounds/strict_inbound.go
@@ -255,7 +255,9 @@ func StrictInboundPorts() {
 				universal.Cluster, "demo-client-not-in-mesh", serviceAddress,
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Exitcode).To(Or(Equal(52)))
+			// 52 = CURLE_GOT_NOTHING (TLS alert, clean close)
+			// 56 = CURLE_RECV_ERROR (TCP RST when no filter chain matches)
+			g.Expect(resp.Exitcode).To(Or(Equal(52), Equal(56)))
 		}, "30s", "1s").Should(Succeed())
 
 		// and


### PR DESCRIPTION
## Motivation

Notice a flake

## Implementation information

Saw that we fixed it on the master but not on 2.13

## Supporting documentation

> Changelog: skip

