### PR TITLE
docs(MADR): rethink releasing pipeline

### DIFF
--- a/docs/madr/decisions/104-rethink-releasing-pipeline.md
+++ b/docs/madr/decisions/104-rethink-releasing-pipeline.md
@@ -9,7 +9,7 @@ Technical Story: https://github.com/kumahq/kuma/issues/16973
 Pushing a `vX.Y.Z` tag runs the full `build-test-distribute.yaml`, including the
 entire e2e suite, before any artifact ships. Recent tag runs: v2.13.8 218m,
 v2.14.0 124m, v2.12.12 119m, v2.11.16 102m (~2–3.5h), on top of the manual steps in
-`.claude/rules/release.md`.
+the team-mesh release issues.
 
 On a tag push (`FULL_MATRIX=true`):
 
@@ -18,7 +18,8 @@ On a tag push (`FULL_MATRIX=true`):
   multizone / gatewayapi × versions × amd64/arm64 × CNI × IPv6) at `max-parallel: 5`,
   ~25–35m each. This is the long pole.
 - `build_publish` is `needs: [check, test]`, so it waits for the whole matrix;
-  the build itself is cheap (binaries ~13m, images ~6–8m parallel).
+  the build itself is cheap (binaries ~13m, independently reducible via build
+  caching; images ~6–8m parallel).
 - `provenance` (tags only) plus `distributions`.
 
 The core inefficiency: the tag is HEAD of `release-X.Y`, which already ran the full
@@ -27,11 +28,13 @@ we re-run ~90–150m of e2e and gate all publishing behind it. Secondary problem
 the flakiest CI stage, so a flake can fail an otherwise-good release.
 
 One constraint shapes the options. The version is ldflags-injected from the git tag
-(`version.sh`, `mk/build.mk`), so release-branch artifacts (`2.14.1-<hash>`) cannot be
-byte-promoted to GA (`2.14.0`). Any fix either rebuilds on the tag or changes how the
-version is derived.
+(`version.sh`, `mk/build.mk`): a build on `release-2.14` is stamped as the next-patch
+preview (`X.Y.Z-preview.<hash>`), not the version its GA tag carries (`X.Y.Z`), so
+branch artifacts cannot be byte-promoted to GA. Any fix either rebuilds on the tag or
+changes how the version is derived.
 
-Goals: tag-to-artifacts well under an hour; no weaker supply-chain
+Goals: the tag re-runs no step already validated on the green release-branch SHA
+(build and publish only, not re-test); no weaker supply-chain
 (SBOM/provenance/signing/scan); fewer release failures from flakes or operator error.
 Non-goals: changing cadence/branching/tag format; adopting external infra (Prow/GCB).
 
@@ -58,8 +61,11 @@ on GitHub Actions, the closest templates for us.
 
 ### Option 1 — Skip e2e on the tag; gate on the branch (recommended)
 
-- No e2e (and no e2e smoke) on the tag. Keep `test_unit` and container-structure
-  tests, which are fast and validate the artifact. Drop the ~90–150m matrix.
+- No re-test on the tag: drop unit and e2e. The source is identical to the green
+  branch SHA, so re-running them adds nothing. Verify only what the tag build *changes*
+  versus that SHA — the ldflags version. That is covered by the container-structure
+  tests on the freshly-built image (already in `_build_publish.yaml`) plus an assert
+  that the built binary reports the tag version.
 - Build and publish without the e2e gate, so the build starts right after the gate.
 - Hard-enforce a green tagged SHA. The first job asserts the commit has a passing
   `build-test-distribute` run on its branch (`gh api` check-runs), else it fails.
@@ -102,21 +108,23 @@ Today the release path lives in `build-test-distribute.yaml` via scattered
 - A, more conditionals in the shared workflow. (+) smallest diff. (−) more
   tag-vs-PR branching in an already-conditional workflow; release stays hard to read;
   shared concurrency/permissions.
-- B, a dedicated `release-publish.yaml` (`tags: ["v*"]`) reusing
+- B, a dedicated `release-publish.yaml` triggered on release tags, reusing
   `_build_publish.yaml` and `_provenance.yaml`, never `_test.yaml`; drop the tag trigger
   from `build-test-distribute.yaml`; `release.yaml` keeps changelog/version
-  bookkeeping. (+) linear readable release flow; own concurrency/permissions; no
-  duplicated build logic; matches the Envoy/Cilium/Argo pattern; natural host for the
-  rehearsal and a future RC. (−) new file plus a one-time trigger migration.
+  bookkeeping. The tag filter must match `v?X.Y.Z`, not just `v*`: older branches like
+  `release-2.9` ship *unprefixed* `2.9.x` tags. (+) linear readable release flow; own
+  concurrency/permissions; no duplicated build logic; matches the Envoy/Cilium/Argo
+  pattern; natural host for the rehearsal and a future RC. (−) new file plus a one-time
+  trigger migration.
 
 Picked B.
 
 ### Release rehearsal (scheduled dry-run)
 
 Moving the gate off the tag introduces a risk: the release machinery breaks and we find
-out only at release time. A scheduled rehearsal de-risks it. Checking the
-Makefiles, `version.sh`, `helm.sh`, the workflows, and the tool docs shows this is mostly
-config, not new tooling:
+out only at release time. A scheduled rehearsal de-risks it. The
+Makefiles, `version.sh`, `helm.sh`, the workflows, and the tool docs confirm this is
+mostly config, not new tooling:
 
 - Already runs on every master and `release-X.Y` push: `version.sh` stamps a
   `-preview.v<hash>` version that auto-routes to `notary-internal` and preview
@@ -161,7 +169,9 @@ Option 1 ships now, with Options 2 and 3 as follow-up.
 - Dropping the redundant e2e removes the flakiest release gate.
 - Residual risk: the branch run goes stale against the tag. The exact green-SHA gate,
   RC soak, or a one-off branch matrix before tagging mitigate this.
-- `test_unit` and container-structure tests act as a fast tag tripwire.
+- Container-structure on the freshly-built image plus a binary-version assert are the
+  only tag-specific checks; they verify exactly what the tag build changes (the
+  ldflags), nothing the green branch run already covered.
 - The rehearsal continuously validates build, publish, and sign (plus provenance and
   helm once the gates loosen). Only the real GitHub Release and prod routing stay
   tag-only.
@@ -180,7 +190,8 @@ Adopt Option 1, as a dedicated release workflow plus a scheduled rehearsal:
 - A dedicated `release-publish.yaml` reusing `_build_publish.yaml` and
   `_provenance.yaml`, never `_test.yaml`; drop the tag trigger from
   `build-test-distribute.yaml`.
-- No e2e or smoke on the tag; keep `test_unit` and container-structure tests.
+- No re-test on the tag: drop unit and e2e; keep container-structure on the
+  freshly-built image plus a binary-version assert (the ldflags delta).
 - Hard-enforce a green tagged SHA.
 - A scheduled rehearsal of build, publish, sign, SBOM, scan, and provenance (loosen
   the tag-only `if`s, keep the preview/internal targets); route the helm release to a
@@ -192,7 +203,9 @@ decoupling is undecided.
 
 ## Notes
 
-Resolved: no smoke e2e on the tag; the green-SHA gate is hard-enforced; RC tags deferred.
+Resolved: no re-test on the tag (drop unit and e2e; keep only container-structure plus
+a binary-version assert, the ldflags delta); the green-SHA gate is hard-enforced; RC
+tags deferred.
 
 Open: version decoupling (undecided; rebuild-on-tag is fine for Option 1); the exact
 green-SHA mechanism and rehearsal cadence/scope (impl detail); provisioning a test

--- a/docs/madr/decisions/104-rethink-releasing-pipeline.md
+++ b/docs/madr/decisions/104-rethink-releasing-pipeline.md
@@ -63,19 +63,23 @@ on GitHub Actions, the closest templates for us.
 
 - No re-test on the tag: drop unit and e2e. The source is identical to the green
   branch SHA, so re-running them adds nothing. Verify only what the tag build *changes*
-  versus that SHA — the ldflags version. That is covered by the container-structure
-  tests on the freshly-built image (already in `_build_publish.yaml`) plus an assert
-  that the built binary reports the tag version.
-- Build and publish without the e2e gate, so the build starts right after the gate.
-- Hard-enforce a green tagged SHA. The first job asserts the commit has a passing
-  `build-test-distribute` run on its branch (`gh api` check-runs), else it fails.
+  versus that SHA, the ldflags version, via the container-structure tests on the
+  freshly-built image (already in `_build_publish.yaml`) plus an assert that the built
+  binary reports the tag version.
+- `check`'s lint/`make check`/SBOM is redundant for the same reason; only its metadata
+  outputs (`IMAGES`/`REGISTRY`/`VERSION_NAME`) are needed downstream, so keep those.
+- With e2e skipped, `test` completes immediately and `build_publish` publishes right
+  away instead of waiting ~90m.
+- Hard-enforce a green tagged SHA: the tagged commit must have a passing
+  `build-test-distribute` run (full matrix) on its branch, else the release fails. This
+  reuses the existing run, not new machinery.
 
-After this, green-SHA gate ~1m, `build_publish` ~15m, plus provenance/distributions,
-lands at roughly 20–30m versus the current 100–220m.
+After this, `build_publish` ~15m plus provenance/distributions lands at roughly 20–30m
+versus the current 100–220m.
 
 - (+) Answers the issue; no new infra, staging, or version change; removes the flakiest stage.
-- (−) Loses the exact-tag re-test (mitigated by the hard green-SHA gate, RC soak, and
-  rehearsal); still rebuilds on the tag (~15m, fine).
+- (−) Loses the exact-tag re-test (mitigated by the hard green-SHA gate and, for risky
+  releases, RC soak); still rebuilds on the tag (~15m, fine).
 
 ### Option 2 — RC + promotion by digest (build once, ship the tested bits)
 
@@ -100,60 +104,55 @@ one tool (extend `release-tool`), like Envoy and `cmrel`.
 
 Keep re-testing on the tag. This is the problem itself, and the lone outlier among peers.
 
-### Implementation: dedicated release workflow vs. conditionals (orthogonal to Options 1–4)
+### Implementation: reuse the existing skip mechanism vs. a dedicated workflow
 
-Today the release path lives in `build-test-distribute.yaml` via scattered
-`ref_type=='tag'` / `FULL_MATRIX` / `ALLOW_PUSH` conditionals.
+Orthogonal to Options 1–4: how to wire the tag pipeline. Today the release path lives in
+`build-test-distribute.yaml`, which runs on every PR, master, and release-branch push,
+so it builds and publishes a preview on every push.
 
-- A, more conditionals in the shared workflow. (+) smallest diff. (−) more
-  tag-vs-PR branching in an already-conditional workflow; release stays hard to read;
-  shared concurrency/permissions.
-- B, a dedicated `release-publish.yaml` triggered on release tags, reusing
-  `_build_publish.yaml` and `_provenance.yaml`, never `_test.yaml`; drop the tag trigger
-  from `build-test-distribute.yaml`; `release.yaml` keeps changelog/version
-  bookkeeping. The tag filter must match `v?X.Y.Z`, not just `v*`: older branches like
-  `release-2.9` ship *unprefixed* `2.9.x` tags. (+) linear readable release flow; own
-  concurrency/permissions; no duplicated build logic; matches the Envoy/Cilium/Argo
-  pattern; natural host for the rehearsal and a future RC. (−) new file plus a one-time
+- A, stay in the monolith and reuse the existing `ci/skip-test` mechanism. Tags don't
+  skip today: `_test.yaml` keys the skip off PR labels
+  (`github.event.pull_request.labels`), which are empty on a tag push, so the full matrix
+  runs. Add `github.ref_type == 'tag'` next to that condition and e2e/unit skip on the
+  tag; the existing `needs:` chain then lets `build_publish` proceed. (+) roughly a
+  one-condition change, no new workflow; the publish path stays exercised on every push,
+  so it cannot rot between releases. (−) the monolith keeps its tag-vs-PR conditionals.
+- B, a dedicated `release-publish.yaml` on tags, reusing `_build_publish.yaml` and
+  `_provenance.yaml`, never `_test.yaml`. (+) a linear, readable release flow. (−) it
+  runs only on tags, so the publish path is no longer exercised between releases and can
+  break unnoticed (the predictability the monolith gives for free); plus a new file and
   trigger migration.
 
-Picked B.
+Picked A. The monolith already publishes on every push, the strongest guard that the
+release machinery works, and reusing `ci/skip-test` keeps the change tiny. (An earlier
+draft picked B with a scheduled rehearsal to re-create that exercise; maintainer review
+pointed out the monolith already provides it, making both the dedicated workflow and the
+rehearsal unnecessary.)
 
-### Release rehearsal (scheduled dry-run)
+### The publish path is already exercised continuously (no separate rehearsal)
 
-Moving the gate off the tag introduces a risk: the release machinery breaks and we find
-out only at release time. A scheduled rehearsal de-risks it. The
-Makefiles, `version.sh`, `helm.sh`, the workflows, and the tool docs confirm this is
-mostly config, not new tooling:
+Moving the gate off the tag raises a question: does the release machinery still get
+exercised? It does, for free. `build-test-distribute.yaml` runs on every master and
+`release-X.Y` push with `ALLOW_PUSH=true`, so every push already builds, pushes, signs,
+and pulps a `-preview.<hash>` artifact through the same `_build_publish.yaml` the release
+uses (`version.sh` auto-routes preview versions to `notary-internal` and the preview
+Cloudsmith repo). That continuous run is the rehearsal; a separate scheduled one would be
+redundant machinery.
 
-- Already runs on every master and `release-X.Y` push: `version.sh` stamps a
-  `-preview.v<hash>` version that auto-routes to `notary-internal` and preview
-  Cloudsmith, and `ALLOW_PUSH=true` triggers a real build, push, sign, and pulp plus a
-  helm *package* via `_build_publish.yaml`. The rehearsal just decouples this from e2e
-  and schedules it.
-- Provenance: SLSA generators v2.1.0 support `schedule`, `push`, and `workflow_dispatch`
-  (not `pull_request`); the generic one still emits `.intoto.jsonl` when
-  `upload-assets=false` (already wired as `upload-assets: ref_type=='tag'`); containers
-  push to an alt repo. So we loosen the job `if`, no new mode.
-- Sign, SBOM, and scan (Kong actions): `signature_registry` is free-form (already
-  `notary-internal`), OIDC signing is keyless (no tag needed), and
-  `upload-sbom-release-assets` defaults to false. Already off-tag ready.
-- Helm release (`cr` 1.8.1): `cr upload` and `cr index` target any owner/repo via flags
-  (`helm.sh` routes `GH_OWNER`/`GH_REPO`). Point them at a throwaway test charts repo
-  (plus a token).
-
-Excluded by design: a real GitHub Release on `kumahq/kuma`, and prod
-registry/notary/Cloudsmith. Caveats: run on `schedule` or `workflow_dispatch`, and
-provision a test charts repo. This follows the nightly-build pattern (Istio, Knative,
-k8s `krel stage`, `cmrel --mock`). It complements the existing `release.yaml` daily
-`--check`, which verifies the *last* release's prod artifacts.
+The only steps not exercised between releases are the tag-gated ones: SLSA provenance
+upload, the helm chart release to `kumahq/charts`, and the GitHub Release. They are first
+exercised at release time. If that risk ever bites, revisit it with Option 2 rather than
+standing up separate rehearsal machinery.
 
 ### Evolution
 
 This started from the issue's "skip the full suite on the tag." Peer research confirmed
-it is the industry norm; only Linkerd re-tests. The bigger wins, digest promotion and
-the stage/publish split, depend on a version rework and an RC process Kuma lacks. So
-Option 1 ships now, with Options 2 and 3 as follow-up.
+it is the industry norm; only Linkerd re-tests. An early draft added a dedicated
+`release-publish.yaml` plus a scheduled rehearsal; maintainer review showed the monolith
+already publishes a preview on every push, so reusing the existing `ci/skip-test`
+mechanism is enough and the extra machinery was dropped. The bigger wins, digest
+promotion and the stage/publish split, depend on a version rework and an RC process Kuma
+lacks. So Option 1 ships now, with Options 2 and 3 as follow-up.
 
 ## Security implications and review
 
@@ -172,9 +171,10 @@ Option 1 ships now, with Options 2 and 3 as follow-up.
 - Container-structure on the freshly-built image plus a binary-version assert are the
   only tag-specific checks; they verify exactly what the tag build changes (the
   ldflags), nothing the green branch run already covered.
-- The rehearsal continuously validates build, publish, and sign (plus provenance and
-  helm once the gates loosen). Only the real GitHub Release and prod routing stay
-  tag-only.
+- Every push already builds and publishes a preview through the release's own
+  `_build_publish.yaml`, so the publish/sign path is validated continuously; only the
+  tag-gated steps (provenance upload, helm release, GitHub Release) are first exercised
+  at release time.
 
 ## Implications for Kong Mesh
 
@@ -185,36 +185,34 @@ Option 1 ships now, with Options 2 and 3 as follow-up.
 
 ## Decision
 
-Adopt Option 1, as a dedicated release workflow plus a scheduled rehearsal:
+Adopt Option 1, implemented in the existing `build-test-distribute.yaml`. No new
+workflow, no scheduled rehearsal:
 
-- A dedicated `release-publish.yaml` reusing `_build_publish.yaml` and
-  `_provenance.yaml`, never `_test.yaml`; drop the tag trigger from
-  `build-test-distribute.yaml`.
-- No re-test on the tag: drop unit and e2e; keep container-structure on the
-  freshly-built image plus a binary-version assert (the ldflags delta).
-- Hard-enforce a green tagged SHA.
-- A scheduled rehearsal of build, publish, sign, SBOM, scan, and provenance (loosen
-  the tag-only `if`s, keep the preview/internal targets); route the helm release to a
-  test charts repo; run on `schedule` or `workflow_dispatch`.
+- Skip e2e and unit on the tag by extending the existing `ci/skip-test` condition with
+  `github.ref_type == 'tag'`; the existing `needs:` chain then lets `build_publish`
+  publish immediately.
+- Verify only the ldflags delta: container-structure on the freshly-built image plus a
+  binary-version assert. Keep `check`'s metadata computation, skip its redundant
+  validation.
+- Hard-enforce a green tagged SHA, reusing the commit's existing branch run.
+- No separate rehearsal: every push already builds and publishes a preview through the
+  same `_build_publish.yaml`.
 
-This cuts ~100–220m down to ~20–30m with no new infra. Options 2 (RC plus digest
-promotion) and 3 (stage/publish split) are follow-up; RC is deferred; version
-decoupling is undecided.
+This cuts ~100–220m to ~20–30m with roughly a one-condition change. Options 2 (RC plus
+digest promotion, the KEG/k8s model) and 3 (stage/publish split) are follow-up; RC is
+deferred; version decoupling is undecided.
 
 ## Notes
 
-Resolved: no re-test on the tag (drop unit and e2e; keep only container-structure plus
-a binary-version assert, the ldflags delta); the green-SHA gate is hard-enforced; RC
-tags deferred.
+Resolved: no re-test on the tag (drop unit and e2e; keep only container-structure plus a
+binary-version assert, the ldflags delta); implement via the existing `ci/skip-test`
+mechanism in the monolith, not a new workflow; no separate rehearsal (per-push preview
+builds already exercise publish); the green-SHA gate is hard-enforced; RC tags deferred.
 
 Open: version decoupling (undecided; rebuild-on-tag is fine for Option 1); the exact
-green-SHA mechanism and rehearsal cadence/scope (impl detail); provisioning a test
-charts repo and token for the helm rehearsal leg.
+green-SHA enforcement mechanism (impl detail).
 
 Sources. Peer projects: Kubernetes (sig-release handbook, promo-tools), Istio (release-builder,
 daily-release), Envoy (RELEASES.md, `_publish_build.yml`), Cilium
 (`build-images-releases.yaml`), cert-manager (`cmrel`), Knative (`hack/release.sh`),
-Argo CD (`release.yaml`), Linkerd (`release.yml`). Tools: slsa-github-generator
-generic+container READMEs; helm/chart-releaser `cr` flags; Kong/public-shared-actions
-security-actions (`upload-sbom-release-assets` default false, free-form
-`signature_registry`).
+Argo CD (`release.yaml`), Linkerd (`release.yml`).

--- a/docs/madr/decisions/104-rethink-releasing-pipeline.md
+++ b/docs/madr/decisions/104-rethink-releasing-pipeline.md
@@ -72,9 +72,9 @@ on GitHub Actions, the closest templates for us.
   away instead of waiting ~90m.
 
 - Hard-enforce a green tagged SHA: a guard job on the tag fails the release unless the
-  tagged commit already has a trustworthy full-matrix `build-test-distribute` run on its
-  branch (mechanism in "Enforcing the green tagged SHA"). This reads an existing run, not
-  new test machinery.
+  tagged commit already has a trustworthy full-matrix `build-test-distribute` push run on
+  its branch that both tested green and published its preview (mechanism in "Enforcing the
+  green tagged SHA"). This reads an existing run, not new test machinery.
 
 After this, `build_publish` ~15m plus provenance/distributions lands at roughly 20–30m
 versus the current 100–220m.
@@ -140,9 +140,10 @@ skip to the tagged commit being green, so by itself it would happily ship an unt
 A guard job runs first on the tag and gates the rest of the pipeline on a verified-green
 SHA. There are two ways to react to a missing green run:
 
-- Fail-hard (chosen): if the tagged SHA has no trustworthy green run, the tag fails
-  immediately, before anything builds. The releaser greens the branch (or
-  `workflow_dispatch` a full run on that SHA) and re-tags.
+- Fail-hard (chosen): if the tagged SHA has no trustworthy green *and published* run, the
+  tag fails immediately, before anything builds. The releaser re-runs the branch's push CI
+  (a re-run keeps `event == push`, so it re-tests *and* re-publishes the preview) and
+  re-tags.
 
 - Re-run-on-tag (rejected): fall back to running unit and e2e on the tag when no green run
   is found. Rejected because it re-introduces the flaky ~90–150m e2e this MADR removes,
@@ -150,26 +151,33 @@ SHA. There are two ways to react to a missing green run:
   tag-run flake can fail the release, the secondary problem the MADR set out to fix. It is
   also the lone-outlier (Linkerd) model we are moving away from.
 
-We pick fail-hard: the premise is that the branch SHA is already fully tested, so the gate
-must *enforce* that invariant, not silently re-test when it is absent. The failure surfaces
-in seconds and is actionable, and because `workflow_dispatch` also runs the full matrix,
-recovery is "dispatch a run on the SHA, then tag."
+We pick fail-hard: the premise is that the branch SHA is already fully tested *and has
+already published a preview*, so the gate must *enforce* both invariants, not silently
+re-test when they are absent. The failure surfaces in seconds and is actionable, and
+because a branch push both runs the full matrix and publishes, recovery is "re-run the
+branch's push CI on the SHA, then tag."
 
-Picking the run is the fiddly part (a SHA can have several runs, and older `pull_request`
-runs may have skipped e2e), so the lookup is explicit:
+Picking the run is the fiddly part (a SHA can have several runs, and only some both tested
+*and* published), so the lookup is explicit:
 
 - List `build-test-distribute.yaml` runs for the tagged SHA (`head_sha`), completed, with
-  `event` in {`push`, `workflow_dispatch`}; both force `FULL_MATRIX=true` and carry no PR
-  labels, so e2e always ran. This excludes `pull_request` runs, the only ones that can set
-  `SKIP_E2E_TESTS` or reduce the matrix.
+  `event == push`. A push forces `FULL_MATRIX=true` (so e2e always ran) and is the only
+  event that sets `ALLOW_PUSH=true` (so it also released a `-preview.<hash>` artifact). This
+  excludes `pull_request` runs (which can set `SKIP_E2E_TESTS` or reduce the matrix) *and*
+  `workflow_dispatch` runs (which run the full matrix but leave `ALLOW_PUSH=false`, so they
+  build without publishing anything — passing the old test-only gate while shipping no
+  artifact).
 
 - Keep `conclusion == success` and take the most recent.
 
-- Guard against an emptied matrix: fetch that run's jobs and require `test_unit` and the
-  `test_e2e*` jobs to be present and successful. A skipped-e2e run still reports overall
-  success but has no e2e jobs, so presence is the real check.
+- Guard against an emptied matrix *and a build-only run*: fetch that run's jobs and require
+  the tested jobs (`test_unit`, `test_e2e*`) plus the publish jobs — `digest-images` (the
+  `ALLOW_PUSH` sentinel, absent on any non-publishing run), `build-binaries`, `build-images`,
+  and `publish-helm` — to be present and successful. A skipped-e2e run reports overall
+  success but has no e2e jobs, and a non-publishing run has no `digest-images` job, so
+  presence is the real check.
 
-- No match ⇒ fail the tag, with a message pointing at branch CI / `workflow_dispatch`.
+- No match ⇒ fail the tag, with a message pointing at the branch push CI.
 
 ### The publish path is already exercised continuously (no separate rehearsal)
 
@@ -180,6 +188,11 @@ and publishes a `-preview.<hash>` artifact through the same `_build_publish.yaml
 uses (`version.sh` auto-routes preview versions to `notary-internal` and the preview
 Cloudsmith repo). That continuous run is the rehearsal; a separate scheduled one would be
 redundant machinery.
+
+The green-SHA gate turns this from an assumption into an enforced precondition: it accepts
+only a `push` run for the tagged SHA — i.e. one that actually published that SHA's preview —
+so the tag never ships a tree whose build-and-publish path has not already run green. A
+SHA greened only by `workflow_dispatch` (full matrix, but `ALLOW_PUSH=false`) is rejected.
 
 The only steps not exercised between releases are the tag-gated ones: SLSA provenance
 upload, the helm chart release to `kumahq/charts`, and the GitHub Release. They are first
@@ -200,7 +213,9 @@ lacks. So Option 1 ships now, with Options 2 and 3 as follow-up.
 
 - e2e is not a security control; SBOM, provenance, signing, and scan live in
   `build_publish` and `provenance`, which Option 1 leaves unchanged.
-- New risk: tagging a never-green commit, mitigated by the hard green-SHA gate.
+- New risk: tagging a never-green or never-published commit, mitigated by the hard green-SHA
+  gate, which requires a green push run that already tested and signed/published a preview
+  for the SHA.
 - Container-structure tests stay, so artifact regressions are still caught on the tag.
 - Option 2 *strengthens* security, since the scanned and signed bits are the shipped bits.
 
@@ -210,6 +225,9 @@ lacks. So Option 1 ships now, with Options 2 and 3 as follow-up.
 - Dropping the redundant e2e removes the flakiest release gate.
 - Residual risk: the branch run goes stale against the tag. The hard (fail-hard) green-SHA
   gate mitigates this today; RC soak would add to it once Option 2 lands.
+- Requiring a *published* push run for the SHA also rejects a tree that tested green but
+  never published (e.g. greened only via `workflow_dispatch`), so the tag's build-and-publish
+  never runs cold at release time.
 
 - Container-structure on the freshly-built image plus a binary-version assert are the
   only tag-specific checks; they verify exactly what the tag build changes (the
@@ -240,8 +258,9 @@ workflow, no scheduled rehearsal:
   binary-version assert. Keep `check`'s metadata computation, skip its redundant
   validation.
 
-- Hard-enforce a green tagged SHA via a guard job that fails the tag unless the commit has
-  a green full-matrix run (fail-hard; see "Enforcing the green tagged SHA").
+- Hard-enforce a green, already-published tagged SHA via a guard job that fails the tag
+  unless the commit has a green full-matrix `push` run that also released its preview
+  (fail-hard; see "Enforcing the green tagged SHA").
 
 - No separate rehearsal: every push already builds and publishes a preview through the
   same `_build_publish.yaml`.
@@ -259,7 +278,9 @@ binary-version assert, the ldflags delta); implement by extending the two skip g
 (`_test.yaml:21` and `:82`) in the monolith, not a new workflow (the `ci/skip-test` label
 never fires on a tag, so this is a `ref_type=='tag'` clause, not the label); no separate
 rehearsal (per-push preview builds already exercise publish); the green-SHA gate is
-hard-enforced (fail-hard, not re-run-on-tag); RC tags deferred; version decoupling is out
+hard-enforced (fail-hard, not re-run-on-tag) and requires a green *push* run that also
+published a preview for the SHA, not merely a green test run; RC tags deferred; version
+decoupling is out
 of scope for Option 1 (rebuild-on-tag stamps the version) and belongs to Option 2.
 
 Open: none for Option 1. Option 2 (digest promotion) still needs version decoupling and an

--- a/docs/madr/decisions/104-rethink-releasing-pipeline.md
+++ b/docs/madr/decisions/104-rethink-releasing-pipeline.md
@@ -8,7 +8,7 @@ Technical Story: https://github.com/kumahq/kuma/issues/16973
 
 Pushing a `vX.Y.Z` tag runs the full `build-test-distribute.yaml`, including the
 entire e2e suite, before any artifact ships. Recent tag runs: v2.13.8 218m,
-v2.14.0 124m, v2.12.12 119m, v2.11.16 102m (~2–3.5h), on top of the manual steps in
+v2.14.0 124m, v2.12.12 119m, v2.11.16 102m (~1.7–3.6h), on top of the manual steps in
 the team-mesh release issues.
 
 On a tag push (`FULL_MATRIX=true`):
@@ -70,16 +70,19 @@ on GitHub Actions, the closest templates for us.
   outputs (`IMAGES`/`REGISTRY`/`VERSION_NAME`) are needed downstream, so keep those.
 - With e2e skipped, `test` completes immediately and `build_publish` publishes right
   away instead of waiting ~90m.
-- Hard-enforce a green tagged SHA: the tagged commit must have a passing
-  `build-test-distribute` run (full matrix) on its branch, else the release fails. This
-  reuses the existing run, not new machinery.
+
+- Hard-enforce a green tagged SHA: a guard job on the tag fails the release unless the
+  tagged commit already has a trustworthy full-matrix `build-test-distribute` run on its
+  branch (mechanism in "Enforcing the green tagged SHA"). This reads an existing run, not
+  new test machinery.
 
 After this, `build_publish` ~15m plus provenance/distributions lands at roughly 20–30m
 versus the current 100–220m.
 
 - (+) Answers the issue; no new infra, staging, or version change; removes the flakiest stage.
-- (−) Loses the exact-tag re-test (mitigated by the hard green-SHA gate and, for risky
-  releases, RC soak); still rebuilds on the tag (~15m, fine).
+- (−) Loses the exact-tag re-test, mitigated by the hard green-SHA gate. (Kuma has no RC
+  process today, so RC soak is not a current fallback; it only becomes available under
+  Option 2.) Still rebuilds on the tag (~15m, fine).
 
 ### Option 2 — RC + promotion by digest (build once, ship the tested bits)
 
@@ -110,13 +113,14 @@ Orthogonal to Options 1–4: how to wire the tag pipeline. Today the release pat
 `build-test-distribute.yaml`, which runs on every PR, master, and release-branch push,
 so it builds and publishes a preview on every push.
 
-- A, stay in the monolith and reuse the existing `ci/skip-test` mechanism. Tags don't
-  skip today: `_test.yaml` keys the skip off PR labels
-  (`github.event.pull_request.labels`), which are empty on a tag push, so the full matrix
-  runs. Add `github.ref_type == 'tag'` next to that condition and e2e/unit skip on the
-  tag; the existing `needs:` chain then lets `build_publish` proceed. (+) roughly a
-  one-condition change, no new workflow; the publish path stays exercised on every push,
-  so it cannot rot between releases. (−) the monolith keeps its tag-vs-PR conditionals.
+- A, stay in the monolith. Tags carry no PR labels, so `ci/skip-test` can't fire on a tag;
+  instead add `|| github.ref_type == 'tag'` to the two guards that label drives —
+  `test_unit`'s `if:` (`_test.yaml:21`) and the `SKIP_E2E_TESTS` env (`_test.yaml:82`,
+  which empties the e2e matrix). That skips unit and e2e on the tag; the existing `needs:`
+  chain then lets `build_publish` proceed. (+) two-line change, no new workflow; the
+  publish path stays exercised on every push, so it can't rot. (−) the monolith keeps its
+  tag-vs-PR conditionals.
+
 - B, a dedicated `release-publish.yaml` on tags, reusing `_build_publish.yaml` and
   `_provenance.yaml`, never `_test.yaml`. (+) a linear, readable release flow. (−) it
   runs only on tags, so the publish path is no longer exercised between releases and can
@@ -124,17 +128,55 @@ so it builds and publishes a preview on every push.
   trigger migration.
 
 Picked A. The monolith already publishes on every push, the strongest guard that the
-release machinery works, and reusing `ci/skip-test` keeps the change tiny. (An earlier
-draft picked B with a scheduled rehearsal to re-create that exercise; maintainer review
+release machinery works, and extending the existing skip guards keeps the change tiny.
+(An earlier draft picked B with a scheduled rehearsal to re-create that exercise; review
 pointed out the monolith already provides it, making both the dedicated workflow and the
 rehearsal unnecessary.)
+
+### Enforcing the green tagged SHA
+
+The `github.ref_type == 'tag'` skip is unconditional on its own; nothing about it ties the
+skip to the tagged commit being green, so by itself it would happily ship an untested tag.
+A guard job runs first on the tag and gates the rest of the pipeline on a verified-green
+SHA. There are two ways to react to a missing green run:
+
+- Fail-hard (chosen): if the tagged SHA has no trustworthy green run, the tag fails
+  immediately, before anything builds. The releaser greens the branch (or
+  `workflow_dispatch` a full run on that SHA) and re-tags.
+
+- Re-run-on-tag (rejected): fall back to running unit and e2e on the tag when no green run
+  is found. Rejected because it re-introduces the flaky ~90–150m e2e this MADR removes,
+  precisely at release time; it keeps a second, rarely-exercised code path that rots; and a
+  tag-run flake can fail the release, the secondary problem the MADR set out to fix. It is
+  also the lone-outlier (Linkerd) model we are moving away from.
+
+We pick fail-hard: the premise is that the branch SHA is already fully tested, so the gate
+must *enforce* that invariant, not silently re-test when it is absent. The failure surfaces
+in seconds and is actionable, and because `workflow_dispatch` also runs the full matrix,
+recovery is "dispatch a run on the SHA, then tag."
+
+Picking the run is the fiddly part (a SHA can have several runs, and older `pull_request`
+runs may have skipped e2e), so the lookup is explicit:
+
+- List `build-test-distribute.yaml` runs for the tagged SHA (`head_sha`), completed, with
+  `event` in {`push`, `workflow_dispatch`}; both force `FULL_MATRIX=true` and carry no PR
+  labels, so e2e always ran. This excludes `pull_request` runs, the only ones that can set
+  `SKIP_E2E_TESTS` or reduce the matrix.
+
+- Keep `conclusion == success` and take the most recent.
+
+- Guard against an emptied matrix: fetch that run's jobs and require `test_unit` and the
+  `test_e2e*` jobs to be present and successful. A skipped-e2e run still reports overall
+  success but has no e2e jobs, so presence is the real check.
+
+- No match ⇒ fail the tag, with a message pointing at branch CI / `workflow_dispatch`.
 
 ### The publish path is already exercised continuously (no separate rehearsal)
 
 Moving the gate off the tag raises a question: does the release machinery still get
 exercised? It does, for free. `build-test-distribute.yaml` runs on every master and
 `release-X.Y` push with `ALLOW_PUSH=true`, so every push already builds, pushes, signs,
-and pulps a `-preview.<hash>` artifact through the same `_build_publish.yaml` the release
+and publishes a `-preview.<hash>` artifact through the same `_build_publish.yaml` the release
 uses (`version.sh` auto-routes preview versions to `notary-internal` and the preview
 Cloudsmith repo). That continuous run is the rehearsal; a separate scheduled one would be
 redundant machinery.
@@ -149,9 +191,9 @@ standing up separate rehearsal machinery.
 This started from the issue's "skip the full suite on the tag." Peer research confirmed
 it is the industry norm; only Linkerd re-tests. An early draft added a dedicated
 `release-publish.yaml` plus a scheduled rehearsal; maintainer review showed the monolith
-already publishes a preview on every push, so reusing the existing `ci/skip-test`
-mechanism is enough and the extra machinery was dropped. The bigger wins, digest
-promotion and the stage/publish split, depend on a version rework and an RC process Kuma
+already publishes a preview on every push, so extending the existing skip guards with a
+`ref_type=='tag'` clause is enough and the extra machinery was dropped. The bigger wins,
+digest promotion and the stage/publish split, depend on a version rework and an RC process Kuma
 lacks. So Option 1 ships now, with Options 2 and 3 as follow-up.
 
 ## Security implications and review
@@ -166,8 +208,9 @@ lacks. So Option 1 ships now, with Options 2 and 3 as follow-up.
 
 - Faster releases mean faster security-patch turnaround.
 - Dropping the redundant e2e removes the flakiest release gate.
-- Residual risk: the branch run goes stale against the tag. The exact green-SHA gate,
-  RC soak, or a one-off branch matrix before tagging mitigate this.
+- Residual risk: the branch run goes stale against the tag. The hard (fail-hard) green-SHA
+  gate mitigates this today; RC soak would add to it once Option 2 lands.
+
 - Container-structure on the freshly-built image plus a binary-version assert are the
   only tag-specific checks; they verify exactly what the tag build changes (the
   ldflags), nothing the green branch run already covered.
@@ -188,29 +231,39 @@ lacks. So Option 1 ships now, with Options 2 and 3 as follow-up.
 Adopt Option 1, implemented in the existing `build-test-distribute.yaml`. No new
 workflow, no scheduled rehearsal:
 
-- Skip e2e and unit on the tag by extending the existing `ci/skip-test` condition with
-  `github.ref_type == 'tag'`; the existing `needs:` chain then lets `build_publish`
-  publish immediately.
+- Skip e2e and unit on the tag by adding a `github.ref_type == 'tag'` clause to the two
+  guards the `ci/skip-test` label drives — `test_unit`'s `if:` (`_test.yaml:21`) and the
+  `SKIP_E2E_TESTS` env (`_test.yaml:82`) that empties the e2e matrix; the existing
+  `needs:` chain then lets `build_publish` publish immediately.
+
 - Verify only the ldflags delta: container-structure on the freshly-built image plus a
   binary-version assert. Keep `check`'s metadata computation, skip its redundant
   validation.
-- Hard-enforce a green tagged SHA, reusing the commit's existing branch run.
+
+- Hard-enforce a green tagged SHA via a guard job that fails the tag unless the commit has
+  a green full-matrix run (fail-hard; see "Enforcing the green tagged SHA").
+
 - No separate rehearsal: every push already builds and publishes a preview through the
   same `_build_publish.yaml`.
 
-This cuts ~100–220m to ~20–30m with roughly a one-condition change. Options 2 (RC plus
-digest promotion, the KEG/k8s model) and 3 (stage/publish split) are follow-up; RC is
-deferred; version decoupling is undecided.
+This cuts ~100–220m to ~20–30m with a two-line change. Options 2 (RC plus
+digest promotion, the k8s/Istio model) and 3 (stage/publish split) are follow-up; RC is
+deferred. Version decoupling is out of scope here: Option 1 rebuilds on the tag and stamps
+the correct version, so it needs no decoupling; it is a prerequisite only for Option 2 and
+is decided there if that is ever taken up.
 
 ## Notes
 
 Resolved: no re-test on the tag (drop unit and e2e; keep only container-structure plus a
-binary-version assert, the ldflags delta); implement via the existing `ci/skip-test`
-mechanism in the monolith, not a new workflow; no separate rehearsal (per-push preview
-builds already exercise publish); the green-SHA gate is hard-enforced; RC tags deferred.
+binary-version assert, the ldflags delta); implement by extending the two skip guards
+(`_test.yaml:21` and `:82`) in the monolith, not a new workflow (the `ci/skip-test` label
+never fires on a tag, so this is a `ref_type=='tag'` clause, not the label); no separate
+rehearsal (per-push preview builds already exercise publish); the green-SHA gate is
+hard-enforced (fail-hard, not re-run-on-tag); RC tags deferred; version decoupling is out
+of scope for Option 1 (rebuild-on-tag stamps the version) and belongs to Option 2.
 
-Open: version decoupling (undecided; rebuild-on-tag is fine for Option 1); the exact
-green-SHA enforcement mechanism (impl detail).
+Open: none for Option 1. Option 2 (digest promotion) still needs version decoupling and an
+RC cadence before it can be adopted.
 
 Sources. Peer projects: Kubernetes (sig-release handbook, promo-tools), Istio (release-builder,
 daily-release), Envoy (RELEASES.md, `_publish_build.yml`), Cilium

--- a/docs/madr/decisions/104-rethink-releasing-pipeline.md
+++ b/docs/madr/decisions/104-rethink-releasing-pipeline.md
@@ -1,0 +1,207 @@
+# Rethink the releasing pipeline to release faster
+
+- Status: accepted
+
+Technical Story: https://github.com/kumahq/kuma/issues/16973
+
+## Context and Problem Statement
+
+Pushing a `vX.Y.Z` tag runs the full `build-test-distribute.yaml`, including the
+entire e2e suite, before any artifact ships. Recent tag runs: v2.13.8 218m,
+v2.14.0 124m, v2.12.12 119m, v2.11.16 102m (~2–3.5h), on top of the manual steps in
+`.claude/rules/release.md`.
+
+On a tag push (`FULL_MATRIX=true`):
+
+- `check` ~13m (lint, `make check`, SBOM/CVE).
+- `test`: `test_unit` ~23m plus the full e2e matrix, ~17 jobs (k8s / universal /
+  multizone / gatewayapi × versions × amd64/arm64 × CNI × IPv6) at `max-parallel: 5`,
+  ~25–35m each. This is the long pole.
+- `build_publish` is `needs: [check, test]`, so it waits for the whole matrix;
+  the build itself is cheap (binaries ~13m, images ~6–8m parallel).
+- `provenance` (tags only) plus `distributions`.
+
+The core inefficiency: the tag is HEAD of `release-X.Y`, which already ran the full
+matrix (release prereq: "CI green on `release-X.Y`"). The tree is byte-identical, yet
+we re-run ~90–150m of e2e and gate all publishing behind it. Secondary problem: e2e is
+the flakiest CI stage, so a flake can fail an otherwise-good release.
+
+One constraint shapes the options. The version is ldflags-injected from the git tag
+(`version.sh`, `mk/build.mk`), so release-branch artifacts (`2.14.1-<hash>`) cannot be
+byte-promoted to GA (`2.14.0`). Any fix either rebuilds on the tag or changes how the
+version is derived.
+
+Goals: tag-to-artifacts well under an hour; no weaker supply-chain
+(SBOM/provenance/signing/scan); fewer release failures from flakes or operator error.
+Non-goals: changing cadence/branching/tag format; adopting external infra (Prow/GCB).
+
+## Design
+
+### How peer projects release
+
+Axis = does the full test suite re-run on the tag?
+
+| Project | Re-tests on tag? | Mechanism |
+|:--------|:-----------------|:----------|
+| Kubernetes | No | `krel stage`→`release`; images promoted by **digest** |
+| Istio | No | `release-builder` build/publish split; copy staging→prod |
+| Envoy | No | tag job builds+signs+publishes only; SHA idempotency guard |
+| Cilium | No | tag job builds+signs only; gate = branch CI + RC + protected env |
+| cert-manager | No | `cmrel stage`/`publish`; e2e gated on the branch |
+| Knative | No (promote) | `--from-latest-nightly` retags nightly, `SKIP_TESTS=1` |
+| Argo CD | No | release workflow runs zero tests; 7-week RC freeze |
+| **Linkerd** | **Yes** | rebuilds + runs full integration suite on tag |
+
+Only Linkerd re-tests on the tag, which is Kuma's current model. Everyone else gates on
+the branch/RC and makes the tag build-and-publish only. Envoy and Cilium do it natively
+on GitHub Actions, the closest templates for us.
+
+### Option 1 — Skip e2e on the tag; gate on the branch (recommended)
+
+- No e2e (and no e2e smoke) on the tag. Keep `test_unit` and container-structure
+  tests, which are fast and validate the artifact. Drop the ~90–150m matrix.
+- Build and publish without the e2e gate, so the build starts right after the gate.
+- Hard-enforce a green tagged SHA. The first job asserts the commit has a passing
+  `build-test-distribute` run on its branch (`gh api` check-runs), else it fails.
+
+After this, green-SHA gate ~1m, `build_publish` ~15m, plus provenance/distributions,
+lands at roughly 20–30m versus the current 100–220m.
+
+- (+) Answers the issue; no new infra, staging, or version change; removes the flakiest stage.
+- (−) Loses the exact-tag re-test (mitigated by the hard green-SHA gate, RC soak, and
+  rehearsal); still rebuilds on the tag (~15m, fine).
+
+### Option 2 — RC + promotion by digest (build once, ship the tested bits)
+
+`vX.Y.Z-rc.N` builds and tests once; GA promotes the RC artifacts by digest with no
+rebuild or retest. This is the k8s/Istio gold standard.
+
+- Blocker: the version is baked into the binary, so RC images carry `-rc.N`. Promotion
+  needs the version decoupled from the build (runtime or retag), a larger change to
+  `version.sh`, the build, and the registry.
+- (+) The tested bits are the shipped bits, with RC soak. (−) Needs a staging registry,
+  promotion tooling, version rework, and a new RC cadence.
+
+### Option 3 — Stage/publish split via one resumable release tool
+
+`stage` (build once, pinned) and `publish` (promote), as numbered idempotent steps in
+one tool (extend `release-tool`), like Envoy and `cmrel`.
+
+- (+) Fixes the *error-prone* half: resumable, decoupled publishing, one RC/GA path.
+- (−) Medium effort, and orthogonal to the e2e waste, so it layers on top of Option 1.
+
+### Option 4 — Status quo (rejected)
+
+Keep re-testing on the tag. This is the problem itself, and the lone outlier among peers.
+
+### Implementation: dedicated release workflow vs. conditionals (orthogonal to Options 1–4)
+
+Today the release path lives in `build-test-distribute.yaml` via scattered
+`ref_type=='tag'` / `FULL_MATRIX` / `ALLOW_PUSH` conditionals.
+
+- A, more conditionals in the shared workflow. (+) smallest diff. (−) more
+  tag-vs-PR branching in an already-conditional workflow; release stays hard to read;
+  shared concurrency/permissions.
+- B, a dedicated `release-publish.yaml` (`tags: ["v*"]`) reusing
+  `_build_publish.yaml` and `_provenance.yaml`, never `_test.yaml`; drop the tag trigger
+  from `build-test-distribute.yaml`; `release.yaml` keeps changelog/version
+  bookkeeping. (+) linear readable release flow; own concurrency/permissions; no
+  duplicated build logic; matches the Envoy/Cilium/Argo pattern; natural host for the
+  rehearsal and a future RC. (−) new file plus a one-time trigger migration.
+
+Picked B.
+
+### Release rehearsal (scheduled dry-run)
+
+Moving the gate off the tag introduces a risk: the release machinery breaks and we find
+out only at release time. A scheduled rehearsal de-risks it. Checking the
+Makefiles, `version.sh`, `helm.sh`, the workflows, and the tool docs shows this is mostly
+config, not new tooling:
+
+- Already runs on every master and `release-X.Y` push: `version.sh` stamps a
+  `-preview.v<hash>` version that auto-routes to `notary-internal` and preview
+  Cloudsmith, and `ALLOW_PUSH=true` triggers a real build, push, sign, and pulp plus a
+  helm *package* via `_build_publish.yaml`. The rehearsal just decouples this from e2e
+  and schedules it.
+- Provenance: SLSA generators v2.1.0 support `schedule`, `push`, and `workflow_dispatch`
+  (not `pull_request`); the generic one still emits `.intoto.jsonl` when
+  `upload-assets=false` (already wired as `upload-assets: ref_type=='tag'`); containers
+  push to an alt repo. So we loosen the job `if`, no new mode.
+- Sign, SBOM, and scan (Kong actions): `signature_registry` is free-form (already
+  `notary-internal`), OIDC signing is keyless (no tag needed), and
+  `upload-sbom-release-assets` defaults to false. Already off-tag ready.
+- Helm release (`cr` 1.8.1): `cr upload` and `cr index` target any owner/repo via flags
+  (`helm.sh` routes `GH_OWNER`/`GH_REPO`). Point them at a throwaway test charts repo
+  (plus a token).
+
+Excluded by design: a real GitHub Release on `kumahq/kuma`, and prod
+registry/notary/Cloudsmith. Caveats: run on `schedule` or `workflow_dispatch`, and
+provision a test charts repo. This follows the nightly-build pattern (Istio, Knative,
+k8s `krel stage`, `cmrel --mock`). It complements the existing `release.yaml` daily
+`--check`, which verifies the *last* release's prod artifacts.
+
+### Evolution
+
+This started from the issue's "skip the full suite on the tag." Peer research confirmed
+it is the industry norm; only Linkerd re-tests. The bigger wins, digest promotion and
+the stage/publish split, depend on a version rework and an RC process Kuma lacks. So
+Option 1 ships now, with Options 2 and 3 as follow-up.
+
+## Security implications and review
+
+- e2e is not a security control; SBOM, provenance, signing, and scan live in
+  `build_publish` and `provenance`, which Option 1 leaves unchanged.
+- New risk: tagging a never-green commit, mitigated by the hard green-SHA gate.
+- Container-structure tests stay, so artifact regressions are still caught on the tag.
+- Option 2 *strengthens* security, since the scanned and signed bits are the shipped bits.
+
+## Reliability implications
+
+- Faster releases mean faster security-patch turnaround.
+- Dropping the redundant e2e removes the flakiest release gate.
+- Residual risk: the branch run goes stale against the tag. The exact green-SHA gate,
+  RC soak, or a one-off branch matrix before tagging mitigate this.
+- `test_unit` and container-structure tests act as a fast tag tripwire.
+- The rehearsal continuously validates build, publish, and sign (plus provenance and
+  helm once the gates loosen). Only the real GitHub Release and prod routing stay
+  tag-only.
+
+## Implications for Kong Mesh
+
+- The downstream fork mirrors this pipeline; port "skip e2e plus green-SHA gate" directly.
+- For Option 2 later, the downstream needs a matching staging registry and a version
+  change, and syncs by promoting rather than rebuilding.
+- Drop "wait for full suite on tag" from the downstream runbooks.
+
+## Decision
+
+Adopt Option 1, as a dedicated release workflow plus a scheduled rehearsal:
+
+- A dedicated `release-publish.yaml` reusing `_build_publish.yaml` and
+  `_provenance.yaml`, never `_test.yaml`; drop the tag trigger from
+  `build-test-distribute.yaml`.
+- No e2e or smoke on the tag; keep `test_unit` and container-structure tests.
+- Hard-enforce a green tagged SHA.
+- A scheduled rehearsal of build, publish, sign, SBOM, scan, and provenance (loosen
+  the tag-only `if`s, keep the preview/internal targets); route the helm release to a
+  test charts repo; run on `schedule` or `workflow_dispatch`.
+
+This cuts ~100–220m down to ~20–30m with no new infra. Options 2 (RC plus digest
+promotion) and 3 (stage/publish split) are follow-up; RC is deferred; version
+decoupling is undecided.
+
+## Notes
+
+Resolved: no smoke e2e on the tag; the green-SHA gate is hard-enforced; RC tags deferred.
+
+Open: version decoupling (undecided; rebuild-on-tag is fine for Option 1); the exact
+green-SHA mechanism and rehearsal cadence/scope (impl detail); provisioning a test
+charts repo and token for the helm rehearsal leg.
+
+Sources. Peer projects: Kubernetes (sig-release handbook, promo-tools), Istio (release-builder,
+daily-release), Envoy (RELEASES.md, `_publish_build.yml`), Cilium
+(`build-images-releases.yaml`), cert-manager (`cmrel`), Knative (`hack/release.sh`),
+Argo CD (`release.yaml`), Linkerd (`release.yml`). Tools: slsa-github-generator
+generic+container READMEs; helm/chart-releaser `cr` flags; Kong/public-shared-actions
+security-actions (`upload-sbom-release-assets` default false, free-form
+`signature_registry`).


### PR DESCRIPTION
## Motivation

Releasing is slow (~2–3.5h per tag) and error-prone: pushing a `vX.Y.Z` tag re-runs the full e2e matrix that the release branch already passed, and gates all publishing behind it. Addresses #16973.

## Implementation information

MADR only, no code. Proposes Option 1: skip e2e on the tag, gate on a green release-branch SHA, build/publish via a dedicated tag-triggered `release-publish.yaml`, plus a scheduled release rehearsal. Surveys peer projects (only Linkerd re-tests on the tag) and records Options 2 (RC + digest promotion) and 3 (stage/publish split) as follow-ups. Rehearsal feasibility is verified against the actual tooling (SLSA generators, chart-releaser, Kong security actions, `version.sh` preview routing).

## Supporting documentation

- MADR: `docs/madr/decisions/104-rethink-releasing-pipeline.md`
- Issue: #16973

> Changelog: skip