### PR TITLE
fix(kri): add KRI to overviews and OpenAPI items

### DIFF
--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -47,6 +47,15 @@ components:
   schemas:
     DataplaneItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
@@ -72,6 +81,11 @@ components:
               description: Type of the backend (Kuma ships with 'prometheus')
               type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         name:
           type: string
         networking:

--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -95,6 +95,15 @@ components:
                   type: array
               type: object
           type: object
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
@@ -170,6 +179,11 @@ components:
               description: Name of the enabled backend
               type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         mtls:
           description: |-
             mTLS settings.

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -142,11 +142,25 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
           type: object
         mesh:
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
           type: string
         name:
           type: string

--- a/api/mesh/v1alpha1/zoneegress/rest.yaml
+++ b/api/mesh/v1alpha1/zoneegress/rest.yaml
@@ -47,10 +47,24 @@ components:
   schemas:
     ZoneEgressItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         name:
           type: string
         networking:

--- a/api/mesh/v1alpha1/zoneingress/rest.yaml
+++ b/api/mesh/v1alpha1/zoneingress/rest.yaml
@@ -69,10 +69,24 @@ components:
                 type: object
             type: object
           type: array
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         name:
           type: string
         networking:

--- a/api/system/v1alpha1/secret/rest.yaml
+++ b/api/system/v1alpha1/secret/rest.yaml
@@ -47,6 +47,11 @@ components:
   schemas:
     SecretItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
         data:
           description: Value of the secret
           format: byte
@@ -56,6 +61,11 @@ components:
             type: string
           type: object
         mesh:
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
           type: string
         name:
           type: string

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.json
@@ -7,6 +7,7 @@
       "name": "experiment",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_dp_default___experiment_",
       "dataplane": {
         "networking": {
           "address": "127.0.0.1",
@@ -103,6 +104,7 @@
       "name": "degraded-dp",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_dp_default___degraded-dp_",
       "dataplane": {
         "networking": {
           "address": "127.0.0.1",
@@ -198,6 +200,7 @@
       "name": "offline-dp",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_dp_default___offline-dp_",
       "dataplane": {
         "networking": {
           "address": "127.0.0.1",
@@ -294,6 +297,7 @@
       "name": "example",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_dp_default___example_",
       "dataplane": {
         "networking": {
           "address": "127.0.0.1",

--- a/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-dataplanes.golden.yaml
@@ -60,6 +60,7 @@ items:
           gitCommit: 9d868cd8681c4021bb4a10bf2306ca613ba4de42
           gitTag: v1.0.2
           version: 1.0.2
+  kri: kri_dp_default___experiment_
   mesh: default
   modificationTime: "2019-07-17T18:08:41Z"
   name: experiment
@@ -124,6 +125,7 @@ items:
           gitCommit: 9d868cd8681c4021bb4a10bf2306ca613ba4de42
           gitTag: v1.0.2
           version: 1.0.2
+  kri: kri_dp_default___degraded-dp_
   mesh: default
   modificationTime: "2019-07-17T18:08:41Z"
   name: degraded-dp
@@ -189,6 +191,7 @@ items:
           gitCommit: 9d868cd8681c4021bb4a10bf2306ca613ba4de42
           gitTag: v1.0.2
           version: 1.0.2
+  kri: kri_dp_default___offline-dp_
   mesh: default
   modificationTime: "2019-07-17T18:08:41Z"
   name: offline-dp
@@ -210,6 +213,7 @@ items:
       id: "2"
     - controlPlaneInstanceId: node-003
       id: "3"
+  kri: kri_dp_default___example_
   mesh: default
   modificationTime: "2019-07-17T18:08:41Z"
   name: example

--- a/app/kumactl/cmd/inspect/testdata/inspect-zone-ingress.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-zone-ingress.golden.yaml
@@ -1,5 +1,6 @@
 items:
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_zi____zone-ingress-1_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zone-ingress-1
   type: ZoneIngressOverview
@@ -39,6 +40,7 @@ items:
           gitTag: v1.0.2
           version: 1.0.2
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_zi____zone-ingress-2_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zone-ingress-2
   type: ZoneIngressOverview
@@ -80,6 +82,7 @@ items:
           gitTag: v1.0.2
           version: 1.0.2
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_zi____zone-ingress-3_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zone-ingress-3
   type: ZoneIngressOverview

--- a/app/kumactl/cmd/inspect/testdata/inspect-zone-ingresses.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-zone-ingresses.golden.json
@@ -6,6 +6,7 @@
       "name": "zone-ingress-1",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_zi____zone-ingress-1_",
       "zoneIngress": {},
       "zoneIngressInsight": {
         "subscriptions": [
@@ -63,6 +64,7 @@
       "name": "zone-ingress-2",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_zi____zone-ingress-2_",
       "zoneIngress": {},
       "zoneIngressInsight": {
         "subscriptions": [
@@ -122,6 +124,7 @@
       "name": "zone-ingress-3",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_zi____zone-ingress-3_",
       "zoneIngress": {},
       "zoneIngressInsight": {
         "subscriptions": [

--- a/app/kumactl/cmd/inspect/testdata/inspect-zone.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-zone.golden.yaml
@@ -1,5 +1,6 @@
 items:
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_z____zone-1_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zone-1
   type: ZoneOverview
@@ -72,6 +73,7 @@ items:
           gitTag: v1.0.0
           version: 1.0.0
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_z____zone-2_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zone-2
   type: ZoneOverview
@@ -86,6 +88,7 @@ items:
     - globalInstanceId: node-003
       id: "3"
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_z____zone-3_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zone-3
   type: ZoneOverview

--- a/app/kumactl/cmd/inspect/testdata/inspect-zoneegress.golden.yaml
+++ b/app/kumactl/cmd/inspect/testdata/inspect-zoneegress.golden.yaml
@@ -1,5 +1,6 @@
 items:
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_ze____zoneegress-1_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zoneegress-1
   type: ZoneEgressOverview
@@ -39,6 +40,7 @@ items:
           gitTag: v1.0.2
           version: 1.0.2
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_ze____zoneegress-2_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zoneegress-2
   type: ZoneEgressOverview
@@ -80,6 +82,7 @@ items:
           gitTag: v1.0.2
           version: 1.0.2
 - creationTime: "2018-07-17T16:05:36.995Z"
+  kri: kri_ze____zoneegress-3_
   modificationTime: "2019-07-17T18:08:41Z"
   name: zoneegress-3
   type: ZoneEgressOverview

--- a/app/kumactl/cmd/inspect/testdata/inspect-zoneegresses.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-zoneegresses.golden.json
@@ -6,6 +6,7 @@
       "name": "zoneegress-1",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_ze____zoneegress-1_",
       "zoneEgress": {},
       "zoneEgressInsight": {
         "subscriptions": [
@@ -63,6 +64,7 @@
       "name": "zoneegress-2",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_ze____zoneegress-2_",
       "zoneEgress": {},
       "zoneEgressInsight": {
         "subscriptions": [
@@ -122,6 +124,7 @@
       "name": "zoneegress-3",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_ze____zoneegress-3_",
       "zoneEgress": {},
       "zoneEgressInsight": {
         "subscriptions": [

--- a/app/kumactl/cmd/inspect/testdata/inspect-zones.golden.json
+++ b/app/kumactl/cmd/inspect/testdata/inspect-zones.golden.json
@@ -6,6 +6,7 @@
       "name": "zone-1",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_z____zone-1_",
       "zone": {
         "enabled": true
       },
@@ -108,6 +109,7 @@
       "name": "zone-2",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_z____zone-2_",
       "zone": {
         "enabled": true
       },
@@ -133,6 +135,7 @@
       "name": "zone-3",
       "creationTime": "2018-07-17T16:05:36.995Z",
       "modificationTime": "2019-07-17T18:08:41Z",
+      "kri": "kri_z____zone-3_",
       "zone": {
         "enabled": false
       },

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5472,6 +5472,15 @@ components:
       type: object
     DataplaneItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
@@ -5503,6 +5512,11 @@ components:
               description: Type of the backend (Kuma ships with 'prometheus')
               type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         name:
           type: string
         networking:
@@ -6271,6 +6285,15 @@ components:
                   type: array
               type: object
           type: object
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
@@ -6357,6 +6380,11 @@ components:
               description: Name of the enabled backend
               type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         mtls:
           description: |-
             mTLS settings.
@@ -10138,11 +10166,25 @@ components:
                 type: object
               type: array
           type: object
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
           type: object
         mesh:
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
           type: string
         name:
           type: string
@@ -17369,10 +17411,24 @@ components:
           example: '0001-01-01T00:00:00Z'
     ZoneEgressItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         name:
           type: string
         networking:
@@ -17429,10 +17485,24 @@ components:
                 type: object
             type: object
           type: array
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
         labels:
           additionalProperties:
             type: string
           type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
         name:
           type: string
         networking:
@@ -18394,6 +18464,11 @@ components:
       type: object
     SecretItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
         data:
           description: Value of the secret
           format: byte
@@ -18403,6 +18478,11 @@ components:
             type: string
           type: object
         mesh:
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
           type: string
         name:
           type: string

--- a/pkg/api-server/dataplane_overview_endpoints_test.go
+++ b/pkg/api-server/dataplane_overview_endpoints_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Dataplane Overview Endpoints", func() {
 	"mesh": "mesh1",
 	"creationTime": "2018-07-17T16:05:36.995Z",
 	"modificationTime": "2018-07-17T16:05:36.995Z",
+	"kri": "kri_dp_mesh1___dp-1_",
 	"dataplane": {
 		"networking": {
 			"address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights.json
@@ -7,6 +7,7 @@
    "name": "dp-1",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-1_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -46,6 +47,7 @@
    "name": "dp-no-insights",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-no-insights_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -68,6 +70,7 @@
    "name": "gateway-builtin",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-builtin_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -103,6 +106,7 @@
    "name": "gateway-delegated",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-delegated_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_gateway_builtin.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_gateway_builtin.json
@@ -7,6 +7,7 @@
    "name": "gateway-builtin",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-builtin_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_gateway_delegated.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_gateway_delegated.json
@@ -7,6 +7,7 @@
    "name": "gateway-delegated",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-delegated_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_gateway_true.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_gateway_true.json
@@ -7,6 +7,7 @@
    "name": "gateway-builtin",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-builtin_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -42,6 +43,7 @@
    "name": "gateway-delegated",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-delegated_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_name_gateway.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_name_gateway.json
@@ -7,6 +7,7 @@
    "name": "gateway-builtin",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-builtin_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -42,6 +43,7 @@
    "name": "gateway-delegated",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-delegated_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_name_tew.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_name_tew.json
@@ -7,6 +7,7 @@
    "name": "gateway-builtin",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-builtin_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -42,6 +43,7 @@
    "name": "gateway-delegated",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-delegated_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_service_backend.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_service_backend.json
@@ -7,6 +7,7 @@
    "name": "dp-1",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-1_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -46,6 +47,7 @@
    "name": "dp-no-insights",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-no-insights_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_service_backend_tag_version_v1.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_service_backend_tag_version_v1.json
@@ -7,6 +7,7 @@
    "name": "dp-1",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-1_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -46,6 +47,7 @@
    "name": "dp-no-insights",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-no-insights_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_service_ck.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_service_ck.json
@@ -7,6 +7,7 @@
    "name": "dp-1",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-1_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -46,6 +47,7 @@
    "name": "dp-no-insights",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-no-insights_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_tagcolumn_tag_v.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_insights_tag_tagcolumn_tag_v.json
@@ -7,6 +7,7 @@
    "name": "dp-1",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-1_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -46,6 +47,7 @@
    "name": "dp-no-insights",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___dp-no-insights_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/api-server/testdata/meshes_mesh1_dataplanes_overview_name_tew.json
+++ b/pkg/api-server/testdata/meshes_mesh1_dataplanes_overview_name_tew.json
@@ -7,6 +7,7 @@
    "name": "gateway-builtin",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-builtin_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",
@@ -42,6 +43,7 @@
    "name": "gateway-delegated",
    "creationTime": "2018-07-17T16:05:36.995Z",
    "modificationTime": "2018-07-17T16:05:36.995Z",
+   "kri": "kri_dp_mesh1___gateway-delegated_",
    "dataplane": {
     "networking": {
      "address": "127.0.0.1",

--- a/pkg/core/kri/kri.go
+++ b/pkg/core/kri/kri.go
@@ -70,9 +70,16 @@ func FromResourceMetaE[T ~string](rm core_model.ResourceMeta, resourceType T) (I
 
 	rType := core_model.ResourceType(resourceType)
 
-	if desc, err := registry.Global().DescriptorFor(rType); err != nil {
+	// an overview shares its base resource's identity: DataplaneOverview -> Dataplane
+	if base, isOverview := strings.CutSuffix(string(rType), "Overview"); isOverview {
+		rType = core_model.ResourceType(base)
+	}
+
+	desc, err := registry.Global().DescriptorFor(rType)
+	if err != nil {
 		return Identifier{}, err
-	} else if desc.ShortName == "" {
+	}
+	if desc.ShortName == "" { // types without a ShortName aren't addressable by KRI
 		return Identifier{}, nil
 	}
 

--- a/pkg/core/kri/kri_suite_test.go
+++ b/pkg/core/kri/kri_suite_test.go
@@ -1,0 +1,11 @@
+package kri_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestKRI(t *testing.T) {
+	test.RunSpecs(t, "KRI Suite")
+}

--- a/pkg/core/kri/kri_test.go
+++ b/pkg/core/kri/kri_test.go
@@ -1,0 +1,40 @@
+package kri_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	// register core resource types (Dataplane, *Overview, ...) in the global registry
+	_ "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	rest_v1alpha1 "github.com/kumahq/kuma/v2/pkg/core/resources/model/rest/v1alpha1"
+)
+
+var _ = Describe("FromResourceMetaE", func() {
+	meta := rest_v1alpha1.ResourceMeta{
+		Mesh: "kuma-runner",
+		Name: "grpc-service-84c8b47975-kg5xx_4455fx6cb5fd2494.kuma-system",
+		Labels: map[string]string{
+			mesh_proto.ZoneTag:          "east",
+			mesh_proto.KubeNamespaceTag: "kuma-runner-ns",
+			mesh_proto.DisplayName:      "grpc-service-84c8b47975-kg5xx",
+		},
+	}
+
+	It("should resolve an overview to the underlying resource KRI", func() {
+		// Overview shares the identity of the underlying resource: its KRI must
+		// point at the actual Dataplane (kri_dp_...), not the overview type.
+		id, err := kri.FromResourceMetaE(meta, "DataplaneOverview")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(id.String()).To(Equal("kri_dp_kuma-runner_east_kuma-runner-ns_grpc-service-84c8b47975-kg5xx_"))
+	})
+
+	It("should produce the same KRI for the overview and its base resource", func() {
+		overview, err := kri.FromResourceMetaE(meta, "DataplaneOverview")
+		Expect(err).ToNot(HaveOccurred())
+		base, err := kri.FromResourceMetaE(meta, "Dataplane")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(overview.String()).To(Equal(base.String()))
+	})
+})

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -483,6 +483,27 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			schemaMap.Set("mesh", &jsonschema.Schema{Type: "string"})
 		}
 		schemaMap.Set("labels", &jsonschema.Schema{Type: "object", AdditionalProperties: &jsonschema.Schema{Type: "string"}})
+		// kri is only emitted at runtime for resources that have a ShortName
+		// (see pkg/core/kri), so only advertise it in the schema for those.
+		if r.ShortName != "" {
+			schemaMap.Set("kri", &jsonschema.Schema{
+				Type:        "string",
+				ReadOnly:    true,
+				Description: "Kuma Resource Identifier (KRI) of the given resource",
+			})
+		}
+		schemaMap.Set("creationTime", &jsonschema.Schema{
+			Type:        "string",
+			Format:      "date-time",
+			ReadOnly:    true,
+			Description: "Time at which the resource was created",
+		})
+		schemaMap.Set("modificationTime", &jsonschema.Schema{
+			Type:        "string",
+			Format:      "date-time",
+			ReadOnly:    true,
+			Description: "Time at which the resource was updated",
+		})
 		s, err := reflector.reflectFromType(tpe, true)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Motivation

Two related KRI gaps surfaced by users:

1. Computed `*Overview` resources (`DataplaneOverview`, `ZoneIngressOverview`, `ZoneEgressOverview`, `ZoneOverview`) did not serialize the `kri` field, even though an overview is just a merge of a resource and its insight and therefore shares the underlying resource's identity.
2. The OpenAPI `*Item` schemas for core resources (`DataplaneItem`, `MeshGatewayItem`, ...) were missing `kri`, `creationTime` and `modificationTime` (kumahq/kuma#16923).

> Changelog: fix(kri): add KRI to overviews and OpenAPI items

## Implementation information

**Overviews (runtime serialization).** `kri.FromResourceMetaE` computed the KRI from the resource's `type`, which for an overview is e.g. `DataplaneOverview` — a type that is unregistered and has no `ShortName`, so the lookup bailed out and no `kri` was emitted. The fix resolves an overview type to its base type (strip the `Overview` suffix, look up the base descriptor) so the emitted KRI points at the actual resource, e.g. `DataplaneOverview` -> `kri_dp_...`. Overviews intentionally keep no `ShortName` of their own (a duplicate short name would make `FromString` ambiguous).

**OpenAPI items (generated spec).** Core resource `*Item` schemas are built programmatically by `resource-gen` (`tools/resource-gen/pkg/generator/main.go`), not from the policy template, and only set `type`/`name`/`mesh`/`labels` plus reflected proto fields. Added `kri`, `creationTime` and `modificationTime` to that schema. `kri` is only advertised for resources that have a `ShortName`, matching runtime behaviour (Secret, which has none, gets the timestamps but no `kri`). Regenerated the per-resource `rest.yaml` files and the bundled `docs/generated/openapi.yaml`.

Verified both gateway cases do emit a KRI (they are not skipped): gateway dataplanes serialize `kri_dp_...` and `MeshGateway` serializes `kri_mgw_...`.

## Supporting documentation

- kumahq/kuma#16923