### PR TITLE
fix(api-server): handle wrapped IssuerDisabled errors correctly

### DIFF
--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -129,7 +129,7 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  "Bad Request",
 			Detail: err.Error(),
 		}
-	case err == tokens.IssuerDisabled:
+	case errors.Is(err, tokens.IssuerDisabled):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  title,


### PR DESCRIPTION
## Motivation

When a token issuer wraps `tokens.IssuerDisabled` with additional context
  (e.g. `errors.Wrap(tokens.IssuerDisabled, "... is disabled (config.key)")`),
  the error handler's `err == tokens.IssuerDisabled` check fails because
  wrapped errors don't satisfy pointer equality. The error falls through to
  the `default` branch, which logs it and returns a 500 with no useful message.

  Users see `Could not issue a token (Internal Server Error)` instead of
  something actionable.

## Implementation information

One-line change: replace `err == tokens.IssuerDisabled` with
  `errors.Is(err, tokens.IssuerDisabled)` in the HTTP error handler.
  `errors.Is` walks the unwrap chain, so both bare and wrapped sentinels
  are caught correctly and mapped to 400 with the full error message.

