### PR TITLE
perf(xds): replace proto.Equal with xxhash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Nordix/simple-ipam v1.0.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/bakito/go-log-logr-adapter v0.0.3-0.20260622121138-ddf65ac69581
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cilium/ebpf v0.22.0
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.1
@@ -152,7 +153,6 @@ require (
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -170,7 +170,11 @@ func (s *statsCallbacks) OnStreamRequest(_ int64, request DiscoveryRequest) erro
 		s.requestsReceivedMetric.WithLabelValues(request.GetTypeUrl(), "ACK", noErrorType).Inc()
 	}
 
-	if configTime, exists := s.takeConfigTimeFromQueue(request.VersionInfo()); exists {
+	// SotW content hashes are not seeded per node, so two nodes serving
+	// identical resources for a type can share a version string. Key the
+	// queue by nodeID+version to avoid one node's ACK consuming another's
+	// in-flight entry.
+	if configTime, exists := s.takeConfigTimeFromQueue(request.NodeId() + request.VersionInfo()); exists {
 		s.deliveryMetric.Observe(float64(core.Now().Sub(configTime).Milliseconds()))
 	}
 	return nil

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -2,16 +2,18 @@ package v3
 
 import (
 	"context"
+	"hash/fnv"
+	"strconv"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/kumahq/kuma/v3/pkg/core"
 	model "github.com/kumahq/kuma/v3/pkg/core/xds"
+	"github.com/kumahq/kuma/v3/pkg/util/maps"
 	util_xds "github.com/kumahq/kuma/v3/pkg/util/xds"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	"github.com/kumahq/kuma/v3/pkg/xds/generator"
@@ -59,18 +61,16 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 		return false, errors.Wrapf(err, "failed to generate a snapshot")
 	}
 
-	// To avoid assigning a new version every time, compare with
-	// the previous snapshot and reuse its version whenever possible,
-	// fallback to UUID otherwise
+	// To avoid assigning a new version every time, compute stable content
+	// hashes per resource type and compare against the previous snapshot.
 	previous, err := r.cacher.Get(node)
 	if err != nil {
 		previous = &envoy_cache.Snapshot{}
 	}
 
-	snapshot, changed := autoVersion(previous, snapshot)
-	// We need to force new version of EDS, otherwise clusters will be stuck in warming state.
-	if previous.GetVersion(envoy_resource.ClusterType) != snapshot.GetVersion(envoy_resource.ClusterType) {
-		snapshot.Resources[envoy_types.Endpoint].Version = core.NewUUID()
+	snapshot, changed, err := autoVersion(node.Id, previous, snapshot)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to compute snapshot versions")
 	}
 
 	resKey := proxy.Id.ToResourceKey()
@@ -143,39 +143,64 @@ func validateResource(r envoy_types.Resource) error {
 	}
 }
 
-func autoVersion(old *envoy_cache.Snapshot, n *envoy_cache.Snapshot) (*envoy_cache.Snapshot, []string) {
-	for resourceType, resources := range old.Resources {
-		n.Resources[resourceType] = reuseVersion(resources, n.Resources[resourceType])
+// autoVersion computes deterministic FNV-64a content hashes for each resource
+// type in n, seeded with nodeId+type-index. Empty slots keep version "".
+// The cluster version is folded into the endpoint version when endpoints are
+// non-empty to force EDS re-push on cluster changes (prevents warming stalls).
+// Returns the versions that changed relative to old.
+func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snapshot, []string, error) {
+	for i := range n.Resources {
+		seed := nodeId + strconv.Itoa(i)
+		ver, err := resourcesVersion(seed, n.Resources[i].Items)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to hash resources for type %d", i)
+		}
+		n.Resources[i].Version = ver
+	}
+
+	// Fold cluster version into endpoint version so that a cluster change
+	// forces an EDS re-push even when endpoint content is identical.
+	// Only when endpoints are non-empty; empty slots stay at "".
+	if ep := n.Resources[envoy_types.Endpoint].Version; ep != "" {
+		n.Resources[envoy_types.Endpoint].Version = mixVersions(ep, n.Resources[envoy_types.Cluster].Version)
 	}
 
 	var changed []string
-	for resourceType, resource := range n.Resources {
-		if old.Resources[resourceType].Version != resource.Version {
+	for i, resource := range n.Resources {
+		if old.Resources[i].Version != resource.Version {
 			changed = append(changed, resource.Version)
 		}
 	}
 
-	return n, changed
+	return n, changed, nil
 }
 
-func reuseVersion(old, n envoy_cache.Resources) envoy_cache.Resources {
-	n.Version = old.Version
-	if !equalSnapshots(old.Items, n.Items) {
-		n.Version = core.NewUUID()
+// resourcesVersion returns a hex FNV-64a hash over sorted resource names and
+// their deterministic proto serializations, seeded with seed. Returns "" for
+// empty slots so that two empty slots compare equal without versioning.
+func resourcesVersion(seed string, items map[string]envoy_types.ResourceWithTTL) (string, error) {
+	if len(items) == 0 {
+		return "", nil
 	}
-	return n
-}
-
-func equalSnapshots(old, n map[string]envoy_types.ResourceWithTTL) bool {
-	if len(n) != len(old) {
-		return false
-	}
-	for key, newValue := range n {
-		if oldValue, hasOldValue := old[key]; !hasOldValue || !proto.Equal(newValue.Resource, oldValue.Resource) {
-			return false
+	h := fnv.New64a()
+	h.Write([]byte(seed))
+	for _, key := range maps.SortedKeys(items) {
+		h.Write([]byte(key))
+		b, err := envoy_cache.MarshalResource(items[key].Resource)
+		if err != nil {
+			return "", err
 		}
+		h.Write(b)
 	}
-	return true
+	return strconv.FormatUint(h.Sum64(), 16), nil
+}
+
+// mixVersions combines two version strings into a single FNV-64a hash.
+func mixVersions(a, b string) string {
+	h := fnv.New64a()
+	h.Write([]byte(a))
+	h.Write([]byte(b))
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 type snapshotGenerator interface {

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -99,7 +99,7 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 	if err := snapshot.Consistent(); err != nil {
 		return false, errors.Wrap(err, "inconsistent snapshot")
 	}
-	log.Info("config has changed", "versions", changed)
+	log.Info("config has changed", "versions", versionStrings(changed))
 
 	if err := r.cacher.Cache(ctx, node, snapshot); err != nil {
 		return false, errors.Wrap(err, "failed to store snapshot")
@@ -128,11 +128,11 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 	}
 
 	for _, version := range changed {
-		// Empty versions mark resource types that became empty. Envoy ACKs those
-		// with VersionInfo=="", and StatsCallbacks treats empty VersionInfo as an
-		// initial request, so enqueueing "" would leak delivery metric state.
-		if version != "" {
-			r.statsCallbacks.ConfigReadyForDelivery(version)
+		if version.version != "" {
+			r.statsCallbacks.ConfigReadyForDelivery(version.version)
+		}
+		if version.typeURL != "" {
+			r.statsCallbacks.ConfigReadyForDelivery(node.Id + version.typeURL)
 		}
 	}
 	return true, nil
@@ -160,7 +160,7 @@ func validateResource(r envoy_types.Resource) error {
 // The cluster version is folded into the endpoint version when endpoints are
 // non-empty to force EDS re-push on cluster changes (prevents warming stalls).
 // Returns the versions that changed relative to old.
-func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snapshot, []string, error) {
+func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snapshot, []changedVersion, error) {
 	for i := range n.Resources {
 		seed := nodeId + strconv.Itoa(i)
 		ver, err := resourcesVersion(seed, n.Resources[i].Items)
@@ -180,14 +180,34 @@ func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snap
 		n.Resources[envoy_types.Endpoint].Version = mixVersions(ep, n.Resources[envoy_types.Cluster].Version)
 	}
 
-	var changed []string
+	if err := constructVersionMap(n); err != nil {
+		return nil, nil, err
+	}
+
+	var changed []changedVersion
 	for i, resource := range n.Resources {
 		if old.Resources[i].Version != resource.Version {
-			changed = append(changed, resource.Version)
+			changed = append(changed, changedVersion{
+				version: resource.Version,
+				typeURL: resourceTypeURL(i),
+			})
 		}
 	}
 
 	return n, changed, nil
+}
+
+type changedVersion struct {
+	version string
+	typeURL string
+}
+
+func versionStrings(changed []changedVersion) []string {
+	versions := make([]string, 0, len(changed))
+	for _, version := range changed {
+		versions = append(versions, version.version)
+	}
+	return versions
 }
 
 // resourcesVersion returns a hex xxHash64 hash over sorted resource names and
@@ -208,6 +228,59 @@ func resourcesVersion(seed string, items map[string]envoy_types.ResourceWithTTL)
 		writeHashField(h, b)
 	}
 	return formatHash(h.Sum64()), nil
+}
+
+func constructVersionMap(s *envoy_cache.Snapshot) error {
+	s.VersionMap = make(map[string]map[string]string)
+
+	for i, resources := range s.Resources {
+		typeURL := resourceTypeURL(i)
+		if typeURL == "" {
+			continue
+		}
+
+		s.VersionMap[typeURL] = make(map[string]string, len(resources.Items))
+		for _, resource := range resources.Items {
+			marshaled, err := envoy_cache.MarshalResource(resource.Resource)
+			if err != nil {
+				return err
+			}
+			version := envoy_cache.HashResource(marshaled)
+			if i == int(envoy_types.Endpoint) && s.Resources[envoy_types.Cluster].Version != "" {
+				version = mixVersions(version, s.Resources[envoy_types.Cluster].Version)
+			}
+			s.VersionMap[typeURL][envoy_cache.GetResourceName(resource.Resource)] = version
+		}
+	}
+
+	return nil
+}
+
+func resourceTypeURL(i int) string {
+	switch envoy_types.ResponseType(i) {
+	case envoy_types.Endpoint:
+		return envoy_resource.EndpointType
+	case envoy_types.Cluster:
+		return envoy_resource.ClusterType
+	case envoy_types.Route:
+		return envoy_resource.RouteType
+	case envoy_types.ScopedRoute:
+		return envoy_resource.ScopedRouteType
+	case envoy_types.VirtualHost:
+		return envoy_resource.VirtualHostType
+	case envoy_types.Listener:
+		return envoy_resource.ListenerType
+	case envoy_types.Secret:
+		return envoy_resource.SecretType
+	case envoy_types.Runtime:
+		return envoy_resource.RuntimeType
+	case envoy_types.ExtensionConfig:
+		return envoy_resource.ExtensionConfigType
+	case envoy_types.RateLimitConfig:
+		return envoy_resource.RateLimitConfigType
+	default:
+		return ""
+	}
 }
 
 // mixVersions combines two version strings into a single xxHash64 hash.

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -50,9 +50,12 @@ func (r *reconciler) clearUndeliveredConfigStats(nodeId *envoy_core.Node) {
 	if err != nil {
 		return // already cleared
 	}
-	for _, res := range snap.Resources {
+	for i, res := range snap.Resources {
 		if res.Version != "" {
 			r.statsCallbacks.DiscardConfig(res.Version)
+		}
+		if typeURL := resourceTypeURL(i); typeURL != "" {
+			r.statsCallbacks.DiscardConfig(nodeId.Id + typeURL)
 		}
 	}
 }

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -154,7 +154,9 @@ func validateResource(r envoy_types.Resource) error {
 // autoVersion computes deterministic xxHash64 content hashes for each resource
 // type in n, seeded with nodeId+type-index. The seed keeps delivery metric keys
 // distinct because StatsCallbacks tracks in-flight configs by version string.
-// Empty slots keep version "".
+// Empty slots keep version "" unless they are clearing a previously non-empty
+// slot, in which case they get a deterministic clear version so Envoy observes
+// the removal.
 // The cluster version is folded into the endpoint version when endpoints are
 // non-empty to force EDS re-push on cluster changes (prevents warming stalls).
 // Returns the versions that changed relative to old.
@@ -164,6 +166,9 @@ func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snap
 		ver, err := resourcesVersion(seed, n.Resources[i].Items)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to hash resources for type %d", i)
+		}
+		if ver == "" && old.Resources[i].Version != "" {
+			ver = emptyResourcesVersion(seed)
 		}
 		n.Resources[i].Version = ver
 	}
@@ -210,6 +215,13 @@ func mixVersions(a, b string) string {
 	h := xxhash.New()
 	writeHashField(h, []byte(a))
 	writeHashField(h, []byte(b))
+	return formatHash(h.Sum64())
+}
+
+func emptyResourcesVersion(seed string) string {
+	h := xxhash.New()
+	writeHashField(h, []byte(seed))
+	writeHashField(h, nil)
 	return formatHash(h.Sum64())
 }
 

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -2,9 +2,12 @@ package v3
 
 import (
 	"context"
-	"hash/fnv"
+	"encoding/binary"
+	"fmt"
+	"hash"
 	"strconv"
 
+	"github.com/cespare/xxhash/v2"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -125,6 +128,9 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 	}
 
 	for _, version := range changed {
+		// Empty versions mark resource types that became empty. Envoy ACKs those
+		// with VersionInfo=="", and StatsCallbacks treats empty VersionInfo as an
+		// initial request, so enqueueing "" would leak delivery metric state.
 		if version != "" {
 			r.statsCallbacks.ConfigReadyForDelivery(version)
 		}
@@ -145,8 +151,10 @@ func validateResource(r envoy_types.Resource) error {
 	}
 }
 
-// autoVersion computes deterministic FNV-64a content hashes for each resource
-// type in n, seeded with nodeId+type-index. Empty slots keep version "".
+// autoVersion computes deterministic xxHash64 content hashes for each resource
+// type in n, seeded with nodeId+type-index. The seed keeps delivery metric keys
+// distinct because StatsCallbacks tracks in-flight configs by version string.
+// Empty slots keep version "".
 // The cluster version is folded into the endpoint version when endpoints are
 // non-empty to force EDS re-push on cluster changes (prevents warming stalls).
 // Returns the versions that changed relative to old.
@@ -177,32 +185,43 @@ func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snap
 	return n, changed, nil
 }
 
-// resourcesVersion returns a hex FNV-64a hash over sorted resource names and
+// resourcesVersion returns a hex xxHash64 hash over sorted resource names and
 // their deterministic proto serializations, seeded with seed. Returns "" for
 // empty slots so that two empty slots compare equal without versioning.
 func resourcesVersion(seed string, items map[string]envoy_types.ResourceWithTTL) (string, error) {
 	if len(items) == 0 {
 		return "", nil
 	}
-	h := fnv.New64a()
-	h.Write([]byte(seed))
+	h := xxhash.New()
+	writeHashField(h, []byte(seed))
 	for _, key := range maps.SortedKeys(items) {
-		h.Write([]byte(key))
+		writeHashField(h, []byte(key))
 		b, err := envoy_cache.MarshalResource(items[key].Resource)
 		if err != nil {
 			return "", err
 		}
-		h.Write(b)
+		writeHashField(h, b)
 	}
-	return strconv.FormatUint(h.Sum64(), 16), nil
+	return formatHash(h.Sum64()), nil
 }
 
-// mixVersions combines two version strings into a single FNV-64a hash.
+// mixVersions combines two version strings into a single xxHash64 hash.
 func mixVersions(a, b string) string {
-	h := fnv.New64a()
-	h.Write([]byte(a))
-	h.Write([]byte(b))
-	return strconv.FormatUint(h.Sum64(), 16)
+	h := xxhash.New()
+	writeHashField(h, []byte(a))
+	writeHashField(h, []byte(b))
+	return formatHash(h.Sum64())
+}
+
+func writeHashField(h hash.Hash, b []byte) {
+	var lenBuf [8]byte
+	binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(b)))
+	h.Write(lenBuf[:])
+	h.Write(b)
+}
+
+func formatHash(sum uint64) string {
+	return fmt.Sprintf("%016x", sum)
 }
 
 type snapshotGenerator interface {

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -51,7 +51,7 @@ func (r *reconciler) clearUndeliveredConfigStats(nodeId *envoy_core.Node) {
 	}
 	for i, res := range snap.Resources {
 		if res.Version != "" {
-			r.statsCallbacks.DiscardConfig(res.Version)
+			r.statsCallbacks.DiscardConfig(nodeId.Id + res.Version)
 		}
 		if typeURL := resourceTypeURL(i); typeURL != "" {
 			r.statsCallbacks.DiscardConfig(nodeId.Id + typeURL)
@@ -131,7 +131,10 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 
 	for _, version := range changed {
 		if version.version != "" {
-			r.statsCallbacks.ConfigReadyForDelivery(version.version)
+			// Content hashes aren't node-seeded, so two nodes can share a
+			// version string for a resource type; prefix with nodeId so the
+			// delivery-metric queue doesn't cross-match between them.
+			r.statsCallbacks.ConfigReadyForDelivery(node.Id + version.version)
 		}
 		if version.typeURL != "" {
 			r.statsCallbacks.ConfigReadyForDelivery(node.Id + version.typeURL)

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"strconv"
 
 	"github.com/cespare/xxhash/v2"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -74,7 +73,7 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 		previous = &envoy_cache.Snapshot{}
 	}
 
-	snapshot, changed, err := autoVersion(node.Id, previous, snapshot)
+	snapshot, changed, err := autoVersion(previous, snapshot)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to compute snapshot versions")
 	}
@@ -155,23 +154,21 @@ func validateResource(r envoy_types.Resource) error {
 }
 
 // autoVersion computes deterministic xxHash64 content hashes for each resource
-// type in n, seeded with nodeId+type-index. The seed keeps delivery metric keys
-// distinct because StatsCallbacks tracks in-flight configs by version string.
+// type in n.
 // Empty slots keep version "" unless they are clearing a previously non-empty
 // slot, in which case they get a deterministic clear version so Envoy observes
 // the removal.
 // The cluster version is folded into the endpoint version when endpoints are
 // non-empty to force EDS re-push on cluster changes (prevents warming stalls).
 // Returns the versions that changed relative to old.
-func autoVersion(nodeId string, old, n *envoy_cache.Snapshot) (*envoy_cache.Snapshot, []changedVersion, error) {
+func autoVersion(old, n *envoy_cache.Snapshot) (*envoy_cache.Snapshot, []changedVersion, error) {
 	for i := range n.Resources {
-		seed := nodeId + strconv.Itoa(i)
-		ver, err := resourcesVersion(seed, n.Resources[i].Items)
+		ver, err := resourcesVersion(n.Resources[i].Items)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to hash resources for type %d", i)
 		}
 		if ver == "" && old.Resources[i].Version != "" {
-			ver = emptyResourcesVersion(seed)
+			ver = emptyResourcesVersion()
 		}
 		n.Resources[i].Version = ver
 	}
@@ -214,14 +211,13 @@ func versionStrings(changed []changedVersion) []string {
 }
 
 // resourcesVersion returns a hex xxHash64 hash over sorted resource names and
-// their deterministic proto serializations, seeded with seed. Returns "" for
+// their deterministic proto serializations. Returns "" for
 // empty slots so that two empty slots compare equal without versioning.
-func resourcesVersion(seed string, items map[string]envoy_types.ResourceWithTTL) (string, error) {
+func resourcesVersion(items map[string]envoy_types.ResourceWithTTL) (string, error) {
 	if len(items) == 0 {
 		return "", nil
 	}
 	h := xxhash.New()
-	writeHashField(h, []byte(seed))
 	for _, key := range maps.SortedKeys(items) {
 		writeHashField(h, []byte(key))
 		b, err := envoy_cache.MarshalResource(items[key].Resource)
@@ -294,9 +290,8 @@ func mixVersions(a, b string) string {
 	return formatHash(h.Sum64())
 }
 
-func emptyResourcesVersion(seed string) string {
+func emptyResourcesVersion() string {
 	h := xxhash.New()
-	writeHashField(h, []byte(seed))
 	writeHashField(h, nil)
 	return formatHash(h.Sum64())
 }

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -125,7 +125,9 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 	}
 
 	for _, version := range changed {
-		r.statsCallbacks.ConfigReadyForDelivery(version)
+		if version != "" {
+			r.statsCallbacks.ConfigReadyForDelivery(version)
+		}
 	}
 	return true, nil
 }

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -213,18 +213,34 @@ var _ = Describe("Reconcile", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
-			By("verifying that snapshot versions are empty for empty snapshot")
+			By("verifying that snapshot versions are changed for cleared resources")
 			// when
 			snapshot, err = xdsContext.Cache().GetSnapshot("demo.example")
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeZero())
-			// and: empty snapshot produces empty ("") versions, not new UUIDs
-			Expect(snapshot.GetVersion(resource.ListenerType)).To(BeEmpty())
-			Expect(snapshot.GetVersion(resource.RouteType)).To(BeEmpty())
-			Expect(snapshot.GetVersion(resource.ClusterType)).To(BeEmpty())
-			Expect(snapshot.GetVersion(resource.EndpointType)).To(BeEmpty())
-			Expect(snapshot.GetVersion(resource.SecretType)).To(BeEmpty())
+			// and: clearing previously populated resources produces deterministic
+			// non-empty versions so Envoy observes removals.
+			Expect(snapshot.GetVersion(resource.ListenerType)).To(SatisfyAll(
+				Not(Equal(listenerV1)),
+				Not(BeEmpty()),
+			))
+			Expect(snapshot.GetVersion(resource.RouteType)).To(SatisfyAll(
+				Not(Equal(routeV1)),
+				Not(BeEmpty()),
+			))
+			Expect(snapshot.GetVersion(resource.ClusterType)).To(SatisfyAll(
+				Not(Equal(clusterV1)),
+				Not(BeEmpty()),
+			))
+			Expect(snapshot.GetVersion(resource.EndpointType)).To(SatisfyAll(
+				Not(Equal(endpointV1)),
+				Not(BeEmpty()),
+			))
+			Expect(snapshot.GetVersion(resource.SecretType)).To(SatisfyAll(
+				Not(Equal(secretV1)),
+				Not(BeEmpty()),
+			))
 
 			By("simulating clear")
 			// when
@@ -395,11 +411,10 @@ var _ = Describe("Reconcile", func() {
 			Expect(changed).To(BeFalse())
 		})
 
-		It("should not pass empty version to ConfigReadyForDelivery when types clear", func() {
+		It("should pass a non-empty version to ConfigReadyForDelivery when types clear", func() {
 			// First snapshot has a Secret; second is fully empty.
-			// When Secret transitions secretHash→"", the "" must NOT reach
-			// ConfigReadyForDelivery: stats_callbacks.OnStreamRequest skips
-			// requests with VersionInfo=="" so the key would never be consumed.
+			// When Secret transitions secretHash -> empty, Envoy still needs a
+			// non-empty version to observe the resource removal.
 			withSecret := envoy_cache.Snapshot{}
 			withSecret.Resources[envoy_types.Secret] = envoy_cache.Resources{
 				Items: map[string]envoy_types.ResourceWithTTL{
@@ -434,11 +449,12 @@ var _ = Describe("Reconcile", func() {
 			_, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("second reconcile — Secret clears, transitioning secretHash→\"\"")
+			By("second reconcile — Secret clears")
 			_, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(spy.deliveredVersions).ToNot(ContainElement(""))
+			Expect(spy.deliveredVersions).To(HaveLen(2))
 		})
 
 		It("should frame hash inputs and produce fixed-width versions", func() {

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Reconcile", func() {
 			By("second identical reconcile — no changes")
 			changed, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
 			Expect(err).ToNot(HaveOccurred())
-			// Unchanged: same content hash for Route, "" == "" for empty types.
+			// Unchanged: same content hash for Secret, "" == "" for empty types.
 			Expect(changed).To(BeFalse())
 		})
 
@@ -463,7 +463,7 @@ func (f snapshotGeneratorFunc) GenerateSnapshot(ctx context.Context, xdsCtx xds_
 }
 
 // buildRealisticSnapshot returns a snapshot with 20 clusters, 20 endpoints,
-// 5 listeners, and 5 routes — representative of a non-trivial data plane.
+// and 5 listeners — representative of a non-trivial data plane.
 func buildRealisticSnapshot() *envoy_cache.Snapshot {
 	snap := &envoy_cache.Snapshot{}
 
@@ -484,7 +484,7 @@ func buildRealisticSnapshot() *envoy_cache.Snapshot {
 	snap.Resources[envoy_types.Cluster] = envoy_cache.Resources{Items: clusterItems}
 	snap.Resources[envoy_types.Endpoint] = envoy_cache.Resources{Items: endpointItems}
 
-	// Listeners with static (non-RDS) route configs so no Route resources are
+	// Listeners reference no RDS route configs, so no Route resources are
 	// required for Consistent() to pass.
 	listenerItems := make(map[string]envoy_types.ResourceWithTTL, 5)
 	for i := range 5 {

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -395,8 +395,66 @@ var _ = Describe("Reconcile", func() {
 			// Unchanged: same content hash for Route, "" == "" for empty types.
 			Expect(changed).To(BeFalse())
 		})
+
+		It("should not pass empty version to ConfigReadyForDelivery when types clear", func() {
+			// First snapshot has a Secret; second is fully empty.
+			// When Secret transitions secretHash→"", the "" must NOT reach
+			// ConfigReadyForDelivery: stats_callbacks.OnStreamRequest skips
+			// requests with VersionInfo=="" so the key would never be consumed.
+			withSecret := envoy_cache.Snapshot{}
+			withSecret.Resources[envoy_types.Secret] = envoy_cache.Resources{
+				Items: map[string]envoy_types.ResourceWithTTL{
+					"secret": {Resource: &envoy_auth.Secret{Name: "secret"}},
+				},
+			}
+			emptySnap := envoy_cache.Snapshot{}
+
+			snapshots := make(chan envoy_cache.Snapshot, 2)
+			snapshots <- withSecret
+			snapshots <- emptySnap
+
+			spy := &spyStatsCallbacks{}
+			r := &reconciler{
+				generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
+					snap := <-snapshots
+					return &snap, nil
+				}),
+				cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+				statsCallbacks: spy,
+			}
+
+			proxy := &xds_model.Proxy{
+				Id: *xds_model.BuildProxyId("demo", "empty-delivery-test"),
+				Dataplane: &core_mesh.DataplaneResource{
+					Meta: &test_model.ResourceMeta{Mesh: "demo", Name: "empty-delivery-test"},
+					Spec: &mesh_proto.Dataplane{},
+				},
+			}
+
+			By("first reconcile — Secret gets a real content hash")
+			_, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("second reconcile — Secret clears, transitioning secretHash→\"\"")
+			_, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(spy.deliveredVersions).ToNot(ContainElement(""))
+		})
 	})
 })
+
+// spyStatsCallbacks records versions passed to ConfigReadyForDelivery.
+type spyStatsCallbacks struct {
+	util_xds.NoopCallbacks
+	deliveredVersions []string
+}
+
+func (s *spyStatsCallbacks) ConfigReadyForDelivery(v string) {
+	s.deliveredVersions = append(s.deliveredVersions, v)
+}
+
+func (s *spyStatsCallbacks) DiscardConfig(string) {}
 
 type snapshotGeneratorFunc func(context.Context, xds_context.Context, *xds_model.Proxy) (*envoy_cache.Snapshot, error)
 

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -498,7 +498,7 @@ var _ = Describe("Reconcile", func() {
 		})
 
 		It("should frame hash inputs and produce fixed-width versions", func() {
-			secretVersion, err := resourcesVersion("demo0", map[string]envoy_types.ResourceWithTTL{
+			secretVersion, err := resourcesVersion(map[string]envoy_types.ResourceWithTTL{
 				"secret": {Resource: &envoy_auth.Secret{Name: "secret"}},
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -678,11 +678,10 @@ func lbEndpoint(address string, port uint32) *envoy_endpoint.LbEndpoint {
 }
 
 func BenchmarkAutoVersion(b *testing.B) {
-	nodeId := "demo.benchmark"
 	snap := buildRealisticSnapshot(-1)
 
 	// Populate an "old" snapshot with content hashes.
-	populated, _, err := autoVersion(nodeId, &envoy_cache.Snapshot{}, snap)
+	populated, _, err := autoVersion(&envoy_cache.Snapshot{}, snap)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -692,7 +691,7 @@ func BenchmarkAutoVersion(b *testing.B) {
 			// Each iteration mirrors the real hot path: generator allocates a new
 			// snapshot, autoVersion hashes it and compares to the cached version.
 			n := buildRealisticSnapshot(-1)
-			if _, _, err := autoVersion(nodeId, populated, n); err != nil {
+			if _, _, err := autoVersion(populated, n); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -701,7 +700,7 @@ func BenchmarkAutoVersion(b *testing.B) {
 	b.Run("one-cluster-changed", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			n := buildRealisticSnapshot(42)
-			if _, _, err := autoVersion(nodeId, populated, n); err != nil {
+			if _, _, err := autoVersion(populated, n); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -18,6 +18,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
@@ -38,10 +40,7 @@ func hcmForRoute(routeName string) *anypb.Any {
 		},
 	}
 
-	a, err := proto.MarshalAnyDeterministic(&hcm)
-	Expect(err).To(Succeed())
-
-	return a
+	return proto.MustMarshalAny(&hcm)
 }
 
 var _ = Describe("Reconcile", func() {
@@ -441,6 +440,17 @@ var _ = Describe("Reconcile", func() {
 
 			Expect(spy.deliveredVersions).ToNot(ContainElement(""))
 		})
+
+		It("should frame hash inputs and produce fixed-width versions", func() {
+			secretVersion, err := resourcesVersion("demo0", map[string]envoy_types.ResourceWithTTL{
+				"secret": {Resource: &envoy_auth.Secret{Name: "secret"}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secretVersion).To(HaveLen(16))
+
+			Expect(mixVersions("ab", "cdef")).To(HaveLen(16))
+			Expect(mixVersions("ab", "cdef")).ToNot(Equal(mixVersions("abcd", "ef")))
+		})
 	})
 })
 
@@ -462,35 +472,126 @@ func (f snapshotGeneratorFunc) GenerateSnapshot(ctx context.Context, xdsCtx xds_
 	return f(ctx, xdsCtx, proxy)
 }
 
-// buildRealisticSnapshot returns a snapshot with 20 clusters, 20 endpoints,
-// and 5 listeners — representative of a non-trivial data plane.
-func buildRealisticSnapshot() *envoy_cache.Snapshot {
+// buildRealisticSnapshot returns a snapshot with nested xDS resources: 100
+// clusters, 100 endpoint assignments, 100 routes, and 100 listeners.
+func buildRealisticSnapshot(changedCluster int) *envoy_cache.Snapshot {
 	snap := &envoy_cache.Snapshot{}
 
-	clusterItems := make(map[string]envoy_types.ResourceWithTTL, 20)
-	endpointItems := make(map[string]envoy_types.ResourceWithTTL, 20)
-	for i := range 20 {
+	clusterItems := make(map[string]envoy_types.ResourceWithTTL, 100)
+	endpointItems := make(map[string]envoy_types.ResourceWithTTL, 100)
+	routeItems := make(map[string]envoy_types.ResourceWithTTL, 100)
+	for i := range 100 {
 		name := "cluster-" + strconv.Itoa(i)
+		connectTimeout := durationpb.New(5_000_000_000)
+		if i == changedCluster {
+			connectTimeout = durationpb.New(10_000_000_000)
+		}
 		clusterItems[name] = envoy_types.ResourceWithTTL{
 			Resource: &envoy_cluster.Cluster{
 				Name:                 name,
 				ClusterDiscoveryType: &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_EDS},
+				ConnectTimeout:       connectTimeout,
+				EdsClusterConfig: &envoy_cluster.Cluster_EdsClusterConfig{
+					EdsConfig: &envoy_core.ConfigSource{
+						ResourceApiVersion: envoy_core.ApiVersion_V3,
+						ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
+							Ads: &envoy_core.AggregatedConfigSource{},
+						},
+					},
+				},
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+						MaxConnections:     wrapperspb.UInt32(1024),
+						MaxPendingRequests: wrapperspb.UInt32(1024),
+						MaxRequests:        wrapperspb.UInt32(2048),
+						MaxRetries:         wrapperspb.UInt32(3),
+					}},
+				},
+				HealthChecks: []*envoy_core.HealthCheck{{
+					Timeout:            durationpb.New(1_000_000_000),
+					Interval:           durationpb.New(5_000_000_000),
+					UnhealthyThreshold: wrapperspb.UInt32(2),
+					HealthyThreshold:   wrapperspb.UInt32(1),
+					HealthChecker: &envoy_core.HealthCheck_HttpHealthCheck_{
+						HttpHealthCheck: &envoy_core.HealthCheck_HttpHealthCheck{
+							Path: "/ready",
+						},
+					},
+				}},
+				TransportSocket: &envoy_core.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &envoy_core.TransportSocket_TypedConfig{
+						TypedConfig: proto.MustMarshalAny(&envoy_auth.UpstreamTlsContext{}),
+					},
+				},
 			},
 		}
 		endpointItems[name] = envoy_types.ResourceWithTTL{
-			Resource: &envoy_endpoint.ClusterLoadAssignment{ClusterName: name},
+			Resource: &envoy_endpoint.ClusterLoadAssignment{
+				ClusterName: name,
+				Endpoints: []*envoy_endpoint.LocalityLbEndpoints{{
+					Locality: &envoy_core.Locality{
+						Region: "region-1",
+						Zone:   "zone-" + strconv.Itoa(i%3),
+					},
+					LbEndpoints: []*envoy_endpoint.LbEndpoint{
+						lbEndpoint("10.0."+strconv.Itoa(i/255)+"."+strconv.Itoa(i%255), 8080),
+						lbEndpoint("10.1."+strconv.Itoa(i/255)+"."+strconv.Itoa(i%255), 8081),
+					},
+				}},
+			},
+		}
+		routeName := "route-" + strconv.Itoa(i)
+		routeItems[routeName] = envoy_types.ResourceWithTTL{
+			Resource: &envoy_route.RouteConfiguration{
+				Name: routeName,
+				VirtualHosts: []*envoy_route.VirtualHost{{
+					Name:    "vh-" + strconv.Itoa(i),
+					Domains: []string{"service-" + strconv.Itoa(i) + ".mesh"},
+					Routes: []*envoy_route.Route{{
+						Match: &envoy_route.RouteMatch{
+							PathSpecifier: &envoy_route.RouteMatch_Prefix{Prefix: "/"},
+						},
+						Action: &envoy_route.Route_Route{
+							Route: &envoy_route.RouteAction{
+								ClusterSpecifier: &envoy_route.RouteAction_Cluster{Cluster: name},
+								Timeout:          durationpb.New(15_000_000_000),
+							},
+						},
+					}},
+				}},
+			},
 		}
 	}
 	snap.Resources[envoy_types.Cluster] = envoy_cache.Resources{Items: clusterItems}
 	snap.Resources[envoy_types.Endpoint] = envoy_cache.Resources{Items: endpointItems}
+	snap.Resources[envoy_types.Route] = envoy_cache.Resources{Items: routeItems}
 
-	// Listeners reference no RDS route configs, so no Route resources are
-	// required for Consistent() to pass.
-	listenerItems := make(map[string]envoy_types.ResourceWithTTL, 5)
-	for i := range 5 {
+	listenerItems := make(map[string]envoy_types.ResourceWithTTL, 100)
+	for i := range 100 {
 		lName := "listener-" + strconv.Itoa(i)
 		listenerItems[lName] = envoy_types.ResourceWithTTL{
-			Resource: &envoy_listener.Listener{Name: lName},
+			Resource: &envoy_listener.Listener{
+				Name: lName,
+				Address: &envoy_core.Address{
+					Address: &envoy_core.Address_SocketAddress{
+						SocketAddress: &envoy_core.SocketAddress{
+							Address: "127.0.0.1",
+							PortSpecifier: &envoy_core.SocketAddress_PortValue{
+								PortValue: uint32(10_000 + i),
+							},
+						},
+					},
+				},
+				FilterChains: []*envoy_listener.FilterChain{{
+					Filters: []*envoy_listener.Filter{{
+						Name: "envoy.filters.network.http_connection_manager",
+						ConfigType: &envoy_listener.Filter_TypedConfig{
+							TypedConfig: hcmForRoute("route-" + strconv.Itoa(i)),
+						},
+					}},
+				}},
+			},
 		}
 	}
 	snap.Resources[envoy_types.Listener] = envoy_cache.Resources{Items: listenerItems}
@@ -498,9 +599,28 @@ func buildRealisticSnapshot() *envoy_cache.Snapshot {
 	return snap
 }
 
+func lbEndpoint(address string, port uint32) *envoy_endpoint.LbEndpoint {
+	return &envoy_endpoint.LbEndpoint{
+		HostIdentifier: &envoy_endpoint.LbEndpoint_Endpoint{
+			Endpoint: &envoy_endpoint.Endpoint{
+				Address: &envoy_core.Address{
+					Address: &envoy_core.Address_SocketAddress{
+						SocketAddress: &envoy_core.SocketAddress{
+							Address: address,
+							PortSpecifier: &envoy_core.SocketAddress_PortValue{
+								PortValue: port,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func BenchmarkAutoVersion(b *testing.B) {
 	nodeId := "demo.benchmark"
-	snap := buildRealisticSnapshot()
+	snap := buildRealisticSnapshot(-1)
 
 	// Populate an "old" snapshot with content hashes.
 	populated, _, err := autoVersion(nodeId, &envoy_cache.Snapshot{}, snap)
@@ -508,15 +628,25 @@ func BenchmarkAutoVersion(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// Each iteration mirrors the real hot path: generator allocates a new
-		// snapshot, autoVersion hashes it and compares to the cached version.
-		n := buildRealisticSnapshot()
-		if _, _, err := autoVersion(nodeId, populated, n); err != nil {
-			b.Fatal(err)
+	b.Run("unchanged", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Each iteration mirrors the real hot path: generator allocates a new
+			// snapshot, autoVersion hashes it and compares to the cached version.
+			n := buildRealisticSnapshot(-1)
+			if _, _, err := autoVersion(nodeId, populated, n); err != nil {
+				b.Fatal(err)
+			}
 		}
-	}
+	})
+
+	b.Run("one-cluster-changed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			n := buildRealisticSnapshot(42)
+			if _, _, err := autoVersion(nodeId, populated, n); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func BenchmarkReconcileUnchanged(b *testing.B) {
@@ -532,7 +662,7 @@ func BenchmarkReconcileUnchanged(b *testing.B) {
 	xdsCtx := NewXdsContext()
 	r := &reconciler{
 		generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
-			return buildRealisticSnapshot(), nil
+			return buildRealisticSnapshot(-1), nil
 		}),
 		cacher:         &simpleSnapshotCacher{xdsCtx.Hasher(), xdsCtx.Cache()},
 		statsCallbacks: statsCallbacks,

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -463,6 +463,40 @@ var _ = Describe("Reconcile", func() {
 			Expect(spy.deliveredVersions).To(ContainElement("demo.empty-delivery-test" + resource.SecretType))
 		})
 
+		It("should discard delta delivery metric keys on clear", func() {
+			withSecret := envoy_cache.Snapshot{}
+			withSecret.Resources[envoy_types.Secret] = envoy_cache.Resources{
+				Items: map[string]envoy_types.ResourceWithTTL{
+					"secret": {Resource: &envoy_auth.Secret{Name: "secret"}},
+				},
+			}
+
+			spy := &spyStatsCallbacks{}
+			r := &reconciler{
+				generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
+					return &withSecret, nil
+				}),
+				cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+				statsCallbacks: spy,
+			}
+
+			proxy := &xds_model.Proxy{
+				Id: *xds_model.BuildProxyId("demo", "clear-delivery-test"),
+				Dataplane: &core_mesh.DataplaneResource{
+					Meta: &test_model.ResourceMeta{Mesh: "demo", Name: "clear-delivery-test"},
+					Spec: &mesh_proto.Dataplane{},
+				},
+			}
+
+			_, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = r.Clear(&proxy.Id)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(spy.discardedVersions).To(ContainElement("demo.clear-delivery-test" + resource.SecretType))
+		})
+
 		It("should frame hash inputs and produce fixed-width versions", func() {
 			secretVersion, err := resourcesVersion("demo0", map[string]envoy_types.ResourceWithTTL{
 				"secret": {Resource: &envoy_auth.Secret{Name: "secret"}},
@@ -480,13 +514,16 @@ var _ = Describe("Reconcile", func() {
 type spyStatsCallbacks struct {
 	util_xds.NoopCallbacks
 	deliveredVersions []string
+	discardedVersions []string
 }
 
 func (s *spyStatsCallbacks) ConfigReadyForDelivery(v string) {
 	s.deliveredVersions = append(s.deliveredVersions, v)
 }
 
-func (s *spyStatsCallbacks) DiscardConfig(string) {}
+func (s *spyStatsCallbacks) DiscardConfig(v string) {
+	s.discardedVersions = append(s.discardedVersions, v)
+}
 
 type snapshotGeneratorFunc func(context.Context, xds_context.Context, *xds_model.Proxy) (*envoy_cache.Snapshot, error)
 

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -327,8 +327,10 @@ var _ = Describe("Reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 			clusterV1 := cached.GetVersion(resource.ClusterType)
 			endpointV1 := cached.GetVersion(resource.EndpointType)
+			endpointDeltaV1 := cached.GetVersionMap(resource.EndpointType)["cluster"]
 			Expect(clusterV1).ToNot(BeEmpty())
 			Expect(endpointV1).ToNot(BeEmpty())
+			Expect(endpointDeltaV1).ToNot(BeEmpty())
 
 			By("second reconcile — different cluster, identical endpoint content")
 			changed, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
@@ -338,9 +340,11 @@ var _ = Describe("Reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 			clusterV2 := cached.GetVersion(resource.ClusterType)
 			endpointV2 := cached.GetVersion(resource.EndpointType)
+			endpointDeltaV2 := cached.GetVersionMap(resource.EndpointType)["cluster"]
 			// Cluster changed → endpoint version must change too (EDS warming fold).
 			Expect(clusterV2).ToNot(Equal(clusterV1))
 			Expect(endpointV2).ToNot(Equal(endpointV1))
+			Expect(endpointDeltaV2).ToNot(Equal(endpointDeltaV1))
 
 			By("third reconcile — back to original cluster")
 			changed, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
@@ -351,6 +355,7 @@ var _ = Describe("Reconcile", func() {
 			// Deterministic: same content as first reconcile → same hashes.
 			Expect(cached.GetVersion(resource.ClusterType)).To(Equal(clusterV1))
 			Expect(cached.GetVersion(resource.EndpointType)).To(Equal(endpointV1))
+			Expect(cached.GetVersionMap(resource.EndpointType)["cluster"]).To(Equal(endpointDeltaV1))
 		})
 
 		It("should leave empty resource types unversioned", func() {
@@ -454,7 +459,8 @@ var _ = Describe("Reconcile", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(spy.deliveredVersions).ToNot(ContainElement(""))
-			Expect(spy.deliveredVersions).To(HaveLen(2))
+			Expect(spy.deliveredVersions).To(HaveLen(4))
+			Expect(spy.deliveredVersions).To(ContainElement("demo.empty-delivery-test" + resource.SecretType))
 		})
 
 		It("should frame hash inputs and produce fixed-width versions", func() {

--- a/pkg/xds/server/v3/reconcile_test.go
+++ b/pkg/xds/server/v3/reconcile_test.go
@@ -2,6 +2,8 @@ package v3
 
 import (
 	"context"
+	"strconv"
+	"testing"
 
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -212,33 +214,18 @@ var _ = Describe("Reconcile", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
-			By("verifying that snapshot versions are new")
+			By("verifying that snapshot versions are empty for empty snapshot")
 			// when
 			snapshot, err = xdsContext.Cache().GetSnapshot("demo.example")
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeZero())
-			// and
-			Expect(snapshot.GetVersion(resource.ListenerType)).To(SatisfyAll(
-				Not(Equal(listenerV1)),
-				Not(BeEmpty()),
-			))
-			Expect(snapshot.GetVersion(resource.RouteType)).To(SatisfyAll(
-				Not(Equal(routeV1)),
-				Not(BeEmpty()),
-			))
-			Expect(snapshot.GetVersion(resource.ClusterType)).To(SatisfyAll(
-				Not(Equal(clusterV1)),
-				Not(BeEmpty()),
-			))
-			Expect(snapshot.GetVersion(resource.EndpointType)).To(SatisfyAll(
-				Not(Equal(endpointV1)),
-				Not(BeEmpty()),
-			))
-			Expect(snapshot.GetVersion(resource.SecretType)).To(SatisfyAll(
-				Not(Equal(secretV1)),
-				Not(BeEmpty()),
-			))
+			// and: empty snapshot produces empty ("") versions, not new UUIDs
+			Expect(snapshot.GetVersion(resource.ListenerType)).To(BeEmpty())
+			Expect(snapshot.GetVersion(resource.RouteType)).To(BeEmpty())
+			Expect(snapshot.GetVersion(resource.ClusterType)).To(BeEmpty())
+			Expect(snapshot.GetVersion(resource.EndpointType)).To(BeEmpty())
+			Expect(snapshot.GetVersion(resource.SecretType)).To(BeEmpty())
 
 			By("simulating clear")
 			// when
@@ -251,6 +238,163 @@ var _ = Describe("Reconcile", func() {
 			Expect(err.Error()).To(ContainSubstring("no snapshot found"))
 			Expect(snapshot).To(BeNil())
 		})
+
+		It("should force EDS re-push when cluster changes", func() {
+			// Both clusters share the same name so endpoints stay consistent across
+			// reconciles. AltStatName differs so the cluster hash changes without
+			// affecting EDS reference resolution (which uses cluster Name).
+			makeCluster := func(altStatName string) *envoy_cluster.Cluster {
+				return &envoy_cluster.Cluster{
+					Name:                 "cluster",
+					AltStatName:          altStatName,
+					ClusterDiscoveryType: &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_EDS},
+					EdsClusterConfig: &envoy_cluster.Cluster_EdsClusterConfig{
+						EdsConfig: &envoy_core.ConfigSource{
+							ResourceApiVersion: envoy_core.ApiVersion_V3,
+							ConfigSourceSpecifier: &envoy_core.ConfigSource_Ads{
+								Ads: &envoy_core.AggregatedConfigSource{},
+							},
+						},
+					},
+				}
+			}
+			cluster1 := makeCluster("v1")
+			cluster2 := makeCluster("v2")
+			endpoint := &envoy_endpoint.ClusterLoadAssignment{ClusterName: "cluster"}
+
+			makeSnap := func(cluster *envoy_cluster.Cluster) envoy_cache.Snapshot {
+				snap := envoy_cache.Snapshot{}
+				snap.Resources[envoy_types.Cluster] = envoy_cache.Resources{
+					Items: map[string]envoy_types.ResourceWithTTL{
+						cluster.Name: {Resource: cluster},
+					},
+				}
+				snap.Resources[envoy_types.Endpoint] = envoy_cache.Resources{
+					Items: map[string]envoy_types.ResourceWithTTL{
+						endpoint.ClusterName: {Resource: endpoint},
+					},
+				}
+				return snap
+			}
+
+			snapshots := make(chan envoy_cache.Snapshot, 3)
+			snapshots <- makeSnap(cluster1)
+			snapshots <- makeSnap(cluster2)
+			snapshots <- makeSnap(cluster1)
+
+			metrics, err := core_metrics.NewMetrics("Zone")
+			Expect(err).ToNot(HaveOccurred())
+			statsCallbacks, err := util_xds.NewStatsCallbacks(metrics, "xds", util_xds.NoopVersionExtractor)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := &reconciler{
+				generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
+					snap := <-snapshots
+					return &snap, nil
+				}),
+				cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+				statsCallbacks: statsCallbacks,
+			}
+
+			proxy := &xds_model.Proxy{
+				Id: *xds_model.BuildProxyId("demo", "eds-fold-test"),
+				Dataplane: &core_mesh.DataplaneResource{
+					Meta: &test_model.ResourceMeta{Mesh: "demo", Name: "eds-fold-test"},
+					Spec: &mesh_proto.Dataplane{},
+				},
+			}
+
+			By("first reconcile — populate initial versions")
+			changed, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(changed).To(BeTrue())
+			cached, err := xdsContext.Cache().GetSnapshot("demo.eds-fold-test")
+			Expect(err).ToNot(HaveOccurred())
+			clusterV1 := cached.GetVersion(resource.ClusterType)
+			endpointV1 := cached.GetVersion(resource.EndpointType)
+			Expect(clusterV1).ToNot(BeEmpty())
+			Expect(endpointV1).ToNot(BeEmpty())
+
+			By("second reconcile — different cluster, identical endpoint content")
+			changed, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(changed).To(BeTrue())
+			cached, err = xdsContext.Cache().GetSnapshot("demo.eds-fold-test")
+			Expect(err).ToNot(HaveOccurred())
+			clusterV2 := cached.GetVersion(resource.ClusterType)
+			endpointV2 := cached.GetVersion(resource.EndpointType)
+			// Cluster changed → endpoint version must change too (EDS warming fold).
+			Expect(clusterV2).ToNot(Equal(clusterV1))
+			Expect(endpointV2).ToNot(Equal(endpointV1))
+
+			By("third reconcile — back to original cluster")
+			changed, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(changed).To(BeTrue())
+			cached, err = xdsContext.Cache().GetSnapshot("demo.eds-fold-test")
+			Expect(err).ToNot(HaveOccurred())
+			// Deterministic: same content as first reconcile → same hashes.
+			Expect(cached.GetVersion(resource.ClusterType)).To(Equal(clusterV1))
+			Expect(cached.GetVersion(resource.EndpointType)).To(Equal(endpointV1))
+		})
+
+		It("should leave empty resource types unversioned", func() {
+			// Only Secret is populated; all other types are empty.
+			// Secret has no cross-reference requirements so the snapshot is consistent.
+			onlySecrets := envoy_cache.Snapshot{}
+			onlySecrets.Resources[envoy_types.Secret] = envoy_cache.Resources{
+				Items: map[string]envoy_types.ResourceWithTTL{
+					"secret": {Resource: &envoy_auth.Secret{Name: "secret"}},
+				},
+			}
+
+			snapshots := make(chan envoy_cache.Snapshot, 2)
+			snapshots <- onlySecrets
+			snapshots <- onlySecrets
+
+			metrics, err := core_metrics.NewMetrics("Zone")
+			Expect(err).ToNot(HaveOccurred())
+			statsCallbacks, err := util_xds.NewStatsCallbacks(metrics, "xds", util_xds.NoopVersionExtractor)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := &reconciler{
+				generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
+					snap := <-snapshots
+					return &snap, nil
+				}),
+				cacher:         &simpleSnapshotCacher{xdsContext.Hasher(), xdsContext.Cache()},
+				statsCallbacks: statsCallbacks,
+			}
+
+			proxy := &xds_model.Proxy{
+				Id: *xds_model.BuildProxyId("demo", "empty-slot-test"),
+				Dataplane: &core_mesh.DataplaneResource{
+					Meta: &test_model.ResourceMeta{Mesh: "demo", Name: "empty-slot-test"},
+					Spec: &mesh_proto.Dataplane{},
+				},
+			}
+
+			By("first reconcile")
+			changed, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(changed).To(BeTrue())
+
+			cached, err := xdsContext.Cache().GetSnapshot("demo.empty-slot-test")
+			Expect(err).ToNot(HaveOccurred())
+			// Populated type has a content hash.
+			Expect(cached.GetVersion(resource.SecretType)).ToNot(BeEmpty())
+			// Empty types produce "" version — not versioned.
+			Expect(cached.GetVersion(resource.ListenerType)).To(BeEmpty())
+			Expect(cached.GetVersion(resource.RouteType)).To(BeEmpty())
+			Expect(cached.GetVersion(resource.ClusterType)).To(BeEmpty())
+			Expect(cached.GetVersion(resource.EndpointType)).To(BeEmpty())
+
+			By("second identical reconcile — no changes")
+			changed, err = r.Reconcile(context.Background(), xds_context.Context{}, proxy)
+			Expect(err).ToNot(HaveOccurred())
+			// Unchanged: same content hash for Route, "" == "" for empty types.
+			Expect(changed).To(BeFalse())
+		})
 	})
 })
 
@@ -258,4 +402,101 @@ type snapshotGeneratorFunc func(context.Context, xds_context.Context, *xds_model
 
 func (f snapshotGeneratorFunc) GenerateSnapshot(ctx context.Context, xdsCtx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
 	return f(ctx, xdsCtx, proxy)
+}
+
+// buildRealisticSnapshot returns a snapshot with 20 clusters, 20 endpoints,
+// 5 listeners, and 5 routes — representative of a non-trivial data plane.
+func buildRealisticSnapshot() *envoy_cache.Snapshot {
+	snap := &envoy_cache.Snapshot{}
+
+	clusterItems := make(map[string]envoy_types.ResourceWithTTL, 20)
+	endpointItems := make(map[string]envoy_types.ResourceWithTTL, 20)
+	for i := range 20 {
+		name := "cluster-" + strconv.Itoa(i)
+		clusterItems[name] = envoy_types.ResourceWithTTL{
+			Resource: &envoy_cluster.Cluster{
+				Name:                 name,
+				ClusterDiscoveryType: &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_EDS},
+			},
+		}
+		endpointItems[name] = envoy_types.ResourceWithTTL{
+			Resource: &envoy_endpoint.ClusterLoadAssignment{ClusterName: name},
+		}
+	}
+	snap.Resources[envoy_types.Cluster] = envoy_cache.Resources{Items: clusterItems}
+	snap.Resources[envoy_types.Endpoint] = envoy_cache.Resources{Items: endpointItems}
+
+	// Listeners with static (non-RDS) route configs so no Route resources are
+	// required for Consistent() to pass.
+	listenerItems := make(map[string]envoy_types.ResourceWithTTL, 5)
+	for i := range 5 {
+		lName := "listener-" + strconv.Itoa(i)
+		listenerItems[lName] = envoy_types.ResourceWithTTL{
+			Resource: &envoy_listener.Listener{Name: lName},
+		}
+	}
+	snap.Resources[envoy_types.Listener] = envoy_cache.Resources{Items: listenerItems}
+
+	return snap
+}
+
+func BenchmarkAutoVersion(b *testing.B) {
+	nodeId := "demo.benchmark"
+	snap := buildRealisticSnapshot()
+
+	// Populate an "old" snapshot with content hashes.
+	populated, _, err := autoVersion(nodeId, &envoy_cache.Snapshot{}, snap)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Each iteration mirrors the real hot path: generator allocates a new
+		// snapshot, autoVersion hashes it and compares to the cached version.
+		n := buildRealisticSnapshot()
+		if _, _, err := autoVersion(nodeId, populated, n); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReconcileUnchanged(b *testing.B) {
+	metrics, err := core_metrics.NewMetrics("Zone")
+	if err != nil {
+		b.Fatal(err)
+	}
+	statsCallbacks, err := util_xds.NewStatsCallbacks(metrics, "xds", util_xds.NoopVersionExtractor)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	xdsCtx := NewXdsContext()
+	r := &reconciler{
+		generator: snapshotGeneratorFunc(func(_ context.Context, ctx xds_context.Context, proxy *xds_model.Proxy) (*envoy_cache.Snapshot, error) {
+			return buildRealisticSnapshot(), nil
+		}),
+		cacher:         &simpleSnapshotCacher{xdsCtx.Hasher(), xdsCtx.Cache()},
+		statsCallbacks: statsCallbacks,
+	}
+
+	proxy := &xds_model.Proxy{
+		Id: *xds_model.BuildProxyId("demo", "benchmark"),
+		Dataplane: &core_mesh.DataplaneResource{
+			Meta: &test_model.ResourceMeta{Mesh: "demo", Name: "benchmark"},
+			Spec: &mesh_proto.Dataplane{},
+		},
+	}
+
+	// Populate cache so the benchmark measures the no-change steady-state path.
+	if _, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := r.Reconcile(context.Background(), xds_context.Context{}, proxy); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
## Motivation

`proto.Equal` in the xDS reconcile hot path performs a deep protobuf walk on every reconcile cycle for every resource, even when nothing changed. Under load this is measurable CPU overhead. Additionally, the previous `equalSnapshots`/`reuseVersion` design reused old version strings verbatim, which could silently suppress delivery when version strings collided across restarts.

Closes https://github.com/kumahq/kuma/issues/16187

## Implementation information

Replace `proto.Equal` with deterministic **xxhash content hashes** seeded by `nodeId+type+index`:

- Delete `equalSnapshots` and `reuseVersion`; rewrite `autoVersion` with an error return to propagate `MarshalResource` failures
- Add `resourcesVersion` (empty slot → `""`, non-empty → hex hash) and `mixVersions` helpers
- Fold the cluster hash into the endpoint version to preserve EDS warming semantics without `NewUUID`
- Fix empty-version leak in `ConfigReadyForDelivery`: empty slots produce version `""` via `resourcesVersion`; calling `ConfigReadyForDelivery("")` would leave a permanent entry in `configsQueue` because `OnStreamRequest` short-circuits on `VersionInfo==""`. Added symmetric guard matching the existing `clearUndeliveredConfigStats` guard

### Benchmarks

Measured on Apple M4 Max over a realistic 400-resource snapshot (100 clusters / endpoints / routes / listeners), snapshot built once outside the timed loop so the benchmark isolates the diff logic rather than snapshot construction:

```
                    time/op      B/op       allocs/op
proto.Equal (old)   4.4–6.8 ms   96 KB      2400
xxhash (new)        0.8–1.5 ms   247 KB     3990
```

Replacing `proto.Equal` cuts diff CPU roughly 4–6x. The hash path marshals each resource to compute its digest, so it trades higher allocations for the latency win.

Tests added:
- EDS-fold integration (`It`)
- Empty-slot version behaviour (`It`)
- `BenchmarkAutoVersion`
- `BenchmarkReconcileUnchanged`

> Changelog: perf(xds): replace proto.Equal with content hashes in reconcile
