### PR TITLE
build(kind): use explicit kubeconfig on cleanup

### DIFF
--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -65,8 +65,8 @@ kind/wait:
 
 .PHONY: kind/stop
 kind/stop: kind/cleanup-docker-credentials
-	@$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
-	@rm -f $(KUBECONFIG_DIR)/$(KIND_KUBECONFIG)
+	@$(KIND) delete cluster --kubeconfig $(KIND_KUBECONFIG) --name $(KIND_CLUSTER_NAME)
+	@rm -f $(KIND_KUBECONFIG)
 
 .PHONY: kind/stop/all
 kind/stop/all:


### PR DESCRIPTION
## Motivation
The release-2.9 multizone job reproduced locally as a post-suite cleanup failure: the e2e specs passed, then `kind delete cluster` contended on the default kubeconfig instead of using the per-cluster kubeconfig created for the test cluster.

## Changes
- Pass `--kubeconfig $(KIND_KUBECONFIG)` to `kind delete cluster`.
- Remove the actual kubeconfig path with `rm -f $(KIND_KUBECONFIG)` instead of prefixing it with `$(KUBECONFIG_DIR)` again.

## Verification
- Created a throwaway kind cluster named `kuma-cleanup-repro` with kubeconfig `/Users/marcin.skalski/.kube/kind-kuma-cleanup-repro-config`.
- Ran `KIND_CLUSTER_NAME=kuma-cleanup-repro make kind/stop`.
- Result: cluster deleted and kubeconfig file removed; command exited 0.