### PR TITLE
docs(upgrade): split combined patch upgrade section

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,7 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
-## Upgrade to `2.13.7`, `2.12.11`, `2.11.14`, `2.9.16`, `2.7.26`
+## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.
 
@@ -53,6 +53,22 @@ A new explicit flag preserves the previous insecure behavior:
 - `kumactl config control-planes add --skip-verify`
 
 Do not use this in production.
+
+## Upgrade to `2.12.11`
+
+See [Insecure TLS fallback removed when no CA cert is provided](#insecure-tls-fallback-removed-when-no-ca-cert-is-provided).
+
+## Upgrade to `2.11.14`
+
+See [Insecure TLS fallback removed when no CA cert is provided](#insecure-tls-fallback-removed-when-no-ca-cert-is-provided).
+
+## Upgrade to `2.9.16`
+
+See [Insecure TLS fallback removed when no CA cert is provided](#insecure-tls-fallback-removed-when-no-ca-cert-is-provided).
+
+## Upgrade to `2.7.26`
+
+See [Insecure TLS fallback removed when no CA cert is provided](#insecure-tls-fallback-removed-when-no-ca-cert-is-provided).
 
 ## Upgrade to `2.14.x`
 


### PR DESCRIPTION
## Motivation

The downstream automation parses upgrade sections of the form ``## Upgrade to `X` `` with a single version. The combined ``## Upgrade to `2.13.7`, `2.12.11`, `2.11.14`, `2.9.16`, `2.7.26` `` header broke that assumption.

## Implementation information

Keep the full instructions under ``2.13.7`` and give each other patch release (``2.12.11``, ``2.11.14``, ``2.9.16``, ``2.7.26``) its own section that links to the shared `Insecure TLS fallback removed when no CA cert is provided` subsection rather than the whole `2.13.7` section. This avoids duplicating the content, and means any future `2.13.7`-only notes won't be implied for the other patches.

## Supporting documentation

N/A