### PR TITLE
fix(policy): match ignored inbounds for Dataplane

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -239,9 +239,6 @@ func allDataplanesSelected(ref common_api.TargetRef) bool {
 func inboundsSelectedBySectionName(sectionName string, dpp *core_mesh.DataplaneResource) []core_rules.InboundListener {
 	var selectedInbounds []core_rules.InboundListener
 	for _, inbound := range dpp.Spec.GetNetworking().Inbound {
-		if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
-			continue
-		}
 		if sectionName == "" || inbound.Name == sectionName {
 			intf := dpp.Spec.GetNetworking().ToInboundInterface(inbound)
 			selectedInbounds = append(selectedInbounds, core_rules.InboundListener{

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/10.dataplane.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/10.dataplane.yaml
@@ -1,0 +1,13 @@
+type: Dataplane
+mesh: mesh-1
+name: dp-1
+labels:
+  app: web
+networking:
+  address: 1.1.1.1
+  inbound:
+    - port: 8080
+      tags:
+        kuma.io/service: web
+        app: web
+      state: Ignored

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/10.golden.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/10.golden.yaml
@@ -1,0 +1,20 @@
+items:
+- creationTime: "0001-01-01T00:00:00Z"
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: mp-1
+  spec:
+    default:
+      appendMatch:
+      - port: 443
+        protocol: tls
+        type: Domain
+        value: example.com
+      passthroughMode: Matched
+    targetRef:
+      kind: Dataplane
+      labels:
+        app: web
+  type: MeshPassthrough
+next: null
+total: 0

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/10.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/dataplanepolicies/10.policies.yaml
@@ -1,0 +1,16 @@
+# 10. policies with targetRef.kind=Dataplane + labels select ignored inbounds
+type: MeshPassthrough
+mesh: mesh-1
+name: mp-1
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      app: web
+  default:
+    passthroughMode: Matched
+    appendMatch:
+      - type: Domain
+        value: example.com
+        port: 443
+        protocol: tls


### PR DESCRIPTION
## Motivation

Completes the release-2.11 backport ([#16340](https://github.com/kumahq/kuma/pull/16340)) of [#16323](https://github.com/kumahq/kuma/pull/16323).

The cherry-pick only dropped the `Ignored` skip in `inboundsSelectedByTags`, missing the same skip in  `inboundsSelectedBySectionName`, which handles the `targetRef.kind: Dataplane` branch.

As a result, on release-2.11, policies with `targetRef.kind: Dataplane` + `labels`/`name`/`sectionName` are still silently dropped on DPPs whose inbounds are `Ignored` (e.g. during Argo Rollouts pod-template-hash transitions).

## Implementation information

- Remove the `Ignored` skip in `inboundsSelectedBySectionName` (`pkg/plugins/policies/core/matchers/dataplane.go`).
- Add regression test case `10.*` exercising `MeshPassthrough` with `targetRef.kind: Dataplane` + `labels` against a DPP whose inbound is `Ignored`. The existing `07.*` case only covers `MeshServiceSubset`, which routes through the already-patched helper.

## Supporting documentation

- Original PR: [#16323](https://github.com/kumahq/kuma/pull/16323)
- Incomplete backport: [#16340](https://github.com/kumahq/kuma/pull/16340)