### PR TITLE
ci(actions): disable persist-credentials in e2e readiness

### DIFF
--- a/.github/workflows/e2e-v3-readiness.yml
+++ b/.github/workflows/e2e-v3-readiness.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download kuma3-preflight (checksum-verified)
         id: preflight
@@ -72,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download kuma3-preflight (checksum-verified)
         id: preflight


### PR DESCRIPTION
## Motivation

The `e2e-v3-readiness.yml` `actions/checkout` steps only read the repo to build and run the e2e suites — they never push. Persisting the default `GITHUB_TOKEN` in the local git config is therefore an unnecessary attack surface (a compromised third-party action could read it). Flagged by Aikido on the downstream auto-upgrade PR.

> Changelog: skip

## Implementation information

Set `persist-credentials: false` on both checkout steps (audit + report jobs).

## Supporting documentation

None.