### PR TITLE
test(e2e): add assertion to legacy tests

### DIFF
--- a/test/e2e/bootstrap/corefile_template.go
+++ b/test/e2e/bootstrap/corefile_template.go
@@ -69,6 +69,7 @@ data:
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(k8sCluster)
 		Expect(k8sCluster.TriggerDeleteNamespace(appNamespace)).To(Succeed())
 		Expect(k8sCluster.DeleteKuma()).To(Succeed())
 		Expect(k8sCluster.DismissCluster()).To(Succeed())

--- a/test/e2e/cni/taint_controller_race.go
+++ b/test/e2e/cni/taint_controller_race.go
@@ -61,6 +61,7 @@ metadata:
 	})
 
 	E2EAfterEach(func() {
+		ControlPlaneAssertions(cluster)
 		Expect(cluster.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.DismissCluster()).To(Succeed())

--- a/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
+++ b/test/e2e/compatibility/cp_compatibility_kubernetes_multizone.go
@@ -49,6 +49,7 @@ func CpCompatibilityMultizoneKubernetes() {
 			WithTimeout(6 * time.Second).
 			WithRetries(60)
 		E2EDeferCleanup(func() {
+			ControlPlaneAssertions(globalCluster)
 			Expect(globalCluster.DeleteKuma()).To(Succeed())
 			Expect(globalCluster.DismissCluster()).To(Succeed())
 		})
@@ -63,6 +64,7 @@ func CpCompatibilityMultizoneKubernetes() {
 			WithTimeout(6 * time.Second).
 			WithRetries(60)
 		E2EDeferCleanup(func() {
+			ControlPlaneAssertions(zoneCluster)
 			Expect(zoneCluster.DeleteNamespace(TestNamespace)).To(Succeed())
 			Expect(zoneCluster.DeleteKuma()).To(Succeed())
 			Expect(zoneCluster.DismissCluster()).To(Succeed())

--- a/test/e2e/externalservices/locality_multizone_hybrid.go
+++ b/test/e2e/externalservices/locality_multizone_hybrid.go
@@ -88,7 +88,10 @@ func ExternalServicesOnMultizoneHybridWithLocalityAwareLb() {
 		).To(Succeed())
 	})
 
-	AfterAll(func() {
+	E2EAfterAll(func() {
+		ControlPlaneAssertions(global)
+		ControlPlaneAssertions(zone1)
+		ControlPlaneAssertions(zone4)
 		Expect(zone1.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(zone1.DeleteKuma()).To(Succeed())
 		Expect(zone1.DismissCluster()).To(Succeed())

--- a/test/e2e/federation/federation_kubernetes.go
+++ b/test/e2e/federation/federation_kubernetes.go
@@ -64,6 +64,8 @@ func FederateKubeZoneCPToKubeGlobal() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(global)
+		ControlPlaneAssertions(zone)
 		Expect(zone.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(global.DeleteKuma()).To(Succeed())
 		Expect(zone.DeleteKuma()).To(Succeed())

--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -57,6 +57,8 @@ func FederateKubeZoneCPToUniversalGlobal() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(global)
+		ControlPlaneAssertions(zone)
 		Expect(zone.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(zone.DeleteKuma()).To(Succeed())
 		Expect(global.DeleteKuma()).To(Succeed())

--- a/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_and_zone_universal_mode.go
@@ -87,6 +87,8 @@ func GlobalAndZoneInUniversalModeWithHelmChart() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(globalCluster)
+		ControlPlaneAssertions(zoneCluster)
 		DebugCPLogs(globalCluster)
 		DebugCPLogs(zoneCluster)
 		Expect(globalCluster.DeleteKuma()).To(Succeed())

--- a/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_universal_mode_and_zone.go
@@ -99,6 +99,8 @@ func ZoneAndGlobalInUniversalModeWithHelmChart() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(globalCluster)
+		ControlPlaneAssertions(zoneCluster)
 		Expect(zoneCluster.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(globalCluster.DeleteKuma()).To(Succeed())
 		Expect(zoneCluster.DeleteKuma()).To(Succeed())

--- a/test/e2e/helm/kuma_helm_deploy_global_zone.go
+++ b/test/e2e/helm/kuma_helm_deploy_global_zone.go
@@ -82,6 +82,8 @@ interCp:
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(c1)
+		ControlPlaneAssertions(c2)
 		Expect(c2.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(c1.DeleteKuma()).To(Succeed())
 		Expect(c2.DeleteKuma()).To(Succeed())

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -42,6 +42,9 @@ func UpgradingWithHelmChartMultizone() {
 	})
 
 	E2EAfterEach(func() {
+		ControlPlaneAssertions(global)
+		ControlPlaneAssertions(zoneK8s)
+		ControlPlaneAssertions(zoneUniversal)
 		grp := sync.WaitGroup{}
 		grp.Add(3)
 		go func() {
@@ -158,15 +161,28 @@ spec:
 				}, "30s", "1s").Should(Equal(2), "have remote and local zoneIngress")
 			}
 
+			// Scale down ingress before upgrading so the pod is never running against a
+			// mixed-version CP. Without this, the ingress can connect to an old CP replica
+			// first (enable_reuse_port=false) and then receive enable_reuse_port=true from
+			// the upgraded CP, which Envoy rejects indefinitely. ingress.replicas=0 ensures
+			// Helm does not override the scale-down during the upgrade.
+			By("scale down zone ingress before upgrade")
+			Expect(zoneK8s.(*K8sCluster).StopZoneIngress()).To(Succeed())
+
 			By("upgrade Zone")
 			// when
 			err = zoneK8s.(*K8sCluster).UpgradeKuma(core.Zone,
 				WithHelmReleaseName(releaseName),
 				WithHelmChartPath(Config.HelmChartPath),
 				ClearNoHelmOpts(),
+				WithHelmOpt("ingress.replicas", "0"),
 			)
 			Expect(err).ToNot(HaveOccurred())
 
+			// Wait until the upgraded zone CP has re-established its KDS connection to
+			// global before starting the ingress, so the ingress always connects to the
+			// new CP and never to a stale replica.
+			By("wait for upgraded zone CP to connect to global")
 			Eventually(func(g Gomega) {
 				result := &system.ZoneInsightResource{}
 				api.FetchResource(g, global, result, "", "kuma-2")
@@ -180,6 +196,9 @@ spec:
 				}
 				g.Expect(newZoneConnected).To(BeTrue())
 			}, "60s", "1s").Should(Succeed())
+
+			By("start zone ingress after upgrade")
+			Expect(zoneK8s.(*K8sCluster).StartZoneIngress()).To(Succeed())
 
 			// Wait for zone ingresses to settle after upgrade before checking consistency.
 			// After Helm upgrade returns, the old zone ingress pod may still be in Terminating

--- a/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_mesh_services_k8s.go
@@ -64,6 +64,7 @@ spec:
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(KubeCluster)
 		Expect(KubeCluster.DeleteNamespace(namespace)).To(Succeed())
 		Expect(KubeCluster.DeleteMesh(meshName)).To(Succeed())
 	})

--- a/test/e2e/reachableservices/auto_reachable_services_k8s.go
+++ b/test/e2e/reachableservices/auto_reachable_services_k8s.go
@@ -45,6 +45,7 @@ func AutoReachableServices() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(KubeCluster)
 		Expect(KubeCluster.DeleteNamespace(namespace)).To(Succeed())
 		Expect(KubeCluster.DeleteNamespace(esNamespace)).To(Succeed())
 		Expect(KubeCluster.DeleteMesh(meshName)).To(Succeed())

--- a/test/e2e/resilience/resilience_multizone_k8s.go
+++ b/test/e2e/resilience/resilience_multizone_k8s.go
@@ -56,6 +56,8 @@ func ResilienceMultizoneK8s() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(global)
+		ControlPlaneAssertions(zone1)
 		Expect(zone1.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(zone1.DeleteKuma()).To(Succeed())
 		Expect(zone1.DismissCluster()).To(Succeed())

--- a/test/e2e/skipinboundtags/skip_inbound_tags.go
+++ b/test/e2e/skipinboundtags/skip_inbound_tags.go
@@ -82,6 +82,7 @@ spec:
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(KubeCluster)
 		Expect(KubeCluster.DeleteNamespace(namespace)).To(Succeed())
 		Expect(KubeCluster.DeleteMesh(meshName)).To(Succeed())
 	})

--- a/test/e2e/transparentproxy/transparentproxy_configmap_kubernetes.go
+++ b/test/e2e/transparentproxy/transparentproxy_configmap_kubernetes.go
@@ -76,6 +76,7 @@ func TransparentProxyConfigMap() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(cluster)
 		Expect(cluster.TriggerDeleteNamespace(namespaceExternal)).To(Succeed())
 		Expect(cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(cluster.DeleteKuma()).To(Succeed())

--- a/test/e2e/webhooks/cert_manager.go
+++ b/test/e2e/webhooks/cert_manager.go
@@ -59,6 +59,7 @@ func CertManagerCAInjection() {
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(cluster)
 		Expect(cluster.DeleteKuma()).To(Succeed())
 		Expect(cluster.TriggerDeleteNamespace(namespace)).To(Succeed())
 		Expect(cluster.DeleteDeployment(certmanager.DeploymentName)).To(Succeed())

--- a/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
+++ b/test/e2e/zoneegress/externalservices/zoneegress_externalservices_hybrid.go
@@ -154,6 +154,9 @@ conf:
 	})
 
 	E2EAfterAll(func() {
+		ControlPlaneAssertions(global)
+		ControlPlaneAssertions(zone1)
+		ControlPlaneAssertions(zone4)
 		Expect(zone1.DeleteNamespace(TestNamespace)).To(Succeed())
 		Expect(zone1.DeleteKuma()).To(Succeed())
 		Expect(zone1.DismissCluster()).To(Succeed())


### PR DESCRIPTION
## Motivation

Check if there are NACK in legacy test to know if we introduced a breaking change

## Implementation information

Added a NACK check to all e2e tests. In helm upgrade I had to scale down ingress and up after starting to avoid situation that Ingress is spawned with a flag for new config and connects to old CP, that causes errors in listener upgrade

## Supporting documentation

Fix #16764

Recreated from https://github.com/kumahq/kuma/pull/16774 (original author OOO) and rebased onto master.

> Changelog: skip
