### PR TITLE
feat(db): add tolerateNewerDBVersions flag

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -55,6 +55,11 @@ store:
       keyPath: # ENV: KUMA_STORE_POSTGRES_TLS_KEY_PATH
       # Path to the root certificate. Used in verifyCa and verifyFull modes.
       caPath: # ENV: KUMA_STORE_POSTGRES_TLS_ROOT_CERT_PATH
+    # SkipMigrationCheck makes `migrate up` a no-op when the DB is at a newer
+    # version than the binary, and relaxes the boot-time migration gate from
+    # strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended for
+    # blue/green CP upgrades where a newer CP owns schema migrations.
+    skipMigrationCheck: false # ENV: KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK
     # ReadReplica is a setting for a DB replica used only for read queries
     readReplica:
       # Host of the Postgres DB read replica. If not set, read replica is not used.

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -55,11 +55,11 @@ store:
       keyPath: # ENV: KUMA_STORE_POSTGRES_TLS_KEY_PATH
       # Path to the root certificate. Used in verifyCa and verifyFull modes.
       caPath: # ENV: KUMA_STORE_POSTGRES_TLS_ROOT_CERT_PATH
-    # SkipMigrationCheck makes `migrate up` a no-op when the DB is at a newer
-    # version than the binary, and relaxes the boot-time migration gate from
-    # strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended for
-    # blue/green CP upgrades where a newer CP owns schema migrations.
-    skipMigrationCheck: false # ENV: KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK
+    # TolerateNewerDBVersions makes `migrate up` a no-op when the DB is at a
+    # newer version than the binary, and relaxes the boot-time migration gate
+    # from strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended
+    # for blue/green CP upgrades where a newer CP owns schema migrations.
+    tolerateNewerDBVersions: false # ENV: KUMA_STORE_POSTGRES_TOLERATE_NEWER_DB_VERSIONS
     # ReadReplica is a setting for a DB replica used only for read queries
     readReplica:
       # Host of the Postgres DB read replica. If not set, read replica is not used.

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -55,6 +55,11 @@ store:
       keyPath: # ENV: KUMA_STORE_POSTGRES_TLS_KEY_PATH
       # Path to the root certificate. Used in verifyCa and verifyFull modes.
       caPath: # ENV: KUMA_STORE_POSTGRES_TLS_ROOT_CERT_PATH
+    # SkipMigrationCheck makes `migrate up` a no-op when the DB is at a newer
+    # version than the binary, and relaxes the boot-time migration gate from
+    # strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended for
+    # blue/green CP upgrades where a newer CP owns schema migrations.
+    skipMigrationCheck: false # ENV: KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK
     # ReadReplica is a setting for a DB replica used only for read queries
     readReplica:
       # Host of the Postgres DB read replica. If not set, read replica is not used.

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -55,11 +55,11 @@ store:
       keyPath: # ENV: KUMA_STORE_POSTGRES_TLS_KEY_PATH
       # Path to the root certificate. Used in verifyCa and verifyFull modes.
       caPath: # ENV: KUMA_STORE_POSTGRES_TLS_ROOT_CERT_PATH
-    # SkipMigrationCheck makes `migrate up` a no-op when the DB is at a newer
-    # version than the binary, and relaxes the boot-time migration gate from
-    # strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended for
-    # blue/green CP upgrades where a newer CP owns schema migrations.
-    skipMigrationCheck: false # ENV: KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK
+    # TolerateNewerDBVersions makes `migrate up` a no-op when the DB is at a
+    # newer version than the binary, and relaxes the boot-time migration gate
+    # from strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended
+    # for blue/green CP upgrades where a newer CP owns schema migrations.
+    tolerateNewerDBVersions: false # ENV: KUMA_STORE_POSTGRES_TOLERATE_NEWER_DB_VERSIONS
     # ReadReplica is a setting for a DB replica used only for read queries
     readReplica:
       # Host of the Postgres DB read replica. If not set, read replica is not used.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Postgres.ReadReplica.Host).To(Equal("ro.host"))
 			Expect(cfg.Store.Postgres.ReadReplica.Port).To(Equal(uint(35432)))
 			Expect(cfg.Store.Postgres.ReadReplica.Ratio).To(Equal(uint(80)))
-			Expect(cfg.Store.Postgres.SkipMigrationCheck).To(BeTrue())
+			Expect(cfg.Store.Postgres.TolerateNewerDBVersions).To(BeTrue())
 
 			Expect(cfg.ApiServer.ReadOnly).To(BeTrue())
 			Expect(cfg.ApiServer.HTTP.Enabled).To(BeFalse())
@@ -450,7 +450,7 @@ store:
       host: ro.host
       port: 35432
       ratio: 80
-    skipMigrationCheck: true
+    tolerateNewerDBVersions: true
   kubernetes:
     systemNamespace: test-namespace
   cache:
@@ -907,7 +907,7 @@ meshService:
 				"KUMA_STORE_POSTGRES_READ_REPLICA_PORT":                                                    "35432",
 				"KUMA_STORE_POSTGRES_READ_REPLICA_RATIO":                                                   "80",
 				"KUMA_STORE_POSTGRES_MAX_CONNECTION_IDLE_TIME":                                             "99s",
-				"KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK":                                                 "true",
+				"KUMA_STORE_POSTGRES_TOLERATE_NEWER_DB_VERSIONS":                                           "true",
 				"KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE":                                                   "test-namespace",
 				"KUMA_STORE_CACHE_ENABLED":                                                                 "false",
 				"KUMA_STORE_CACHE_EXPIRATION_TIME":                                                         "3s",

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -127,6 +127,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Store.Postgres.ReadReplica.Host).To(Equal("ro.host"))
 			Expect(cfg.Store.Postgres.ReadReplica.Port).To(Equal(uint(35432)))
 			Expect(cfg.Store.Postgres.ReadReplica.Ratio).To(Equal(uint(80)))
+			Expect(cfg.Store.Postgres.SkipMigrationCheck).To(BeTrue())
 
 			Expect(cfg.ApiServer.ReadOnly).To(BeTrue())
 			Expect(cfg.ApiServer.HTTP.Enabled).To(BeFalse())
@@ -449,6 +450,7 @@ store:
       host: ro.host
       port: 35432
       ratio: 80
+    skipMigrationCheck: true
   kubernetes:
     systemNamespace: test-namespace
   cache:
@@ -905,6 +907,7 @@ meshService:
 				"KUMA_STORE_POSTGRES_READ_REPLICA_PORT":                                                    "35432",
 				"KUMA_STORE_POSTGRES_READ_REPLICA_RATIO":                                                   "80",
 				"KUMA_STORE_POSTGRES_MAX_CONNECTION_IDLE_TIME":                                             "99s",
+				"KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK":                                                 "true",
 				"KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE":                                                   "test-namespace",
 				"KUMA_STORE_CACHE_ENABLED":                                                                 "false",
 				"KUMA_STORE_CACHE_EXPIRATION_TIME":                                                         "3s",

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -76,6 +76,14 @@ type PostgresStoreConfig struct {
 	// from strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended
 	// for blue/green CP upgrades where a newer CP owns schema migrations and
 	// an older CP shares the same DB.
+	//
+	// Safety precondition: every migration in the skew range MUST be
+	// backwards compatible. New columns must be nullable or have a default;
+	// no drops, renames, type changes, NOT NULL additions without a default,
+	// or NOTIFY-trigger payload changes that an older CP reads or writes.
+	// The flag does not verify this; the operator is responsible. Boot is
+	// still refused when schema_migrations is dirty (a migration is in
+	// progress or failed).
 	TolerateNewerDBVersions bool `json:"tolerateNewerDBVersions" envconfig:"kuma_store_postgres_tolerate_newer_db_versions"`
 }
 

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -71,6 +71,12 @@ type PostgresStoreConfig struct {
 	MaxListQueryElements uint32 `json:"maxListQueryElements" envconfig:"kuma_store_postgres_max_list_query_elements"`
 	// ReadReplica is a setting for a DB replica used only for read queries
 	ReadReplica ReadReplica `json:"readReplica"`
+	// SkipMigrationCheck makes `migrate up` a no-op when the DB is at a newer
+	// version than the binary, and relaxes the boot-time migration gate from
+	// strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended for
+	// blue/green CP upgrades where a newer CP owns schema migrations and an
+	// older CP shares the same DB.
+	SkipMigrationCheck bool `json:"skipMigrationCheck" envconfig:"kuma_store_postgres_skip_migration_check"`
 }
 
 type ReadReplica struct {

--- a/pkg/config/plugins/resources/postgres/config.go
+++ b/pkg/config/plugins/resources/postgres/config.go
@@ -71,12 +71,12 @@ type PostgresStoreConfig struct {
 	MaxListQueryElements uint32 `json:"maxListQueryElements" envconfig:"kuma_store_postgres_max_list_query_elements"`
 	// ReadReplica is a setting for a DB replica used only for read queries
 	ReadReplica ReadReplica `json:"readReplica"`
-	// SkipMigrationCheck makes `migrate up` a no-op when the DB is at a newer
-	// version than the binary, and relaxes the boot-time migration gate from
-	// strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended for
-	// blue/green CP upgrades where a newer CP owns schema migrations and an
-	// older CP shares the same DB.
-	SkipMigrationCheck bool `json:"skipMigrationCheck" envconfig:"kuma_store_postgres_skip_migration_check"`
+	// TolerateNewerDBVersions makes `migrate up` a no-op when the DB is at a
+	// newer version than the binary, and relaxes the boot-time migration gate
+	// from strict equality (dbVer == fileVer) to dbVer >= fileVer. Intended
+	// for blue/green CP upgrades where a newer CP owns schema migrations and
+	// an older CP shares the same DB.
+	TolerateNewerDBVersions bool `json:"tolerateNewerDBVersions" envconfig:"kuma_store_postgres_tolerate_newer_db_versions"`
 }
 
 type ReadReplica struct {

--- a/pkg/plugins/resources/postgres/migrate.go
+++ b/pkg/plugins/resources/postgres/migrate.go
@@ -42,8 +42,8 @@ func MigrateDb(cfg postgres_cfg.PostgresStoreConfig) (core_plugins.DbVersion, er
 			if err != nil {
 				return 0, err
 			}
-			if cfg.SkipMigrationCheck && dbVer > appVer {
-				migrateLog.Info("DB is at a newer migration version than the binary; skipping migration because SkipMigrationCheck is enabled", "dbVersion", dbVer, "binaryVersion", appVer)
+			if cfg.TolerateNewerDBVersions && dbVer > appVer {
+				migrateLog.Info("DB is at a newer migration version than the binary; tolerating because TolerateNewerDBVersions is enabled", "dbVersion", dbVer, "binaryVersion", appVer)
 				return dbVer, core_plugins.AlreadyMigrated
 			}
 			return 0, errors.Errorf("DB is migrated to newer version than Kuma. DB migration version %d. Kuma migration version %d. Run newer version of Kuma", dbVer, appVer)
@@ -95,7 +95,7 @@ func IsDbMigrated(cfg postgres_cfg.PostgresStoreConfig) (bool, error) {
 		return false, err
 	}
 
-	if cfg.SkipMigrationCheck {
+	if cfg.TolerateNewerDBVersions {
 		return dbVer >= fileVer, nil
 	}
 	return dbVer == fileVer, nil

--- a/pkg/plugins/resources/postgres/migrate.go
+++ b/pkg/plugins/resources/postgres/migrate.go
@@ -82,7 +82,7 @@ func IsDbMigrated(cfg postgres_cfg.PostgresStoreConfig) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	dbVer, _, err := m.Version()
+	dbVer, dirty, err := m.Version()
 	if err != nil {
 		if err == migrate.ErrNilVersion {
 			return false, nil
@@ -96,6 +96,9 @@ func IsDbMigrated(cfg postgres_cfg.PostgresStoreConfig) (bool, error) {
 	}
 
 	if cfg.TolerateNewerDBVersions {
+		if dirty {
+			return false, errors.Errorf("database schema_migrations row is dirty at version %d (a migration is in progress or failed); refusing to boot even with TolerateNewerDBVersions enabled", dbVer)
+		}
 		return dbVer >= fileVer, nil
 	}
 	return dbVer == fileVer, nil

--- a/pkg/plugins/resources/postgres/migrate.go
+++ b/pkg/plugins/resources/postgres/migrate.go
@@ -11,11 +11,14 @@ import (
 	"github.com/pkg/errors"
 
 	postgres_cfg "github.com/kumahq/kuma/v3/pkg/config/plugins/resources/postgres"
+	"github.com/kumahq/kuma/v3/pkg/core"
 	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
 	common_postgres "github.com/kumahq/kuma/v3/pkg/plugins/common/postgres"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/postgres/migrations"
 	"github.com/kumahq/kuma/v3/pkg/util/data"
 )
+
+var migrateLog = core.Log.WithName("postgres-migrate")
 
 func MigrateDb(cfg postgres_cfg.PostgresStoreConfig) (core_plugins.DbVersion, error) {
 	m, err := newMigrate(cfg)
@@ -38,6 +41,10 @@ func MigrateDb(cfg postgres_cfg.PostgresStoreConfig) (core_plugins.DbVersion, er
 			appVer, err := newestMigration()
 			if err != nil {
 				return 0, err
+			}
+			if cfg.SkipMigrationCheck {
+				migrateLog.Info("DB is at a newer migration version than the binary; skipping migration because SkipMigrationCheck is enabled", "dbVersion", dbVer, "binaryVersion", appVer)
+				return dbVer, core_plugins.AlreadyMigrated
 			}
 			return 0, errors.Errorf("DB is migrated to newer version than Kuma. DB migration version %d. Kuma migration version %d. Run newer version of Kuma", dbVer, appVer)
 		}
@@ -88,6 +95,9 @@ func IsDbMigrated(cfg postgres_cfg.PostgresStoreConfig) (bool, error) {
 		return false, err
 	}
 
+	if cfg.SkipMigrationCheck {
+		return dbVer >= fileVer, nil
+	}
 	return dbVer == fileVer, nil
 }
 

--- a/pkg/plugins/resources/postgres/migrate.go
+++ b/pkg/plugins/resources/postgres/migrate.go
@@ -42,7 +42,7 @@ func MigrateDb(cfg postgres_cfg.PostgresStoreConfig) (core_plugins.DbVersion, er
 			if err != nil {
 				return 0, err
 			}
-			if cfg.SkipMigrationCheck {
+			if cfg.SkipMigrationCheck && dbVer > appVer {
 				migrateLog.Info("DB is at a newer migration version than the binary; skipping migration because SkipMigrationCheck is enabled", "dbVersion", dbVer, "binaryVersion", appVer)
 				return dbVer, core_plugins.AlreadyMigrated
 			}

--- a/pkg/plugins/resources/postgres/migrate_test.go
+++ b/pkg/plugins/resources/postgres/migrate_test.go
@@ -52,6 +52,33 @@ var _ = Describe("Migrate", func() {
 		Expect(err).To(MatchError(fmt.Sprintf("DB is migrated to newer version than Kuma. DB migration version 9999999999. Kuma migration version %d. Run newer version of Kuma", dbVersion)))
 	})
 
+	It("should not error when DB has a newer migration version and SkipMigrationCheck is enabled", func() {
+		// given a DB migrated past the binary's newest migration
+		cfg, err := c.Config()
+		Expect(err).ToNot(HaveOccurred())
+		_, err = postgres.MigrateDb(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		sql, err := common_postgres.ConnectToDb(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		res, err := sql.Exec("UPDATE schema_migrations SET version = 9999999999")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RowsAffected()).To(Equal(int64(1)))
+
+		// when the bypass flag is set
+		cfg.SkipMigrationCheck = true
+		ver, err := postgres.MigrateDb(cfg)
+
+		// then MigrateDb returns AlreadyMigrated with the DB version
+		Expect(err).To(Equal(plugins.AlreadyMigrated))
+		Expect(ver).To(Equal(plugins.DbVersion(9999999999)))
+
+		// and IsDbMigrated returns true
+		migrated, err := postgres.IsDbMigrated(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(migrated).To(BeTrue())
+	})
+
 	It("should indicate if db is migrated", func() {
 		// given
 		cfg, err := c.Config()

--- a/pkg/plugins/resources/postgres/migrate_test.go
+++ b/pkg/plugins/resources/postgres/migrate_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Migrate", func() {
 
 		sql, err := common_postgres.ConnectToDb(cfg)
 		Expect(err).ToNot(HaveOccurred())
+		defer sql.Close()
 		res, err := sql.Exec("UPDATE schema_migrations SET version = 9999999999")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.RowsAffected()).To(Equal(int64(1)))

--- a/pkg/plugins/resources/postgres/migrate_test.go
+++ b/pkg/plugins/resources/postgres/migrate_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Migrate", func() {
 		Expect(err).To(MatchError(fmt.Sprintf("DB is migrated to newer version than Kuma. DB migration version 9999999999. Kuma migration version %d. Run newer version of Kuma", dbVersion)))
 	})
 
-	It("should not error when DB has a newer migration version and SkipMigrationCheck is enabled", func() {
+	It("should not error when DB has a newer migration version and TolerateNewerDBVersions is enabled", func() {
 		// given a DB migrated past the binary's newest migration
 		cfg, err := c.Config()
 		Expect(err).ToNot(HaveOccurred())
@@ -67,7 +67,7 @@ var _ = Describe("Migrate", func() {
 		Expect(res.RowsAffected()).To(Equal(int64(1)))
 
 		// when the bypass flag is set
-		cfg.SkipMigrationCheck = true
+		cfg.TolerateNewerDBVersions = true
 		ver, err := postgres.MigrateDb(cfg)
 
 		// then MigrateDb returns AlreadyMigrated with the DB version


### PR DESCRIPTION
## Motivation

For upgrades, older CP currently refuses to boot once a newer CP has advanced the schema: `migrate up` errors on "DB newer than binary" and `IsDbMigrated` requires strict `dbVer == fileVer`. This PR adds an opt-in env var to relax both gates so the newer CP can own migrations while the older CP keeps running.

## Implementation information

Adds `SkipMigrationCheck` (env `KUMA_STORE_POSTGRES_SKIP_MIGRATION_CHECK`, default off) that turns the "DB newer than binary" branch of `MigrateDb` into `AlreadyMigrated` and switches `IsDbMigrated` to `dbVer >= fileVer`. The bypass only fires when `dbVer > appVer`, so unrelated "file does not exist" errors still fail loudly.

## Supporting documentation

closes https://github.com/Kong/kong-mesh/issues/9977