### PR TITLE
refactor(api-server): extract computeLabels

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -453,6 +453,27 @@ func (r *resourceEndpoints) clearMeshTrustOrigin(resRest rest.Resource, meshName
 	}
 }
 
+// computeLabels derives the full label set for a resource from its descriptor,
+// spec and meta, applying the control-plane mode, zone, k8s and namespace context
+// shared by create and update.
+func (r *resourceEndpoints) computeLabels(
+	descriptor core_model.ResourceTypeDescriptor,
+	spec core_model.ResourceSpec,
+	meta core_model.ResourceMeta,
+	meshName string,
+) (map[string]string, error) {
+	return resource_labels.Compute(
+		descriptor,
+		spec,
+		meta.GetLabels(),
+		meshName,
+		resource_labels.WithNamespace(resource_labels.GetNamespace(meta, r.systemNamespace)),
+		resource_labels.WithMode(r.mode),
+		resource_labels.WithK8s(r.isK8s),
+		resource_labels.WithZone(r.zoneName),
+	)
+}
+
 func (r *resourceEndpoints) createResource(
 	ctx context.Context,
 	name string,
@@ -495,16 +516,7 @@ func (r *resourceEndpoints) createResource(
 		}
 	}
 
-	labels, err := resource_labels.Compute(
-		res.Descriptor(),
-		res.GetSpec(),
-		res.GetMeta().GetLabels(),
-		meshName,
-		resource_labels.WithNamespace(resource_labels.GetNamespace(res.GetMeta(), r.systemNamespace)),
-		resource_labels.WithMode(r.mode),
-		resource_labels.WithK8s(r.isK8s),
-		resource_labels.WithZone(r.zoneName),
-	)
+	labels, err := r.computeLabels(res.Descriptor(), res.GetSpec(), res.GetMeta(), meshName)
 	if err != nil {
 		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")
 		return
@@ -543,16 +555,7 @@ func (r *resourceEndpoints) updateResource(
 	r.clearMeshTrustOrigin(newResRest, meshName, currentRes.GetMeta().GetName())
 
 	// Compute labels for current state BEFORE modifying spec
-	currentLabels, err := resource_labels.Compute(
-		currentRes.Descriptor(),
-		currentRes.GetSpec(),
-		currentRes.GetMeta().GetLabels(),
-		meshName,
-		resource_labels.WithNamespace(resource_labels.GetNamespace(currentRes.GetMeta(), r.systemNamespace)),
-		resource_labels.WithMode(r.mode),
-		resource_labels.WithK8s(r.isK8s),
-		resource_labels.WithZone(r.zoneName),
-	)
+	currentLabels, err := r.computeLabels(currentRes.Descriptor(), currentRes.GetSpec(), currentRes.GetMeta(), meshName)
 	if err != nil {
 		rest_errors.HandleError(ctx, response, err, "Could not compute current labels")
 		return
@@ -561,16 +564,7 @@ func (r *resourceEndpoints) updateResource(
 	_ = currentRes.SetSpec(newResRest.GetSpec())
 
 	// Compute labels for new request
-	labels, err := resource_labels.Compute(
-		currentRes.Descriptor(),
-		currentRes.GetSpec(),
-		newResRest.GetMeta().GetLabels(),
-		meshName,
-		resource_labels.WithNamespace(resource_labels.GetNamespace(newResRest.GetMeta(), r.systemNamespace)),
-		resource_labels.WithMode(r.mode),
-		resource_labels.WithK8s(r.isK8s),
-		resource_labels.WithZone(r.zoneName),
-	)
+	labels, err := r.computeLabels(currentRes.Descriptor(), currentRes.GetSpec(), newResRest.GetMeta(), meshName)
 	if err != nil {
 		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")
 		return


### PR DESCRIPTION
## Motivation

`createResource` and `updateResource` in `pkg/api-server/resource_endpoints.go` each built a resource's label set with the same eight-line `resource_labels.Compute(...)` call — three sites in total, differing only in which `descriptor` / `spec` / `meta` they passed. The shared option tail (`WithNamespace`/`WithMode`/`WithK8s`/`WithZone`) had to be kept identical by hand; adding a label dimension meant editing three places. Rule of Three is met, so it's now worth folding.

> Changelog: skip

## Implementation information

Extract `r.computeLabels(descriptor, spec, meta, meshName)`, which holds the shared options; the three call sites pass only what varies. `labels`/`namespace` both derive from the passed `meta`, so a single `meta` argument covers both.

Structural change only — behavior is unchanged:
- the distinct per-call-site error messages are preserved at the call sites (not hidden in the helper);
- the "compute current labels BEFORE `SetSpec`" ordering in `updateResource` is untouched.

Covered by the existing label tests (`should compute labels on update of the resource`, `should set origin label automatically ...`); full `pkg/api-server` suite passes, `golangci-lint` reports 0 issues.

## Supporting documentation

First structural step from a refactoring review of this file (the top churn × size hotspot in `pkg/`), following two behavioral bug fixes to the same file shipped separately. Endorsed unanimously by the review (Rule of Three) with no dissent.
