### PR TITLE
test(meshproxy): fix It desc, unskip migration test

### DIFF
--- a/test/e2e_env/multizone/meshproxy/migration.go
+++ b/test/e2e_env/multizone/meshproxy/migration.go
@@ -147,7 +147,7 @@ func Migration() {
 		Expect(multizone.Global.DeleteMesh(blueMeshName)).To(Succeed())
 	})
 
-	It("should deploy zone proxies to meshproxymig-red with no interruptions for meshproxymig-blue", func(ctx SpecContext) {
+	It("should deploy zone proxies to meshproxymig-red with no interruptions for both meshes", func(ctx SpecContext) {
 		assertTrafficForBothMeshes()
 
 		runDuringMigration(ctx, []trafficCheck{redTraffic, blueTraffic}, func() {
@@ -157,7 +157,7 @@ func Migration() {
 		})
 	})
 
-	It("should deploy zone proxies to meshproxymig-blue with no interruptions for meshproxymig-red", func(ctx SpecContext) {
+	It("should deploy zone proxies to meshproxymig-blue with no interruptions for both meshes", func(ctx SpecContext) {
 		assertTrafficForBothMeshes()
 
 		runDuringMigration(ctx, []trafficCheck{redTraffic, blueTraffic}, func() {


### PR DESCRIPTION
## Motivation

> Changelog: skip

Two `It` block descriptions in the MeshProxy migration e2e test named the wrong mesh (each said "for meshproxymig-blue"/"meshproxymig-red" when the test actually asserts traffic for both meshes).

The tests were also skipped on master (#17161) due to a flaky zero-downtime check. The root cause (non-deterministic inbound SAN ordering causing listener churn/drain during migration) was fixed in #17144, which is already merged, so re-enabling here.

## Implementation information

- Corrected both `It` descriptions to "for both meshes" to match what the test actually verifies.
- Removed the `Skip(...)` calls added in #17102, now that #17144 addresses the underlying flake.

## Supporting documentation

- Flake tracking: https://github.com/kumahq/kuma/issues/17161
- Root-cause fix: #17144