### PR TITLE
fix(xds): reduce xds config size from 16mb to 4mb

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -102,10 +102,10 @@ bootstrapServer:
     xdsConnectTimeout: 1s # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_CONNECT_TIMEOUT
     # Cap on the gRPC C-Core receive flow-control window for the kuma-dp xDS
     # client. Set as the GoogleGrpc channel arg `grpc.max_receive_message_length`.
-    # Default 16 MiB is large enough for gateway DPs with 450+ listeners; the
+    # Default 4 MiB is large enough for gateway DPs with 450+ listeners; the
     # gRPC C-Core default of 4 MiB sizes the per-stream HTTP/2 receive window
     # too small for the initial xDS push on those DPs and stalls the stream.
-    xdsGrpcMaxReceiveMessageBytes: 16777216 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_GRPC_MAX_RECEIVE_MESSAGE_BYTES
+    xdsGrpcMaxReceiveMessageBytes: 4194304 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_GRPC_MAX_RECEIVE_MESSAGE_BYTES
 #  Monitoring Assignment Discovery Service (MADS) server configuration
 monitoringAssignmentServer:
   # Whether the MADS server is enabled

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -102,10 +102,10 @@ bootstrapServer:
     xdsConnectTimeout: 1s # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_CONNECT_TIMEOUT
     # Cap on the gRPC C-Core receive flow-control window for the kuma-dp xDS
     # client. Set as the GoogleGrpc channel arg `grpc.max_receive_message_length`.
-    # Default 16 MiB is large enough for gateway DPs with 450+ listeners; the
+    # Default 4 MiB is large enough for gateway DPs with 450+ listeners; the
     # gRPC C-Core default of 4 MiB sizes the per-stream HTTP/2 receive window
     # too small for the initial xDS push on those DPs and stalls the stream.
-    xdsGrpcMaxReceiveMessageBytes: 16777216 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_GRPC_MAX_RECEIVE_MESSAGE_BYTES
+    xdsGrpcMaxReceiveMessageBytes: 4194304 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_GRPC_MAX_RECEIVE_MESSAGE_BYTES
 #  Monitoring Assignment Discovery Service (MADS) server configuration
 monitoringAssignmentServer:
   # Whether the MADS server is enabled

--- a/pkg/config/xds/bootstrap/config.go
+++ b/pkg/config/xds/bootstrap/config.go
@@ -66,7 +66,7 @@ type BootstrapParamsConfig struct {
 	// Sets `grpc.max_receive_message_length` on the GoogleGrpc xDS channel in
 	// Envoy's bootstrap. Caps inbound xDS message size and sizes the per-stream
 	// HTTP/2 receive window.
-	// Default: 16 MiB.
+	// Default: 4 MiB.
 	XdsGrpcMaxReceiveMessageBytes uint32 `json:"xdsGrpcMaxReceiveMessageBytes" envconfig:"kuma_bootstrap_server_params_xds_grpc_max_receive_message_bytes"`
 	// Path to the template of Corefile for data planes to use
 	CorefileTemplatePath string `json:"corefileTemplatePath" envconfig:"kuma_bootstrap_server_params_corefile_template_path"`
@@ -105,16 +105,15 @@ func (b *BootstrapParamsConfig) Validate() error {
 
 func DefaultBootstrapParamsConfig() *BootstrapParamsConfig {
 	return &BootstrapParamsConfig{
-		AdminAddress:         "127.0.0.1", // by default, Envoy Admin interface should listen on loopback address
-		AdminPort:            9901,
-		EnvoyAdminUnixSocket: true,
-		ReadinessPort:        9902,
-		AdminAccessLogPath:   os.DevNull,
-		XdsHost:              "", // by default, it is the same host as the one used by kuma-dp to connect to the control plane
-		XdsPort:              0,  // by default, it is autoconfigured from KUMA_XDS_SERVER_GRPC_PORT
-		XdsConnectTimeout:    config_types.Duration{Duration: 1 * time.Second},
-		// 16 MiB — large enough for gateway DPs with hundreds of listeners.
-		XdsGrpcMaxReceiveMessageBytes: 16777216,
+		AdminAddress:                  "127.0.0.1", // by default, Envoy Admin interface should listen on loopback address
+		AdminPort:                     9901,
+		EnvoyAdminUnixSocket:          true,
+		ReadinessPort:                 9902,
+		AdminAccessLogPath:            os.DevNull,
+		XdsHost:                       "", // by default, it is the same host as the one used by kuma-dp to connect to the control plane
+		XdsPort:                       0,  // by default, it is autoconfigured from KUMA_XDS_SERVER_GRPC_PORT
+		XdsConnectTimeout:             config_types.Duration{Duration: 1 * time.Second},
+		XdsGrpcMaxReceiveMessageBytes: 4194304,
 		CorefileTemplatePath:          "", // by default, data plane will use the embedded Corefile to be the template
 	}
 }

--- a/pkg/config/xds/bootstrap/testdata/default-config.golden.yaml
+++ b/pkg/config/xds/bootstrap/testdata/default-config.golden.yaml
@@ -6,6 +6,6 @@ params:
   envoyAdminUnixSocket: true
   readinessPort: 9902
   xdsConnectTimeout: 1s
-  xdsGrpcMaxReceiveMessageBytes: 16777216
+  xdsGrpcMaxReceiveMessageBytes: 4194304
   xdsHost: ""
   xdsPort: 0

--- a/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.default-config-token-path.golden.yaml
@@ -33,7 +33,7 @@ dynamicResources:
             grpc.keepalive_timeout_ms:
               intValue: "30000"
             grpc.max_receive_message_length:
-              intValue: "16777216"
+              intValue: "4194304"
         channelCredentials:
           sslCredentials:
             rootCerts:
@@ -71,7 +71,7 @@ hdsConfig:
           grpc.keepalive_timeout_ms:
             intValue: "30000"
           grpc.max_receive_message_length:
-            intValue: "16777216"
+            intValue: "4194304"
       channelCredentials:
         sslCredentials:
           rootCerts:

--- a/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
+++ b/pkg/xds/bootstrap/testdata/generator.gateway.golden.yaml
@@ -23,7 +23,7 @@ dynamicResources:
             grpc.keepalive_timeout_ms:
               intValue: "30000"
             grpc.max_receive_message_length:
-              intValue: "16777216"
+              intValue: "4194304"
         channelCredentials:
           sslCredentials:
             rootCerts:
@@ -61,7 +61,7 @@ hdsConfig:
           grpc.keepalive_timeout_ms:
             intValue: "30000"
           grpc.max_receive_message_length:
-            intValue: "16777216"
+            intValue: "4194304"
       channelCredentials:
         sslCredentials:
           rootCerts:


### PR DESCRIPTION
## Motivation

PR that introduced a flag to increase a xDS config size over grpc was merged but we shouldn't bump the memory to 16MB but keep it 4MB as it's the default

## Implementation information

Reduce to 4MB

Changes part of #https://github.com/kumahq/kuma/pull/16775 which introduced config size but we keep it 4MiB as a default is