### PR TITLE
fix(docs): make openapi merge order locale-independent

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -69,7 +69,7 @@ docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES) | docs/generated docs
 			REDOCLY_SUPPRESS_UPDATE_NOTICE=true mise exec -- redocly bundle $$f -o $(BUILD_DIR)/openapi-bundled/$$f || echo "Skipping $$f"; \
 		done
 	@echo "Merging all bundled specs..."
-	@mise exec -- oas-toolkit merge $$(find $(BUILD_DIR)/openapi-bundled -name '*.yaml' | sort) > $@
+	@mise exec -- oas-toolkit merge $$(find $(BUILD_DIR)/openapi-bundled -name '*.yaml' | LC_ALL=C sort) > $@
 	@$(MAKE) --no-print-directory validate/openapi-generated-docs
 
 # Prepare $(OAPI_TMP_DIR) with a normalized directory layout for the generator


### PR DESCRIPTION
## Motivation

`make check` produced a non-empty diff in `docs/generated/openapi.yaml` on a clean `master` — generation was not reproducible across machines.

## Implementation information

The merge step ordered specs via a bare `find ... | sort`, which uses the caller's locale collation. C collation sorts `dataplane/` before `dataplaneoverview/`, but en_US.UTF-8 ignores punctuation and reverses them, reshuffling the merged paths. Forcing `LC_ALL=C sort` makes the order deterministic. Verified regeneration now yields a zero diff.

## Supporting documentation

> Changelog: skip