### PR TITLE
fix(xds): ignore workload status in mesh hash

### DIFF
--- a/pkg/core/resources/apis/workload/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/helpers.go
@@ -14,8 +14,8 @@ func (w *WorkloadResource) IsLocalWorkload() bool {
 }
 
 func (w *WorkloadResource) Hash() []byte {
-	// xDS currently depends on Workload identity/membership only. Future
-	// xDS-relevant Workload fields must revisit this hash; re-adding version
-	// or status would restore mesh-wide recomputes on status-only writes.
+	// Hashes identity only, not version/status, so status-only writes don't
+	// trigger mesh-wide xDS recomputes. xDS currently depends on Workload
+	// identity/membership only.
 	return core_model.HashMetaIdentity(w)
 }

--- a/pkg/core/resources/apis/workload/api/v1alpha1/helpers.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/helpers.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 )
 
 func (w *WorkloadResource) IsLocalWorkload() bool {
@@ -10,4 +11,11 @@ func (w *WorkloadResource) IsLocalWorkload() bool {
 		return true // no origin label means local resource
 	}
 	return origin == string(mesh_proto.ZoneResourceOrigin)
+}
+
+func (w *WorkloadResource) Hash() []byte {
+	// xDS currently depends on Workload identity/membership only. Future
+	// xDS-relevant Workload fields must revisit this hash; re-adding version
+	// or status would restore mesh-wide recomputes on status-only writes.
+	return core_model.HashMetaIdentity(w)
 }

--- a/pkg/core/resources/apis/workload/api/v1alpha1/helpers_test.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/helpers_test.go
@@ -1,0 +1,65 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/api/v1alpha1"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+)
+
+var _ = Describe("WorkloadResource Hash", func() {
+	workload := func(mesh, name, version string, status api.WorkloadStatus) *api.WorkloadResource {
+		return &api.WorkloadResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh:    mesh,
+				Name:    name,
+				Version: version,
+			},
+			Spec:   &api.Workload{},
+			Status: &status,
+		}
+	}
+
+	It("ignores resource version and status", func() {
+		first := workload("mesh-1", "backend", "1", api.WorkloadStatus{
+			DataplaneProxies: api.DataplaneProxies{
+				Total:     1,
+				Connected: 1,
+				Healthy:   1,
+			},
+		})
+		second := workload("mesh-1", "backend", "2", api.WorkloadStatus{
+			DataplaneProxies: api.DataplaneProxies{
+				Total:     3,
+				Connected: 2,
+				Healthy:   1,
+			},
+		})
+
+		Expect(second.Hash()).To(Equal(first.Hash()))
+	})
+
+	It("changes when the name changes", func() {
+		first := workload("mesh-1", "backend", "1", api.WorkloadStatus{})
+		second := workload("mesh-1", "frontend", "1", api.WorkloadStatus{})
+
+		Expect(second.Hash()).ToNot(Equal(first.Hash()))
+	})
+
+	It("changes when the mesh changes", func() {
+		first := workload("mesh-1", "backend", "1", api.WorkloadStatus{})
+		second := workload("mesh-2", "backend", "1", api.WorkloadStatus{})
+
+		Expect(second.Hash()).ToNot(Equal(first.Hash()))
+	})
+
+	It("hashes empty identity consistently", func() {
+		first := workload("", "", "1", api.WorkloadStatus{})
+		second := workload("", "", "2", api.WorkloadStatus{
+			DataplaneProxies: api.DataplaneProxies{Total: 1},
+		})
+
+		Expect(second.Hash()).To(Equal(first.Hash()))
+	})
+})

--- a/pkg/core/resources/apis/workload/api/v1alpha1/suite_test.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/suite_test.go
@@ -6,6 +6,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/test"
 )
 
-func TestMeshTrust(t *testing.T) {
+func TestWorkload(t *testing.T) {
 	test.RunSpecs(t, "Workload Suite")
 }

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -107,8 +107,8 @@ func Hash(resource Resource) []byte {
 
 func HashMeta(r Resource) []byte {
 	hasher := fnv.New128a()
-	meta := writeMetaIdentity(hasher, r)
-	_, _ = hasher.Write([]byte(meta.GetVersion()))
+	writeMetaIdentity(hasher, r)
+	_, _ = hasher.Write([]byte(r.GetMeta().GetVersion()))
 	return hasher.Sum(nil)
 }
 
@@ -118,12 +118,11 @@ func HashMetaIdentity(r Resource) []byte {
 	return hasher.Sum(nil)
 }
 
-func writeMetaIdentity(hasher hash.Hash, r Resource) ResourceMeta {
+func writeMetaIdentity(hasher hash.Hash, r Resource) {
 	meta := r.GetMeta()
 	_, _ = hasher.Write([]byte(r.Descriptor().Name))
 	_, _ = hasher.Write([]byte(meta.GetMesh()))
 	_, _ = hasher.Write([]byte(meta.GetName()))
-	return meta
 }
 
 func Deprecations(resource Resource) []string {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"hash"
 	"hash/fnv"
 	"reflect"
 	"strings"
@@ -107,11 +108,22 @@ func Hash(resource Resource) []byte {
 func HashMeta(r Resource) []byte {
 	meta := r.GetMeta()
 	hasher := fnv.New128a()
+	writeMetaIdentity(hasher, r)
+	_, _ = hasher.Write([]byte(meta.GetVersion()))
+	return hasher.Sum(nil)
+}
+
+func HashMetaIdentity(r Resource) []byte {
+	hasher := fnv.New128a()
+	writeMetaIdentity(hasher, r)
+	return hasher.Sum(nil)
+}
+
+func writeMetaIdentity(hasher hash.Hash, r Resource) {
+	meta := r.GetMeta()
 	_, _ = hasher.Write([]byte(r.Descriptor().Name))
 	_, _ = hasher.Write([]byte(meta.GetMesh()))
 	_, _ = hasher.Write([]byte(meta.GetName()))
-	_, _ = hasher.Write([]byte(meta.GetVersion()))
-	return hasher.Sum(nil)
 }
 
 func Deprecations(resource Resource) []string {

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -106,9 +106,8 @@ func Hash(resource Resource) []byte {
 }
 
 func HashMeta(r Resource) []byte {
-	meta := r.GetMeta()
 	hasher := fnv.New128a()
-	writeMetaIdentity(hasher, r)
+	meta := writeMetaIdentity(hasher, r)
 	_, _ = hasher.Write([]byte(meta.GetVersion()))
 	return hasher.Sum(nil)
 }
@@ -119,11 +118,12 @@ func HashMetaIdentity(r Resource) []byte {
 	return hasher.Sum(nil)
 }
 
-func writeMetaIdentity(hasher hash.Hash, r Resource) {
+func writeMetaIdentity(hasher hash.Hash, r Resource) ResourceMeta {
 	meta := r.GetMeta()
 	_, _ = hasher.Write([]byte(r.Descriptor().Name))
 	_, _ = hasher.Write([]byte(meta.GetMesh()))
 	_, _ = hasher.Write([]byte(meta.GetName()))
+	return meta
 }
 
 func Deprecations(resource Resource) []string {

--- a/pkg/xds/context/testdata/meshcontext_hash/workload-membership.change.yaml
+++ b/pkg/xds/context/testdata/meshcontext_hash/workload-membership.change.yaml
@@ -1,0 +1,9 @@
+type: Workload
+name: frontend
+mesh: mesh-1
+spec: {}
+status:
+  dataplaneProxies:
+    total: 1
+    connected: 1
+    healthy: 1

--- a/pkg/xds/context/testdata/meshcontext_hash/workload-membership.input.yaml
+++ b/pkg/xds/context/testdata/meshcontext_hash/workload-membership.input.yaml
@@ -1,0 +1,13 @@
+# mesh-1 true
+type: Mesh
+name: mesh-1
+---
+type: Workload
+name: backend
+mesh: mesh-1
+spec: {}
+status:
+  dataplaneProxies:
+    total: 1
+    connected: 1
+    healthy: 1

--- a/pkg/xds/context/testdata/meshcontext_hash/workload-status-version.change.yaml
+++ b/pkg/xds/context/testdata/meshcontext_hash/workload-status-version.change.yaml
@@ -1,0 +1,9 @@
+type: Workload
+name: backend
+mesh: mesh-1
+spec: {}
+status:
+  dataplaneProxies:
+    total: 3
+    connected: 2
+    healthy: 1

--- a/pkg/xds/context/testdata/meshcontext_hash/workload-status-version.input.yaml
+++ b/pkg/xds/context/testdata/meshcontext_hash/workload-status-version.input.yaml
@@ -1,0 +1,13 @@
+# mesh-1 false
+type: Mesh
+name: mesh-1
+---
+type: Workload
+name: backend
+mesh: mesh-1
+spec: {}
+status:
+  dataplaneProxies:
+    total: 1
+    connected: 1
+    healthy: 1

--- a/pkg/xds/metrics/metrics.go
+++ b/pkg/xds/metrics/metrics.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Metrics struct {
-	XdsGenerations          *prometheus.HistogramVec
-	XdsGenerationsErrors    prometheus.Counter
-	KubeAuthCache           *prometheus.CounterVec
-	CertExpirationTimestamp *prometheus.GaugeVec
-	SnapshotResources       *prometheus.HistogramVec
+	XdsGenerations             *prometheus.HistogramVec
+	XdsGenerationsErrors       prometheus.Counter
+	KubeAuthCache              *prometheus.CounterVec
+	CertExpirationTimestamp    *prometheus.GaugeVec
+	SnapshotResources          *prometheus.HistogramVec
+	DataplaneConfigRegenerated *prometheus.CounterVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -37,15 +38,27 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		Help:    "Distribution of resource counts per xDS snapshot by resource type.",
 		Buckets: prometheus.ExponentialBuckets(1, 2, 12),
 	}, []string{"resource_type"})
-	if err := metrics.BulkRegister(xdsGenerations, xdsGenerationsErrors, kubeAuthCache, certExpirationTimestamp, snapshotResources); err != nil {
+	dataplaneConfigRegenerated := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "xds_dataplane_config_regenerated_total",
+		Help: "Counter of successful Dataplane xDS reconcile attempts triggered by mesh-context hash changes.",
+	}, []string{"mesh"})
+	if err := metrics.BulkRegister(
+		xdsGenerations,
+		xdsGenerationsErrors,
+		kubeAuthCache,
+		certExpirationTimestamp,
+		snapshotResources,
+		dataplaneConfigRegenerated,
+	); err != nil {
 		return nil, err
 	}
 
 	return &Metrics{
-		XdsGenerations:          xdsGenerations,
-		XdsGenerationsErrors:    xdsGenerationsErrors,
-		KubeAuthCache:           kubeAuthCache,
-		CertExpirationTimestamp: certExpirationTimestamp,
-		SnapshotResources:       snapshotResources,
+		XdsGenerations:             xdsGenerations,
+		XdsGenerationsErrors:       xdsGenerationsErrors,
+		KubeAuthCache:              kubeAuthCache,
+		CertExpirationTimestamp:    certExpirationTimestamp,
+		SnapshotResources:          snapshotResources,
+		DataplaneConfigRegenerated: dataplaneConfigRegenerated,
 	}, nil
 }

--- a/pkg/xds/sync/dataplane_watchdog.go
+++ b/pkg/xds/sync/dataplane_watchdog.go
@@ -212,6 +212,9 @@ func (d *DataplaneWatchdog) syncDataplane(ctx context.Context) (SyncResult, erro
 	if err != nil {
 		return SyncResult{}, errors.Wrap(err, "could not reconcile")
 	}
+	if syncForConfig && d.XdsMetrics != nil {
+		d.XdsMetrics.DataplaneConfigRegenerated.WithLabelValues(d.key.Mesh).Inc()
+	}
 	d.lastHash = meshCtx.Hash
 	d.lastIdentityHash = identityHash
 

--- a/pkg/xds/sync/dataplane_watchdog_test.go
+++ b/pkg/xds/sync/dataplane_watchdog_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/client-go/util/cert"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
@@ -26,6 +27,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/xds/cache/mesh"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	"github.com/kumahq/kuma/v3/pkg/xds/envoy"
+	xds_metrics "github.com/kumahq/kuma/v3/pkg/xds/metrics"
 	"github.com/kumahq/kuma/v3/pkg/xds/secrets"
 	"github.com/kumahq/kuma/v3/pkg/xds/server"
 	"github.com/kumahq/kuma/v3/pkg/xds/sync"
@@ -73,6 +75,7 @@ var _ = Describe("Dataplane Watchdog", func() {
 	var resManager manager.ResourceManager
 	var snapshotReconciler *staticSnapshotReconciler
 	var deps sync.DataplaneWatchdogDependencies
+	var xdsMetrics *xds_metrics.Metrics
 
 	BeforeEach(func() {
 		snapshotReconciler = &staticSnapshotReconciler{}
@@ -91,6 +94,8 @@ var _ = Describe("Dataplane Watchdog", func() {
 			nil,
 		)
 		newMetrics, err := metrics.NewMetrics(zone)
+		Expect(err).ToNot(HaveOccurred())
+		xdsMetrics, err = xds_metrics.NewMetrics(newMetrics)
 		Expect(err).ToNot(HaveOccurred())
 		cache, err := mesh.NewCache(cacheExpirationTime, meshContextBuilder, newMetrics)
 		Expect(err).ToNot(HaveOccurred())
@@ -117,6 +122,7 @@ var _ = Describe("Dataplane Watchdog", func() {
 			},
 			MeshCache:  cache,
 			ResManager: resManager,
+			XdsMetrics: xdsMetrics,
 		}
 
 		pair, err := envoy_admin_tls.GenerateCA()
@@ -191,6 +197,23 @@ var _ = Describe("Dataplane Watchdog", func() {
 			// then
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshotReconciler.proxy).To(BeNil())
+		})
+
+		It("should count successful config-hash-triggered reconciles only", func() {
+			// when
+			_, err := watchdog.Sync(ctx)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testutil.ToFloat64(xdsMetrics.DataplaneConfigRegenerated.WithLabelValues(resKey.Mesh))).To(Equal(1.0))
+
+			// when
+			time.Sleep(cacheExpirationTime)
+			_, err = watchdog.Sync(ctx)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testutil.ToFloat64(xdsMetrics.DataplaneConfigRegenerated.WithLabelValues(resKey.Mesh))).To(Equal(1.0))
 		})
 	})
 })


### PR DESCRIPTION
## Motivation

Workload status updates should not force mesh-wide XDS recomputation when the effective workload membership and routing inputs have not changed.

This addresses the Workload amplifier (fix 2) from https://github.com/kumahq/kuma/issues/17062: `Workload` now hashes identity only, so `workload.status-updater` writes no longer bump the mesh-wide hash. The general resourceVersion-based hashing issue (fix 1 in the issue, affecting other hashed resources such as Dataplane label/annotation writes) is out of scope here and tracked separately in the issue.

## Implementation information

- Add workload helpers and mesh context hash coverage to compare only XDS-relevant workload state.
- Mark ignored status-only resource updates so the dataplane watchdog can skip unnecessary mesh-wide syncs.
- Add metrics coverage for skipped synchronization caused by unchanged mesh context hashes.

Part of https://github.com/kumahq/kuma/issues/17062