### PR TITLE
docs(kuma-cp): document Dataplane inbound name source

### DIFF
--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -607,7 +607,11 @@ type Dataplane_Networking_Inbound struct {
 	ServiceProbe *Dataplane_Networking_Inbound_ServiceProbe `protobuf:"bytes,8,opt,name=serviceProbe,proto3" json:"serviceProbe,omitempty"`
 	// State describes the current state of the listener.
 	State Dataplane_Networking_Inbound_State `protobuf:"varint,9,opt,name=state,proto3,enum=kuma.mesh.v1alpha1.Dataplane_Networking_Inbound_State" json:"state,omitempty"`
-	// Name adds another way of referencing this port, usable with MeshService
+	// Name adds another way of referencing this port, usable with MeshService.
+	// On Kubernetes, this is derived from the pod container port name that
+	// matches the Service's targetPort, not from the Service port name. It
+	// is empty when the matched container port is unnamed, or when a
+	// numeric targetPort has no matching declared container port.
 	Name string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
 	// Protocol of the service (tcp, http, grpc, etc).
 	Protocol      string `protobuf:"bytes,11,opt,name=protocol,proto3" json:"protocol,omitempty"`

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -611,7 +611,10 @@ type Dataplane_Networking_Inbound struct {
 	// On Kubernetes, this is derived from the pod container port name that
 	// matches the Service's targetPort, not from the Service port name. It
 	// is empty when the matched container port is unnamed, or when a
-	// numeric targetPort has no matching declared container port.
+	// numeric targetPort has no matching declared container port. A string
+	// targetPort with no matching named container port is not represented
+	// here at all: the inbound is dropped instead of being emitted with an
+	// empty name.
 	Name string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
 	// Protocol of the service (tcp, http, grpc, etc).
 	Protocol      string `protobuf:"bytes,11,opt,name=protocol,proto3" json:"protocol,omitempty"`

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -157,7 +157,10 @@ message Dataplane {
       // On Kubernetes, this is derived from the pod container port name that
       // matches the Service's targetPort, not from the Service port name. It
       // is empty when the matched container port is unnamed, or when a
-      // numeric targetPort has no matching declared container port.
+      // numeric targetPort has no matching declared container port. A string
+      // targetPort with no matching named container port is not represented
+      // here at all: the inbound is dropped instead of being emitted with an
+      // empty name.
       string name = 10;
 
       // Protocol of the service (tcp, http, grpc, etc).

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -153,7 +153,11 @@ message Dataplane {
       // State describes the current state of the listener.
       State state = 9;
 
-      // Name adds another way of referencing this port, usable with MeshService
+      // Name adds another way of referencing this port, usable with MeshService.
+      // On Kubernetes, this is derived from the pod container port name that
+      // matches the Service's targetPort, not from the Service port name. It
+      // is empty when the matched container port is unnamed, or when a
+      // numeric targetPort has no matching declared container port.
       string name = 10;
 
       // Protocol of the service (tcp, http, grpc, etc).

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -195,7 +195,10 @@ components:
                       On Kubernetes, this is derived from the pod container port name that
                       matches the Service's targetPort, not from the Service port name. It
                       is empty when the matched container port is unnamed, or when a
-                      numeric targetPort has no matching declared container port.
+                      numeric targetPort has no matching declared container port. A string
+                      targetPort with no matching named container port is not represented
+                      here at all: the inbound is dropped instead of being emitted with an
+                      empty name.
                     type: string
                   port:
                     description: |-

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -190,8 +190,12 @@ components:
                         type: boolean
                     type: object
                   name:
-                    description: Name adds another way of referencing this port, usable
-                      with MeshService
+                    description: |-
+                      Name adds another way of referencing this port, usable with MeshService.
+                      On Kubernetes, this is derived from the pod container port name that
+                      matches the Service's targetPort, not from the Service port name. It
+                      is empty when the matched container port is unnamed, or when a
+                      numeric targetPort has no matching declared container port.
                     type: string
                   port:
                     description: |-

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -126,8 +126,12 @@ components:
                             type: boolean
                         type: object
                       name:
-                        description: Name adds another way of referencing this port,
-                          usable with MeshService
+                        description: |-
+                          Name adds another way of referencing this port, usable with MeshService.
+                          On Kubernetes, this is derived from the pod container port name that
+                          matches the Service's targetPort, not from the Service port name. It
+                          is empty when the matched container port is unnamed, or when a
+                          numeric targetPort has no matching declared container port.
                         type: string
                       port:
                         description: |-

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -131,7 +131,10 @@ components:
                           On Kubernetes, this is derived from the pod container port name that
                           matches the Service's targetPort, not from the Service port name. It
                           is empty when the matched container port is unnamed, or when a
-                          numeric targetPort has no matching declared container port.
+                          numeric targetPort has no matching declared container port. A string
+                          targetPort with no matching named container port is not represented
+                          here at all: the inbound is dropped instead of being emitted with an
+                          empty name.
                         type: string
                       port:
                         description: |-

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5701,7 +5701,15 @@ components:
                       when a
 
                       numeric targetPort has no matching declared container
-                      port.
+                      port. A string
+
+                      targetPort with no matching named container port is not
+                      represented
+
+                      here at all: the inbound is dropped instead of being
+                      emitted with an
+
+                      empty name.
                     type: string
                   port:
                     description: >-
@@ -17786,7 +17794,15 @@ components:
                           or when a
 
                           numeric targetPort has no matching declared container
-                          port.
+                          port. A string
+
+                          targetPort with no matching named container port is
+                          not represented
+
+                          here at all: the inbound is dropped instead of being
+                          emitted with an
+
+                          empty name.
                         type: string
                       port:
                         description: >-

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5689,7 +5689,19 @@ components:
                   name:
                     description: >-
                       Name adds another way of referencing this port, usable
-                      with MeshService
+                      with MeshService.
+
+                      On Kubernetes, this is derived from the pod container port
+                      name that
+
+                      matches the Service's targetPort, not from the Service
+                      port name. It
+
+                      is empty when the matched container port is unnamed, or
+                      when a
+
+                      numeric targetPort has no matching declared container
+                      port.
                     type: string
                   port:
                     description: >-
@@ -17762,7 +17774,19 @@ components:
                       name:
                         description: >-
                           Name adds another way of referencing this port, usable
-                          with MeshService
+                          with MeshService.
+
+                          On Kubernetes, this is derived from the pod container
+                          port name that
+
+                          matches the Service's targetPort, not from the Service
+                          port name. It
+
+                          is empty when the matched container port is unnamed,
+                          or when a
+
+                          numeric targetPort has no matching declared container
+                          port.
                         type: string
                       port:
                         description: >-

--- a/docs/generated/raw/protos/Dataplane.json
+++ b/docs/generated/raw/protos/Dataplane.json
@@ -165,7 +165,7 @@
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name adds another way of referencing this port, usable with MeshService"
+                    "description": "Name adds another way of referencing this port, usable with MeshService. On Kubernetes, this is derived from the pod container port name that matches the Service's targetPort, not from the Service port name. It is empty when the matched container port is unnamed, or when a numeric targetPort has no matching declared container port."
                 },
                 "protocol": {
                     "type": "string",

--- a/docs/generated/raw/protos/Dataplane.json
+++ b/docs/generated/raw/protos/Dataplane.json
@@ -165,7 +165,7 @@
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name adds another way of referencing this port, usable with MeshService. On Kubernetes, this is derived from the pod container port name that matches the Service's targetPort, not from the Service port name. It is empty when the matched container port is unnamed, or when a numeric targetPort has no matching declared container port."
+                    "description": "Name adds another way of referencing this port, usable with MeshService. On Kubernetes, this is derived from the pod container port name that matches the Service's targetPort, not from the Service port name. It is empty when the matched container port is unnamed, or when a numeric targetPort has no matching declared container port. A string targetPort with no matching named container port is not represented here at all: the inbound is dropped instead of being emitted with an empty name."
                 },
                 "protocol": {
                     "type": "string",

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -181,7 +181,7 @@
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name adds another way of referencing this port, usable with MeshService. On Kubernetes, this is derived from the pod container port name that matches the Service's targetPort, not from the Service port name. It is empty when the matched container port is unnamed, or when a numeric targetPort has no matching declared container port."
+                    "description": "Name adds another way of referencing this port, usable with MeshService. On Kubernetes, this is derived from the pod container port name that matches the Service's targetPort, not from the Service port name. It is empty when the matched container port is unnamed, or when a numeric targetPort has no matching declared container port. A string targetPort with no matching named container port is not represented here at all: the inbound is dropped instead of being emitted with an empty name."
                 },
                 "protocol": {
                     "type": "string",

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -181,7 +181,7 @@
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name adds another way of referencing this port, usable with MeshService"
+                    "description": "Name adds another way of referencing this port, usable with MeshService. On Kubernetes, this is derived from the pod container port name that matches the Service's targetPort, not from the Service port name. It is empty when the matched container port is unnamed, or when a numeric targetPort has no matching declared container port."
                 },
                 "protocol": {
                     "type": "string",


### PR DESCRIPTION
## Motivation

The `Dataplane.Networking.Inbound.name` field's derivation on Kubernetes was undocumented, making it unclear when it is populated versus empty.

## Implementation information

Expand the field comment in `dataplane.proto` to document that the name comes from the matching pod container port, not the Service port, and clarify the empty/dropped cases. Regenerated proto artifacts and OpenAPI docs accordingly.

Closes https://github.com/kumahq/kuma-website/issues/2171

_Generated by Sybra harness_