### PR TITLE
refactor(api-server): extract shared context

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -66,13 +66,19 @@ const (
 		" You can still use 'kumactl' or the HTTP API to modify the rest of the resource on the global control plane.\n"
 )
 
+// resourceEndpointsContext holds the dependencies shared by the resource handlers.
+type resourceEndpointsContext struct {
+	mode           config_core.CpMode
+	zoneName       string
+	resManager     manager.ResourceManager
+	descriptor     core_model.ResourceTypeDescriptor
+	resourceAccess access.ResourceAccess
+}
+
 type resourceEndpoints struct {
-	mode                   config_core.CpMode
+	resourceEndpointsContext
+
 	federatedZone          bool
-	zoneName               string
-	resManager             manager.ResourceManager
-	descriptor             core_model.ResourceTypeDescriptor
-	resourceAccess         access.ResourceAccess
 	k8sMapper              k8s.ResourceMapperFunc
 	filter                 func(request *restful.Request) (store.ListFilterFunc, error)
 	meshContextBuilder     xds_context.MeshContextBuilder
@@ -770,7 +776,7 @@ func (r *resourceEndpoints) doesNameLengthFitsGlobal(name string) bool {
 	return len(fmt.Sprintf("%s.%s", r.zoneName, name)) < 253
 }
 
-func (r *resourceEndpoints) meshFromRequest(request *restful.Request) (string, error) {
+func (r *resourceEndpointsContext) meshFromRequest(request *restful.Request) (string, error) {
 	if r.descriptor.Scope == core_model.ScopeMesh {
 		meshName := request.PathParameter("mesh")
 		if meshName == "" { // Handle lists across all meshes

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -296,12 +296,14 @@ func addResourcesEndpoints(
 			definition.ReadOnly = definition.IsReadOnly(cfg.Mode == config_core.Global, cfg.IsFederatedZoneCP())
 		}
 		endpoints := resourceEndpoints{
+			resourceEndpointsContext: resourceEndpointsContext{
+				mode:           cfg.Mode,
+				resManager:     resManager,
+				descriptor:     definition,
+				resourceAccess: resourceAccess,
+			},
 			k8sMapper:                    k8sMapper,
-			mode:                         cfg.Mode,
 			federatedZone:                cfg.IsFederatedZoneCP(),
-			resManager:                   resManager,
-			descriptor:                   definition,
-			resourceAccess:               resourceAccess,
 			filter:                       filters.Resource(definition),
 			meshContextBuilder:           meshContextBuilder,
 			disableOriginLabelValidation: cfg.Multizone.Zone.DisableOriginLabelValidation,


### PR DESCRIPTION
## Motivation

`resourceEndpoints` in `pkg/api-server/resource_endpoints.go` is a 14-field struct that serves the entire REST surface for every resource type — route registration, CRUD, validation, and the inspect family (`_rules`/`_policies`/`_config`). It's the top churn × size hotspot in `pkg/`. The goal is to split it into per-responsibility handlers (CRUD vs inspect) over a shared base, done incrementally so each step is behavior-preserving and reviewable.

> Changelog: skip

## Implementation information

This is the first, foundational step: extract `resourceEndpointsContext` holding the dependencies both future handlers need (`mode`, `zoneName`, `resManager`, `descriptor`, `resourceAccess`) plus the shared `meshFromRequest` lookup, and embed it in `resourceEndpoints`.

Because the context is embedded, method bodies are unchanged — `r.mode`, `r.resManager`, `r.meshFromRequest(...)` etc. still resolve transparently, including through the second embed level in `serviceInsightEndpoints`. The only edits are the struct split, the `meshFromRequest` receiver, and the construction site in `server.go`.

Structural change only — behavior is unchanged; full `pkg/api-server` suite passes and `golangci-lint` reports 0 issues.

## Supporting documentation

Step 1 of an SRP decomposition from a refactoring review of this file. Follow-ups extract `resourceInspectHandler` (the hot inspect block) and `resourceCrudHandler`, each embedding this context; go-restful stays at the handler edge (no DTO/use-case layer).
