### PR TITLE
fix(mads): remove noisy MeshMetrics/metrics coexistence log

### DIFF
--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -21,8 +21,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/xds/cache/mesh"
 )
 
-var log = core.Log.WithName("mads").WithName("v1").WithName("reconcile")
-
 func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, resourceGenerator generator.ResourceGenerator, meshCache *mesh.Cache, inboundTagsDisabled bool) *SnapshotGenerator {
 	return &SnapshotGenerator{
 		resourceManager:     resourceManager,
@@ -48,10 +46,6 @@ func (s *SnapshotGenerator) GenerateSnapshot(ctx context.Context) (map[string]en
 	meshes, err := s.getMeshesWithPrometheusEnabled(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(meshes) > 0 && len(meshesWithMeshMetrics) > 0 {
-		log.Info("it is not supported to use both MeshMetrics policy and 'metrics' under Mesh resource. For now MeshMetrics will take precedence. If migrating please remove the 'metrics' section and apply an equivalent MeshMetrics resource")
 	}
 
 	var resources []*core_xds.Resource


### PR DESCRIPTION
## Motivation

The MADS snapshot generator logged this info message on **every** snapshot generation whenever both a `MeshMetrics` policy and a `metrics` section under the `Mesh` resource were present:

> it is not supported to use both MeshMetrics policy and 'metrics' under Mesh resource. For now MeshMetrics will take precedence. ...

This is extremely noisy (fires on each reconcile) and makes it hard to try out `MeshMetrics` while a legacy `metrics` section still exists.

## Implementation

Remove the log line and the now-unused package-level `log` var. `MeshMetrics` precedence behavior is unchanged.

> Changelog: Removed a noisy info log emitted on every MADS snapshot generation when both MeshMetrics and Mesh 'metrics' were configured.

## Backport

Should be backported to all active release branches (the message exists on 2.7 through 2.14).