### PR TITLE
fix(ServiceInsight): don't compute when meshServices.mode is Exclusive

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -371,9 +371,16 @@ func (r *resyncer) processEvent(ctx context.Context, start time.Time, event resy
 		return errors.Wrap(err, "unable to get ExternalServices to recompute insights")
 	}
 
+	// When meshServices.mode is Exclusive, kuma.io/service based ServiceInsights are no longer relevant
+	meshRes := core_mesh.NewMeshResource()
+	if err := r.rm.Get(ctx, meshRes, store.GetByKey(event.mesh, model.NoMesh)); err != nil {
+		return errors.Wrap(err, "unable to get Mesh to recompute insights")
+	}
+	exclusiveMeshServices := meshRes.Spec.MeshServicesMode() == mesh_proto.Mesh_MeshServices_Exclusive
+
 	anyChanged := false
 	if event.flag&FlagService == FlagService {
-		err, changed := r.createOrUpdateServiceInsight(ctx, event.mesh, dpOverviews, externalServices.Items)
+		err, changed := r.createOrUpdateServiceInsight(ctx, event.mesh, dpOverviews, externalServices.Items, exclusiveMeshServices)
 		if err != nil {
 			return errors.Wrap(err, "unable to resync ServiceInsight")
 		}
@@ -382,7 +389,7 @@ func (r *resyncer) processEvent(ctx context.Context, start time.Time, event resy
 		}
 	}
 	if event.flag&FlagMesh == FlagMesh {
-		err, changed := r.createOrUpdateMeshInsight(ctx, event.mesh, dpOverviews, externalServices.Items, event.types)
+		err, changed := r.createOrUpdateMeshInsight(ctx, event.mesh, dpOverviews, externalServices.Items, event.types, exclusiveMeshServices)
 		if err != nil {
 			return errors.Wrap(err, "unable to resync MeshInsight")
 		}
@@ -461,10 +468,14 @@ func (r *resyncer) createOrUpdateServiceInsight(
 	mesh string,
 	dpOverviews []*core_mesh.DataplaneOverviewResource,
 	externalServices []*core_mesh.ExternalServiceResource,
+	exclusiveMeshServices bool,
 ) (error, bool) {
-	log := kuma_log.AddFieldsFromCtx(log, ctx, r.extensions).WithValues("mesh", mesh) // Add info
 	insight := &mesh_proto.ServiceInsight{
 		Services: map[string]*mesh_proto.ServiceInsight_Service{},
+	}
+	if exclusiveMeshServices {
+		// set ServiceInsight with empty Services map
+		return r.upsertServiceInsight(ctx, mesh, insight)
 	}
 
 	zonesMap := map[string]map[string]struct{}{}
@@ -528,6 +539,11 @@ func (r *resyncer) createOrUpdateServiceInsight(
 		}
 	}
 
+	return r.upsertServiceInsight(ctx, mesh, insight)
+}
+
+func (r *resyncer) upsertServiceInsight(ctx context.Context, mesh string, insight *mesh_proto.ServiceInsight) (error, bool) {
+	log := kuma_log.AddFieldsFromCtx(log, ctx, r.extensions).WithValues("mesh", mesh) // Add info
 	key := ServiceInsightKey(mesh)
 	changed := false
 	err := manager.Upsert(ctx, r.rm, key, core_mesh.NewServiceInsightResource(), func(resource model.Resource) error {
@@ -561,6 +577,7 @@ func (r *resyncer) createOrUpdateMeshInsight(
 	dpOverviews []*core_mesh.DataplaneOverviewResource,
 	externalServices []*core_mesh.ExternalServiceResource,
 	types map[model.ResourceType]struct{},
+	exclusiveMeshServices bool,
 ) (error, bool) {
 	log := kuma_log.AddFieldsFromCtx(log, ctx, r.extensions).WithValues("mesh", mesh) // Add info
 	insight := &mesh_proto.MeshInsight{
@@ -632,20 +649,24 @@ func (r *resyncer) createOrUpdateMeshInsight(
 		updateTotal(envoyVersion, insight.DpVersions.Envoy)
 		updateMTLS(dpInsight.GetMTLS(), status, insight.MTLS)
 
-		if svc := networking.GetGateway().GetTags()[mesh_proto.ServiceTag]; svc != "" {
-			internalServices[svc] = struct{}{}
-		}
+		// internalServices is only used for the Services stat, which we don't report in
+		// Exclusive mode, so skip building it then.
+		if !exclusiveMeshServices {
+			if svc := networking.GetGateway().GetTags()[mesh_proto.ServiceTag]; svc != "" {
+				internalServices[svc] = struct{}{}
+			}
 
-		for _, inbound := range networking.GetInbound() {
-			if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
-				continue
+			for _, inbound := range networking.GetInbound() {
+				if inbound.State == mesh_proto.Dataplane_Networking_Inbound_Ignored {
+					continue
+				}
+				// With KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED inbounds have no
+				// kuma.io/service tag, so there is no service to count here.
+				if inbound.GetService() == "" {
+					continue
+				}
+				internalServices[inbound.GetService()] = struct{}{}
 			}
-			// With KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED inbounds have no
-			// kuma.io/service tag, so there is no service to count here.
-			if inbound.GetService() == "" {
-				continue
-			}
-			internalServices[inbound.GetService()] = struct{}{}
 		}
 	}
 
@@ -654,10 +675,12 @@ func (r *resyncer) createOrUpdateMeshInsight(
 	insight.DataplanesByType.Gateway.PartiallyDegraded = insight.GetDataplanesByType().GetGatewayBuiltin().GetPartiallyDegraded() + insight.GetDataplanesByType().GetGatewayDelegated().GetPartiallyDegraded()
 	insight.DataplanesByType.Gateway.Total = insight.GetDataplanesByType().GetGatewayBuiltin().GetTotal() + insight.GetDataplanesByType().GetGatewayDelegated().GetTotal()
 
-	insight.Services = &mesh_proto.MeshInsight_ServiceStat{
-		Total:    uint32(len(internalServices) + len(externalServices)),
-		Internal: uint32(len(internalServices)),
-		External: uint32(len(externalServices)),
+	if !exclusiveMeshServices {
+		insight.Services = &mesh_proto.MeshInsight_ServiceStat{
+			Total:    uint32(len(internalServices) + len(externalServices)),
+			Internal: uint32(len(internalServices)),
+			External: uint32(len(externalServices)),
+		}
 	}
 
 	key := MeshInsightKey(mesh)

--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -361,6 +361,18 @@ func (r *resyncer) processEvent(ctx context.Context, start time.Time, event resy
 	startProcessingTime := r.now()
 	r.idleTime.Observe(float64(startProcessingTime.Sub(start).Milliseconds()))
 	r.timeToProcessItem.Observe(float64(startProcessingTime.Sub(event.time).Milliseconds()))
+
+	// When meshServices.mode is Exclusive, kuma.io/service based ServiceInsights are no longer relevant.
+	meshRes := core_mesh.NewMeshResource()
+	if err := r.rm.Get(ctx, meshRes, store.GetByKey(event.mesh, model.NoMesh)); err != nil {
+		if store.IsNotFound(err) {
+			// Mesh no longer exists, there is nothing to recompute. This can happen when Mesh is being deleted.
+			return nil
+		}
+		return errors.Wrap(err, "unable to get Mesh to recompute insights")
+	}
+	exclusiveMeshServices := meshRes.Spec.MeshServicesMode() == mesh_proto.Mesh_MeshServices_Exclusive
+
 	dpOverviews, err := r.dpOverviews(ctx, event.mesh)
 	if err != nil {
 		return errors.Wrap(err, "unable to get DataplaneOverviews to recompute insights")
@@ -370,13 +382,6 @@ func (r *resyncer) processEvent(ctx context.Context, start time.Time, event resy
 	if err := r.rm.List(ctx, externalServices, store.ListByMesh(event.mesh)); err != nil {
 		return errors.Wrap(err, "unable to get ExternalServices to recompute insights")
 	}
-
-	// When meshServices.mode is Exclusive, kuma.io/service based ServiceInsights are no longer relevant
-	meshRes := core_mesh.NewMeshResource()
-	if err := r.rm.Get(ctx, meshRes, store.GetByKey(event.mesh, model.NoMesh)); err != nil {
-		return errors.Wrap(err, "unable to get Mesh to recompute insights")
-	}
-	exclusiveMeshServices := meshRes.Spec.MeshServicesMode() == mesh_proto.Mesh_MeshServices_Exclusive
 
 	anyChanged := false
 	if event.flag&FlagService == FlagService {

--- a/pkg/insights/resyncer_test.go
+++ b/pkg/insights/resyncer_test.go
@@ -596,6 +596,56 @@ var _ = Describe("Insight Persistence", func() {
 		}).Should(Succeed())
 	})
 
+	It("should not compute services when meshServices.mode is Exclusive", func() {
+		// given a mesh with meshServices.mode=Exclusive
+		mesh := core_mesh.NewMeshResource()
+		mesh.Spec.MeshServices = &mesh_proto.Mesh_MeshServices{Mode: mesh_proto.Mesh_MeshServices_Exclusive}
+		err := rm.Create(context.Background(), mesh, store.CreateByKey("mesh-1", model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		dp1 := core_mesh.NewDataplaneResource()
+		dp1.Spec = &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "10.0.0.1",
+				Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+					{
+						Port: 5000,
+						Tags: map[string]string{
+							"kuma.io/service": "backend",
+						},
+					},
+				},
+			},
+		}
+		err = rm.Create(context.Background(), dp1, store.CreateByKey("dp1", "mesh-1"))
+		Expect(err).ToNot(HaveOccurred())
+
+		externalService := core_mesh.NewExternalServiceResource()
+		externalService.Spec = &mesh_proto.ExternalService{
+			Tags: map[string]string{"kuma.io/service": "external-service"},
+			Networking: &mesh_proto.ExternalService_Networking{
+				Address: "foobar:8080",
+			},
+		}
+		err = rm.Create(context.Background(), externalService, store.CreateByKey("es1", "mesh-1"))
+		Expect(err).ToNot(HaveOccurred())
+
+		step(stepsToResync)
+
+		// then the MeshInsight is computed but reports no Services stat
+		Eventually(func(g Gomega) {
+			meshInsight := core_mesh.NewMeshInsightResource()
+			err := rm.Get(context.Background(), meshInsight, store.GetBy(insights.MeshInsightKey("mesh-1")))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(meshInsight.Spec.Services).To(BeNil())
+		}).Should(Succeed())
+
+		// and no ServiceInsight is created since the empty insight equals the default spec
+		serviceInsight := core_mesh.NewServiceInsightResource()
+		err = rm.Get(context.Background(), serviceInsight, store.GetBy(insights.ServiceInsightKey("mesh-1")))
+		Expect(store.IsNotFound(err)).To(BeTrue())
+	})
+
 	It("should not create a service insight entry for inbounds without a kuma.io/service tag", func() {
 		// KUMA_EXPERIMENTAL_INBOUND_TAGS_DISABLED strips the kuma.io/service tag from inbounds
 		err := rm.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey("mesh-1", model.NoMesh))


### PR DESCRIPTION
## Motivation

When `meshServices.mode` is `Exclusive` user still can see the service counter in GUI being greater than 0.

<img width="566" height="254" alt="image" src="https://github.com/user-attachments/assets/b872a4cd-7cf8-4f7d-8578-130241ca35d2" />

## Implementation information

Check Mesh object and skip service insight compute when mode is `Exclusive`.

## Supporting documentation

<!-- Is there a MADR? An Issue? A related PR? -->

Updates https://github.com/kumahq/kuma/issues/16913
