### PR TITLE
fix(motb): remove name from backendResourceRef

### DIFF
--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -157,18 +157,13 @@ const (
 )
 
 // BackendResourceRef is a reference to a backend resource within the same
-// mesh. Used by observability policies to point at a
-// MeshOpenTelemetryBackend. Use Name for same-cluster references, Labels
-// for cross-zone references where KDS hashes the resource name.
+// mesh. Used by observability policies to point at a MeshOpenTelemetryBackend
+// via label matching. When multiple resources match, the oldest by creation time wins.
 type BackendResourceRef struct {
 	// Kind of the backend resource.
 	Kind BackendResourceKind `json:"kind"`
-	// Name of the referenced resource (metadata.name). Use for same-cluster
-	// references. Mutually exclusive with Labels.
-	Name string `json:"name,omitempty"`
-	// Labels to match the referenced resource. Use for cross-zone references
-	// where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-	// Name. When multiple resources match, the oldest by creation time wins.
+	// Labels to match the referenced resource. When multiple resources match,
+	// the oldest by creation time wins.
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -4089,9 +4089,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -8187,9 +8186,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -10276,9 +10274,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -10532,9 +10529,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -10837,9 +10833,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -4093,11 +4093,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -8196,11 +8191,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -10290,11 +10280,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -10551,11 +10536,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -10861,11 +10841,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -4089,9 +4089,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -8187,9 +8186,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -10276,9 +10274,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -10532,9 +10529,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -10837,9 +10833,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -4093,11 +4093,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -8196,11 +8191,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -10290,11 +10280,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -10551,11 +10536,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -10861,11 +10841,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -4113,11 +4113,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -8216,11 +8211,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -10310,11 +10300,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -10571,11 +10556,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -10881,11 +10861,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -4109,9 +4109,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -8207,9 +8206,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -10296,9 +10294,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -10552,9 +10549,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -10857,9 +10853,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -689,11 +689,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -950,11 +945,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -1260,11 +1250,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -6337,11 +6322,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object
@@ -10368,11 +10348,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -685,9 +685,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -941,9 +940,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -1246,9 +1244,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -6318,9 +6315,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind
@@ -10344,9 +10340,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -155,9 +155,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -411,9 +410,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -716,9 +714,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -159,11 +159,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -420,11 +415,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -730,11 +720,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -107,11 +107,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -103,9 +103,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -105,9 +105,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -109,11 +109,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -6687,13 +6687,9 @@ components:
                                         type: string
                                       description: >-
                                         Labels to match the referenced resource.
-                                        Use for cross-zone references
+                                        When multiple resources match,
 
-                                        where KDS adds a hash suffix to
-                                        metadata.name. Mutually exclusive with
-
-                                        Name. When multiple resources match, the
-                                        oldest by creation time wins.
+                                        the oldest by creation time wins.
                                       type: object
                                   required:
                                     - kind
@@ -6986,13 +6982,9 @@ components:
                                         type: string
                                       description: >-
                                         Labels to match the referenced resource.
-                                        Use for cross-zone references
+                                        When multiple resources match,
 
-                                        where KDS adds a hash suffix to
-                                        metadata.name. Mutually exclusive with
-
-                                        Name. When multiple resources match, the
-                                        oldest by creation time wins.
+                                        the oldest by creation time wins.
                                       type: object
                                   required:
                                     - kind
@@ -7347,13 +7339,9 @@ components:
                                         type: string
                                       description: >-
                                         Labels to match the referenced resource.
-                                        Use for cross-zone references
+                                        When multiple resources match,
 
-                                        where KDS adds a hash suffix to
-                                        metadata.name. Mutually exclusive with
-
-                                        Name. When multiple resources match, the
-                                        oldest by creation time wins.
+                                        the oldest by creation time wins.
                                       type: object
                                   required:
                                     - kind
@@ -12502,14 +12490,10 @@ components:
                                 additionalProperties:
                                   type: string
                                 description: >-
-                                  Labels to match the referenced resource. Use
-                                  for cross-zone references
+                                  Labels to match the referenced resource. When
+                                  multiple resources match,
 
-                                  where KDS adds a hash suffix to metadata.name.
-                                  Mutually exclusive with
-
-                                  Name. When multiple resources match, the
-                                  oldest by creation time wins.
+                                  the oldest by creation time wins.
                                 type: object
                             required:
                               - kind
@@ -16637,14 +16621,10 @@ components:
                                 additionalProperties:
                                   type: string
                                 description: >-
-                                  Labels to match the referenced resource. Use
-                                  for cross-zone references
+                                  Labels to match the referenced resource. When
+                                  multiple resources match,
 
-                                  where KDS adds a hash suffix to metadata.name.
-                                  Mutually exclusive with
-
-                                  Name. When multiple resources match, the
-                                  oldest by creation time wins.
+                                  the oldest by creation time wins.
                                 type: object
                             required:
                               - kind

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -6695,14 +6695,6 @@ components:
                                         Name. When multiple resources match, the
                                         oldest by creation time wins.
                                       type: object
-                                    name:
-                                      description: >-
-                                        Name of the referenced resource
-                                        (metadata.name). Use for same-cluster
-
-                                        references. Mutually exclusive with
-                                        Labels.
-                                      type: string
                                   required:
                                     - kind
                                   type: object
@@ -7002,14 +6994,6 @@ components:
                                         Name. When multiple resources match, the
                                         oldest by creation time wins.
                                       type: object
-                                    name:
-                                      description: >-
-                                        Name of the referenced resource
-                                        (metadata.name). Use for same-cluster
-
-                                        references. Mutually exclusive with
-                                        Labels.
-                                      type: string
                                   required:
                                     - kind
                                   type: object
@@ -7371,14 +7355,6 @@ components:
                                         Name. When multiple resources match, the
                                         oldest by creation time wins.
                                       type: object
-                                    name:
-                                      description: >-
-                                        Name of the referenced resource
-                                        (metadata.name). Use for same-cluster
-
-                                        references. Mutually exclusive with
-                                        Labels.
-                                      type: string
                                   required:
                                     - kind
                                   type: object
@@ -12535,13 +12511,6 @@ components:
                                   Name. When multiple resources match, the
                                   oldest by creation time wins.
                                 type: object
-                              name:
-                                description: >-
-                                  Name of the referenced resource
-                                  (metadata.name). Use for same-cluster
-
-                                  references. Mutually exclusive with Labels.
-                                type: string
                             required:
                               - kind
                             type: object
@@ -16677,13 +16646,6 @@ components:
                                   Name. When multiple resources match, the
                                   oldest by creation time wins.
                                 type: object
-                              name:
-                                description: >-
-                                  Name of the referenced resource
-                                  (metadata.name). Use for same-cluster
-
-                                  references. Mutually exclusive with Labels.
-                                type: string
                             required:
                               - kind
                             type: object

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -155,9 +155,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -411,9 +410,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -716,9 +714,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -159,11 +159,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -420,11 +415,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -730,11 +720,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -107,11 +107,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -103,9 +103,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -105,9 +105,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -109,11 +109,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/pkg/core/resources/apis/meshopentelemetrybackend/status_updater.go
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/status_updater.go
@@ -219,18 +219,10 @@ func buildBackendIndex(motbs []*motb_api.MeshOpenTelemetryBackendResource) map[s
 	return indexByMesh
 }
 
-// resolveRef resolves a BackendResourceRef to a MOTB name within a mesh.
-// Handles both Name-based (direct lookup) and Labels-based (label matching,
-// oldest wins) references.
+// resolveRef resolves a BackendResourceRef to a MOTB name within a mesh via label matching (oldest wins).
 func resolveRef(indexByMesh map[string]*backendIndex, mesh string, ref *common_api.BackendResourceRef) (string, bool) {
 	idx := indexByMesh[mesh]
 	if idx == nil {
-		return "", false
-	}
-	if ref.Name != "" {
-		if _, exists := idx.byName[ref.Name]; exists {
-			return ref.Name, true
-		}
 		return "", false
 	}
 	if len(ref.Labels) > 0 {
@@ -255,13 +247,8 @@ func matchByLabels(resources []motbEntry, selector map[string]string) (string, b
 	return "", false
 }
 
-// backendRefKey returns a string key for a BackendResourceRef for use in
-// deduplication maps. Name-based refs use the name directly, labels-based
-// refs use a sorted label representation.
+// backendRefKey returns a string key for a BackendResourceRef for use in deduplication maps.
 func backendRefKey(ref *common_api.BackendResourceRef) string {
-	if ref.Name != "" {
-		return ref.Name
-	}
 	parts := make([]string, 0, len(ref.Labels))
 	for _, k := range util_maps.SortedKeys(ref.Labels) {
 		parts = append(parts, k+"="+ref.Labels[k])

--- a/pkg/core/resources/apis/meshopentelemetrybackend/status_updater_test.go
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/status_updater_test.go
@@ -61,7 +61,8 @@ var _ = Describe("StatusUpdater", func() {
 			},
 			Protocol: pointer.To(motb_api.ProtocolGRPC),
 		}
-		allOpts := append([]store.CreateOptionsFunc{store.CreateByKey(name, core_model.DefaultMesh)}, opts...)
+		defaultLabels := store.CreateWithLabels(map[string]string{mesh_proto.DisplayName: name})
+		allOpts := append([]store.CreateOptionsFunc{store.CreateByKey(name, core_model.DefaultMesh), defaultLabels}, opts...)
 		Expect(resManager.Create(context.Background(), motb, allOpts...)).To(Succeed())
 	}
 
@@ -140,8 +141,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshmetric_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshmetric_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "main-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "main-collector"},
 							},
 						},
 					},
@@ -169,8 +170,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshtrace_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshtrace_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "trace-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "trace-collector"},
 							},
 						},
 					},
@@ -201,8 +202,8 @@ var _ = Describe("StatusUpdater", func() {
 								Type: meshaccesslog_api.OtelTelemetryBackendType,
 								OpenTelemetry: &meshaccesslog_api.OtelBackend{
 									BackendRef: &common_api.BackendResourceRef{
-										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Name: "log-collector",
+										Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+										Labels: map[string]string{mesh_proto.DisplayName: "log-collector"},
 									},
 								},
 							},
@@ -233,8 +234,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshmetric_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshmetric_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "shared-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "shared-collector"},
 							},
 						},
 					},
@@ -252,8 +253,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshtrace_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshtrace_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "shared-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "shared-collector"},
 							},
 						},
 					},
@@ -281,8 +282,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshmetric_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshmetric_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "main-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "main-collector"},
 							},
 						},
 					},
@@ -324,8 +325,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshmetric_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshmetric_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "main-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "main-collector"},
 							},
 						},
 					},
@@ -363,8 +364,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshmetric_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshmetric_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "missing-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "missing-collector"},
 							},
 						},
 					},
@@ -377,7 +378,7 @@ var _ = Describe("StatusUpdater", func() {
 			Type:    common_api.BackendRefsResolvedCondition,
 			Status:  kube_meta.ConditionFalse,
 			Reason:  common_api.UnresolvedBackendRefsReason,
-			Message: "Unresolved MeshOpenTelemetryBackend references: missing-collector",
+			Message: "Unresolved MeshOpenTelemetryBackend references: labels:kuma.io/display-name=missing-collector",
 		}))
 	})
 
@@ -390,8 +391,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshtrace_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshtrace_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "missing-trace-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "missing-trace-collector"},
 							},
 						},
 					},
@@ -404,7 +405,7 @@ var _ = Describe("StatusUpdater", func() {
 			Type:    common_api.BackendRefsResolvedCondition,
 			Status:  kube_meta.ConditionFalse,
 			Reason:  common_api.UnresolvedBackendRefsReason,
-			Message: "Unresolved MeshOpenTelemetryBackend references: missing-trace-collector",
+			Message: "Unresolved MeshOpenTelemetryBackend references: labels:kuma.io/display-name=missing-trace-collector",
 		}))
 	})
 
@@ -420,8 +421,8 @@ var _ = Describe("StatusUpdater", func() {
 								Type: meshaccesslog_api.OtelTelemetryBackendType,
 								OpenTelemetry: &meshaccesslog_api.OtelBackend{
 									BackendRef: &common_api.BackendResourceRef{
-										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Name: "missing-log-collector",
+										Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+										Labels: map[string]string{mesh_proto.DisplayName: "missing-log-collector"},
 									},
 								},
 							},
@@ -436,7 +437,7 @@ var _ = Describe("StatusUpdater", func() {
 			Type:    common_api.BackendRefsResolvedCondition,
 			Status:  kube_meta.ConditionFalse,
 			Reason:  common_api.UnresolvedBackendRefsReason,
-			Message: "Unresolved MeshOpenTelemetryBackend references: missing-log-collector",
+			Message: "Unresolved MeshOpenTelemetryBackend references: labels:kuma.io/display-name=missing-log-collector",
 		}))
 	})
 
@@ -449,8 +450,8 @@ var _ = Describe("StatusUpdater", func() {
 						Type: meshmetric_api.OpenTelemetryBackendType,
 						OpenTelemetry: &meshmetric_api.OpenTelemetryBackend{
 							BackendRef: &common_api.BackendResourceRef{
-								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-								Name: "appearing-collector",
+								Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{mesh_proto.DisplayName: "appearing-collector"},
 							},
 						},
 					},
@@ -463,7 +464,7 @@ var _ = Describe("StatusUpdater", func() {
 			Type:    common_api.BackendRefsResolvedCondition,
 			Status:  kube_meta.ConditionFalse,
 			Reason:  common_api.UnresolvedBackendRefsReason,
-			Message: "Unresolved MeshOpenTelemetryBackend references: appearing-collector",
+			Message: "Unresolved MeshOpenTelemetryBackend references: labels:kuma.io/display-name=appearing-collector",
 		}))
 
 		createMOTB("appearing-collector")

--- a/pkg/core/validators/common_validators.go
+++ b/pkg/core/validators/common_validators.go
@@ -292,8 +292,7 @@ func ValidateLength(path PathBuilder, maxLength int, v string) ValidationError {
 	return err
 }
 
-// ValidateBackendResourceRef checks that a BackendResourceRef has a valid kind
-// and exactly one of name or labels set.
+// ValidateBackendResourceRef checks that a BackendResourceRef has a valid kind and labels set.
 func ValidateBackendResourceRef(ref *common_api.BackendResourceRef) ValidationError {
 	var verr ValidationError
 	if ref == nil {
@@ -303,11 +302,8 @@ func ValidateBackendResourceRef(ref *common_api.BackendResourceRef) ValidationEr
 		verr.AddErrorAt(RootedAt("kind"),
 			MakeFieldMustBeOneOfErr("kind", string(common_api.BackendResourceMeshOpenTelemetryBackend)))
 	}
-	if ref.Name == "" && len(ref.Labels) == 0 {
-		verr.AddViolation("", MustHaveExactlyOneOf("backendRef", "name", "labels"))
-	}
-	if ref.Name != "" && len(ref.Labels) > 0 {
-		verr.AddViolation("", MustHaveOnlyOne("backendRef", "name", "labels"))
+	if len(ref.Labels) == 0 {
+		verr.AddViolation("", MustHaveExactlyOneOf("backendRef", "labels"))
 	}
 	return verr
 }

--- a/pkg/plugins/policies/core/xds/otel.go
+++ b/pkg/plugins/policies/core/xds/otel.go
@@ -81,17 +81,13 @@ func ResolveOtelBackend(
 
 func resolveFromBackendRef(ref *common_api.BackendResourceRef, resources xds_context.Resources) *ResolvedOtelBackend {
 	var backend *motb_api.MeshOpenTelemetryBackendResource
-	switch {
-	case ref.Name != "":
-		backend = resolveBackendResourceByName(resources, ref.Name)
-	case len(ref.Labels) > 0:
+	if len(ref.Labels) > 0 {
 		backend = resolveBackendResourceByLabels(resources, ref.Labels)
 	}
 
 	if backend == nil {
 		otelLog.Info(
 			"MeshOpenTelemetryBackend not found, skipping backend",
-			"name", ref.Name,
 			"labels", ref.Labels,
 		)
 		return nil
@@ -123,20 +119,6 @@ func resolvedFromSpec(backend *motb_api.MeshOpenTelemetryBackendResource) *Resol
 		Path:      basePath,
 		Name:      core_model.GetDisplayName(backend.GetMeta()),
 	}
-}
-
-// resolveBackendResourceByName looks up by display name (the user-facing name
-// without the namespace suffix that Kubernetes adds internally).
-func resolveBackendResourceByName(
-	resources xds_context.Resources,
-	name string,
-) *motb_api.MeshOpenTelemetryBackendResource {
-	for _, backend := range resources.MeshOpenTelemetryBackends().Items {
-		if core_model.GetDisplayName(backend.GetMeta()) == name {
-			return backend
-		}
-	}
-	return nil
 }
 
 // resolveBackendResourceByLabels matches all labels and picks the oldest on collision.

--- a/pkg/plugins/policies/core/xds/otel_test.go
+++ b/pkg/plugins/policies/core/xds/otel_test.go
@@ -46,8 +46,8 @@ var _ = Describe("ResolveOtelBackend", func() {
 
 	Describe("priority order", func() {
 		backendRef := &common_api.BackendResourceRef{
-			Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-			Name: "my-backend",
+			Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+			Labels: map[string]string{mesh_proto.DisplayName: "my-backend"},
 		}
 		motbList := &motb_api.MeshOpenTelemetryBackendResourceList{}
 
@@ -97,13 +97,13 @@ var _ = Describe("ResolveOtelBackend", func() {
 			}
 		}
 		backendRef := &common_api.BackendResourceRef{
-			Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-			Name: "collector",
+			Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+			Labels: map[string]string{mesh_proto.DisplayName: "collector"},
 		}
 
 		It("should default to port 4317 and empty address when endpoint is nil", func() {
 			backend := motb_api.NewMeshOpenTelemetryBackendResource()
-			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default"})
+			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default", Labels: map[string]string{mesh_proto.DisplayName: "collector"}})
 			backend.Spec.Protocol = new(motb_api.ProtocolGRPC)
 
 			result := policies_xds.ResolveOtelBackend(
@@ -116,7 +116,7 @@ var _ = Describe("ResolveOtelBackend", func() {
 
 		It("should default to port 4317 when only address is set", func() {
 			backend := motb_api.NewMeshOpenTelemetryBackendResource()
-			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default"})
+			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default", Labels: map[string]string{mesh_proto.DisplayName: "collector"}})
 			backend.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector.example")}
 			backend.Spec.Protocol = new(motb_api.ProtocolGRPC)
 
@@ -130,7 +130,7 @@ var _ = Describe("ResolveOtelBackend", func() {
 
 		It("should use empty address when only port is set", func() {
 			backend := motb_api.NewMeshOpenTelemetryBackendResource()
-			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default"})
+			backend.SetMeta(&test_model.ResourceMeta{Name: "collector", Mesh: "default", Labels: map[string]string{mesh_proto.DisplayName: "collector"}})
 			backend.Spec.Endpoint = &motb_api.Endpoint{Port: new(int32(4318))}
 			backend.Spec.Protocol = new(motb_api.ProtocolGRPC)
 
@@ -155,14 +155,14 @@ var _ = Describe("ResolveOtelBackend", func() {
 
 		It("should enable HTTPS for HTTP protocol on port 443", func() {
 			backend := motb_api.NewMeshOpenTelemetryBackendResource()
-			backend.SetMeta(&test_model.ResourceMeta{Name: "https-collector", Mesh: "default"})
+			backend.SetMeta(&test_model.ResourceMeta{Name: "https-collector", Mesh: "default", Labels: map[string]string{mesh_proto.DisplayName: "https-collector"}})
 			backend.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector.example"), Port: new(int32(443))}
 			backend.Spec.Protocol = new(motb_api.ProtocolHTTP)
 
 			result := policies_xds.ResolveOtelBackend(
 				&common_api.BackendResourceRef{
-					Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-					Name: "https-collector",
+					Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+					Labels: map[string]string{mesh_proto.DisplayName: "https-collector"},
 				},
 				"",
 				dummyParser,
@@ -175,14 +175,14 @@ var _ = Describe("ResolveOtelBackend", func() {
 
 		It("should not enable HTTPS for HTTP protocol on non-443 port", func() {
 			backend := motb_api.NewMeshOpenTelemetryBackendResource()
-			backend.SetMeta(&test_model.ResourceMeta{Name: "http-collector", Mesh: "default"})
+			backend.SetMeta(&test_model.ResourceMeta{Name: "http-collector", Mesh: "default", Labels: map[string]string{mesh_proto.DisplayName: "http-collector"}})
 			backend.Spec.Endpoint = &motb_api.Endpoint{Address: new("collector.example"), Port: new(int32(4318))}
 			backend.Spec.Protocol = new(motb_api.ProtocolHTTP)
 
 			result := policies_xds.ResolveOtelBackend(
 				&common_api.BackendResourceRef{
-					Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-					Name: "http-collector",
+					Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+					Labels: map[string]string{mesh_proto.DisplayName: "http-collector"},
 				},
 				"",
 				dummyParser,

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -252,9 +252,8 @@ components:
                                       additionalProperties:
                                         type: string
                                       description: |-
-                                        Labels to match the referenced resource. Use for cross-zone references
-                                        where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                        Name. When multiple resources match, the oldest by creation time wins.
+                                        Labels to match the referenced resource. When multiple resources match,
+                                        the oldest by creation time wins.
                                       type: object
                                   required:
                                     - kind
@@ -503,9 +502,8 @@ components:
                                       additionalProperties:
                                         type: string
                                       description: |-
-                                        Labels to match the referenced resource. Use for cross-zone references
-                                        where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                        Name. When multiple resources match, the oldest by creation time wins.
+                                        Labels to match the referenced resource. When multiple resources match,
+                                        the oldest by creation time wins.
                                       type: object
                                   required:
                                     - kind
@@ -796,9 +794,8 @@ components:
                                       additionalProperties:
                                         type: string
                                       description: |-
-                                        Labels to match the referenced resource. Use for cross-zone references
-                                        where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                        Name. When multiple resources match, the oldest by creation time wins.
+                                        Labels to match the referenced resource. When multiple resources match,
+                                        the oldest by creation time wins.
                                       type: object
                                   required:
                                     - kind

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -256,11 +256,6 @@ components:
                                         where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                         Name. When multiple resources match, the oldest by creation time wins.
                                       type: object
-                                    name:
-                                      description: |-
-                                        Name of the referenced resource (metadata.name). Use for same-cluster
-                                        references. Mutually exclusive with Labels.
-                                      type: string
                                   required:
                                     - kind
                                   type: object
@@ -512,11 +507,6 @@ components:
                                         where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                         Name. When multiple resources match, the oldest by creation time wins.
                                       type: object
-                                    name:
-                                      description: |-
-                                        Name of the referenced resource (metadata.name). Use for same-cluster
-                                        references. Mutually exclusive with Labels.
-                                      type: string
                                   required:
                                     - kind
                                   type: object
@@ -810,11 +800,6 @@ components:
                                         where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                         Name. When multiple resources match, the oldest by creation time wins.
                                       type: object
-                                    name:
-                                      description: |-
-                                        Name of the referenced resource (metadata.name). Use for same-cluster
-                                        references. Mutually exclusive with Labels.
-                                      type: string
                                   required:
                                     - kind
                                   type: object

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
@@ -107,7 +107,8 @@ from:
           openTelemetry:
             backendRef:
               kind: MeshOpenTelemetryBackend
-              name: my-otel
+              labels:
+                kuma.io/display-name: my-otel
 `),
 			Entry("openTelemetry with backendRef using labels", `
 targetRef:
@@ -524,14 +525,15 @@ from:
             endpoint: otel-collector:4317
             backendRef:
               kind: MeshOpenTelemetryBackend
-              name: my-otel
+              labels:
+                kuma.io/display-name: my-otel
 `,
 				expected: `
 violations:
   - field: spec.from[0].default.backends[0].openTelemetry
     message: "openTelemetry must have only one type defined: endpoint, backendRef"`,
 			}),
-			Entry("openTelemetry backendRef neither name nor labels", testCase{
+			Entry("openTelemetry backendRef no labels", testCase{
 				inputYaml: `
 targetRef:
   kind: MeshService
@@ -549,7 +551,7 @@ from:
 				expected: `
 violations:
   - field: spec.from[0].default.backends[0].openTelemetry.backendRef
-    message: "backendRef must have exactly one defined: name, labels"`,
+    message: "backendRef must have exactly one defined: labels"`,
 			}),
 			Entry("openTelemetry attribute key with spaces", testCase{
 				inputYaml: `

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -155,9 +155,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -411,9 +410,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind
@@ -716,9 +714,8 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          Labels to match the referenced resource. Use for cross-zone references
-                                          where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                          Name. When multiple resources match, the oldest by creation time wins.
+                                          Labels to match the referenced resource. When multiple resources match,
+                                          the oldest by creation time wins.
                                         type: object
                                     required:
                                     - kind

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -159,11 +159,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -420,11 +415,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object
@@ -730,11 +720,6 @@ spec:
                                           where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                           Name. When multiple resources match, the oldest by creation time wins.
                                         type: object
-                                      name:
-                                        description: |-
-                                          Name of the referenced resource (metadata.name). Use for same-cluster
-                                          references. Mutually exclusive with Labels.
-                                        type: string
                                     required:
                                     - kind
                                     type: object

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -1096,8 +1096,9 @@ var _ = Describe("MeshAccessLog", func() {
 
 		motb := motb_api.NewMeshOpenTelemetryBackendResource()
 		motb.SetMeta(&test_model.ResourceMeta{
-			Mesh: "default",
-			Name: backendName,
+			Mesh:   "default",
+			Name:   backendName,
+			Labels: map[string]string{mesh_proto.DisplayName: backendName},
 		})
 		motb.Spec.Endpoint = &motb_api.Endpoint{
 			Address: pointer.To("collector.mesh"),
@@ -1163,8 +1164,8 @@ var _ = Describe("MeshAccessLog", func() {
 								Type: api.OtelTelemetryBackendType,
 								OpenTelemetry: &api.OtelBackend{
 									BackendRef: &common_api.BackendResourceRef{
-										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Name: backendName,
+										Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+										Labels: map[string]string{mesh_proto.DisplayName: backendName},
 									},
 								},
 							}},

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -206,11 +206,6 @@ components:
                                   where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                   Name. When multiple resources match, the oldest by creation time wins.
                                 type: object
-                              name:
-                                description: |-
-                                  Name of the referenced resource (metadata.name). Use for same-cluster
-                                  references. Mutually exclusive with Labels.
-                                type: string
                             required:
                               - kind
                             type: object

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -202,9 +202,8 @@ components:
                                 additionalProperties:
                                   type: string
                                 description: |-
-                                  Labels to match the referenced resource. Use for cross-zone references
-                                  where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                  Name. When multiple resources match, the oldest by creation time wins.
+                                  Labels to match the referenced resource. When multiple resources match,
+                                  the oldest by creation time wins.
                                 type: object
                             required:
                               - kind

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
@@ -59,7 +59,8 @@ default:
       openTelemetry:
         backendRef:
           kind: MeshOpenTelemetryBackend
-          name: my-otel
+          labels:
+            kuma.io/display-name: my-otel
 `),
 	)
 
@@ -253,13 +254,14 @@ default:
         endpoint: otel-collector:4778
         backendRef:
           kind: MeshOpenTelemetryBackend
-          name: my-otel
+          labels:
+            kuma.io/display-name: my-otel
 `),
 		ErrorCase(
-			"openTelemetry backendRef neither name nor labels",
+			"openTelemetry backendRef no labels",
 			validators.Violation{
 				Field:   "spec.default.backends.backend[0].openTelemetry.backendRef",
-				Message: "backendRef must have exactly one defined: name, labels",
+				Message: "backendRef must have exactly one defined: labels",
 			},
 			`
 type: MeshMetric

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -107,11 +107,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -103,9 +103,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -667,8 +667,9 @@ var _ = Describe("MeshMetric", func() {
 		newMotb := func() *motb_api.MeshOpenTelemetryBackendResource {
 			motb := motb_api.NewMeshOpenTelemetryBackendResource()
 			motb.SetMeta(&test_model.ResourceMeta{
-				Mesh: "default",
-				Name: backendName,
+				Mesh:   "default",
+				Name:   backendName,
+				Labels: map[string]string{mesh_proto.DisplayName: backendName},
 			})
 			motb.Spec.Endpoint = &motb_api.Endpoint{
 				Address: new("collector.mesh"),
@@ -743,8 +744,8 @@ var _ = Describe("MeshMetric", func() {
 				Type: api.OpenTelemetryBackendType,
 				OpenTelemetry: &api.OpenTelemetryBackend{
 					BackendRef: &common_api.BackendResourceRef{
-						Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-						Name: backendName,
+						Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+						Labels: map[string]string{mesh_proto.DisplayName: backendName},
 					},
 					RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
 				},
@@ -794,8 +795,8 @@ var _ = Describe("MeshMetric", func() {
 					Type: api.OpenTelemetryBackendType,
 					OpenTelemetry: &api.OpenTelemetryBackend{
 						BackendRef: &common_api.BackendResourceRef{
-							Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-							Name: backendName,
+							Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+							Labels: map[string]string{mesh_proto.DisplayName: backendName},
 						},
 						RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
 					},

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -204,9 +204,8 @@ components:
                                 additionalProperties:
                                   type: string
                                 description: |-
-                                  Labels to match the referenced resource. Use for cross-zone references
-                                  where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                  Name. When multiple resources match, the oldest by creation time wins.
+                                  Labels to match the referenced resource. When multiple resources match,
+                                  the oldest by creation time wins.
                                 type: object
                             required:
                               - kind

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -208,11 +208,6 @@ components:
                                   where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                   Name. When multiple resources match, the oldest by creation time wins.
                                 type: object
-                              name:
-                                description: |-
-                                  Name of the referenced resource (metadata.name). Use for same-cluster
-                                  references. Mutually exclusive with Labels.
-                                type: string
                             required:
                               - kind
                             type: object

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/validator_test.go
@@ -113,7 +113,8 @@ default:
       openTelemetry:
         backendRef:
           kind: MeshOpenTelemetryBackend
-          name: my-otel
+          labels:
+            kuma.io/display-name: my-otel
 `),
 		)
 
@@ -464,14 +465,15 @@ default:
         endpoint: otel-collector:4317
         backendRef:
           kind: MeshOpenTelemetryBackend
-          name: my-otel
+          labels:
+            kuma.io/display-name: my-otel
 `,
 				expected: `
 violations:
   - field: spec.default.backends[0].openTelemetry
     message: "openTelemetry must have only one type defined: endpoint, backendRef"`,
 			}),
-			Entry("openTelemetry backendRef neither name nor labels", testCase{
+			Entry("openTelemetry backendRef no labels", testCase{
 				inputYaml: `
 targetRef:
   kind: MeshService
@@ -486,7 +488,7 @@ default:
 				expected: `
 violations:
   - field: spec.default.backends[0].openTelemetry.backendRef
-    message: "backendRef must have exactly one defined: name, labels"`,
+    message: "backendRef must have exactly one defined: labels"`,
 			}),
 			Entry("gateway listener tags not allowed", testCase{
 				inputYaml: `

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -105,9 +105,8 @@ spec:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    Labels to match the referenced resource. Use for cross-zone references
-                                    where KDS adds a hash suffix to metadata.name. Mutually exclusive with
-                                    Name. When multiple resources match, the oldest by creation time wins.
+                                    Labels to match the referenced resource. When multiple resources match,
+                                    the oldest by creation time wins.
                                   type: object
                               required:
                               - kind

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -109,11 +109,6 @@ spec:
                                     where KDS adds a hash suffix to metadata.name. Mutually exclusive with
                                     Name. When multiple resources match, the oldest by creation time wins.
                                   type: object
-                                name:
-                                  description: |-
-                                    Name of the referenced resource (metadata.name). Use for same-cluster
-                                    references. Mutually exclusive with Labels.
-                                  type: string
                               required:
                               - kind
                               type: object

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -562,7 +562,9 @@ var _ = Describe("MeshTrace", func() {
 								OpenTelemetry: &api.OpenTelemetryBackend{
 									BackendRef: &common_api.BackendResourceRef{
 										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Name: "non-existent-backend",
+										Labels: map[string]string{
+											"kuma.io/test": "non-existing",
+										},
 									},
 								},
 							}},
@@ -598,8 +600,9 @@ var _ = Describe("MeshTrace", func() {
 
 		motb := motb_api.NewMeshOpenTelemetryBackendResource()
 		motb.SetMeta(&test_model.ResourceMeta{
-			Mesh: "default",
-			Name: backendName,
+			Mesh:   "default",
+			Name:   backendName,
+			Labels: map[string]string{mesh_proto.DisplayName: backendName},
 		})
 		motb.Spec.Endpoint = &motb_api.Endpoint{
 			Address: new("collector.mesh"),
@@ -645,7 +648,9 @@ var _ = Describe("MeshTrace", func() {
 								OpenTelemetry: &api.OpenTelemetryBackend{
 									BackendRef: &common_api.BackendResourceRef{
 										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Name: backendName,
+										Labels: map[string]string{
+											"kuma.io/display-name": backendName,
+										},
 									},
 								},
 							}},


### PR DESCRIPTION
## Motivation

We have matcher by label and name, it's confusing in case of K8s and resource created on global as their name is usually either `<name>.<namespace>` or name and hash. it's confusing and can cause misconfiguration.

## Implementation information

Remove option to select by name.

## Supporting documentation

Fix: https://github.com/kumahq/kuma/issues/16908

> Changelog: feat(kuma-cp): add MeshOpenTelemetryBackend for shared policy-based OpenTelemetry backends
