### PR TITLE
feat(intercp): add version to catalog instance

### DIFF
--- a/api/system/v1alpha1/inter_cp_ping.pb.go
+++ b/api/system/v1alpha1/inter_cp_ping.pb.go
@@ -27,6 +27,7 @@ type PingRequest struct {
 	Address       string                 `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
 	InterCpPort   uint32                 `protobuf:"varint,3,opt,name=inter_cp_port,json=interCpPort,proto3" json:"inter_cp_port,omitempty"`
 	Ready         bool                   `protobuf:"varint,4,opt,name=ready,proto3" json:"ready,omitempty"`
+	Version       string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -89,6 +90,13 @@ func (x *PingRequest) GetReady() bool {
 	return false
 }
 
+func (x *PingRequest) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 type PingResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Leader        bool                   `protobuf:"varint,1,opt,name=leader,proto3" json:"leader,omitempty"`
@@ -137,13 +145,14 @@ var File_api_system_v1alpha1_inter_cp_ping_proto protoreflect.FileDescriptor
 
 const file_api_system_v1alpha1_inter_cp_ping_proto_rawDesc = "" +
 	"\n" +
-	"'api/system/v1alpha1/inter_cp_ping.proto\x12\x14kuma.system.v1alpha1\"\x82\x01\n" +
+	"'api/system/v1alpha1/inter_cp_ping.proto\x12\x14kuma.system.v1alpha1\"\x9c\x01\n" +
 	"\vPingRequest\x12\x1f\n" +
 	"\vinstance_id\x18\x01 \x01(\tR\n" +
 	"instanceId\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\"\n" +
 	"\rinter_cp_port\x18\x03 \x01(\rR\vinterCpPort\x12\x14\n" +
-	"\x05ready\x18\x04 \x01(\bR\x05ready\"&\n" +
+	"\x05ready\x18\x04 \x01(\bR\x05ready\x12\x18\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\"&\n" +
 	"\fPingResponse\x12\x16\n" +
 	"\x06leader\x18\x01 \x01(\bR\x06leader2c\n" +
 	"\x12InterCpPingService\x12M\n" +

--- a/api/system/v1alpha1/inter_cp_ping.proto
+++ b/api/system/v1alpha1/inter_cp_ping.proto
@@ -9,6 +9,7 @@ message PingRequest {
   string address = 2;
   uint32 inter_cp_port = 3;
   bool ready = 4;
+  string version = 5;
 }
 
 message PingResponse {

--- a/pkg/config/intercp/config.go
+++ b/pkg/config/intercp/config.go
@@ -47,7 +47,7 @@ type CatalogConfig struct {
 	// If empty then it's autoconfigured by taking the first IP of the nonloopback network interface.
 	InstanceAddress string `json:"instanceAddress" envconfig:"kuma_inter_cp_catalog_instance_address"`
 	// InstanceVersion is an opaque label recorded in the catalog for this instance.
-	// Empty in OSS; downstream builds set it to partition work across same-version instances.
+	// By default empty, downstream builds set it to partition work across same-version instances.
 	InstanceVersion string `json:"instanceVersion" envconfig:"kuma_inter_cp_catalog_instance_version"`
 	// Interval on which CP will send heartbeat to a leader.
 	HeartbeatInterval config_types.Duration `json:"heartbeatInterval" envconfig:"kuma_inter_cp_catalog_heartbeat_interval"`

--- a/pkg/config/intercp/config.go
+++ b/pkg/config/intercp/config.go
@@ -46,6 +46,9 @@ type CatalogConfig struct {
 	// InstanceAddress indicates an address on which other control planes can communicate with this CP
 	// If empty then it's autoconfigured by taking the first IP of the nonloopback network interface.
 	InstanceAddress string `json:"instanceAddress" envconfig:"kuma_inter_cp_catalog_instance_address"`
+	// InstanceVersion is an opaque label recorded in the catalog for this instance.
+	// Empty in OSS; downstream builds set it to partition work across same-version instances.
+	InstanceVersion string `json:"instanceVersion" envconfig:"kuma_inter_cp_catalog_instance_version"`
 	// Interval on which CP will send heartbeat to a leader.
 	HeartbeatInterval config_types.Duration `json:"heartbeatInterval" envconfig:"kuma_inter_cp_catalog_heartbeat_interval"`
 	// Interval on which CP will write all instances to a catalog.

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -358,6 +358,7 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.DpServer.Hds.CheckDefaults.UnhealthyThreshold).To(Equal(uint32(9)))
 
 			Expect(cfg.InterCp.Catalog.InstanceAddress).To(Equal("192.168.0.1"))
+			Expect(cfg.InterCp.Catalog.InstanceVersion).To(Equal("v3"))
 			Expect(cfg.InterCp.Catalog.HeartbeatInterval.Duration).To(Equal(time.Second))
 			Expect(cfg.InterCp.Catalog.WriterInterval.Duration).To(Equal(2 * time.Second))
 			Expect(cfg.InterCp.Server.Port).To(Equal(uint16(15683)))
@@ -777,6 +778,7 @@ dpServer:
 interCp:
   catalog:
     instanceAddress: "192.168.0.1"
+    instanceVersion: "v3"
     heartbeatInterval: 1s
     writerInterval: 2s
   server:
@@ -1140,6 +1142,7 @@ meshService:
 				"KUMA_DP_SERVER_HDS_CHECK_HEALTHY_THRESHOLD":                                               "8",
 				"KUMA_DP_SERVER_HDS_CHECK_UNHEALTHY_THRESHOLD":                                             "9",
 				"KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS":                                                   "192.168.0.1",
+				"KUMA_INTER_CP_CATALOG_INSTANCE_VERSION":                                                   "v3",
 				"KUMA_INTER_CP_CATALOG_HEARTBEAT_INTERVAL":                                                 "1s",
 				"KUMA_INTER_CP_CATALOG_WRITER_INTERVAL":                                                    "2s",
 				"KUMA_INTER_CP_SERVER_PORT":                                                                "15683",

--- a/pkg/intercp/catalog/catalog.go
+++ b/pkg/intercp/catalog/catalog.go
@@ -14,6 +14,11 @@ type Instance struct {
 	Address     string `json:"address"`
 	InterCpPort uint16 `json:"interCpPort"`
 	Leader      bool   `json:"leader"`
+	// Version is an opaque label identifying which flavor of the CP this
+	// instance runs. It is empty in OSS; downstream builds can set it (via
+	// Catalog.InstanceVersion) to partition sharding across same-version
+	// instances while keeping a single shared catalog and leader.
+	Version string `json:"version,omitempty"`
 }
 
 func (i Instance) InterCpURL() string {

--- a/pkg/intercp/catalog/catalog.go
+++ b/pkg/intercp/catalog/catalog.go
@@ -15,7 +15,7 @@ type Instance struct {
 	InterCpPort uint16 `json:"interCpPort"`
 	Leader      bool   `json:"leader"`
 	// Version is an opaque label identifying which flavor of the CP this
-	// instance runs. It is empty in OSS; downstream builds can set it (via
+	// instance runs. By default empty, downstream builds can set it (via
 	// Catalog.InstanceVersion) to partition sharding across same-version
 	// instances while keeping a single shared catalog and leader.
 	Version string `json:"version,omitempty"`

--- a/pkg/intercp/catalog/heartbeat_component.go
+++ b/pkg/intercp/catalog/heartbeat_component.go
@@ -52,6 +52,7 @@ func NewHeartbeatComponent(
 			InstanceId:  instance.Id,
 			Address:     instance.Address,
 			InterCpPort: uint32(instance.InterCpPort),
+			Version:     instance.Version,
 		},
 		getClientFn: newClientFn,
 		interval:    interval,

--- a/pkg/intercp/catalog/heartbeat_component_test.go
+++ b/pkg/intercp/catalog/heartbeat_component_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Heartbeats", func() {
 		Address:     "10.10.10.1",
 		InterCpPort: 5679,
 		Leader:      false,
+		Version:     "v3",
 	}
 
 	BeforeEach(func() {
@@ -88,6 +89,7 @@ var _ = Describe("Heartbeats", func() {
 			g.Expect(received.InstanceId).To(Equal(currentInstance.Id))
 			g.Expect(received.Address).To(Equal(currentInstance.Address))
 			g.Expect(received.InterCpPort).To(Equal(uint32(currentInstance.InterCpPort)))
+			g.Expect(received.Version).To(Equal(currentInstance.Version))
 		}, "10s", "100ms").Should(Succeed())
 	})
 

--- a/pkg/intercp/catalog/server.go
+++ b/pkg/intercp/catalog/server.go
@@ -27,7 +27,7 @@ func NewServer(heartbeats *Heartbeats, leaderInfo component.LeaderInfo) system_p
 }
 
 func (s *server) Ping(_ context.Context, request *system_proto.PingRequest) (*system_proto.PingResponse, error) {
-	serverLog.V(1).Info("received ping", "instanceID", request.InstanceId, "address", request.Address, "ready", request.Ready)
+	serverLog.V(1).Info("received ping", "instanceID", request.InstanceId, "address", request.Address, "ready", request.Ready, "version", request.Version)
 	instance := Instance{
 		Id:          request.InstanceId,
 		Address:     request.Address,

--- a/pkg/intercp/catalog/server.go
+++ b/pkg/intercp/catalog/server.go
@@ -33,6 +33,7 @@ func (s *server) Ping(_ context.Context, request *system_proto.PingRequest) (*sy
 		Address:     request.Address,
 		InterCpPort: uint16(request.InterCpPort),
 		Leader:      false,
+		Version:     request.Version,
 	}
 	if request.Ready {
 		s.heartbeats.Add(instance)

--- a/pkg/intercp/catalog/server_test.go
+++ b/pkg/intercp/catalog/server_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Server", func() {
 		Address:     "192.168.0.1",
 		InterCpPort: 1234,
 		Ready:       true,
+		Version:     "v3",
 	}
 
 	It("should add instance to heartbeats", func() {
@@ -41,6 +42,7 @@ var _ = Describe("Server", func() {
 		Expect(instances[0].Address).To(Equal(request.Address))
 		Expect(instances[0].InterCpPort).To(Equal(uint16(request.InterCpPort)))
 		Expect(instances[0].Leader).To(BeFalse())
+		Expect(instances[0].Version).To(Equal(request.Version))
 	})
 
 	It("should remove instance when it's not ready", func() {

--- a/pkg/intercp/components.go
+++ b/pkg/intercp/components.go
@@ -42,6 +42,7 @@ func Setup(rt runtime.Runtime) error {
 		Id:          rt.GetInstanceId(),
 		Address:     cfg.Catalog.InstanceAddress,
 		InterCpPort: cfg.Server.Port,
+		Version:     cfg.Catalog.InstanceVersion,
 	}
 
 	pool := rt.InterCPClientPool()


### PR DESCRIPTION
## Motivation

Downstream builds can run more than one flavor of the control plane (e.g. two product generations) side by side against a single shared inter-CP catalog, which gives them a single shared leader across both flavors. A single leader works: the leader's work is flavor-agnostic and there are no data races by design.

The alternative - splitting the catalog so each flavor gets its own leader - was rejected. Two leaders would mean every leader-scoped component (KDS mux, VIP allocator, hostname generator, the various status updaters/generators, ...) runs twice, and each would have to be proven safe to run concurrently or have version stored somewhere. Keeping one shared catalog and one leader avoids that entirely.

## Implementation information

Add an optional `version` label to the inter-CP catalog `Instance`, carried over the `Ping` RPC (`PingRequest.version`) and sourced from a new `InterCp.Catalog.InstanceVersion` config value. Empty by default.

With this, a downstream `multitenant.Tenants` implementation can read the catalog, filter to same-version instances, and compute its shard bucket over that subset - keeping the single shared catalog/leader.

## Supporting documentation

xrel: https://github.com/Kong/kong-mesh/issues/9991
