### PR TITLE
test(e2e): wait for MeshHTTPRoute convergence

### DIFF
--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -114,7 +114,7 @@ spec:
 `, meshName))(multizone.Global)).To(Succeed())
 
 		Eventually(func(g Gomega) {
-			response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh", client.WithNumberOfRequests(100))
+			response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response).To(
 				And(
@@ -123,7 +123,17 @@ spec:
 					HaveKeyWithValue(MatchRegexp(`^alias-zone2.*`), Not(BeNil())),
 				),
 			)
-		}, "30s", "5s").Should(Succeed())
+		}, "30s", "1s").MustPassRepeatedly(3).Should(Succeed())
+
+		response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh", client.WithNumberOfRequests(100))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).To(
+			And(
+				Not(HaveKey(MatchRegexp(`^zone1.*`))),
+				Not(HaveKey(MatchRegexp(`^zone2.*`))),
+				HaveKeyWithValue(MatchRegexp(`^alias-zone2.*`), Not(BeNil())),
+			),
+		)
 	})
 
 	It("should use MeshHTTPRoute for cross-zone with MeshServiceSubset", func() {


### PR DESCRIPTION
## Motivation
The release-2.13 multizone kind IPv6 MeshHTTPRoute test was reproduced locally with the CI seed. The first 100-request assertion can start while DNS/routes/remote ingress are still converging, so a single early curl timeout can consume the whole Eventually window.

## Changes
- First wait for MeshHTTPRoute convergence with smaller repeated probes.
- Keep the existing 100-request assertion after convergence to verify all traffic uses the alias backend.

## Verification
- IPV6=true K8S_CLUSTER_TOOL=kind KUMA_DEFAULT_RETRIES=60 KUMA_DEFAULT_TIMEOUT=6s GINKGO_OPTS='--procs 2 --github-output' GINKGO_E2E_TEST_FLAGS='--seed=1782095825 --focus=MeshHTTPRoute.No.Zone.Egress.should.use.MeshHTTPRoute.for.cross-zone.communication' make -j2 test/e2e-multizone
- Result: 1 Passed, 0 Failed.

Local note: host ports in test/kind/cluster-ipv6-kuma-1.yaml were temporarily remapped only for local verification to avoid existing user-owned clusters; that local-only change is not included in this PR.