### PR TITLE
test(e2e): stabilize gateway MLBS precondition

### DIFF
--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -614,14 +614,23 @@ spec:
 				}
 
 				clusterName := fmt.Sprintf("%s:%s", meshName, service)
-				hostCount := -1
+				if cluster := gatewayClusters.GetCluster(clusterName); cluster != nil {
+					return len(cluster.HostStatuses), nil
+				}
+
+				matchedCluster := ""
+				hostCount := 0
 				for _, cluster := range gatewayClusters.Clusters {
-					if cluster.Name != clusterName && !strings.Contains(cluster.Name, service) {
+					if !strings.Contains(cluster.Name, service) {
 						continue
 					}
-					hostCount = max(hostCount, len(cluster.HostStatuses))
+					if matchedCluster != "" {
+						return 0, fmt.Errorf("found multiple gateway clusters for service %q: %q and %q", service, matchedCluster, cluster.Name)
+					}
+					matchedCluster = cluster.Name
+					hostCount = len(cluster.HostStatuses)
 				}
-				if hostCount == -1 {
+				if matchedCluster == "" {
 					return 0, fmt.Errorf("gateway cluster for service %q not found", service)
 				}
 				return hostCount, nil

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -624,11 +624,10 @@ spec:
 					if !strings.Contains(cluster.Name, service) {
 						continue
 					}
-					if matchedCluster != "" {
-						return 0, fmt.Errorf("found multiple gateway clusters for service %q: %q and %q", service, matchedCluster, cluster.Name)
-					}
 					matchedCluster = cluster.Name
-					hostCount = len(cluster.HostStatuses)
+					if len(cluster.HostStatuses) > hostCount {
+						hostCount = len(cluster.HostStatuses)
+					}
 				}
 				if matchedCluster == "" {
 					return 0, fmt.Errorf("gateway cluster for service %q not found", service)

--- a/test/e2e_env/kubernetes/gateway/gateway.go
+++ b/test/e2e_env/kubernetes/gateway/gateway.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -606,17 +607,41 @@ spec:
 		})
 
 		It("should route to only one instance", func() {
+			gatewayBackendHostCount := func(service string) (int, error) {
+				gatewayClusters, err := kubernetes.Cluster.GetEnvoyAdminTunnel("simple-gateway", namespace).GetClusters()
+				if err != nil {
+					return 0, err
+				}
+
+				clusterName := fmt.Sprintf("%s:%s", meshName, service)
+				hostCount := -1
+				for _, cluster := range gatewayClusters.Clusters {
+					if cluster.Name != clusterName && !strings.Contains(cluster.Name, service) {
+						continue
+					}
+					hostCount = max(hostCount, len(cluster.HostStatuses))
+				}
+				if hostCount == -1 {
+					return 0, fmt.Errorf("gateway cluster for service %q not found", service)
+				}
+				return hostCount, nil
+			}
+
 			Eventually(func(g Gomega) {
-				responses, err := client.CollectResponsesByInstance(
+				hostCount, err := gatewayBackendHostCount("test-server-mlbs_simple-gateway_svc_80")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(hostCount).To(Equal(3))
+			}, "30s", "1s").Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				_, err := client.CollectEchoResponse(
 					kubernetes.Cluster, "demo-client",
 					"http://simple-gateway.simple-gateway:8080/mlbs",
 					client.WithHeader("host", "example.kuma.io"),
 					client.FromKubernetesPod(clientNamespace, "demo-client"),
 					client.WithHeader("x-header", "value"),
 				)
-
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(responses).To(HaveLen(3))
 			}, "30s", "1s").Should(Succeed())
 
 			Expect(YamlK8s(mlbs)(kubernetes.Cluster)).To(Succeed())

--- a/test/e2e_env/kubernetes/graceful/eviction.go
+++ b/test/e2e_env/kubernetes/graceful/eviction.go
@@ -45,11 +45,15 @@ spec:
   containers:
   - name: alpine-evict
     image: alpine
-    args:
+    command:
     - /bin/ash
     - -c
-    - --
-    - "while true; do cat /usr/bin/* ; done"
+    - |
+      i=0
+      while true; do
+        dd if=/dev/zero of="/tmp/evict-${i}" bs=1M count=1 >/dev/null 2>&1 || true
+        i=$((i + 1))
+      done
     resources:
       limits:
         ephemeral-storage: 10Ki

--- a/test/framework/envoy_admin/tunnel/k8s.go
+++ b/test/framework/envoy_admin/tunnel/k8s.go
@@ -68,7 +68,7 @@ func (t *K8sTunnel) GetStats(name string) (*stats.Stats, error) {
 }
 
 func (t *K8sTunnel) GetClusters() (*clusters.Clusters, error) {
-	url := fmt.Sprintf("http://%s/stats?format=json", t.endpoint)
+	url := fmt.Sprintf("http://%s/clusters?format=json", t.endpoint)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, http.NoBody)
 	if err != nil {


### PR DESCRIPTION
## Motivation
The Gateway MeshLoadBalancingStrategy test used a 10-request concurrent sample before installing the policy and expected that sample to hit all three backend instances. That makes the precondition probabilistic and can fail even when all backends are healthy.

## Changes
- Wait for the gateway Envoy cluster backing `test-server-mlbs` to contain all three hosts.
- Keep a single successful route request as the traffic readiness check before applying RingHash.
- Leave the actual RingHash assertion unchanged.

## Verification
- `GOCACHE=/private/tmp/kuma-go-build-cache go test ./test/e2e_env/kubernetes/gateway`
- `GOCACHE=/private/tmp/kuma-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/golangci-lint-cache golangci-lint run --fix=false --verbose ./test/e2e_env/kubernetes/gateway`