### PR TITLE
fix(ServiceInsights): resyncer produces ServiceInsights with empty name

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -26,6 +26,7 @@ import (
 	util_maps "github.com/kumahq/kuma/v2/pkg/util/maps"
 )
 
+// TODO:
 var log = core.Log.WithName("mesh-insight-resyncer")
 
 const (
@@ -427,6 +428,11 @@ func (r *resyncer) addMeshesToBatch(ctx context.Context, batch *eventBatch, tena
 }
 
 func populateInsight(serviceType mesh_proto.ServiceInsight_Service_Type, insight *mesh_proto.ServiceInsight, svcName string, status core_mesh.Status, backend string, addressPort string) {
+	if svcName == "" {
+		// When KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED is set, inbounds carry no
+		// kuma.io/service tag, so there is no service to track here.
+		return
+	}
 	if _, ok := insight.Services[svcName]; !ok {
 		insight.Services[svcName] = &mesh_proto.ServiceInsight_Service{
 			IssuedBackends: map[string]uint32{},
@@ -633,6 +639,11 @@ func (r *resyncer) createOrUpdateMeshInsight(
 
 		for _, inbound := range networking.GetInbound() {
 			if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
+				continue
+			}
+			// With KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED inbounds have no
+			// kuma.io/service tag, so there is no service to count here.
+			if inbound.GetService() == "" {
 				continue
 			}
 			internalServices[inbound.GetService()] = struct{}{}

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -26,7 +26,6 @@ import (
 	util_maps "github.com/kumahq/kuma/v2/pkg/util/maps"
 )
 
-// TODO:
 var log = core.Log.WithName("mesh-insight-resyncer")
 
 const (

--- a/pkg/insights/resyncer_test.go
+++ b/pkg/insights/resyncer_test.go
@@ -596,6 +596,64 @@ var _ = Describe("Insight Persistence", func() {
 		}).Should(Succeed())
 	})
 
+	It("should not create a service insight entry for inbounds without a kuma.io/service tag", func() {
+		// KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED strips the kuma.io/service tag from inbounds
+		err := rm.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		tagged := core_mesh.NewDataplaneResource()
+		tagged.Spec = &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "10.0.0.1",
+				Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+					{
+						Port: 5000,
+						Tags: map[string]string{
+							"kuma.io/service": "backend",
+						},
+					},
+				},
+			},
+		}
+		untagged := core_mesh.NewDataplaneResource()
+		untagged.Spec = &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "10.0.0.2",
+				Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+					{
+						Port: 5000,
+					},
+				},
+			},
+		}
+
+		for n, entity := range map[string]model.Resource{"tagged": tagged, "untagged": untagged} {
+			err = rm.Create(context.Background(), entity, store.CreateByKey(n, "mesh-1"))
+			Expect(err).ToNot(HaveOccurred(), n)
+		}
+
+		step(stepsToResync)
+
+		// when
+		Eventually(func(g Gomega) {
+			serviceInsight := core_mesh.NewServiceInsightResource()
+			err := rm.Get(context.Background(), serviceInsight, store.GetBy(insights.ServiceInsightKey("mesh-1")))
+			g.Expect(err).ToNot(HaveOccurred())
+			// then the tagged inbound is tracked, but no entry is created for the empty name
+			g.Expect(serviceInsight.Spec.Services).To(HaveKey("backend"))
+			g.Expect(serviceInsight.Spec.Services).ToNot(HaveKey(""))
+		}).Should(Succeed())
+
+		// and the MeshInsight only counts the tagged service, not the untagged inbound
+		Eventually(func(g Gomega) {
+			meshInsight := core_mesh.NewMeshInsightResource()
+			err := rm.Get(context.Background(), meshInsight, store.GetBy(insights.MeshInsightKey("mesh-1")))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(meshInsight.Spec.Services.Internal).To(Equal(uint32(1)))
+			g.Expect(meshInsight.Spec.Services.Total).To(Equal(uint32(1)))
+		}).Should(Succeed())
+	})
+
 	It("should return correct dataplanes statuses in mesh insights", func() {
 		err := rm.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Motivation

When `KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED=true`, inbounds carry no `kuma.io/service` tag, so `inbound.GetService()` returns `""`. The insights resyncer didn't account for this and produced bogus empty-named entries:
- `ServiceInsight` ended up with a single service named `""`.
- `MeshInsight` counted that empty name as a real service, reporting services: `{total: 1, internal: 1}`.

## Implementation information

This PR skips inbounds with an empty service name in both paths, so no phantom `""` service is tracked or counted. Gateway and external-service entries are unaffected, since they keep their `kuma.io/service` tag regardless of the flag.

## Supporting documentation

N/A
