### PR TITLE
ci(actions): preserve PR labels on backports

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -29,6 +29,7 @@ jobs:
       pr_state: ${{ steps.get-pr-info.outputs.pr_state }}
       pr_base_ref: ${{ steps.get-pr-info.outputs.pr_base_ref }}
       pr_merge_commit_sha: ${{ steps.get-pr-info.outputs.pr_merge_commit_sha }}
+      pr_labels: ${{ steps.get-pr-info.outputs.pr_labels }}
     steps:
       - name: get-pr-info
         id: get-pr-info
@@ -66,20 +67,26 @@ jobs:
             ' <<< "$1"
           }
           
-          PR_INFO_JSON=$(gh pr view "$INPUT_PR" --json 'number,title,mergedAt,state,mergeCommit,baseRefName' || echo '{}')
+          PR_INFO_JSON=$(gh pr view "$INPUT_PR" --json 'number,title,mergedAt,state,mergeCommit,baseRefName,labels' || echo '{}')
           PR_INFO_BODY=$(gh pr view "$INPUT_PR" --json 'body' -q '.body' || echo '')
-          
+
           TITLE=$(echo -n "$PR_INFO_JSON" | jq -r '.title //empty')
           CHANGE_LOG=$(get_change_log "$PR_INFO_BODY")
           STATE=$(echo -n "$PR_INFO_JSON" | jq -r '.state //empty')
           BASE_REF=$(echo -n "$PR_INFO_JSON" | jq -r '.baseRefName //empty')
           COMMIT=$(echo -n "$PR_INFO_JSON" | jq -r '.mergeCommit.oid //empty')
-          
+          # Carry the original PR's labels over to the backport PR. Drop labels
+          # that would auto-act on the backport (auto-merge, publish).
+          LABELS=$(echo -n "$PR_INFO_JSON" | jq -r '
+            [.labels[].name | select(. != "ci/auto-merge" and . != "ci/force-publish")]
+            | join(",")')
+
           {
             echo "pr_title=${TITLE}"
             echo "pr_state=${STATE}"
             echo "pr_base_ref=${BASE_REF}"
             echo "pr_merge_commit_sha=${COMMIT}"
+            echo "pr_labels=${LABELS}"
             echo "pr_change_log<<EOF"
             echo "${CHANGE_LOG}"
             echo "EOF"
@@ -111,6 +118,7 @@ jobs:
       PR_TITLE: ${{ needs.pr-info.outputs.pr_title }}
       SHA: ${{ needs.pr-info.outputs.pr_merge_commit_sha }}
       TARGET_BRANCH: ${{ matrix.branch }}
+      PR_LABELS: ${{ needs.pr-info.outputs.pr_labels }}
       USE_APP_TOKEN: ${{ secrets.APP_ID != '' }}
     steps:
       - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
@@ -138,11 +146,12 @@ jobs:
             set -x
           fi
           
-          echo "LABELS=${{ matrix.branch }}" >> "$GITHUB_ENV"
+          BASE_LABELS="${TARGET_BRANCH}${PR_LABELS:+,${PR_LABELS}}"
+          echo "LABELS=${BASE_LABELS}" >> "$GITHUB_ENV"
           if git cherry-pick "${{ env.SHA }}"; then
             echo "Cherry-picked without conflicts!"
           else
-            echo "LABELS=${{ matrix.branch }},conflict" >> "$GITHUB_ENV"
+            echo "LABELS=${BASE_LABELS},conflict" >> "$GITHUB_ENV"
             {
               echo "DIFF<<EOF"
               echo ":warning: :warning: :warning: Conflicts happened when cherry-picking! :warning: :warning: :warning:"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -78,7 +78,7 @@ jobs:
           # Carry the original PR's labels over to the backport PR. Drop labels
           # that would auto-act on the backport (auto-merge, publish).
           LABELS=$(echo -n "$PR_INFO_JSON" | jq -r '
-            [.labels[].name | select(. != "ci/auto-merge" and . != "ci/force-publish")]
+            [(.labels // [])[].name | select(. != "ci/auto-merge" and . != "ci/force-publish")]
             | join(",")')
 
           {


### PR DESCRIPTION
## Motivation

Backport PRs are opened without the labels of the original PR, so reviewers lose context (area/kind/etc.) and `ci/*` labels that tune the test matrix aren't carried over.

> Changelog: skip

## Implementation information

- The backport workflow now reads the original PR's `labels` and applies them to the backport PR, alongside the existing target-branch and `conflict` labels.
- `ci/auto-merge` and `ci/force-publish` are dropped so backports don't silently auto-merge or publish.

For the copied `ci/*` labels to actually re-run CI (labels applied after the PR `opened` event are otherwise ignored until a new commit), this relies on the build workflow triggering on `labeled` events — see the sibling PR https://github.com/kumahq/kuma/pull/17084.

## Supporting documentation

N/A