### PR TITLE
refactor(mesh): route meshServices reads via MeshServicesMode()

### DIFF
--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -75,6 +75,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 	baseMeshContext, err := dle.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 	if err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build MeshContext")
+		return
 	}
 
 	if baseMeshContext.Mesh.Spec.MeshServicesMode() != v1alpha1.Mesh_MeshServices_Exclusive {

--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -77,7 +77,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build MeshContext")
 	}
 
-	if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() != v1alpha1.Mesh_MeshServices_Exclusive {
+	if baseMeshContext.Mesh.Spec.MeshServicesMode() != v1alpha1.Mesh_MeshServices_Exclusive {
 		rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError("can't use _layout endpoint without meshService enabled"), "Bad Request")
 		return
 	}

--- a/pkg/api-server/resource_inspect_endpoints.go
+++ b/pkg/api-server/resource_inspect_endpoints.go
@@ -298,7 +298,7 @@ func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.Register
 			return
 		}
 
-		if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() != mesh_proto.Mesh_MeshServices_Exclusive {
+		if baseMeshContext.Mesh.Spec.MeshServicesMode() != mesh_proto.Mesh_MeshServices_Exclusive {
 			rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError("can't use _policies endpoint without meshService enabled"), "Bad Request")
 			return
 		}

--- a/pkg/core/naming/unified-naming/unified_naming.go
+++ b/pkg/core/naming/unified-naming/unified_naming.go
@@ -13,5 +13,5 @@ func Enabled(meta *core_xds.DataplaneMetadata, mesh *core_mesh.MeshResource) boo
 	}
 
 	return meta.HasFeature(xds_types.FeatureUnifiedResourceNaming) &&
-		mesh.Spec.GetMeshServices().GetMode() == mesh_proto.Mesh_MeshServices_Exclusive
+		mesh.Spec.MeshServicesMode() == mesh_proto.Mesh_MeshServices_Exclusive
 }

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -649,8 +649,8 @@ func (p MeshServiceExclusivePredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	oldMSMode := oldMesh.(*mesh_proto.Mesh).GetMeshServices().GetMode()
-	newMSMode := newMesh.(*mesh_proto.Mesh).GetMeshServices().GetMode()
+	oldMSMode := oldMesh.(*mesh_proto.Mesh).MeshServicesMode()
+	newMSMode := newMesh.(*mesh_proto.Mesh).MeshServicesMode()
 
 	// MeshService mode changed to Exclusive
 	if newMSMode == mesh_proto.Mesh_MeshServices_Exclusive &&

--- a/pkg/xds/bootstrap/template_v3.go
+++ b/pkg/xds/bootstrap/template_v3.go
@@ -63,7 +63,7 @@ func genConfig(parameters configParameters, proxyConfig xds.Proxy, enableReloada
 	getNameOrDefault := system_names.GetNameOrDefault(meshResource != nil &&
 		parameters.Features != nil &&
 		parameters.Features.HasFeature(xds_types.FeatureUnifiedResourceNaming) &&
-		meshResource.Spec.GetMeshServices().GetMode() == mesh_proto.Mesh_MeshServices_Exclusive,
+		meshResource.Spec.MeshServicesMode() == mesh_proto.Mesh_MeshServices_Exclusive,
 	)
 
 	staticClusters, err := buildStaticClusters(


### PR DESCRIPTION
## Motivation

Several call sites read `meshServices.mode` directly instead of going
through the `MeshServicesMode()` helper. This makes it hard to flip the
default mode consistently in one place. Closes https://github.com/kumahq/kuma/issues/17097

## Implementation information

Routed the remaining raw `meshServices.mode` reads through
`MeshServicesMode()` in:
- `pkg/api-server/dataplane_layout_endpoint.go`
- `pkg/api-server/resource_inspect_endpoints.go`
- `pkg/core/naming/unified-naming/unified_naming.go`
- `pkg/plugins/runtime/k8s/controllers/pod_controller.go`
- `pkg/xds/bootstrap/template_v3.go`

Pure routing change, no behavior change while the default remains
`Disabled`.

_Generated by Sybra harness_