### PR TITLE
fix(MeshTrafficPermission): don't fallback to legacy rules when using MeshIdentity

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -83,7 +83,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		}
 
 		inboundRules, ok := mtp.FromRules.InboundRules[key]
-		if !ok || len(inboundRules) == 0 {
+		if (!ok || len(inboundRules) == 0) && proxy.WorkloadIdentity == nil {
 			err := p.configureLegacyRules(mtp, key, listener, res, proxy)
 			if err != nil {
 				return err

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -136,6 +136,56 @@ var _ = Describe("RBAC", func() {
 			Expect(bytes).To(matchers.MatchGoldenYAML(path.Join("testdata", "apply.golden.yaml")))
 		})
 
+		It("should ignore legacy 'from' MTP and default-deny under WorkloadIdentity", func() {
+			// given
+			rs := core_xds.NewResourceSet()
+			ctx := xds_builders.Context().
+				WithMeshBuilder(samples.MeshMTLSBuilder().WithName("mesh-1")).
+				Build()
+
+			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 8080, core_xds.SocketAddressProtocolTCP, true).
+				WithOverwriteName("test_listener").
+				Configure(listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3, envoy.AnonymousResource).
+					Configure(listeners.ServerSideMTLS(ctx.Mesh.Resource, envoy.NewSecretsTracker(ctx.Mesh.Resource.Meta.GetName(), nil), nil, nil, false, false)).
+					Configure(listeners.HttpConnectionManager("test_listener", false, nil, true)))).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			rs.Add(&core_xds.Resource{
+				Name:     listener.GetName(),
+				Origin:   metadata.OriginInbound,
+				Resource: listener,
+			})
+
+			proxy := xds_builders.Proxy().
+				WithDataplane(builders.Dataplane().WithName("dp1").WithMesh("mesh-1").WithServices("backend")).
+				WithWorkloadIdentity(&core_xds.WorkloadIdentity{}).
+				WithPolicies(
+					xds_builders.MatchedPolicies().
+						WithFromPolicy(policies_api.MeshTrafficPermissionType, core_rules.FromRules{
+							Rules: map[core_rules.InboundListener]core_rules.Rules{
+								{Address: "192.168.0.1", Port: 8080}: {
+									{
+										Subset: []subsetutils.Tag{{Key: mesh_proto.ServiceTag, Value: "frontend"}},
+										Conf:   policies_api.Conf{Action: pointer.To[policies_api.Action]("Allow")},
+									},
+								},
+							},
+						}),
+				).
+				Build()
+
+			// when
+			p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
+			Expect(p.Apply(rs, *ctx, proxy)).To(Succeed())
+
+			// then
+			resp, err := rs.List().ToDeltaDiscoveryResponse()
+			Expect(err).ToNot(HaveOccurred())
+			bytes, err := util_proto.ToYAML(resp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bytes).To(matchers.MatchGoldenYAML(path.Join("testdata", "apply-workload-identity-ignores-from.golden.yaml")))
+		})
+
 		It("should enrich matching listener with RBAC filter using matching api", func() {
 			// given
 			rs := core_xds.NewResourceSet()

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/testdata/apply-workload-identity-ignores-from.golden.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/testdata/apply-workload-identity-ignores-from.golden.yaml
@@ -1,0 +1,60 @@
+resources:
+- name: test_listener
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 8080
+    enableReusePort: true
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              matcher:
+                onNoMatch:
+                  action:
+                    name: envoy.filters.rbac.action
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                      action: DENY
+                      name: default
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          statPrefix: test_listener
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    name: test_listener
+    trafficDirection: INBOUND

--- a/test/e2e_env/kubernetes/meshidentity/spire.go
+++ b/test/e2e_env/kubernetes/meshidentity/spire.go
@@ -46,7 +46,7 @@ spec:
 	BeforeAll(func() {
 		err := NewClusterSetup().
 			Install(YamlK8s(samples.MeshDefaultBuilder().WithName(meshName).WithMeshServicesEnabled(v1alpha1.Mesh_MeshServices_Exclusive).KubeYaml())).
-			Install(MeshTrafficPermissionAllowAllKubernetes(meshName)).
+			Install(MeshTrafficPermissionAllowAllKubernetesWorkloadIdentity(meshName, trustDomain)).
 			Install(NamespaceWithSidecarInjection(namespace)).
 			Install(Namespace(spireNamespace)).
 			Install(spire.Install(

--- a/test/e2e_env/multizone/meshidentity/meshidentity.go
+++ b/test/e2e_env/multizone/meshidentity/meshidentity.go
@@ -32,7 +32,11 @@ func Identity() {
 					WithName(meshName).
 					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
 			)).
-			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Install(MeshTrafficPermissionAllowAllUniversalWorkloadIdentity(meshName,
+				fmt.Sprintf("%s.%s.mesh.local", meshName, multizone.KubeZone1.ZoneName()),
+				fmt.Sprintf("%s.%s.mesh.local", meshName, multizone.KubeZone2.ZoneName()),
+				fmt.Sprintf("%s.%s.mesh.local", meshName, multizone.UniZone1.ZoneName()),
+			)).
 			Setup(multizone.Global)).To(Succeed())
 		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
 

--- a/test/e2e_env/multizone/meshidentity/migration.go
+++ b/test/e2e_env/multizone/meshidentity/migration.go
@@ -43,7 +43,13 @@ func Migration() {
 					WithName(meshName).
 					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
 			)).
-			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Install(MeshTrafficPermissionAllowAllUniversalWorkloadIdentity(meshName,
+				// legacy builtin mTLS identity: spiffe://<mesh>/<service>
+				meshName,
+				// MeshIdentity per-zone trust domains after migration
+				fmt.Sprintf("%s.%s.mesh.local", meshName, multizone.KubeZone1.ZoneName()),
+				fmt.Sprintf("%s.%s.mesh.local", meshName, multizone.KubeZone2.ZoneName()),
+			)).
 			Setup(multizone.Global)).To(Succeed())
 		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
 

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
@@ -686,19 +686,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
@@ -695,7 +695,7 @@
                               "name": "envoy.filters.rbac.action",
                               "typedConfig": {
                                 "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
-                                "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies-0_"
                               }
                             }
                           },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
@@ -686,19 +686,43 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
+                  "matcher": {
+                    "matcherList": {
+                      "matchers": [
+                        {
+                          "onMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                              }
+                            }
+                          },
+                          "predicate": {
+                            "singlePredicate": {
+                              "input": {
+                                "name": "envoy.matching.inputs.uri_san",
+                                "typedConfig": {
+                                  "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput"
+                                }
+                              },
+                              "valueMatch": {
+                                "prefix": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local"
+                              }
+                            }
                           }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                        }
+                      ]
+                    },
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-egress.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-egress.golden.json
@@ -381,6 +381,34 @@
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
                         "matcher": {
+                          "matcherList": {
+                            "matchers": [
+                              {
+                                "onMatch": {
+                                  "action": {
+                                    "name": "envoy.filters.rbac.action",
+                                    "typedConfig": {
+                                      "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                    }
+                                  }
+                                },
+                                "predicate": {
+                                  "singlePredicate": {
+                                    "input": {
+                                      "name": "envoy.matching.inputs.uri_san",
+                                      "typedConfig": {
+                                        "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput"
+                                      }
+                                    },
+                                    "valueMatch": {
+                                      "prefix": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          },
                           "onNoMatch": {
                             "action": {
                               "name": "envoy.filters.rbac.action",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-egress.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-egress.golden.json
@@ -389,7 +389,7 @@
                                     "name": "envoy.filters.rbac.action",
                                     "typedConfig": {
                                       "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
-                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies-0_"
                                     }
                                   }
                                 },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,43 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
+                        "matcher": {
+                          "matcherList": {
+                            "matchers": [
+                              {
+                                "onMatch": {
+                                  "action": {
+                                    "name": "envoy.filters.rbac.action",
+                                    "typedConfig": {
+                                      "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                    }
+                                  }
+                                },
+                                "predicate": {
+                                  "singlePredicate": {
+                                    "input": {
+                                      "name": "envoy.matching.inputs.uri_san",
+                                      "typedConfig": {
+                                        "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput"
+                                      }
+                                    },
+                                    "valueMatch": {
+                                      "prefix": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local"
+                                    }
+                                  }
                                 }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                              }
+                            ]
+                          },
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -717,7 +717,7 @@
                                     "name": "envoy.filters.rbac.action",
                                     "typedConfig": {
                                       "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
-                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies-0_"
                                     }
                                   }
                                 },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
@@ -708,19 +708,43 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
+                        "matcher": {
+                          "matcherList": {
+                            "matchers": [
+                              {
+                                "onMatch": {
+                                  "action": {
+                                    "name": "envoy.filters.rbac.action",
+                                    "typedConfig": {
+                                      "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                    }
+                                  }
+                                },
+                                "predicate": {
+                                  "singlePredicate": {
+                                    "input": {
+                                      "name": "envoy.matching.inputs.uri_san",
+                                      "typedConfig": {
+                                        "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput"
+                                      }
+                                    },
+                                    "valueMatch": {
+                                      "prefix": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local"
+                                    }
+                                  }
                                 }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                              }
+                            ]
+                          },
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
@@ -717,7 +717,7 @@
                                     "name": "envoy.filters.rbac.action",
                                     "typedConfig": {
                                       "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
-                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies_"
+                                      "name": "kri_mtp_envoyconfig-zoneproxies_kuma-3__allow-all-envoyconfig-zoneproxies-0_"
                                     }
                                   }
                                 },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
@@ -686,19 +686,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
@@ -911,19 +911,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -933,19 +933,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
@@ -933,19 +933,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
@@ -701,19 +701,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -723,19 +723,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
@@ -723,19 +723,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
@@ -697,19 +697,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -719,19 +719,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
@@ -719,19 +719,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
@@ -686,19 +686,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-demo-client.golden.json
@@ -686,19 +686,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
@@ -686,19 +686,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
@@ -831,19 +831,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -891,19 +891,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
@@ -891,19 +891,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-demo-client.golden.json
@@ -855,19 +855,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -919,19 +919,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server.golden.json
@@ -919,19 +919,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
@@ -837,19 +837,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -900,19 +900,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
@@ -900,19 +900,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
@@ -686,19 +686,15 @@
                 "name": "envoy.filters.network.rbac",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
-                  "rules": {
-                    "policies": {
-                      "MeshTrafficPermission": {
-                        "permissions": [
-                          {
-                            "any": true
-                          }
-                        ],
-                        "principals": [
-                          {
-                            "any": true
-                          }
-                        ]
+                  "matcher": {
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
                       }
                     }
                   },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
@@ -708,19 +708,15 @@
                       "name": "envoy.filters.http.rbac",
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
-                        "rules": {
-                          "policies": {
-                            "MeshTrafficPermission": {
-                              "permissions": [
-                                {
-                                  "any": true
-                                }
-                              ],
-                              "principals": [
-                                {
-                                  "any": true
-                                }
-                              ]
+                        "matcher": {
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
                             }
                           }
                         }

--- a/test/e2e_env/universal/envoyconfig/zoneproxies.go
+++ b/test/e2e_env/universal/envoyconfig/zoneproxies.go
@@ -160,7 +160,10 @@ spec:
 					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
 			),
 		).
-		Install(MeshTrafficPermissionAllowAllUniversal(zoneProxyMeshName)).
+		Install(MeshTrafficPermissionAllowAllUniversalWorkloadIdentity(
+			zoneProxyMeshName,
+			fmt.Sprintf("%s.%s.mesh.local", zoneProxyMeshName, universal.Cluster.ZoneName()),
+		)).
 		Install(YamlUniversal(meshExternalService)).
 		Install(YamlUniversal(meshIdentityYAML)).
 		Install(zoneproxy.Install(

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -212,6 +212,36 @@ spec:
 	return YamlK8s(mtp)
 }
 
+// MeshTrafficPermissionAllowAllKubernetesWorkloadIdentity is the 'rules'-based
+// counterpart of MeshTrafficPermissionAllowAllKubernetes for meshes using
+// MeshIdentity, where the legacy 'from' form is ignored. See
+// MeshTrafficPermissionAllowAllUniversalWorkloadIdentity for the SPIFFE ID
+// prefix constraints.
+func MeshTrafficPermissionAllowAllKubernetesWorkloadIdentity(name string, trustDomains ...string) InstallFunc {
+	fns := make([]InstallFunc, 0, len(trustDomains))
+	for i, td := range trustDomains {
+		mtp := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrafficPermission
+metadata:
+  namespace: %[2]s
+  name: allow-all-%[1]s-%[3]d.%[2]s
+  labels:
+    kuma.io/mesh: %[1]s
+spec:
+  targetRef:
+    kind: Mesh
+  rules:
+    - default:
+        allow:
+          - spiffeID:
+              type: Prefix
+              value: "spiffe://%[4]s"`, name, Config.KumaNamespace, i, td)
+		fns = append(fns, YamlK8s(mtp))
+	}
+	return Combine(fns...)
+}
+
 func MTLSMeshUniversal(name string) InstallFunc {
 	mesh := fmt.Sprintf(`
 type: Mesh
@@ -431,13 +461,18 @@ spec:
 // MeshTrafficPermissionAllowAllUniversalWorkloadIdentity installs an allow-all
 // MeshTrafficPermission using the 'rules' field. Under MeshIdentity the legacy
 // 'from' form is ignored, so meshes with MeshIdentity must use 'rules' with a
-// SPIFFE ID prefix. The prefix must carry the full trust domain (a bare
-// "spiffe://" prefix does not match); the trust domain is configured by the
-// MeshIdentity, so it's passed in rather than derived here.
-func MeshTrafficPermissionAllowAllUniversalWorkloadIdentity(name, trustDomain string) InstallFunc {
-	mtp := fmt.Sprintf(`
+// SPIFFE ID prefix. The value must be a valid SPIFFE ID, i.e. carry the full
+// trust domain and no trailing slash (a bare "spiffe://" or a trailing slash
+// fails validation). One MeshTrafficPermission is installed per trust domain
+// (they're merged anyway), which lets multizone meshes (per-zone trust domains)
+// and migrations (legacy mTLS trust domain "<mesh>" plus identity trust domains)
+// allow every expected client.
+func MeshTrafficPermissionAllowAllUniversalWorkloadIdentity(name string, trustDomains ...string) InstallFunc {
+	fns := make([]InstallFunc, 0, len(trustDomains))
+	for i, td := range trustDomains {
+		mtp := fmt.Sprintf(`
 type: MeshTrafficPermission
-name: allow-all-%[1]s
+name: allow-all-%[1]s-%[2]d
 mesh: %[1]s
 spec:
   targetRef:
@@ -447,8 +482,10 @@ spec:
         allow:
           - spiffeID:
               type: Prefix
-              value: "spiffe://%[2]s"`, name, trustDomain)
-	return YamlUniversal(mtp)
+              value: "spiffe://%[3]s"`, name, i, td)
+		fns = append(fns, YamlUniversal(mtp))
+	}
+	return Combine(fns...)
 }
 
 func YamlUniversal(yaml string) InstallFunc {

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -428,6 +428,29 @@ spec:
 	return YamlUniversal(mtp)
 }
 
+// MeshTrafficPermissionAllowAllUniversalWorkloadIdentity installs an allow-all
+// MeshTrafficPermission using the 'rules' field. Under MeshIdentity the legacy
+// 'from' form is ignored, so meshes with MeshIdentity must use 'rules' with a
+// SPIFFE ID prefix. The prefix must carry the full trust domain (a bare
+// "spiffe://" prefix does not match); the trust domain is configured by the
+// MeshIdentity, so it's passed in rather than derived here.
+func MeshTrafficPermissionAllowAllUniversalWorkloadIdentity(name, trustDomain string) InstallFunc {
+	mtp := fmt.Sprintf(`
+type: MeshTrafficPermission
+name: allow-all-%[1]s
+mesh: %[1]s
+spec:
+  targetRef:
+    kind: Mesh
+  rules:
+    - default:
+        allow:
+          - spiffeID:
+              type: Prefix
+              value: "spiffe://%[2]s"`, name, trustDomain)
+	return YamlUniversal(mtp)
+}
+
 func YamlUniversal(yaml string) InstallFunc {
 	return func(cluster Cluster) error {
 		_, err := retry.DoWithRetryContextE(cluster.GetTesting(), context.Background(), "install yaml resource", DefaultRetries, DefaultTimeout,


### PR DESCRIPTION
## Motivation

It doesn't make sense to fallback to old `spec.from` rules for MeshTrafficPermission when using MeshIdentity. 

## Implementation information

When fallback to legacy rules check that `proxy.WorkloadIdentity` is `nil`.

## Supporting documentation

Fix https://github.com/kumahq/kuma/issues/16907
