### PR TITLE
fix(intercp): distinguish unreachable leader from leader change

### DIFF
--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -102,8 +102,6 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 			if h.heartbeat(ctx, true) {
 				h.metrics.interval.Observe(float64(core.Now().Sub(start).Milliseconds()))
 			}
-			// back off while the leader is unreachable to avoid a
-			// high-volume stream of failure logs on a persistent issue.
 			timer.Reset(h.backoff())
 		case <-stop:
 			// send final heartbeat to gracefully signal that the instance is going down
@@ -134,36 +132,41 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 		"ready", ready,
 	)
 
-	newLeader, err := Leader(ctx, h.catalog)
-	if err != nil {
-		if errors.Is(err, ErrNoLeader) {
-			log.Info("leader is not yet present in the cluster. No heartbeat to send")
-		} else {
-			log.Error(err, "could not resolve the leader from the catalog")
-		}
-		return false
-	}
-
-	// The catalog is the source of truth for who the leader is. Only report a
-	// leader change when the resolved instance id actually differs from the
-	// previously known one - a failed heartbeat is a connectivity problem, not
-	// a leader change.
-	if h.leader == nil || h.leader.Id != newLeader.Id {
-		if newLeader.Id != h.request.InstanceId {
-			previousLeaderAddress := ""
-			if h.leader != nil {
-				previousLeaderAddress = h.leader.Address
+	// The catalog is only consulted when the leader is unknown or heartbeats
+	// are currently failing - in the calm state we keep talking to the
+	// already-known leader instead of reading the catalog on every tick.
+	if h.leader == nil || h.failures > 0 {
+		newLeader, err := Leader(ctx, h.catalog)
+		if err != nil {
+			if errors.Is(err, ErrNoLeader) {
+				log.Info("leader is not yet present in the cluster. No heartbeat to send")
+			} else {
+				log.Error(err, "could not resolve the leader from the catalog")
 			}
-			log.Info(
-				"leader has changed. Creating connection to the new leader.",
-				"previousLeaderAddress", previousLeaderAddress,
-				"newLeaderAddress", newLeader.Address,
-			)
-			h.metrics.leaderChanges.Inc()
+			return false
 		}
-		h.failures = 0
+
+		// The catalog is the source of truth for who the leader is. Only report a
+		// leader change when the resolved instance id actually differs from the
+		// previously known one - a failed heartbeat is a connectivity problem, not
+		// a leader change.
+		if h.leader == nil || h.leader.Id != newLeader.Id {
+			if newLeader.Id != h.request.InstanceId {
+				previousLeaderAddress := ""
+				if h.leader != nil {
+					previousLeaderAddress = h.leader.Address
+				}
+				log.Info(
+					"leader has changed. Creating connection to the new leader.",
+					"previousLeaderAddress", previousLeaderAddress,
+					"newLeaderAddress", newLeader.Address,
+				)
+				h.metrics.leaderChanges.Inc()
+			}
+			h.failures = 0
+		}
+		h.leader = &newLeader
 	}
-	h.leader = &newLeader
 
 	if h.leader.Id == h.request.InstanceId {
 		log.V(1).Info("this instance is a leader. No need to send a heartbeat.")
@@ -200,9 +203,10 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	}
 	h.failures = 0
 	if !resp.Leader {
-		// the instance no longer considers itself the leader; the leader will
-		// be re-resolved from the catalog on the next tick.
+		// the instance no longer considers itself the leader; clear it so the
+		// leader is re-resolved from the catalog on the next tick.
 		log.V(1).Info("instance responded that it is no longer a leader")
+		h.leader = nil
 	}
 	return true
 }

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core"
@@ -17,14 +19,31 @@ import (
 
 var heartbeatLog = core.Log.WithName("intercp").WithName("catalog").WithName("heartbeat")
 
+// maxHeartbeatBackoff caps the exponential backoff applied while the leader
+// cannot be reached, so a persistent connectivity problem does not produce a
+// high-volume stream of failure logs.
+const maxHeartbeatBackoff = 1 * time.Minute
+
+const (
+	reasonUnreachable = "unreachable"
+	reasonError       = "error"
+)
+
+type heartbeatMetrics struct {
+	interval      prometheus.Histogram
+	failures      *prometheus.CounterVec
+	leaderChanges prometheus.Counter
+}
+
 type heartbeatComponent struct {
 	catalog     Catalog
 	getClientFn GetClientFn
 	request     *system_proto.PingRequest
 	interval    time.Duration
 
-	leader *Instance
-	metric prometheus.Histogram
+	leader   *Instance
+	failures int
+	metrics  *heartbeatMetrics
 }
 
 var _ component.Component = &heartbeatComponent{}
@@ -38,11 +57,21 @@ func NewHeartbeatComponent(
 	newClientFn GetClientFn,
 	metrics core_metrics.Metrics,
 ) (component.Component, error) {
-	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "component_heartbeat",
-		Help: "Summary of Inter CP Heartbeat component interval",
-	})
-	if err := metrics.Register(metric); err != nil {
+	m := &heartbeatMetrics{
+		interval: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name: "component_heartbeat",
+			Help: "Summary of Inter CP Heartbeat component interval",
+		}),
+		failures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "component_heartbeat_failures",
+			Help: "Counter of failed Inter CP heartbeats to the leader by reason",
+		}, []string{"reason"}),
+		leaderChanges: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "component_heartbeat_leader_changes",
+			Help: "Counter of observed Inter CP leader changes",
+		}),
+	}
+	if err := metrics.BulkRegister(m.interval, m.failures, m.leaderChanges); err != nil {
 		return nil, err
 	}
 
@@ -55,7 +84,7 @@ func NewHeartbeatComponent(
 		},
 		getClientFn: newClientFn,
 		interval:    interval,
-		metric:      metric,
+		metrics:     m,
 	}, nil
 }
 
@@ -63,16 +92,19 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 	heartbeatLog.Info("starting heartbeats to a leader")
 	ctx := user.Ctx(context.Background(), user.ControlPlane)
 	ctx = multitenant.WithTenant(ctx, multitenant.GlobalTenantID)
-	ticker := time.NewTicker(h.interval)
+	timer := time.NewTimer(h.interval)
+	defer timer.Stop()
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-timer.C:
 			start := core.Now()
-			if !h.heartbeat(ctx, true) {
-				continue
+			if h.heartbeat(ctx, true) {
+				h.metrics.interval.Observe(float64(core.Now().Sub(start).Milliseconds()))
 			}
-			h.metric.Observe(float64(core.Now().Sub(start).Milliseconds()))
+			// back off while the leader is unreachable to avoid a
+			// high-volume stream of failure logs on a persistent issue.
+			timer.Reset(h.backoff())
 		case <-stop:
 			// send final heartbeat to gracefully signal that the instance is going down
 			_ = h.heartbeat(ctx, false)
@@ -81,67 +113,117 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 	}
 }
 
+// backoff returns the delay until the next heartbeat: the configured interval
+// on success, or an exponentially growing delay (capped) after consecutive
+// failures.
+func (h *heartbeatComponent) backoff() time.Duration {
+	if h.failures == 0 {
+		return h.interval
+	}
+	backoff := h.interval << min(h.failures, 16)
+	if backoff <= 0 || backoff > maxHeartbeatBackoff {
+		return maxHeartbeatBackoff
+	}
+	return backoff
+}
+
 func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
-	heartbeatLog := heartbeatLog.WithValues(
+	log := heartbeatLog.WithValues(
 		"instanceId", h.request.InstanceId,
 		"ready", ready,
 	)
-	if h.leader == nil {
-		if err := h.connectToLeader(ctx); err != nil {
-			if err == ErrNoLeader {
-				heartbeatLog.Info("leader is not yet present in the cluster. No heartbeat to send")
-			} else {
-				heartbeatLog.Error(err, "could not connect to leader")
-			}
-			return false
+
+	newLeader, err := Leader(ctx, h.catalog)
+	if err != nil {
+		if errors.Is(err, ErrNoLeader) {
+			log.Info("leader is not yet present in the cluster. No heartbeat to send")
+		} else {
+			log.Error(err, "could not resolve the leader from the catalog")
 		}
+		return false
 	}
+
+	// The catalog is the source of truth for who the leader is. Only report a
+	// leader change when the resolved instance id actually differs from the
+	// previously known one - a failed heartbeat is a connectivity problem, not
+	// a leader change.
+	if h.leader == nil || h.leader.Id != newLeader.Id {
+		if newLeader.Id != h.request.InstanceId {
+			previousLeaderAddress := ""
+			if h.leader != nil {
+				previousLeaderAddress = h.leader.Address
+			}
+			log.Info(
+				"leader has changed. Creating connection to the new leader.",
+				"previousLeaderAddress", previousLeaderAddress,
+				"newLeaderAddress", newLeader.Address,
+			)
+			h.metrics.leaderChanges.Inc()
+		}
+		h.failures = 0
+	}
+	h.leader = &newLeader
+
 	if h.leader.Id == h.request.InstanceId {
-		heartbeatLog.V(1).Info("this instance is a leader. No need to send a heartbeat.")
+		log.V(1).Info("this instance is a leader. No need to send a heartbeat.")
 		return true
 	}
-	heartbeatLog = heartbeatLog.WithValues(
-		"leaderAddress", h.leader.Address,
-	)
-	heartbeatLog.V(1).Info("sending a heartbeat to a leader")
+	log = log.WithValues("leaderAddress", h.leader.Address)
+	log.V(1).Info("sending a heartbeat to a leader")
+
 	h.request.Ready = ready
 	client, err := h.getClientFn(h.leader.InterCpURL())
 	if err != nil {
-		heartbeatLog.Error(err, "could not get or create a client to a leader")
-		h.leader = nil
+		log.Error(err, "could not get or create a client to a leader")
+		h.recordFailure(reasonError)
 		return false
 	}
 	resp, err := client.Ping(ctx, h.request)
 	if err != nil {
-		heartbeatLog.Info("could not send a heartbeat to a leader. It's likely due to leader change", "cause", err)
-		h.leader = nil
+		if isConnectivityError(err) {
+			h.recordFailure(reasonUnreachable)
+			log.Info(
+				"leader is currently unreachable, will retry with backoff. This is a connectivity problem, not a leader change",
+				"cause", err,
+				"consecutiveFailures", h.failures,
+			)
+		} else {
+			h.recordFailure(reasonError)
+			log.Info(
+				"could not send a heartbeat to a leader",
+				"cause", err,
+				"consecutiveFailures", h.failures,
+			)
+		}
 		return false
 	}
+	h.failures = 0
 	if !resp.Leader {
-		heartbeatLog.V(1).Info("instance responded that it is no longer a leader")
-		h.leader = nil
+		// the instance no longer considers itself the leader; the leader will
+		// be re-resolved from the catalog on the next tick.
+		log.V(1).Info("instance responded that it is no longer a leader")
 	}
 	return true
 }
 
-func (h *heartbeatComponent) connectToLeader(ctx context.Context) error {
-	newLeader, err := Leader(ctx, h.catalog)
-	if err != nil {
-		return err
+func (h *heartbeatComponent) recordFailure(reason string) {
+	h.failures++
+	h.metrics.failures.WithLabelValues(reason).Inc()
+}
+
+// isConnectivityError reports whether err indicates the leader could not be
+// reached (as opposed to an application-level error).
+func isConnectivityError(err error) bool {
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
 	}
-	h.leader = &newLeader
-	if h.leader.Id == h.request.InstanceId {
-		return nil
+	switch s.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
 	}
-	heartbeatLog.Info("leader has changed. Creating connection to the new leader.",
-		"previousLeaderAddress", h.leader.Address,
-		"newLeaderAddress", newLeader.Address,
-	)
-	_, err = h.getClientFn(h.leader.InterCpURL())
-	if err != nil {
-		return errors.Wrap(err, "could not create a client to a leader")
-	}
-	return nil
 }
 
 func (h *heartbeatComponent) NeedLeaderElection() bool {

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core"
@@ -24,14 +22,9 @@ var heartbeatLog = core.Log.WithName("intercp").WithName("catalog").WithName("he
 // high-volume stream of failure logs.
 const maxHeartbeatBackoff = 1 * time.Minute
 
-const (
-	reasonUnreachable = "unreachable"
-	reasonError       = "error"
-)
-
 type heartbeatMetrics struct {
 	interval prometheus.Histogram
-	failures *prometheus.CounterVec
+	failures prometheus.Counter
 }
 
 type heartbeatComponent struct {
@@ -61,10 +54,10 @@ func NewHeartbeatComponent(
 			Name: "component_heartbeat",
 			Help: "Summary of Inter CP Heartbeat component interval",
 		}),
-		failures: prometheus.NewCounterVec(prometheus.CounterOpts{
+		failures: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "component_heartbeat_failures",
-			Help: "Counter of failed Inter CP heartbeats to the leader by reason",
-		}, []string{"reason"}),
+			Help: "Counter of failed Inter CP heartbeats to the leader",
+		}),
 	}
 	if err := metrics.BulkRegister(m.interval, m.failures); err != nil {
 		return nil, err
@@ -173,26 +166,17 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	client, err := h.getClientFn(h.leader.InterCpURL())
 	if err != nil {
 		log.Error(err, "could not get or create a client to a leader")
-		h.recordFailure(reasonError)
+		h.recordFailure()
 		return false
 	}
 	resp, err := client.Ping(ctx, h.request)
 	if err != nil {
-		if isConnectivityError(err) {
-			h.recordFailure(reasonUnreachable)
-			log.Info(
-				"leader is currently unreachable, will retry with backoff. This is a connectivity problem, not a leader change",
-				"cause", err,
-				"consecutiveFailures", h.failures,
-			)
-		} else {
-			h.recordFailure(reasonError)
-			log.Info(
-				"could not send a heartbeat to a leader",
-				"cause", err,
-				"consecutiveFailures", h.failures,
-			)
-		}
+		h.recordFailure()
+		log.Info(
+			"could not send a heartbeat to a leader, will retry with backoff. This is a connectivity problem, not a leader change",
+			"cause", err,
+			"consecutiveFailures", h.failures,
+		)
 		return false
 	}
 	h.failures = 0
@@ -205,24 +189,9 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	return true
 }
 
-func (h *heartbeatComponent) recordFailure(reason string) {
+func (h *heartbeatComponent) recordFailure() {
 	h.failures++
-	h.metrics.failures.WithLabelValues(reason).Inc()
-}
-
-// isConnectivityError reports whether err indicates the leader could not be
-// reached (as opposed to an application-level error).
-func isConnectivityError(err error) bool {
-	s, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	switch s.Code() {
-	case codes.Unavailable, codes.DeadlineExceeded:
-		return true
-	default:
-		return false
-	}
+	h.metrics.failures.Inc()
 }
 
 func (h *heartbeatComponent) NeedLeaderElection() bool {

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -30,9 +30,8 @@ const (
 )
 
 type heartbeatMetrics struct {
-	interval      prometheus.Histogram
-	failures      *prometheus.CounterVec
-	leaderChanges prometheus.Counter
+	interval prometheus.Histogram
+	failures *prometheus.CounterVec
 }
 
 type heartbeatComponent struct {
@@ -66,12 +65,8 @@ func NewHeartbeatComponent(
 			Name: "component_heartbeat_failures",
 			Help: "Counter of failed Inter CP heartbeats to the leader by reason",
 		}, []string{"reason"}),
-		leaderChanges: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "component_heartbeat_leader_changes",
-			Help: "Counter of observed Inter CP leader changes",
-		}),
 	}
-	if err := metrics.BulkRegister(m.interval, m.failures, m.leaderChanges); err != nil {
+	if err := metrics.BulkRegister(m.interval, m.failures); err != nil {
 		return nil, err
 	}
 
@@ -161,7 +156,6 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 					"previousLeaderAddress", previousLeaderAddress,
 					"newLeaderAddress", newLeader.Address,
 				)
-				h.metrics.leaderChanges.Inc()
 			}
 			h.failures = 0
 		}

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -123,36 +124,8 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	// The catalog is only consulted when the leader is unknown or heartbeats
 	// are currently failing - in the calm state we keep talking to the
 	// already-known leader instead of reading the catalog on every tick.
-	if h.leader == nil || h.failures > 0 {
-		newLeader, err := Leader(ctx, h.catalog)
-		if err != nil {
-			if errors.Is(err, ErrNoLeader) {
-				log.Info("leader is not yet present in the cluster. No heartbeat to send")
-			} else {
-				log.Error(err, "could not resolve the leader from the catalog")
-			}
-			return false
-		}
-
-		// The catalog is the source of truth for who the leader is. Only report a
-		// leader change when the resolved instance id actually differs from the
-		// previously known one - a failed heartbeat is a connectivity problem, not
-		// a leader change.
-		if h.leader == nil || h.leader.Id != newLeader.Id {
-			if newLeader.Id != h.request.InstanceId {
-				previousLeaderAddress := ""
-				if h.leader != nil {
-					previousLeaderAddress = h.leader.Address
-				}
-				log.Info(
-					"leader has changed. Creating connection to the new leader.",
-					"previousLeaderAddress", previousLeaderAddress,
-					"newLeaderAddress", newLeader.Address,
-				)
-			}
-			h.failures = 0
-		}
-		h.leader = &newLeader
+	if (h.leader == nil || h.failures > 0) && !h.resolveLeader(ctx, log) {
+		return false
 	}
 
 	if h.leader.Id == h.request.InstanceId {
@@ -185,6 +158,41 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 		// leader is re-resolved from the catalog on the next tick.
 		log.V(1).Info("instance responded that it is no longer a leader")
 		h.leader = nil
+	}
+	return true
+}
+
+func (h *heartbeatComponent) resolveLeader(ctx context.Context, log logr.Logger) bool {
+	newLeader, err := Leader(ctx, h.catalog)
+	if err != nil {
+		if errors.Is(err, ErrNoLeader) {
+			log.Info("leader is not yet present in the cluster. No heartbeat to send")
+		} else {
+			log.Error(err, "could not resolve the leader from the catalog")
+			h.recordFailure()
+		}
+		return false
+	}
+
+	leaderChanged := h.leader == nil || h.leader.Id != newLeader.Id
+	if !leaderChanged {
+		h.leader = &newLeader
+		return true
+	}
+
+	previousLeaderAddress := ""
+	if h.leader != nil {
+		previousLeaderAddress = h.leader.Address
+	}
+	h.failures = 0
+	h.leader = &newLeader
+
+	if newLeader.Id != h.request.InstanceId {
+		log.Info(
+			"leader has changed. Creating connection to the new leader.",
+			"previousLeaderAddress", previousLeaderAddress,
+			"newLeaderAddress", newLeader.Address,
+		)
 	}
 	return true
 }

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -162,6 +162,10 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	return true
 }
 
+// resolveLeader refreshes h.leader from the catalog. It returns true when a
+// leader is available and a heartbeat should be sent this tick, and false when
+// there is no leader yet or the catalog read failed (in which case this tick is
+// skipped).
 func (h *heartbeatComponent) resolveLeader(ctx context.Context, log logr.Logger) bool {
 	newLeader, err := Leader(ctx, h.catalog)
 	if err != nil {
@@ -174,9 +178,8 @@ func (h *heartbeatComponent) resolveLeader(ctx context.Context, log logr.Logger)
 		return false
 	}
 
-	leaderChanged := h.leader == nil || h.leader.Id != newLeader.Id
-	if !leaderChanged {
-		h.leader = &newLeader
+	if h.leader != nil && h.leader.Id == newLeader.Id {
+		// same leader as before, nothing to update
 		return true
 	}
 

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -124,7 +124,7 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	// The catalog is only consulted when the leader is unknown or heartbeats
 	// are currently failing - in the calm state we keep talking to the
 	// already-known leader instead of reading the catalog on every tick.
-	if (h.leader == nil || h.failures > 0) && !h.resolveLeader(ctx, log) {
+	if (h.leader == nil || h.failures > 0) && !h.ensureLeader(ctx, log) {
 		return false
 	}
 
@@ -162,11 +162,7 @@ func (h *heartbeatComponent) heartbeat(ctx context.Context, ready bool) bool {
 	return true
 }
 
-// resolveLeader refreshes h.leader from the catalog. It returns true when a
-// leader is available and a heartbeat should be sent this tick, and false when
-// there is no leader yet or the catalog read failed (in which case this tick is
-// skipped).
-func (h *heartbeatComponent) resolveLeader(ctx context.Context, log logr.Logger) bool {
+func (h *heartbeatComponent) ensureLeader(ctx context.Context, log logr.Logger) bool {
 	newLeader, err := Leader(ctx, h.catalog)
 	if err != nil {
 		if errors.Is(err, ErrNoLeader) {

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -114,15 +114,16 @@ func (h *heartbeatComponent) Start(stop <-chan struct{}) error {
 }
 
 // backoff returns the delay until the next heartbeat: the configured interval
-// on success, or an exponentially growing delay (capped) after consecutive
-// failures.
+// on success, or an exponentially growing delay after consecutive failures.
+// The cap never reduces the delay below the configured interval.
 func (h *heartbeatComponent) backoff() time.Duration {
 	if h.failures == 0 {
 		return h.interval
 	}
 	backoff := h.interval << min(h.failures, 16)
-	if backoff <= 0 || backoff > maxHeartbeatBackoff {
-		return maxHeartbeatBackoff
+	maxBackoff := max(maxHeartbeatBackoff, h.interval)
+	if backoff <= 0 || backoff > maxBackoff {
+		return maxBackoff
 	}
 	return backoff
 }

--- a/pkg/intercp/catalog/heartbeat_component_internal_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_internal_test.go
@@ -1,0 +1,53 @@
+package catalog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHeartbeatBackoffDoesNotReduceConfiguredInterval(t *testing.T) {
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		failures int
+		expected time.Duration
+	}{
+		{
+			name:     "successful heartbeat uses configured interval",
+			interval: 10 * time.Second,
+			failures: 0,
+			expected: 10 * time.Second,
+		},
+		{
+			name:     "failed heartbeat backs off below cap",
+			interval: 10 * time.Second,
+			failures: 1,
+			expected: 20 * time.Second,
+		},
+		{
+			name:     "failed heartbeat is capped at max backoff",
+			interval: 10 * time.Second,
+			failures: 4,
+			expected: maxHeartbeatBackoff,
+		},
+		{
+			name:     "configured interval above max backoff is preserved",
+			interval: 2 * time.Minute,
+			failures: 1,
+			expected: 2 * time.Minute,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &heartbeatComponent{
+				interval: tc.interval,
+				failures: tc.failures,
+			}
+
+			if got := h.backoff(); got != tc.expected {
+				t.Fatalf("expected backoff %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/intercp/catalog/heartbeat_component_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_test.go
@@ -2,6 +2,7 @@ package catalog_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -169,6 +170,35 @@ var _ = Describe("Heartbeats", func() {
 		}, "1s", "100ms").Should(Succeed())
 	})
 
+	It("should record failures when the catalog cannot be read", func() {
+		failingMetrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		failingComponent, err := catalog.NewHeartbeatComponent(
+			failingCatalog{err: errors.New("catalog read failed")},
+			currentInstance,
+			10*time.Millisecond,
+			func(string) (system_proto.InterCpPingServiceClient, error) {
+				return pingClient, nil
+			},
+			failingMetrics,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		failingStopCh := make(chan struct{})
+		defer close(failingStopCh)
+		go func() {
+			defer GinkgoRecover()
+			err := failingComponent.Start(failingStopCh)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		Eventually(func(g Gomega) {
+			metric := test_metrics.FindMetric(failingMetrics, "component_heartbeat_failures")
+			g.Expect(metric).ToNot(BeNil())
+			g.Expect(metric.Counter.GetValue()).To(BeNumerically(">", 0))
+		}, "10s", "100ms").Should(Succeed())
+	})
+
 	It("should not send heartbeat if the instance is a leader", func() {
 		// given
 		instance := currentInstance
@@ -183,6 +213,28 @@ var _ = Describe("Heartbeats", func() {
 		}, "1s", "100ms").Should(Succeed())
 	})
 })
+
+type failingCatalog struct {
+	err error
+}
+
+var _ catalog.Catalog = failingCatalog{}
+
+func (f failingCatalog) Instances(context.Context) ([]catalog.Instance, error) {
+	return nil, f.err
+}
+
+func (f failingCatalog) Replace(context.Context, []catalog.Instance) (bool, error) {
+	return false, f.err
+}
+
+func (f failingCatalog) ReplaceLeader(context.Context, catalog.Instance) error {
+	return f.err
+}
+
+func (f failingCatalog) DropLeader(context.Context, catalog.Instance) error {
+	return f.err
+}
 
 type staticPingClient struct {
 	received  *system_proto.PingRequest

--- a/pkg/intercp/catalog/heartbeat_component_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -15,6 +17,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/intercp/catalog"
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
+	test_metrics "github.com/kumahq/kuma/v3/pkg/test/metrics"
 )
 
 var _ = Describe("Heartbeats", func() {
@@ -23,6 +26,7 @@ var _ = Describe("Heartbeats", func() {
 
 	var pingClient *staticPingClient
 	var c catalog.Catalog
+	var metrics core_metrics.Metrics
 
 	currentInstance := catalog.Instance{
 		Id:          "instance-1",
@@ -40,7 +44,8 @@ var _ = Describe("Heartbeats", func() {
 		}
 		pc := pingClient // copy pointer to get rid of data race
 
-		metrics, err := core_metrics.NewMetrics("")
+		var err error
+		metrics, err = core_metrics.NewMetrics("")
 		Expect(err).ToNot(HaveOccurred())
 		heartbeatComponent, err = catalog.NewHeartbeatComponent(
 			c,
@@ -132,6 +137,47 @@ var _ = Describe("Heartbeats", func() {
 		}, "10s", "100ms").Should(Succeed())
 	})
 
+	It("should report unreachable leader as connectivity failure, not a leader change", func() {
+		// given a stable leader in the catalog
+		instances := []catalog.Instance{
+			{
+				Id:          "instance-leader",
+				Address:     "192.168.0.1",
+				InterCpPort: 1234,
+				Leader:      true,
+			},
+		}
+		_, err := c.Replace(context.Background(), instances)
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(pingClient.ServerURL()).To(Equal("grpcs://192.168.0.1:1234"))
+		}, "10s", "100ms").Should(Succeed())
+
+		// the initial connection to the leader counts as one change
+		leaderChanges := func() float64 {
+			metric := test_metrics.FindMetric(metrics, "component_heartbeat_leader_changes")
+			Expect(metric).ToNot(BeNil())
+			return metric.Counter.GetValue()
+		}
+		Eventually(leaderChanges, "10s", "100ms").Should(Equal(float64(1)))
+
+		// when the leader becomes unreachable
+		pingClient.SetError(status.Error(codes.Unavailable, "connection refused"))
+
+		// then failures are recorded as connectivity problems
+		Eventually(func(g Gomega) {
+			metric := test_metrics.FindMetric(metrics, "component_heartbeat_failures", "reason", "unreachable")
+			g.Expect(metric).ToNot(BeNil())
+			g.Expect(metric.Counter.GetValue()).To(BeNumerically(">", 0))
+		}, "10s", "100ms").Should(Succeed())
+
+		// and the stable leader is never reported as changed while unreachable
+		Consistently(func(g Gomega) {
+			g.Expect(leaderChanges()).To(Equal(float64(1)))
+			g.Expect(pingClient.ServerURL()).To(Equal("grpcs://192.168.0.1:1234"))
+		}, "1s", "100ms").Should(Succeed())
+	})
+
 	It("should not send heartbeat if the instance is a leader", func() {
 		// given
 		instance := currentInstance
@@ -151,6 +197,7 @@ type staticPingClient struct {
 	received  *system_proto.PingRequest
 	serverURL string
 	leader    bool
+	err       error
 	sync.Mutex
 }
 
@@ -160,9 +207,18 @@ func (s *staticPingClient) Ping(ctx context.Context, in *system_proto.PingReques
 	s.Lock()
 	defer s.Unlock()
 	s.received = in
+	if s.err != nil {
+		return nil, s.err
+	}
 	return &system_proto.PingResponse{
 		Leader: s.leader,
 	}, nil
+}
+
+func (s *staticPingClient) SetError(err error) {
+	s.Lock()
+	defer s.Unlock()
+	s.err = err
 }
 
 func (s *staticPingClient) Received() *system_proto.PingRequest {

--- a/pkg/intercp/catalog/heartbeat_component_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_test.go
@@ -153,14 +153,6 @@ var _ = Describe("Heartbeats", func() {
 			g.Expect(pingClient.ServerURL()).To(Equal("grpcs://192.168.0.1:1234"))
 		}, "10s", "100ms").Should(Succeed())
 
-		// the initial connection to the leader counts as one change
-		leaderChanges := func() float64 {
-			metric := test_metrics.FindMetric(metrics, "component_heartbeat_leader_changes")
-			Expect(metric).ToNot(BeNil())
-			return metric.Counter.GetValue()
-		}
-		Eventually(leaderChanges, "10s", "100ms").Should(Equal(float64(1)))
-
 		// when the leader becomes unreachable
 		pingClient.SetError(status.Error(codes.Unavailable, "connection refused"))
 
@@ -171,9 +163,8 @@ var _ = Describe("Heartbeats", func() {
 			g.Expect(metric.Counter.GetValue()).To(BeNumerically(">", 0))
 		}, "10s", "100ms").Should(Succeed())
 
-		// and the stable leader is never reported as changed while unreachable
+		// and the stable leader connection is never replaced while unreachable
 		Consistently(func(g Gomega) {
-			g.Expect(leaderChanges()).To(Equal(float64(1)))
 			g.Expect(pingClient.ServerURL()).To(Equal("grpcs://192.168.0.1:1234"))
 		}, "1s", "100ms").Should(Succeed())
 	})

--- a/pkg/intercp/catalog/heartbeat_component_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Heartbeats", func() {
 
 		// then failures are recorded as connectivity problems
 		Eventually(func(g Gomega) {
-			metric := test_metrics.FindMetric(metrics, "component_heartbeat_failures", "reason", "unreachable")
+			metric := test_metrics.FindMetric(metrics, "component_heartbeat_failures")
 			g.Expect(metric).ToNot(BeNil())
 			g.Expect(metric.Counter.GetValue()).To(BeNumerically(">", 0))
 		}, "10s", "100ms").Should(Succeed())


### PR DESCRIPTION
## Motivation

> Changelog: fix(intercp): distinguish unreachable leader from leader change

The inter-CP catalog heartbeat component could not tell "cannot reach the leader" (connectivity) from "the leader actually changed". A persistent network problem reaching the leader's inter-CP port was reported as continuous leader flapping even when the elected leader was stable, making logs actively misleading during incidents. Additionally:

- Every failed `Ping` was logged as "likely due to leader change" and dropped the cached leader, forcing a re-resolve every tick.
- `connectToLeader` reassigned `h.leader` before logging, so `previousLeaderAddress` and `newLeaderAddress` were always identical.
- No backoff: a fixed 5s tick produced a steady, high-volume stream of failure logs while the leader was unreachable.

Fixes kumahq/kuma#17067.

## Implementation information

- The catalog is now the source of truth for the leader identity. It is only consulted when the leader is unknown or heartbeats are failing; in the calm state the component keeps talking to the already-known leader instead of reading the catalog every tick. "leader has changed" is logged only on a real transition, with the true previous address.
- Failed `Ping` calls are logged as connectivity problems with the consecutive failure count, not as leader changes; the cached leader is kept and cleared only when the peer responds it is no longer the leader.
- Exponential backoff (capped at max(1m, configured interval)) is applied on consecutive failures via a resettable timer; the counter resets on success or a genuine leader change.
- New metric: `component_heartbeat_failures` counter, alongside the existing `component_heartbeat` histogram.
- Added a unit test: a stable-but-unreachable leader records connectivity failures without registering a leader change.

## Supporting documentation

- Issue: kumahq/kuma#17067
