### PR TITLE
test(e2e): fix skipinboundtags MTP rules

### DIFF
--- a/test/e2e/skipinboundtags/skip_inbound_tags.go
+++ b/test/e2e/skipinboundtags/skip_inbound_tags.go
@@ -57,7 +57,9 @@ spec:
 					WithName(meshName).
 					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
 			)).
-			Install(MeshTrafficPermissionAllowAllKubernetes(meshName)).
+			// standalone zone CP without global resolves {{ .Zone }} to "default"
+			Install(MeshTrafficPermissionAllowAllKubernetesWorkloadIdentity(meshName,
+				fmt.Sprintf("%s.default.mesh.local", meshName))).
 			Install(YamlK8s(meshIdentity)).
 			Install(Parallel(
 				testserver.Install(


### PR DESCRIPTION
## Motivation

`Skip Inbound Tags on Kubernetes — should allow traffic between services` fails on every `build-test-distribute` run on `release-2.14` since 65a9c48de5 (`fix(MeshTrafficPermission): don't fallback to legacy rules when using MeshIdentity`) with `curl: (22) ... 403`.

The suite uses MeshIdentity, so the proxy gets a WorkloadIdentity and the legacy `spec.from` allow-all MeshTrafficPermission installed by `MeshTrafficPermissionAllowAllKubernetes` is now ignored. With no `rules`-based MTP present, Envoy RBAC denies all inbound traffic.

> Changelog: skip

## Implementation information

Use `MeshTrafficPermissionAllowAllKubernetesWorkloadIdentity` with the trust domain derived from the suite's MeshIdentity template (`{{ .Mesh }}.{{ .Zone }}.mesh.local` → `skip-inbound-tags.kuma-1.mesh.local`) — the same migration 65a9c48de5 applied to the spire and multizone meshidentity suites but missed here.

## Supporting documentation

Verified locally with `make test/e2e/debug E2E_PKG_LIST=./test/e2e/skipinboundtags/...`.