### PR TITLE
test(api-server): add Exclusive-mode inspect golden coverage

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtimeout_meshservice_exclusive.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtimeout_meshservice_exclusive.golden.json
@@ -1,0 +1,57 @@
+{
+ "httpMatches": [],
+ "resource": {
+  "labels": {
+   "k8s.kuma.io/namespace": "kuma-demo",
+   "kuma.io/display-name": "the-gateway"
+  },
+  "mesh": "default",
+  "name": "the-gateway",
+  "type": "MeshGateway"
+ },
+ "rules": [
+  {
+   "fromRules": [],
+   "inboundRules": [],
+   "toResourceRules": [
+    {
+     "conf": [
+      {
+       "connectionTimeout": "2s",
+       "idleTimeout": "20s",
+       "http": {
+        "requestTimeout": "10s"
+       }
+      }
+     ],
+     "origin": [
+      {
+       "resourceMeta": {
+        "labels": {
+         "k8s.kuma.io/namespace": "kuma-demo",
+         "kuma.io/display-name": "mt-on-gateway-exclusive"
+        },
+        "mesh": "default",
+        "name": "mt-on-gateway-exclusive",
+        "type": "MeshTimeout"
+       },
+       "ruleIndex": 0
+      }
+     ],
+     "resourceMeta": {
+      "labels": {
+       "env": "dev"
+      },
+      "mesh": "default",
+      "name": "backend-svc",
+      "type": "MeshService"
+     },
+     "resourceSectionName": ""
+    }
+   ],
+   "toRules": [],
+   "type": "MeshTimeout",
+   "warnings": []
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtimeout_meshservice_exclusive.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshgateways/_rules/meshtimeout_meshservice_exclusive.input.yaml
@@ -1,0 +1,61 @@
+#/meshes/default/meshgateways/the-gateway/_rules 200
+# Exclusive delta: the MeshTimeout's "to" targetRef points at a MeshService
+# resource (instead of Mesh, as in meshgateway.input.yaml). A "to" targeting
+# MeshService is only valid when the policy's top-level targetRef is Mesh
+# (not MeshGateway), so this fixture attaches Mesh-wide instead of directly
+# to the gateway. Under the shipping Exclusive default this populates
+# toResourceRules with the matched MeshService, whereas the Disabled sibling
+# only ever produces a Mesh-wide toRules entry with an empty
+# toResourceRules list.
+type: Mesh
+name: default
+meshServices:
+  mode: Exclusive
+---
+type: MeshGateway
+name: the-gateway
+mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: the-gateway
+selectors:
+  - match:
+      kuma.io/service: gw-1
+conf:
+  listeners:
+    - port: 8080
+      protocol: HTTP
+---
+type: MeshTimeout
+name: mt-on-gateway-exclusive
+mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: mt-on-gateway-exclusive
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshService
+        labels:
+          env: dev
+      default:
+        idleTimeout: 20s
+        connectionTimeout: 2s
+        http:
+          requestTimeout: 10s
+---
+type: MeshService
+name: backend-svc
+mesh: default
+labels:
+  env: dev
+spec:
+  selector:
+    dataplaneTags:
+      app: backend
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http

--- a/pkg/api-server/testdata/resources/inspect/meshservices/_dataplanes/meshservice_multitag_exclusive.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/meshservices/_dataplanes/meshservice_multitag_exclusive.golden.json
@@ -1,0 +1,11 @@
+{
+ "items": [
+  {
+   "labels": {},
+   "mesh": "default",
+   "name": "orders-v2-01",
+   "type": "Dataplane"
+  }
+ ],
+ "total": 1
+}

--- a/pkg/api-server/testdata/resources/inspect/meshservices/_dataplanes/meshservice_multitag_exclusive.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshservices/_dataplanes/meshservice_multitag_exclusive.input.yaml
@@ -1,0 +1,63 @@
+#/meshes/default/meshservices/orders-service/_dataplanes 200
+# Exclusive delta: the MeshService selector carries two dataplaneTags
+# (app + version). Only the dataplane matching BOTH tags is returned,
+# exercising the smallest-set AND-match algorithm (matchByTags) against the
+# shipping Exclusive default. The Disabled siblings in this directory only
+# ever select on a single tag.
+type: Mesh
+meshServices:
+  mode: Exclusive
+name: default
+---
+type: MeshService
+name: orders-service
+mesh: default
+labels:
+  kuma.io/origin: zone
+  kuma.io/env: universal
+spec:
+  selector:
+    dataplaneTags:
+      app: orders
+      version: v2
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+---
+type: Dataplane
+name: orders-v2-01
+mesh: default
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 80
+      tags:
+        kuma.io/service: orders_kuma-demo_svc_80
+        app: orders
+        version: v2
+---
+type: Dataplane
+name: orders-v1-01
+mesh: default
+networking:
+  address: 127.0.0.2
+  inbound:
+    - port: 80
+      tags:
+        kuma.io/service: orders_kuma-demo_svc_80
+        app: orders
+        version: v1
+---
+type: Dataplane
+name: payments-v2-01
+mesh: default
+networking:
+  address: 127.0.0.3
+  inbound:
+    - port: 80
+      tags:
+        kuma.io/service: payments_kuma-demo_svc_80
+        app: payments
+        version: v2

--- a/pkg/api-server/testdata/resources/inspect/meshservices/_dataplanes/meshservice_multitag_exclusive.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/meshservices/_dataplanes/meshservice_multitag_exclusive.input.yaml
@@ -1,9 +1,9 @@
 #/meshes/default/meshservices/orders-service/_dataplanes 200
 # Exclusive delta: the MeshService selector carries two dataplaneTags
 # (app + version). Only the dataplane matching BOTH tags is returned,
-# exercising the smallest-set AND-match algorithm (matchByTags) against the
-# shipping Exclusive default. The Disabled siblings in this directory only
-# ever select on a single tag.
+# exercising the exact tag matching used by the inspect endpoint via
+# meshservice.MatchesDataplane() against the shipping Exclusive default. The
+# Disabled siblings in this directory only ever select on a single tag.
 type: Mesh
 meshServices:
   mode: Exclusive

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes_exclusive.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes_exclusive.golden.json
@@ -1,0 +1,23 @@
+{
+ "items": [
+  {
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "foo-dp-1"
+   },
+   "mesh": "default",
+   "name": "foo-dp-1",
+   "type": "Dataplane"
+  },
+  {
+   "labels": {
+    "k8s.kuma.io/namespace": "kuma-demo",
+    "kuma.io/display-name": "foo-dp-2"
+   },
+   "mesh": "default",
+   "name": "foo-dp-2",
+   "type": "Dataplane"
+  }
+ ],
+ "total": 2
+}

--- a/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes_exclusive.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/policies/_resources/dataplanes/match_meshservice_dataplanes_exclusive.input.yaml
@@ -1,0 +1,83 @@
+#/meshes/default/meshtrafficpermissions/foo/_resources/dataplanes 200
+# Exclusive delta: the policy's targetRef.name matches the KRI-shaped
+# kuma.io/service tag (name_namespace_svc_port) that Exclusive mode generates
+# for a real MeshService resource, instead of the raw legacy service name
+# used by the Disabled sibling (match_meshservice_dataplanes.input.yaml).
+# Two dataplanes carry that generated tag and are both selected; a third
+# dataplane belongs to a different MeshService and is excluded.
+type: Mesh
+meshServices:
+  mode: Exclusive
+name: default
+---
+type: MeshService
+name: foo
+mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+spec:
+  selector:
+    dataplaneTags:
+      app: foo
+  ports:
+    - port: 8080
+      targetPort: 8080
+      appProtocol: http
+---
+type: MeshTrafficPermission
+name: foo
+mesh: default
+spec:
+  targetRef:
+    kind: MeshService
+    name: foo_kuma-demo_svc_8080
+  from:
+    - targetRef:
+        kind: Mesh
+      default:
+        action: Allow
+---
+type: Dataplane
+name: foo-dp-1
+mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: foo-dp-1
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      tags:
+        app: foo
+        k8s.kuma.io/namespace: kuma-demo
+        kuma.io/service: foo_kuma-demo_svc_8080
+---
+type: Dataplane
+name: foo-dp-2
+mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: foo-dp-2
+networking:
+  address: 127.0.0.2
+  inbound:
+    - port: 8080
+      tags:
+        app: foo
+        k8s.kuma.io/namespace: kuma-demo
+        kuma.io/service: foo_kuma-demo_svc_8080
+---
+type: Dataplane
+name: bar-dp-1
+mesh: default
+labels:
+  k8s.kuma.io/namespace: kuma-demo
+  kuma.io/display-name: bar-dp-1
+networking:
+  address: 127.0.0.3
+  inbound:
+    - port: 8080
+      tags:
+        app: bar
+        k8s.kuma.io/namespace: kuma-demo
+        kuma.io/service: bar_kuma-demo_svc_8080

--- a/test/e2e_env/multizone/meshproxy/migration.go
+++ b/test/e2e_env/multizone/meshproxy/migration.go
@@ -147,8 +147,7 @@ func Migration() {
 		Expect(multizone.Global.DeleteMesh(blueMeshName)).To(Succeed())
 	})
 
-	It("should deploy zone proxies to meshproxymig-red with no interruptions for meshproxymig-blue", func(ctx SpecContext) {
-		Skip("flaky zero-downtime check (transient empty response during migration); tracked in https://github.com/kumahq/kuma/issues/17161")
+	It("should deploy zone proxies to meshproxymig-red with no interruptions for both meshes", func(ctx SpecContext) {
 		assertTrafficForBothMeshes()
 
 		runDuringMigration(ctx, []trafficCheck{redTraffic, blueTraffic}, func() {
@@ -158,8 +157,7 @@ func Migration() {
 		})
 	})
 
-	It("should deploy zone proxies to meshproxymig-blue with no interruptions for meshproxymig-red", func(ctx SpecContext) {
-		Skip("flaky zero-downtime check (transient empty response during migration); tracked in https://github.com/kumahq/kuma/issues/17161")
+	It("should deploy zone proxies to meshproxymig-blue with no interruptions for both meshes", func(ctx SpecContext) {
 		assertTrafficForBothMeshes()
 
 		runDuringMigration(ctx, []trafficCheck{redTraffic, blueTraffic}, func() {


### PR DESCRIPTION
## Motivation

MeshService `Exclusive` mode is now the default for nil `meshServices` config, but the api-server inspect endpoints lacked golden-file coverage exercising this mode for MeshTimeout and dataplane matching.

## Implementation information

Adds golden input/output fixtures for:
- MeshTimeout policy matched against an Exclusive-mode MeshService
- Multi-tag MeshService matching in Exclusive mode
- Dataplane matching against an Exclusive-mode MeshService

Closes https://github.com/kumahq/kuma/issues/17163

_Generated by Sybra harness_