### PR TITLE
fix(inbound): check all app containers for readiness when no container declares port

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -31,12 +31,8 @@ func podReady(pod *kube_core.Pod, container *kube_core.Container) bool {
 		}
 	} else {
 		// No container declares the service's targetPort — check all non-sidecar app containers
-		for _, c := range pod.Spec.Containers {
-			if c.Name != util_k8s.KumaSidecarContainerName {
-				if cs := util_k8s.FindContainerStatus(c.Name, pod.Status.ContainerStatuses); cs != nil && !cs.Ready {
-					return false
-				}
-			}
+		if !appContainersReady(pod) {
+			return false
 		}
 	}
 	if cs := util_k8s.FindContainerOrInitContainerStatus(
@@ -48,6 +44,19 @@ func podReady(pod *kube_core.Pod, container *kube_core.Container) bool {
 	}
 	if pod.DeletionTimestamp != nil {
 		return false
+	}
+	return true
+}
+
+// appContainersReady checks if all non-sidecar app containers in the pod are ready.
+// Returns true if all are ready, false if any is not ready.
+func appContainersReady(pod *kube_core.Pod) bool {
+	for _, c := range pod.Spec.Containers {
+		if c.Name != util_k8s.KumaSidecarContainerName {
+			if cs := util_k8s.FindContainerStatus(c.Name, pod.Status.ContainerStatuses); cs != nil && !cs.Ready {
+				return false
+			}
+		}
 	}
 	return true
 }
@@ -131,13 +140,9 @@ func (ic *InboundConverter) inboundForServiceless(zone string, pod *kube_core.Po
 		Ready: true,
 	}
 
-	for _, container := range pod.Spec.Containers {
-		if container.Name != util_k8s.KumaSidecarContainerName {
-			if cs := util_k8s.FindContainerStatus(container.Name, pod.Status.ContainerStatuses); cs != nil && !cs.Ready {
-				state = mesh_proto.Dataplane_Networking_Inbound_NotReady
-				health.Ready = false
-			}
-		}
+	if !appContainersReady(pod) {
+		state = mesh_proto.Dataplane_Networking_Inbound_NotReady
+		health.Ready = false
 	}
 
 	// also we're checking whether kuma-sidecar container is ready

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -21,12 +21,22 @@ import (
 
 // podReady returns false when any of the following is true:
 //   - the given container (if non-nil) is not ready
+//   - when container is nil (no container declares the service's targetPort), any non-sidecar app container is not ready
 //   - the kuma-sidecar container is not ready
 //   - the pod has a DeletionTimestamp (terminating)
 func podReady(pod *kube_core.Pod, container *kube_core.Container) bool {
 	if container != nil {
 		if cs := util_k8s.FindContainerStatus(container.Name, pod.Status.ContainerStatuses); cs != nil && !cs.Ready {
 			return false
+		}
+	} else {
+		// No container declares the service's targetPort — check all non-sidecar app containers
+		for _, c := range pod.Spec.Containers {
+			if c.Name != util_k8s.KumaSidecarContainerName {
+				if cs := util_k8s.FindContainerStatus(c.Name, pod.Status.ContainerStatuses); cs != nil && !cs.Ready {
+					return false
+				}
+			}
 		}
 	}
 	if cs := util_k8s.FindContainerOrInitContainerStatus(

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -21,7 +21,7 @@ import (
 
 // podReady returns false when any of the following is true:
 //   - the given container (if non-nil) is not ready
-//   - when container is nil (no container declares the service's targetPort), any non-sidecar app container is not ready
+//   - when container is nil (no container declares the service's targetPort), all non-sidecar app containers are not ready
 //   - the kuma-sidecar container is not ready
 //   - the pod has a DeletionTimestamp (terminating)
 func podReady(pod *kube_core.Pod, container *kube_core.Container) bool {
@@ -50,6 +50,7 @@ func podReady(pod *kube_core.Pod, container *kube_core.Container) bool {
 
 // appContainersReady checks if all non-sidecar app containers in the pod are ready.
 // Returns true if all are ready, false if any is not ready.
+// Iterates pod.Spec.Containers (app containers only; init containers are not checked).
 func appContainersReady(pod *kube_core.Pod) bool {
 	for _, c := range pod.Spec.Containers {
 		if c.Name != util_k8s.KumaSidecarContainerName {

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -413,13 +413,18 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "43.services-for-pod.yaml",
 			expectedErr:    "conflicting listener types on port 10001",
 		}),
-		Entry("44. Zone proxy Services with non-Exclusive MeshServices mode skips listeners", testCase{
-			pod:              "44.pod.yaml",
-			servicesForPod:   "44.services-for-pod.yaml",
-			dataplane:        "44.dataplane.yaml",
-			meshServicesMode: pointer.To(mesh_proto.Mesh_MeshServices_Everywhere),
-		}),
-	)
+			Entry("45. Service targetPort not declared by any container, app container not ready", testCase{
+				pod:            "45.pod.yaml",
+				servicesForPod: "45.services-for-pod.yaml",
+				dataplane:      "45.dataplane.yaml",
+			}),
+			Entry("44. Zone proxy Services with non-Exclusive MeshServices mode skips listeners", testCase{
+				pod:              "44.pod.yaml",
+				servicesForPod:   "44.services-for-pod.yaml",
+				dataplane:        "44.dataplane.yaml",
+				meshServicesMode: pointer.To(mesh_proto.Mesh_MeshServices_Everywhere),
+			}),
+		)
 
 	DescribeTable("should convert Ingress Pod into an Ingress Dataplane YAML version",
 		func(given testCase) {

--- a/pkg/plugins/runtime/k8s/controllers/testdata/45.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/45.dataplane.yaml
@@ -1,0 +1,22 @@
+type: Dataplane
+mesh: default
+metadata:
+  name: test-server-1-1
+  namespace: demo
+  labels:
+    kuma.io/zone: zone-1
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+      - port: 8443
+        tags:
+          kuma.io/service: test-service_demo_svc
+          kuma.io/protocol: tcp
+          kuma.io/port: "8443"
+          kuma.io/namespace: demo
+          app: example
+          version: "0.1"
+        state: NotReady
+        health:
+          ready: false

--- a/pkg/plugins/runtime/k8s/controllers/testdata/45.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/45.pod.yaml
@@ -1,0 +1,32 @@
+kind: Pod
+metadata:
+  namespace: demo
+  ownerReferences:
+    - name: test-server-1
+      kind: ReplicaSet
+  name: test-server-1-1
+  labels:
+    app: example
+    version: "0.1"
+spec:
+  containers:
+    - name: app-1
+      ports:
+        - containerPort: 7070
+    - name: app-2
+      ports:
+        - containerPort: 6060
+          name: metrics
+    - name: kuma-sidecar
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - name: app-1
+      ready: true
+      started: true
+    - name: app-2
+      ready: false
+      started: true
+    - name: kuma-sidecar
+      ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/45.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/45.services-for-pod.yaml
@@ -1,0 +1,14 @@
+kind: Service
+metadata:
+  namespace: demo
+  name: test-service
+  labels:
+    app: example
+spec:
+  selector:
+    app: example
+  ports:
+    - name: http
+      port: 8443
+      targetPort: 8443
+      protocol: TCP


### PR DESCRIPTION
When a Service's targetPort is not declared by any container's containerPorts, FindPort returns container==nil. The podReady function then skipped the application container readiness check entirely, marking the inbound as ready=true as soon as the kuma-sidecar was ready.

This caused endpoints to enter EDS before the application was actually serving, resulting in 503s during rollouts.

Fix: when container is nil, iterate all non-sidecar containers and check their readiness status, similar to what inboundForServiceless already does.

Fixes #16903