### PR TITLE
fix(policy-gen): don't set mesh label on Global-scoped k8s resources

### DIFF
--- a/pkg/core/resources/apis/hostnamegenerator/k8s/v1alpha1/zz_generated.types.go
+++ b/pkg/core/resources/apis/hostnamegenerator/k8s/v1alpha1/zz_generated.types.go
@@ -13,7 +13,6 @@ import (
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/pkg/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/pkg/registry"
-	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
 )
 
 // HostnameGenerator automatically generates DNS hostnames for services in the mesh based on customizable templates. It provides a consistent naming scheme for service discovery by creating predictable hostnames from service labels and metadata, supporting both MeshService, MeshExternalService, and MeshMultiZoneService resources.
@@ -45,18 +44,12 @@ func (cb *HostnameGenerator) SetObjectMeta(m *metav1.ObjectMeta) {
 }
 
 func (cb *HostnameGenerator) GetMesh() string {
-	if mesh, ok := cb.Labels[metadata.KumaMeshLabel]; ok {
-		return mesh
-	} else {
-		return core_model.DefaultMesh
-	}
+	// HostnameGenerator is a Global-scoped resource and is not bound to a mesh.
+	return ""
 }
 
 func (cb *HostnameGenerator) SetMesh(mesh string) {
-	if cb.Labels == nil {
-		cb.Labels = map[string]string{}
-	}
-	cb.Labels[metadata.KumaMeshLabel] = mesh
+	// HostnameGenerator is a Global-scoped resource, the mesh label must not be set.
 }
 
 func (cb *HostnameGenerator) GetSpec() (core_model.ResourceSpec, error) {

--- a/tools/policy-gen/generator/cmd/k8s_resource.go
+++ b/tools/policy-gen/generator/cmd/k8s_resource.go
@@ -110,7 +110,9 @@ import (
 	{{- if not .SkipRegistration }}
 	"github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/pkg/registry"
 	{{- end }}
+	{{- if not (eq (printf "%s" .Scope) "Global") }}
 	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
+	{{- end }}
 )
 
 {{- if .Description }}
@@ -157,18 +159,27 @@ func (cb *{{.Name}}) SetObjectMeta(m *metav1.ObjectMeta) {
 }
 
 func (cb *{{.Name}}) GetMesh() string {
+{{- if eq (printf "%s" .Scope) "Global" }}
+	// {{.Name}} is a Global-scoped resource and is not bound to a mesh.
+	return ""
+{{- else }}
 	if mesh, ok := cb.Labels[metadata.KumaMeshLabel]; ok {
 		return mesh
 	} else {
 		return core_model.DefaultMesh
 	}
+{{- end }}
 }
 
 func (cb *{{.Name}}) SetMesh(mesh string) {
+{{- if eq (printf "%s" .Scope) "Global" }}
+	// {{.Name}} is a Global-scoped resource, the mesh label must not be set.
+{{- else }}
 	if cb.Labels == nil {
 		cb.Labels = map[string]string{}
 	}
 	cb.Labels[metadata.KumaMeshLabel] = mesh
+{{- end }}
 }
 
 func (cb *{{.Name}}) GetSpec() (core_model.ResourceSpec, error) {


### PR DESCRIPTION
## Motivation

Global-scoped resources such as HostnameGenerator are not bound to a mesh, but the generated k8s wrapper stored a mesh label and defaulted to `default` from GetMesh. This is incorrect for Global-scoped resources.

## Implementation information

Update the `k8s_resource` generator template so that for Global-scoped resources GetMesh returns an empty string and SetMesh is a no-op (and the unused metadata import is dropped). Regenerate the HostnameGenerator k8s types accordingly.

## Supporting documentation

N/A