### PR TITLE
test(e2e): wait for MeshHTTPRoute convergence

### DIFF
--- a/test/e2e_env/multizone/meshhttproute/test.go
+++ b/test/e2e_env/multizone/meshhttproute/test.go
@@ -114,7 +114,7 @@ spec:
 `, meshName))(multizone.Global)).To(Succeed())
 
 		Eventually(func(g Gomega) {
-			response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh", client.WithNumberOfRequests(100))
+			response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(response).To(
 				And(
@@ -123,7 +123,17 @@ spec:
 					HaveKeyWithValue(MatchRegexp(`^alias-zone2.*`), Not(BeNil())),
 				),
 			)
-		}, "30s", "5s").Should(Succeed())
+		}, "30s", "1s").MustPassRepeatedly(3).Should(Succeed())
+
+		response, err := client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server.mesh", client.WithNumberOfRequests(100))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response).To(
+			And(
+				Not(HaveKey(MatchRegexp(`^zone1.*`))),
+				Not(HaveKey(MatchRegexp(`^zone2.*`))),
+				HaveKeyWithValue(MatchRegexp(`^alias-zone2.*`), Not(BeNil())),
+			),
+		)
 	})
 
 	It("should use MeshHTTPRoute for cross-zone with MeshServiceSubset", func() {


### PR DESCRIPTION
## Motivation
The MeshHTTPRoute cross-zone e2e flake reproduced as a convergence race after applying the route: the test immediately sent a 100-request batch through demo-client, and one slow or failed curl could consume the whole 30s Eventually budget even after the route converged.

## Changes
- Wait for MeshHTTPRoute convergence with the default small response sample.
- Require the converged response shape to pass repeatedly.
- Keep the original 100-request assertion as a final post-convergence check.

## Verification
- IPV6=true DOCKER_NETWORK=kind K8S_CLUSTER_TOOL=kind KUMA_DEFAULT_RETRIES=60 KUMA_DEFAULT_TIMEOUT=6s GINKGO_OPTS="--procs 2 --github-output" GINKGO_E2E_TEST_FLAGS="--seed=1782095825 --focus=MeshHTTPRoute.No.Zone.Egress.should.use.MeshHTTPRoute.for.cross-zone.communication" make -j2 test/e2e-multizone
- Result: Ran 1 of 287 Specs in 100.162 seconds; SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 284 Skipped.