### PR TITLE
fix(k8s): renamed cni taint controller

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/cni_taint_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/cni_taint_controller.go
@@ -130,7 +130,7 @@ func (r *CniNodeTaintReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 	}
 
 	return kube_ctrl.NewControllerManagedBy(mgr).
-		Named("kuma-secret-controller").
+		Named("kuma-cni-taint-controller").
 		For(&kube_core.Node{}, builder.WithPredicates(nodeEvents)).
 		Watches(
 			&kube_core.Pod{},


### PR DESCRIPTION
## Motivation

When executing smoke tests I've noticed a conflict on installing CP with CNI as a `cni_taint_controller` has the same name as a secret controller.

## Implementation information

Renamed `cni_taint_controller` to correct one to avoid conflict during installation.
