### PR TITLE
fix(meshtls): sort inbound SAN matchers

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -28,6 +28,7 @@ import (
 	rules_inbound "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/inbound"
 	policies_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtls/api/v1alpha1"
+	util_maps "github.com/kumahq/kuma/v3/pkg/util/maps"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	"github.com/kumahq/kuma/v3/pkg/util/proto"
 	util_slices "github.com/kumahq/kuma/v3/pkg/util/slices"
@@ -442,7 +443,8 @@ func downstreamTLSContext(xdsCtx xds_context.Context, proxy *core_xds.Proxy, con
 	// TODO: do we need this validator since we have a better validator of CA matched with TrustDomain
 	// check: pkg/core/resources/apis/meshtrust/generator/v1alpha1/secrets.go
 	if proxy.WorkloadIdentity.ManagementMode == core_xds.KumaManagementMode {
-		for trustDomain := range xdsCtx.Mesh.CAsByTrustDomain {
+		// sort trust domains so the generated SAN matchers have a stable order
+		for _, trustDomain := range util_maps.SortedKeys(xdsCtx.Mesh.CAsByTrustDomain) {
 			id, err := spiffeid.TrustDomainFromString(trustDomain)
 			if err != nil {
 				return nil, err

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -443,7 +443,6 @@ func downstreamTLSContext(xdsCtx xds_context.Context, proxy *core_xds.Proxy, con
 	// TODO: do we need this validator since we have a better validator of CA matched with TrustDomain
 	// check: pkg/core/resources/apis/meshtrust/generator/v1alpha1/secrets.go
 	if proxy.WorkloadIdentity.ManagementMode == core_xds.KumaManagementMode {
-		// sort trust domains so the generated SAN matchers have a stable order
 		for _, trustDomain := range util_maps.SortedKeys(xdsCtx.Mesh.CAsByTrustDomain) {
 			id, err := spiffeid.TrustDomainFromString(trustDomain)
 			if err != nil {

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -246,6 +246,27 @@ var _ = Describe("MeshTLS", func() {
 				},
 			},
 		}),
+		Entry("strict with multiple MeshTrust and kuma managed identity", testCase{
+			caseName:    "strict-with-multiple-mesh-trust-kuma-managed",
+			meshBuilder: samples.MeshMTLSBuilder(),
+			meshService: true,
+			workloadIdentity: &core_xds.WorkloadIdentity{
+				KRI:            kri.Identifier{ResourceType: meshidentity_api.MeshIdentityType, Mesh: "default", Zone: "default", Name: "my-identity"},
+				ManagementMode: core_xds.KumaManagementMode,
+				IdentitySourceConfigurer: func() bldrs_common.Configurer[envoy_tls.SdsSecretConfig] {
+					return bldrs_tls.SdsSecretConfigSource(
+						"my-secret-name",
+						bldrs_core.NewConfigSource().Configure(bldrs_core.Sds()),
+					)
+				},
+			},
+			// deliberately out of alphabetical order to verify SANs are sorted
+			casByTrustDomain: map[string][]xds_context.PEMBytes{
+				"domain-c": {xds_context.PEMBytes("123")},
+				"domain-a": {xds_context.PEMBytes("456")},
+				"domain-b": {xds_context.PEMBytes("789")},
+			},
+		}),
 		Entry("strict mode + strict mesh = no passthrough listeners", testCase{
 			caseName:    "strict-with-strict-mtls",
 			meshBuilder: samples.MeshMTLSBuilder(),

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.clusters.golden.yaml
@@ -1,0 +1,28 @@
+resources:
+- name: outbound
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: outgoing
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/outgoing
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: mesh_ca:secret:default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: identity_cert:secret:default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -1,0 +1,169 @@
+resources:
+- name: inbound:127.0.0.1:17777
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 17777
+    bindToPort: false
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_127_0_0_1_17777.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: localhost:17777
+          idleTimeout: 7200s
+          statPrefix: localhost_17777
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://domain-a/
+                  sanType: URI
+                - matcher:
+                    prefix: spiffe://domain-b/
+                  sanType: URI
+                - matcher:
+                    prefix: spiffe://domain-c/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_trust_bundle
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: my-secret-name
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: backend
+    name: inbound:127.0.0.1:17777
+    trafficDirection: INBOUND
+- name: inbound:127.0.0.1:17778
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 127.0.0.1
+        portValue: 17778
+    bindToPort: false
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_127_0_0_1_17778.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: localhost:17778
+          idleTimeout: 7200s
+          statPrefix: localhost_17778
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://domain-a/
+                  sanType: URI
+                - matcher:
+                    prefix: spiffe://domain-b/
+                  sanType: URI
+                - matcher:
+                    prefix: spiffe://domain-c/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_trust_bundle
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: my-secret-name
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/service: frontend
+    name: inbound:127.0.0.1:17778
+    trafficDirection: INBOUND
+- name: inbound:passthrough:ipv4
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 15001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        destinationPort: 17777
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv4
+          statPrefix: inbound_passthrough_ipv4
+    - filterChainMatch:
+        destinationPort: 17778
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv4
+          statPrefix: inbound_passthrough_ipv4
+    name: inbound:passthrough:ipv4
+    trafficDirection: INBOUND
+    useOriginalDst: true
+- name: inbound:passthrough:ipv6
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: '::'
+        portValue: 15001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        destinationPort: 17777
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv6
+          statPrefix: inbound_passthrough_ipv6
+    - filterChainMatch:
+        destinationPort: 17778
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: inbound:passthrough:ipv6
+          statPrefix: inbound_passthrough_ipv6
+    name: inbound:passthrough:ipv6
+    trafficDirection: INBOUND
+    useOriginalDst: true

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.policy.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.policy.yaml
@@ -1,0 +1,7 @@
+targetRef:
+  kind: Mesh
+from:
+  - targetRef:
+      kind: Mesh
+    default:
+      mode: Strict


### PR DESCRIPTION
## Motivation

Inbound TLS config dumps had a non-deterministic SAN matcher order. When MeshIdentity (workload identity, Kuma-managed) is used with multiple trust domains, `downstreamTLSContext` built the `matchTypedSubjectAltNames` list by iterating the `CAsByTrustDomain` map directly. Go randomizes map iteration, so successive xDS generations produced the SAN entries in different orders, causing spurious config diffs.

## Implementation information

- Iterate `util_maps.SortedKeys(xdsCtx.Mesh.CAsByTrustDomain)` instead of ranging the map directly, giving a stable, sorted SAN order.
- Outbound (`meshroute.Identities`) already sorts its identities, so no change there.
- Added a `strict-with-multiple-mesh-trust-kuma-managed` test case with three trust domains inserted out of alphabetical order; golden files confirm SANs emit sorted (`domain-a`, `domain-b`, `domain-c`).

## Supporting documentation

> Changelog: fix(meshtls): sort inbound SAN matchers for stable config
