### PR TITLE
docs(release): extend 2.9 EOL to match 2.7

### DIFF
--- a/active-branches.json
+++ b/active-branches.json
@@ -1,1 +1,1 @@
-{"baseBranchPatterns":["release-2.7","release-2.11","release-2.12","release-2.13","release-2.14","master"]}
+{"baseBranchPatterns":["release-2.7","release-2.9","release-2.11","release-2.12","release-2.13","release-2.14","master"]}

--- a/versions.yml
+++ b/versions.yml
@@ -46,9 +46,9 @@
   version: 2.9.17
   release: 2.9.x
   releaseDate: "2024-10-22"
-  endOfLifeDate: "2026-06-22"
+  endOfLifeDate: "2026-10-22"
   branch: release-2.9
-  extensionMonths: 8
+  extensionMonths: 12
 - edition: kuma
   version: 2.10.11
   release: 2.10.x


### PR DESCRIPTION
## Motivation

The daily `release` workflow dropped `release-2.9` from `active-branches.json` because its computed EOL (2026-06-22) passed. 2.9 is still needed as an upgrade stepping-stone for users moving to/from the 2.7 LTS line, so it must stay active at least as long as 2.7 (EOL 2026-10-19).

> Changelog: skip

## Implementation information

The source of truth for branch lifetime is the `.0` GitHub Release body, which `release-tool version-file` parses (`> ExtensionMonths:`). Bumped the `2.9.0` release body annotation `ExtensionMonths: 8 -> 12`, then regenerated `active-branches.json` and `versions.yml` with the same `release-tool` invocation the workflow uses (pinned v1.4.6, `--min-version 2.2.0`, `--edition kuma`). New 2.9 EOL: 2026-10-22.

Files are tool-generated, not hand-edited; without the release-body change the next daily run would revert any manual edit.

## Supporting documentation

`.github/workflows/release.yaml`, `docs/madr/decisions/087-active-branches-renovate-preset.md`