### PR TITLE
test(e2e): weekly v3-readiness preflight capture

### DIFF
--- a/.github/actions/download-kuma3-preflight/action.yml
+++ b/.github/actions/download-kuma3-preflight/action.yml
@@ -1,0 +1,29 @@
+name: Download kuma3-preflight
+description: |
+  Download and checksum-verify the kuma3-preflight release binary (linux/amd64) from the
+  public GoReleaser release in github.com/Kong/kong-mesh-v3-readiness.
+inputs:
+  version:
+    description: kuma3-preflight release tag to download (e.g. v0.1.0).
+    required: true
+outputs:
+  bin:
+    description: Path to the extracted kuma3-preflight binary.
+    value: ${{ steps.download.outputs.bin }}
+runs:
+  using: composite
+  steps:
+    - id: download
+      shell: bash
+      env:
+        TOOL_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        base="https://github.com/Kong/kong-mesh-v3-readiness/releases/download/${TOOL_VERSION}"
+        asset="kuma3-preflight_linux_amd64.tar.gz"
+        mkdir -p "${RUNNER_TEMP}/bin"
+        curl -fsSL "${base}/${asset}" -o "${RUNNER_TEMP}/${asset}"
+        curl -fsSL "${base}/checksums.txt" -o "${RUNNER_TEMP}/checksums.txt"
+        ( cd "${RUNNER_TEMP}" && grep " ${asset}\$" checksums.txt | sha256sum -c - )
+        tar -xzf "${RUNNER_TEMP}/${asset}" -C "${RUNNER_TEMP}/bin" kuma3-preflight
+        echo "bin=${RUNNER_TEMP}/bin/kuma3-preflight" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-v3-readiness.yml
+++ b/.github/workflows/e2e-v3-readiness.yml
@@ -1,0 +1,135 @@
+# Weekly "Kuma 3.0 e2e readiness" report (also runnable on demand).
+#
+# Runs the e2e suites with the kuma3-preflight capture hook (an opt-in AfterEach that
+# audits the live CP after every spec — a no-op unless KUMA3_PREFLIGHT_BIN +
+# KUMA3_PREFLIGHT_DIR are set), then classifies the snapshots into a "what still uses
+# Kuma-3.0-removed features" report shown in the run's job summary.
+#
+# kuma3-preflight is downloaded (checksum-verified) from the public GoReleaser release
+# in github.com/Kong/kong-mesh-v3-readiness — not vendored.
+#
+# kong-mesh consumes this by COPY, not call: its tools/dev/sync_ci.sh syncs it to
+# `kuma-e2e-v3-readiness.yaml`, patching in a kuma checkout (its e2e make includes
+# $(KUMA_DIR)/mk/...) and Kong runners. Keep `runs-on: ubuntu-latest` literal so the
+# sync's use_custom_runners can swap it.
+
+name: E2E v3 readiness
+
+on:
+  schedule:
+    - cron: "0 1 * * 1" # weekly, Monday 01:00 UTC
+  workflow_dispatch: {} # on-demand
+
+permissions:
+  contents: read
+
+env:
+  # kuma3-preflight release to download; kept current by Renovate (see renovate.json).
+  # renovate[github-releases]: depName=Kong/kong-mesh-v3-readiness
+  TOOL_VERSION: v0.1.0
+
+jobs:
+  audit:
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [universal, kubernetes, multizone]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download kuma3-preflight (checksum-verified)
+        run: |
+          set -euo pipefail
+          base="https://github.com/Kong/kong-mesh-v3-readiness/releases/download/${TOOL_VERSION}"
+          asset="kuma3-preflight_linux_amd64.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL "${base}/${asset}" -o "${RUNNER_TEMP}/${asset}"
+          curl -fsSL "${base}/checksums.txt" -o "${RUNNER_TEMP}/checksums.txt"
+          ( cd "${RUNNER_TEMP}" && grep " ${asset}\$" checksums.txt | sha256sum -c - )
+          tar -xzf "${RUNNER_TEMP}/${asset}" -C "${RUNNER_TEMP}/bin" kuma3-preflight
+          {
+            echo "KUMA3_PREFLIGHT_BIN=${RUNNER_TEMP}/bin/kuma3-preflight"
+            echo "KUMA3_PREFLIGHT_DIR=${RUNNER_TEMP}/preflight-${{ matrix.env }}"
+          } >> "$GITHUB_ENV"
+
+      # Reuse the repo's own e2e action so the CP/image build matches normal CI exactly.
+      # It inherits KUMA3_PREFLIGHT_BIN/DIR from $GITHUB_ENV, so the hook captures per spec.
+      - name: Run e2e (${{ matrix.env }}) with capture
+        uses: ./.github/actions/run-e2e
+        with:
+          target: ${{ matrix.env }}
+          k8s_version: kind
+          cni_network_plugin: flannel
+          arch: amd64
+          parallel_runner_id: "0"
+
+      - name: Upload snapshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preflight-${{ matrix.env }}
+          path: ${{ runner.temp }}/preflight-${{ matrix.env }}/*.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  report:
+    needs: audit
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download kuma3-preflight (checksum-verified)
+        run: |
+          set -euo pipefail
+          base="https://github.com/Kong/kong-mesh-v3-readiness/releases/download/${TOOL_VERSION}"
+          asset="kuma3-preflight_linux_amd64.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -fsSL "${base}/${asset}" -o "${RUNNER_TEMP}/${asset}"
+          curl -fsSL "${base}/checksums.txt" -o "${RUNNER_TEMP}/checksums.txt"
+          ( cd "${RUNNER_TEMP}" && grep " ${asset}\$" checksums.txt | sha256sum -c - )
+          tar -xzf "${RUNNER_TEMP}/${asset}" -C "${RUNNER_TEMP}/bin" kuma3-preflight
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: preflight-*
+          path: ${{ runner.temp }}/snapshots
+
+      - name: Classify + write report to the job summary
+        run: |
+          set -euo pipefail
+          bin="${RUNNER_TEMP}/bin/kuma3-preflight"
+          mkdir -p report
+          echo "# Kuma 3.0 e2e readiness — $(date -u +%Y-%m-%d)" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          captured=0
+          for env in universal kubernetes multizone; do
+            dir="${RUNNER_TEMP}/snapshots/preflight-${env}"
+            src="test/e2e_env/${env}"
+            if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ] || [ ! -d "$src" ]; then
+              echo "- _${env}: no snapshots, skipped_" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            # One env's classify failure (e.g. a corrupt snapshot) must not sink the report.
+            if ! "$bin" --classify --source-dir "$src" --reports-dir "$dir" --format markdown --output "report/${env}.md"; then
+              echo "::warning::classify failed for ${env}"
+              continue
+            fi
+            captured=$((captured + 1))
+            "$bin" --classify --source-dir "$src" --reports-dir "$dir" --format json --output "report/${env}.json" || true
+            "$bin" --classify --source-dir "$src" --reports-dir "$dir" --format html --output "report/${env}.html" || true
+            { cat "report/${env}.md"; echo; } >> "$GITHUB_STEP_SUMMARY"
+          done
+          if [ "$captured" -eq 0 ]; then
+            echo "::error::no snapshots captured for any env (CP never came up, or the tool was not downloaded)"
+            exit 1
+          fi
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-readiness-report
+          path: report
+          retention-days: 90

--- a/.github/workflows/e2e-v3-readiness.yml
+++ b/.github/workflows/e2e-v3-readiness.yml
@@ -7,11 +7,6 @@
 #
 # kuma3-preflight is downloaded (checksum-verified) from the public GoReleaser release
 # in github.com/Kong/kong-mesh-v3-readiness — not vendored.
-#
-# kong-mesh consumes this by COPY, not call: its tools/dev/sync_ci.sh syncs it to
-# `kuma-e2e-v3-readiness.yaml`, patching in a kuma checkout (its e2e make includes
-# $(KUMA_DIR)/mk/...) and Kong runners. Keep `runs-on: ubuntu-latest` literal so the
-# sync's use_custom_runners can swap it.
 
 name: E2E v3 readiness
 
@@ -24,9 +19,9 @@ permissions:
   contents: read
 
 env:
-  # kuma3-preflight release to download; kept current by Renovate (see renovate.json).
-  # renovate[github-releases]: depName=Kong/kong-mesh-v3-readiness
-  TOOL_VERSION: v0.1.0
+  # kuma3-preflight release to download; kept current by Renovate.
+  # renovate: datasource=github-releases depName=Kong/kong-mesh-v3-readiness versioning=semver
+  TOOL_VERSION: "v0.1.0"
 
 jobs:
   audit:
@@ -39,17 +34,15 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download kuma3-preflight (checksum-verified)
+        id: preflight
+        uses: ./.github/actions/download-kuma3-preflight
+        with:
+          version: ${{ env.TOOL_VERSION }}
+
+      - name: Configure capture env
         run: |
-          set -euo pipefail
-          base="https://github.com/Kong/kong-mesh-v3-readiness/releases/download/${TOOL_VERSION}"
-          asset="kuma3-preflight_linux_amd64.tar.gz"
-          mkdir -p "${RUNNER_TEMP}/bin"
-          curl -fsSL "${base}/${asset}" -o "${RUNNER_TEMP}/${asset}"
-          curl -fsSL "${base}/checksums.txt" -o "${RUNNER_TEMP}/checksums.txt"
-          ( cd "${RUNNER_TEMP}" && grep " ${asset}\$" checksums.txt | sha256sum -c - )
-          tar -xzf "${RUNNER_TEMP}/${asset}" -C "${RUNNER_TEMP}/bin" kuma3-preflight
           {
-            echo "KUMA3_PREFLIGHT_BIN=${RUNNER_TEMP}/bin/kuma3-preflight"
+            echo "KUMA3_PREFLIGHT_BIN=${{ steps.preflight.outputs.bin }}"
             echo "KUMA3_PREFLIGHT_DIR=${RUNNER_TEMP}/preflight-${{ matrix.env }}"
           } >> "$GITHUB_ENV"
 
@@ -81,15 +74,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download kuma3-preflight (checksum-verified)
-        run: |
-          set -euo pipefail
-          base="https://github.com/Kong/kong-mesh-v3-readiness/releases/download/${TOOL_VERSION}"
-          asset="kuma3-preflight_linux_amd64.tar.gz"
-          mkdir -p "${RUNNER_TEMP}/bin"
-          curl -fsSL "${base}/${asset}" -o "${RUNNER_TEMP}/${asset}"
-          curl -fsSL "${base}/checksums.txt" -o "${RUNNER_TEMP}/checksums.txt"
-          ( cd "${RUNNER_TEMP}" && grep " ${asset}\$" checksums.txt | sha256sum -c - )
-          tar -xzf "${RUNNER_TEMP}/${asset}" -C "${RUNNER_TEMP}/bin" kuma3-preflight
+        id: preflight
+        uses: ./.github/actions/download-kuma3-preflight
+        with:
+          version: ${{ env.TOOL_VERSION }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -97,9 +85,11 @@ jobs:
           path: ${{ runner.temp }}/snapshots
 
       - name: Classify + write report to the job summary
+        env:
+          PREFLIGHT_BIN: ${{ steps.preflight.outputs.bin }}
         run: |
           set -euo pipefail
-          bin="${RUNNER_TEMP}/bin/kuma3-preflight"
+          bin="${PREFLIGHT_BIN}"
           mkdir -p report
           echo "# Kuma 3.0 e2e readiness — $(date -u +%Y-%m-%d)" >> "$GITHUB_STEP_SUMMARY"
           echo >> "$GITHUB_STEP_SUMMARY"

--- a/renovate.json
+++ b/renovate.json
@@ -64,20 +64,6 @@
     {
       "customType": "regex",
       "description": [
-        " Keep the kuma3-preflight release that the e2e v3-readiness nightly downloads",
-        " up to date. The hint sits above the version assignment, e.g.:",
-        " # renovate[github-releases]: depName=Kong/kong-mesh-v3-readiness"
-      ],
-      "managerFilePatterns": ["/^\\.github/workflows/e2e-v3-readiness\\.yml$/"],
-      "matchStrings": [
-        "# renovate\\[(?<datasource>[0-9a-z-]+)\\]: depName=(?<depName>\\S+)\\s+\\w+:\\s*(?<currentValue>\\S+)"
-      ],
-      "datasourceTemplate": "{{{datasource}}}",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": [
         " Parse version pins in Makefiles and .mk files using an inline Renovate hint placed above",
         " a VERSION-like variable assignment. The following line must assign a version variable,",
         " e.g.: 'OAPI_TOOL_VERSION ?= v1.1.7@sha256:…' or 'export FOO_VERSION := \"1.2.3\"'",

--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,20 @@
     {
       "customType": "regex",
       "description": [
+        " Keep the kuma3-preflight release that the e2e v3-readiness nightly downloads",
+        " up to date. The hint sits above the version assignment, e.g.:",
+        " # renovate[github-releases]: depName=Kong/kong-mesh-v3-readiness"
+      ],
+      "managerFilePatterns": ["/^\\.github/workflows/e2e-v3-readiness\\.yml$/"],
+      "matchStrings": [
+        "# renovate\\[(?<datasource>[0-9a-z-]+)\\]: depName=(?<depName>\\S+)\\s+\\w+:\\s*(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "{{{datasource}}}",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": [
         " Parse version pins in Makefiles and .mk files using an inline Renovate hint placed above",
         " a VERSION-like variable assignment. The following line must assign a version variable,",
         " e.g.: 'OAPI_TOOL_VERSION ?= v1.1.7@sha256:…' or 'export FOO_VERSION := \"1.2.3\"'",

--- a/test/e2e_env/kubernetes/kubernetes_suite_test.go
+++ b/test/e2e_env/kubernetes/kubernetes_suite_test.go
@@ -49,6 +49,11 @@ var (
 	_ = E2ESynchronizedBeforeSuite(kubernetes.SetupAndGetState, kubernetes.RestoreState)
 	_ = SynchronizedAfterSuite(func() {}, kubernetes.SynchronizedAfterSuite)
 	_ = ReportAfterSuite("kubernetes after suite", kubernetes.AfterSuite)
+	// Opt-in (KUMA3_PREFLIGHT_BIN + KUMA3_PREFLIGHT_DIR): snapshot the CP after each spec
+	// so kuma3-preflight can classify which tests use Kuma-3.0-removed features. No-op otherwise.
+	_ = AfterEach(func() {
+		CapturePreflightCluster(CurrentSpecReport().FullText(), kubernetes.Cluster)
+	})
 )
 
 var (

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -47,6 +47,11 @@ var (
 	_ = E2ESynchronizedBeforeSuite(multizone.SetupAndGetState, multizone.RestoreState)
 	_ = SynchronizedAfterSuite(func() {}, multizone.SynchronizedAfterSuite)
 	_ = ReportAfterSuite("multizone after suite", multizone.AfterSuite)
+	// Opt-in (KUMA3_PREFLIGHT_BIN + KUMA3_PREFLIGHT_DIR): snapshot the GLOBAL CP after each
+	// spec — one audit of the global covers every zone (resources sync over KDS). No-op otherwise.
+	_ = AfterEach(func() {
+		CapturePreflightCluster(CurrentSpecReport().FullText(), multizone.Global)
+	})
 )
 
 var (

--- a/test/e2e_env/universal/universal_suite_test.go
+++ b/test/e2e_env/universal/universal_suite_test.go
@@ -53,6 +53,13 @@ var (
 	_ = E2ESynchronizedBeforeSuite(universal.SetupAndGetState, universal.RestoreState)
 	_ = SynchronizedAfterSuite(func() {}, universal.SynchronizedAfterSuite)
 	_ = ReportAfterSuite("universal after suite", universal.AfterSuite)
+	// Opt-in (KUMA3_PREFLIGHT_BIN + KUMA3_PREFLIGHT_DIR): snapshot the shared CP after
+	// each spec so kuma3-preflight can classify which tests use Kuma-3.0-removed
+	// features. No-op otherwise. Snapshot filenames carry the parallel-process index,
+	// so concurrent processes sharing the output dir do not collide.
+	_ = AfterEach(func() {
+		CapturePreflightCluster(CurrentSpecReport().FullText(), universal.Cluster)
+	})
 )
 
 var (

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -64,6 +64,11 @@ type E2eConfig struct {
 	Debug                             bool              `json:"debug" envconfig:"KUMA_DEBUG"`
 	DumpDir                           string            `json:"dumpDir" envconfig:"KUMA_DUMP_DIR"`
 	DumpOnSuccess                     bool              `json:"dumpOnSuccess,omitempty" envconfig:"DUMP_ON_SUCCESS"`
+	// Kuma3Preflight* gate the opt-in kuma3-preflight capture hook (see
+	// test/framework/preflight.go). Bin+Dir empty == disabled, so a normal run is a no-op.
+	Kuma3PreflightBin     string        `json:"kuma3PreflightBin,omitempty" envconfig:"KUMA3_PREFLIGHT_BIN"`
+	Kuma3PreflightDir     string        `json:"kuma3PreflightDir,omitempty" envconfig:"KUMA3_PREFLIGHT_DIR"`
+	Kuma3PreflightTimeout time.Duration `json:"kuma3PreflightTimeout,omitempty" envconfig:"KUMA3_PREFLIGHT_TIMEOUT"`
 }
 
 func (c E2eConfig) SupportedVersions() []versions.Version {
@@ -248,6 +253,7 @@ var defaultConf = E2eConfig{
 	KumaExperimentalSidecarContainers: true,
 	DumpDir:                           path.Join("..", "..", "..", "build", "reports", "e2e-debug"),
 	DumpOnSuccess:                     false,
+	Kuma3PreflightTimeout:             45 * time.Second,
 }
 
 func Init(configModificationFunctions ...func(*E2eConfig)) {

--- a/test/framework/preflight.go
+++ b/test/framework/preflight.go
@@ -17,12 +17,14 @@ import (
 
 // This file wires the external `kuma3-preflight` tool into the e2e run so each spec
 // can be classified by the Kuma-3.0-deprecated features it exercises. It is inert
-// unless both KUMA3_PREFLIGHT_BIN (path to a built kuma3-preflight) and
-// KUMA3_PREFLIGHT_DIR (output directory) are set, so it adds nothing to a normal run.
+// unless both Kuma3PreflightBin (path to a built kuma3-preflight) and Kuma3PreflightDir
+// (output directory) are configured (env KUMA3_PREFLIGHT_BIN / KUMA3_PREFLIGHT_DIR),
+// so it adds nothing to a normal run.
 
-// captureTimeout hard-bounds a single capture so a wedged binary can never hang an
-// AfterEach. It is larger than the tool's own --timeout below, which is the normal stop.
-const captureTimeout = 60 * time.Second
+// captureTimeoutBuffer is added to the tool's own --timeout to derive the hard context
+// bound for a single capture: a wedged binary can never hang an AfterEach, yet the
+// context never fires before the tool's own graceful stop.
+const captureTimeoutBuffer = 15 * time.Second
 
 var preflightSeq atomic.Int64
 
@@ -31,7 +33,7 @@ var preflightSlugRe = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 // PreflightCaptureEnabled reports whether snapshot capture is configured. Callers
 // guard on it before resolving the CP address so a normal run does no extra work.
 func PreflightCaptureEnabled() bool {
-	return os.Getenv("KUMA3_PREFLIGHT_BIN") != "" && os.Getenv("KUMA3_PREFLIGHT_DIR") != ""
+	return Config != nil && Config.Kuma3PreflightBin != "" && Config.Kuma3PreflightDir != ""
 }
 
 // CapturePreflightCluster is the suite-facing entry point: it resolves the cluster's
@@ -68,13 +70,24 @@ func safeAPIServerAddress(c Cluster) string {
 	return c.GetKuma().GetAPIServerAddress()
 }
 
+// maxSlugLen bounds the human-readable slug embedded in a snapshot filename. Uniqueness
+// comes from the p%02d-%05d- counter prefix, not the slug, so this only affects
+// readability.
+const maxSlugLen = 100
+
 func preflightSlug(s string) string {
 	s = strings.ToLower(strings.Trim(preflightSlugRe.ReplaceAllString(s, "-"), "-"))
-	if len(s) > 80 {
-		s = s[:80]
-	}
 	if s == "" {
-		s = "spec"
+		return "spec"
+	}
+	if len(s) > maxSlugLen {
+		// FullText() prefixes every spec with its parent Describe/Context, so sibling
+		// specs share a long common head and differ only in the tail (e.g. the
+		// "-http"/"-tcp" variant). Keep both ends so the slug stays a useful identifier
+		// instead of collapsing siblings to the same head-only prefix.
+		head := maxSlugLen/2 - 1
+		tail := maxSlugLen - head - 1
+		s = strings.Trim(s[:head], "-") + "-" + strings.Trim(s[len(s)-tail:], "-")
 	}
 	return s
 }
@@ -87,11 +100,12 @@ func preflightSlug(s string) string {
 // capture problem is logged but never fails the test: exit 1 (blockers found) and exit
 // 3 (inconclusive) are expected outcomes and the report file is still written.
 func CapturePreflight(specName, addr string) {
-	bin := os.Getenv("KUMA3_PREFLIGHT_BIN")
-	dir := os.Getenv("KUMA3_PREFLIGHT_DIR")
-	if bin == "" || dir == "" {
+	if !PreflightCaptureEnabled() {
 		return
 	}
+	bin := Config.Kuma3PreflightBin
+	dir := Config.Kuma3PreflightDir
+	toolTimeout := Config.Kuma3PreflightTimeout
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		ginkgo.GinkgoWriter.Printf("preflight: mkdir %s: %v\n", dir, err)
 		return
@@ -100,9 +114,9 @@ func CapturePreflight(specName, addr string) {
 	name := fmt.Sprintf("p%02d-%05d-%s.json", ginkgo.GinkgoParallelProcess(), seq, preflightSlug(specName))
 	out := filepath.Join(dir, name)
 
-	ctx, cancel := context.WithTimeout(context.Background(), captureTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), toolTimeout+captureTimeoutBuffer)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, bin, "--address", addr, "--format", "json", "--output", out, "--timeout", "45s")
+	cmd := exec.CommandContext(ctx, bin, "--address", addr, "--format", "json", "--output", out, "--timeout", toolTimeout.String())
 	combined, err := cmd.CombinedOutput()
 	if err == nil {
 		return
@@ -114,5 +128,9 @@ func CapturePreflight(specName, addr string) {
 			return
 		}
 	}
+	// GinkgoWriter is only flushed on spec failure and capture never fails the spec, so
+	// also emit a GitHub Actions ::warning:: to stdout: that keeps a broken nightly's
+	// reason one click away instead of buried in passing-spec logs.
 	ginkgo.GinkgoWriter.Printf("preflight: capture failed for %q: %v\n%s\n", specName, err, combined)
+	fmt.Printf("::warning::preflight capture failed for %q: %v\n", specName, err)
 }

--- a/test/framework/preflight.go
+++ b/test/framework/preflight.go
@@ -1,0 +1,118 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+// This file wires the external `kuma3-preflight` tool into the e2e run so each spec
+// can be classified by the Kuma-3.0-deprecated features it exercises. It is inert
+// unless both KUMA3_PREFLIGHT_BIN (path to a built kuma3-preflight) and
+// KUMA3_PREFLIGHT_DIR (output directory) are set, so it adds nothing to a normal run.
+
+// captureTimeout hard-bounds a single capture so a wedged binary can never hang an
+// AfterEach. It is larger than the tool's own --timeout below, which is the normal stop.
+const captureTimeout = 60 * time.Second
+
+var preflightSeq atomic.Int64
+
+var preflightSlugRe = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// PreflightCaptureEnabled reports whether snapshot capture is configured. Callers
+// guard on it before resolving the CP address so a normal run does no extra work.
+func PreflightCaptureEnabled() bool {
+	return os.Getenv("KUMA3_PREFLIGHT_BIN") != "" && os.Getenv("KUMA3_PREFLIGHT_DIR") != ""
+}
+
+// CapturePreflightCluster is the suite-facing entry point: it resolves the cluster's
+// CP API address and captures a snapshot. It is a no-op unless PreflightCaptureEnabled(),
+// and it never lets a capture problem fail a test — resolving the address is guarded
+// (a K8s CP panics if its port-forward isn't up yet). For multizone, pass the global
+// cluster: one audit of the global covers every zone (resources sync over KDS).
+func CapturePreflightCluster(specName string, c Cluster) {
+	if !PreflightCaptureEnabled() {
+		return
+	}
+	addr := safeAPIServerAddress(c)
+	if addr == "" {
+		ginkgo.GinkgoWriter.Printf("preflight: no CP API address for %q, skipping\n", specName)
+		return
+	}
+	CapturePreflight(specName, addr)
+}
+
+// safeAPIServerAddress returns the cluster's CP API address. It recovers from a panic
+// (a K8s CP whose port-forward is not established panics in GetAPIServerAddress) and
+// returns "" so capture stays best-effort and never fails a test.
+func safeAPIServerAddress(c Cluster) string {
+	defer func() {
+		// Capture stays best-effort, but log the panic so a missing snapshot is
+		// diagnosable instead of vanishing silently.
+		if r := recover(); r != nil {
+			ginkgo.GinkgoWriter.Printf("preflight: recovered while resolving CP API address: %v\n", r)
+		}
+	}()
+	if c == nil {
+		return ""
+	}
+	return c.GetKuma().GetAPIServerAddress()
+}
+
+func preflightSlug(s string) string {
+	s = strings.ToLower(strings.Trim(preflightSlugRe.ReplaceAllString(s, "-"), "-"))
+	if len(s) > 80 {
+		s = s[:80]
+	}
+	if s == "" {
+		s = "spec"
+	}
+	return s
+}
+
+// CapturePreflight runs kuma3-preflight against the control plane at addr and writes a
+// JSON snapshot. The filename carries the Ginkgo parallel-process index and a
+// per-process sequence number, so concurrent processes sharing one output directory
+// never collide (the classifier attributes by resource/mesh name, not file order, so
+// ordering is not relied upon). It is a no-op unless PreflightCaptureEnabled(). A
+// capture problem is logged but never fails the test: exit 1 (blockers found) and exit
+// 3 (inconclusive) are expected outcomes and the report file is still written.
+func CapturePreflight(specName, addr string) {
+	bin := os.Getenv("KUMA3_PREFLIGHT_BIN")
+	dir := os.Getenv("KUMA3_PREFLIGHT_DIR")
+	if bin == "" || dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		ginkgo.GinkgoWriter.Printf("preflight: mkdir %s: %v\n", dir, err)
+		return
+	}
+	seq := preflightSeq.Add(1)
+	name := fmt.Sprintf("p%02d-%05d-%s.json", ginkgo.GinkgoParallelProcess(), seq, preflightSlug(specName))
+	out := filepath.Join(dir, name)
+
+	ctx, cancel := context.WithTimeout(context.Background(), captureTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "--address", addr, "--format", "json", "--output", out, "--timeout", "45s")
+	combined, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		switch ee.ExitCode() {
+		case 1, 3: // blockers / inconclusive: expected, snapshot still written
+			return
+		}
+	}
+	ginkgo.GinkgoWriter.Printf("preflight: capture failed for %q: %v\n%s\n", specName, err, combined)
+}


### PR DESCRIPTION
## Motivation

Kuma 3.0 removes many resources, Mesh/Dataplane fields and CP settings the e2e suites
still exercise. We want a weekly that shows, per environment, which tests still use
removed features and how that burns down over time — without adding any load to PR /
regular e2e CI.

> Changelog: skip

## Implementation information

- `test/framework/preflight.go` — opt-in `CapturePreflightCluster` (env-gated by
  `KUMA3_PREFLIGHT_BIN` / `KUMA3_PREFLIGHT_DIR`), wired as a top-level `AfterEach` in the
  three suite bootstraps. **No-op on PR / regular runs**; multizone captures the global
  CP. Each capture runs under a hard `context` timeout, and snapshot filenames carry the
  Ginkgo parallel-process index so concurrent processes never collide.
- `.github/workflows/e2e-v3-readiness.yml` — reusable (`workflow_call`) + weekly
  (`schedule`). Reuses the repo's `run-e2e` action to build images and run
  `make test/e2e-<env>` with capture, then classifies the snapshots into a job-summary +
  artifact report (and **fails if nothing was captured**, so a broken weekly goes red).
- The kuma3-preflight tool is **not vendored**: the jobs download a checksum-verified
  **GoReleaser** release binary from `Kong/kong-mesh-v3-readiness`. The pinned
  `tool_version` is kept current by a **Renovate** custom manager (`renovate.json`).
- kong-mesh reuses this workflow via `uses:` (it `include`s `mk/e2e.new.mk`, so the same
  `make test/e2e-<env>` targets exist there).

Collection is **weekly-only**: the existing `run-e2e` action and `_test.yaml` are
untouched, and the hook is inert unless the weekly sets the two env vars.

Draft until: `Kong/kong-mesh-v3-readiness` publishes a `v0.1.0` release the download
targets (and its releases are reachable from CI), plus a first green weekly on a
large/self-hosted runner.

## Supporting documentation

Drives the e2e v3 rework umbrella kumahq/kuma#17001.

