### PR TITLE
fix(api): add better message for spiffe validator

### DIFF
--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -458,7 +458,7 @@ func ValidateMatch(match common_api.Match) validators.ValidationError {
 	if match.SpiffeID != nil {
 		_, err := spiffeid.FromString(match.SpiffeID.Value)
 		if err != nil {
-			verr.AddViolation("spiffeID", "must be a valid Spiffe ID")
+			verr.AddViolation("spiffeID", fmt.Sprintf("must be a valid Spiffe ID: %s", err))
 		}
 	}
 	if match.SNI != nil {

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
@@ -242,7 +242,7 @@ rules:
 			[]validators.Violation{
 				{
 					Field:   "spec.rules[0].matches[0].spiffeID",
-					Message: "must be a valid Spiffe ID",
+					Message: "must be a valid Spiffe ID: scheme is missing or invalid",
 				},
 			}, `
 type: MeshFaultInjection

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator_test.go
@@ -287,11 +287,11 @@ rules:
 				expected: `
 violations:
   - field: spec.rules[0].allow[0].spiffeID
-    message: must be a valid Spiffe ID
+    message: 'must be a valid Spiffe ID: scheme is missing or invalid'
   - field: spec.rules[0].allowWithShadowDeny[0].spiffeID
-    message: must be a valid Spiffe ID
+    message: 'must be a valid Spiffe ID: scheme is missing or invalid'
   - field: spec.rules[0].deny[0].spiffeID
-    message: must be a valid Spiffe ID
+    message: 'must be a valid Spiffe ID: scheme is missing or invalid'
 `,
 			}),
 		)


### PR DESCRIPTION
## Motivation

When a user provides an invalid SPIFFE ID, the validation error previously returned a generic message ("must be a valid Spiffe ID") that didn't help them understand what was wrong. This change enhances the error message to include the underlying parse error, enabling developers to quickly identify and fix malformed SPIFFE IDs without needing to look up the SPIFFE ID format specification.

## Implementation information

The implementation leverages the existing error returned by `spiffeid.FromString()` and incorporates it directly into the validation message via `fmt.Sprintf`. This approach
   utilizes the detailed error information that was already being generated but previously discarded. The change is minimal and surgical — a single line modification in the core
   validator with corresponding updates to golden test expectations.

## Supporting documentation

Fix #16915 
