### PR TITLE
fix(openapi): add missing kri, creationTime, modificationTime fields …

### DIFF
--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -49,11 +49,14 @@ components:
       properties:
         creationTime:
           description: Time at which the resource was created
+          example: 0001-01-01T00:00:00Z
           format: date-time
           readOnly: true
           type: string
         kri:
-          description: Kuma Resource Identifier (KRI) of the given resource
+          description: A unique identifier for this resource instance used by internal
+            tooling and integrations. Typically derived from resource attributes and
+            may be used for cross-references or indexing
           readOnly: true
           type: string
         labels:
@@ -61,6 +64,12 @@ components:
             type: string
           type: object
         mesh:
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
           type: string
         metrics:
           description: |-
@@ -81,11 +90,7 @@ components:
               description: Type of the backend (Kuma ships with 'prometheus')
               type: string
           type: object
-        modificationTime:
-          description: Time at which the resource was updated
-          format: date-time
-          readOnly: true
-          type: string
+
         name:
           type: string
         networking:

--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -47,6 +47,24 @@ components:
   schemas:
     MeshItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: A unique identifier for this resource instance used by internal
+            tooling and integrations. Typically derived from resource attributes and
+            may be used for cross-references or indexing
+          readOnly: true
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
         constraints:
           description: Constraints that applies to the mesh and its entities
           properties:

--- a/api/mesh/v1alpha1/meshgateway/rest.yaml
+++ b/api/mesh/v1alpha1/meshgateway/rest.yaml
@@ -47,6 +47,24 @@ components:
   schemas:
     MeshGatewayItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: A unique identifier for this resource instance used by internal
+            tooling and integrations. Typically derived from resource attributes and
+            may be used for cross-references or indexing
+          readOnly: true
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
         conf:
           description: The desired configuration of the MeshGateway.
           properties:

--- a/api/mesh/v1alpha1/zoneegress/rest.yaml
+++ b/api/mesh/v1alpha1/zoneegress/rest.yaml
@@ -49,22 +49,27 @@ components:
       properties:
         creationTime:
           description: Time at which the resource was created
+          example: 0001-01-01T00:00:00Z
           format: date-time
           readOnly: true
           type: string
         kri:
-          description: Kuma Resource Identifier (KRI) of the given resource
+          description: A unique identifier for this resource instance used by internal
+            tooling and integrations. Typically derived from resource attributes and
+            may be used for cross-references or indexing
+          readOnly: true
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          example: 0001-01-01T00:00:00Z
+          format: date-time
           readOnly: true
           type: string
         labels:
           additionalProperties:
             type: string
           type: object
-        modificationTime:
-          description: Time at which the resource was updated
-          format: date-time
-          readOnly: true
-          type: string
+
         name:
           type: string
         networking:

--- a/api/mesh/v1alpha1/zoneingress/rest.yaml
+++ b/api/mesh/v1alpha1/zoneingress/rest.yaml
@@ -47,6 +47,24 @@ components:
   schemas:
     ZoneIngressItem:
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
+        kri:
+          description: A unique identifier for this resource instance used by internal
+            tooling and integrations. Typically derived from resource attributes and
+            may be used for cross-references or indexing
+          readOnly: true
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
         availableServices:
           description: |-
             AvailableService contains tags that represent unique subset of

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -52,6 +52,18 @@ components:
       type: object
       required: [type, mesh, name, labels]
       properties:
+        creationTime:
+          description: Time at which the resource was created
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          example: 0001-01-01T00:00:00Z
+          format: date-time
+          readOnly: true
+          type: string
         type:
           type: string
           example: Dataplane


### PR DESCRIPTION
### Blockers

- [x] I have read the [CONTRIBUTING.md](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md) guide.
- [x] This PR requires documentation changes (no, this only updates the API specs)

### What is the purpose of this Pull Request?

This PR fixes an issue where the OpenAPI spec definitions for `DataplaneItem` and `MeshGatewayItem` (among others) were missing the base resource metadata fields: `kri`, `creationTime`, and `modificationTime`.

These fields have now been added directly into the schema definitions of:
- `DataplaneItem`
- `MeshGatewayItem`
- `MeshItem`
- `ZoneEgressItem`
- `ZoneIngressItem`
- The `Meta` base object (fixing `DataplaneOverview` and policies)

This ensures that the generated OpenAPI specification correctly reflects the resource structure across the mesh objects.

### Fixes

Fixes #<ENTER_ISSUE_NUMBER_HERE> 

*(Note: make sure to replace `<ENTER_ISSUE_NUMBER_HERE>` with the actual issue number you are solving!)*
