### PR TITLE
fix(api-server): rules panic and role validation

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -714,7 +714,7 @@ func (r *resourceEndpoints) validateLabels(resource rest.Resource) validators.Va
 	}
 
 	if r.descriptor.IsPluginOriginated && r.descriptor.IsPolicy {
-		r.validatePolicyRole(resource)
+		err.AddError("", r.validatePolicyRole(resource))
 	}
 
 	for _, k := range maps.SortedKeys(resource.GetMeta().GetLabels()) {
@@ -1316,6 +1316,7 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 		baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build Mesh context")
+			return
 		}
 
 		resources := xds_context.Resources{

--- a/pkg/api-server/resource_endpoints_test.go
+++ b/pkg/api-server/resource_endpoints_test.go
@@ -46,6 +46,20 @@ func (s *errOnGetStore) Get(ctx context.Context, res model.Resource, opts ...cor
 	return s.ResourceStore.Get(ctx, res, opts...)
 }
 
+// errOnListStore wraps a real store but returns listErr for Lists of the specified resource type.
+type errOnListStore struct {
+	core_store.ResourceStore
+	listErr     error
+	listErrType model.ResourceType
+}
+
+func (s *errOnListStore) List(ctx context.Context, list model.ResourceList, opts ...core_store.ListOptionsFunc) error {
+	if s.listErr != nil && list.GetItemType() == s.listErrType {
+		return s.listErr
+	}
+	return s.ResourceStore.List(ctx, list, opts...)
+}
+
 var _ = Describe("Resource Endpoints", func() {
 	var apiServer *api_server.ApiServer
 	var resourceStore core_store.ResourceStore
@@ -415,5 +429,66 @@ var _ = Describe("Resource Endpoints on Zone, label origin", func() {
 			mesh_proto.MeshTag:             mesh,
 			mesh_proto.EnvTag:              "universal",
 		}))
+	})
+
+	It("should return 500 and not drop the connection when the mesh context build fails on _rules", func() {
+		// given: a store that fails to List policies, so building the mesh context
+		// inside the _rules handler returns an error
+		realStore := core_store.NewPaginationStore(memory.NewStore())
+		failingStore := &errOnListStore{
+			ResourceStore: realStore,
+			listErr:       fmt.Errorf("connection refused"),
+			listErrType:   v1alpha1.MeshTrafficPermissionType,
+		}
+		apiServerWithErr, _, stopErr := StartApiServer(
+			NewTestApiServerConfigurer().
+				WithStore(failingStore).
+				WithDisableOriginLabelValidation(true),
+		)
+		defer stopErr()
+
+		// pre-create mesh + dataplane (Gets go to the real store and succeed)
+		Expect(realStore.Create(context.Background(), core_mesh.NewMeshResource(), core_store.CreateByKey("default", model.NoMesh))).To(Succeed())
+		dp := builders.Dataplane().WithName("dp-1").WithServices("backend").Build()
+		Expect(realStore.Create(context.Background(), dp, core_store.CreateByKey("dp-1", "default"))).To(Succeed())
+
+		// when: GET _rules - BuildBaseMeshContextIfChanged fails on the policy List
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+			fmt.Sprintf("http://%s/meshes/default/dataplanes/dp-1/_rules", apiServerWithErr.Address()), http.NoBody)
+		Expect(err).ToNot(HaveOccurred())
+		resp, err := http.DefaultClient.Do(req)
+
+		// then: a clean error response, not a panic that drops the connection
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+	})
+
+	It("should return 400 when a policy carries a non-system policy-role label", func() {
+		// given
+		apiServer, store, stop := createServer(false, false)
+		defer stop()
+		createMesh(store)
+
+		// when: PUT a MeshTrafficPermission with a non-system kuma.io/policy-role
+		res := &rest_v1alpha1.Resource{
+			ResourceMeta: rest_v1alpha1.ResourceMeta{
+				Name: "mtp-role",
+				Mesh: mesh,
+				Type: string(v1alpha1.MeshTrafficPermissionType),
+				Labels: map[string]string{
+					mesh_proto.PolicyRoleLabel: string(mesh_proto.WorkloadOwnerPolicyRole),
+				},
+			},
+			Spec: builders.MeshTrafficPermission().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddFrom(builders.TargetRefMesh(), v1alpha1.Allow).
+				Build().Spec,
+		}
+		resp, err := put(apiServer.Address(), v1alpha1.MeshTrafficPermissionResourceTypeDescriptor, "mtp-role", res)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 	})
 })


### PR DESCRIPTION
## Motivation

Two error paths in the resource API server swallowed failures, found during a review of `pkg/api-server/resource_endpoints.go`:

1. The `_rules` inspect endpoint called `HandleError` when the mesh context build failed but did not `return`, so it went on to dereference a nil context and panic. Panic recovery is disabled in the go-restful container, so net/http drops the connection — a client hitting `_rules` during a transient store failure gets a dropped connection instead of a `500`.
2. `validateLabels` called `validatePolicyRole` but discarded its returned validation error, so a non-system `kuma.io/policy-role` label was accepted instead of rejected on create/update.

> Changelog: fix(api-server): rules panic and role validation

## Implementation information

- `rulesForResource`: add the missing `return` after the build-context error so the request ends with a clean `500`.
- `validateLabels`: accumulate the `validatePolicyRole` result via `err.AddError("", ...)`, matching the `validateOriginForWrite` handling right above it.

Both are behavior changes (not refactors), each with a black-box test driving the real HTTP server: a store wrapper that fails the policy `List` during the mesh-context build, and a `PUT` carrying a non-system policy-role label. The policy-role check runs only on the REST/kumactl write path; KDS sync writes through the store/manager and is unaffected.

## Supporting documentation

Found via a refactoring review of this file (the top churn × size hotspot in `pkg/`); a separate adversarial pass confirmed both paths are reachable and that the role check does not run on the KDS sync path.
