### PR TITLE
fix(meshservice): don't remove synced services

### DIFF
--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -313,6 +313,9 @@ func (g *Generator) generate(ctx context.Context, mesh string, dataplanes []*cor
 	}
 
 	for _, meshService := range meshServices {
+		if !meshService.IsLocalMeshService() {
+			continue
+		}
 		if managedBy, ok := meshService.GetMeta().GetLabels()[mesh_proto.ManagedByLabel]; !ok || managedBy != managedByValue {
 			continue
 		}
@@ -466,6 +469,10 @@ func (g *Generator) Start(stop <-chan struct{}) error {
 					g.generate(ctx, mesh, dataplanes.Items, meshServices.Items)
 				} else {
 					for _, meshService := range meshCtx.Resources.MeshServices().Items {
+						if !meshService.IsLocalMeshService() {
+							// Synced from another zone via KDS, this zone's generator must not delete it.
+							continue
+						}
 						if managedBy, ok := meshService.GetMeta().GetLabels()[mesh_proto.ManagedByLabel]; !ok || managedBy != managedByValue {
 							continue
 						}

--- a/pkg/core/resources/apis/meshservice/generate/generator_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator_test.go
@@ -363,6 +363,41 @@ var _ = Describe("MeshService generator", func() {
 		}, "2s", "100ms").Should(Succeed())
 	})
 
+	It("should not delete MeshService synced from another zone", func() {
+		// MeshService generated in another zone and synced here via KDS: it
+		// keeps the generator's managed-by label but has origin=global and no
+		// local Dataplane backing it. The generator must leave it untouched.
+		ms := meshservice_api.NewMeshServiceResource()
+		ms.Spec = &meshservice_api.MeshService{
+			Selector: meshservice_api.Selector{
+				DataplaneTags: &map[string]string{mesh_proto.ServiceTag: "remote-backend"},
+			},
+			Ports: []meshservice_api.Port{{
+				Name:        pointer.To("80"),
+				Port:        80,
+				TargetPort:  pointer.To(intstr.FromInt(80)),
+				AppProtocol: core_meta.ProtocolTCP,
+			}},
+		}
+		Expect(resManager.Create(
+			context.Background(),
+			ms,
+			store.CreateByKey("remote-backend", model.DefaultMesh),
+			store.CreateWithLabels(map[string]string{
+				mesh_proto.ManagedByLabel:      "meshservice-generator",
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.GlobalResourceOrigin),
+				mesh_proto.ZoneTag:             "other-zone",
+			}),
+		)).To(Succeed())
+
+		// It's never marked for deletion nor removed.
+		Consistently(func(g Gomega) {
+			synced := meshservice_api.NewMeshServiceResource()
+			g.Expect(resManager.Get(context.Background(), synced, store.GetByKey("remote-backend", model.DefaultMesh))).To(Succeed())
+			g.Expect(synced.GetMeta().GetLabels()).ToNot(HaveKey(mesh_proto.DeletionGracePeriodStartedLabel))
+		}, "2s", "100ms").Should(Succeed())
+	})
+
 	It("should not delete MeshService if a Dataplane comes back", func() {
 		err := samples.DataplaneBackendBuilder().Create(resManager)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Motivation

While running 2 universal zones on the VM i've noticed that MeshService from another zone was removed

## Implementation information

We are not checking if MeshService is local and we set a timer to remove a remote MeshService. Added a check to not remove synced services
