### PR TITLE
chore(deps/dev): bump buf from 1.70.0 to 1.71.0

### DIFF
--- a/api/mesh/v1alpha1/gateway_route.proto
+++ b/api/mesh/v1alpha1/gateway_route.proto
@@ -31,12 +31,8 @@ message MeshGatewayRoute {
     // which the gateway will forward.
     map<string, string> destination = 2 [(validate.rules).map = {
       min_pairs: 1
-      keys: {
-        string: {min_len: 1}
-      }
-      values: {
-        string: {min_len: 1}
-      }
+      keys: {string: {min_len: 1}}
+      values: {string: {min_len: 1}}
     }];
   }
 

--- a/api/mesh/v1alpha1/traffic_route.proto
+++ b/api/mesh/v1alpha1/traffic_route.proto
@@ -44,12 +44,8 @@ message TrafficRoute {
     // in the latter case an endpoint is an External Service.
     map<string, string> destination = 2 [(validate.rules).map = {
       min_pairs: 1
-      keys: {
-        string: {min_len: 1}
-      }
-      values: {
-        string: {min_len: 1}
-      }
+      keys: {string: {min_len: 1}}
+      values: {string: {min_len: 1}}
     }];
   }
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ experimental = true # To enable installation of Go tools from source with mise.
 
 [tools]
 actionlint = "1.7.12"
-buf = "1.70.0"
+buf = "1.71.0"
 container-structure-test = "1.22.1"
 ginkgo = "2.31.0"
 go = "1.26.4"


### PR DESCRIPTION
## Motivation

Keeps the buf protobuf toolchain up-to-date. buf 1.71.0 ships with formatter/linting fixes; the follow-up commit applies the resulting proto format changes.

## Implementation information

- `mise.toml`: update buf version from `1.70.0` to `1.71.0`
- Apply buf 1.71.0 proto formatter output across `.proto` files

> Changelog: skip