### PR TITLE
docs(docs): document CI labels for PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,22 @@ git push --no-verify <remote> branch-name    # ALWAYS use --no-verify
 - **Base branch**: `master`
 - **PR template**: `.github/PULL_REQUEST_TEMPLATE.md`
 - **Changelog**: from PR title or `> Changelog: {<desc>,skip}`
-- **CI labels**: MUST use `gh pr create --label "ci/..."`. Labels added after creation are ignored by CI
+- **CI labels**: MUST set with `gh pr create --label "ci/..."`. Most gate on `pull_request` `opened/synchronize` events, so labels added after creation only take effect on the next push — set them at creation time. See label table below
 - **MADR**: `docs/madr/decisions/000-template.md` for features/architecture decisions
 - **Downstream refs**: say "downstream project" or "enterprise fork". Never mention Kong Mesh in PRs/commits (private repo)
+
+### Behavior-changing CI labels
+
+Set at creation with `--label`. When opening PRs, apply these deliberately:
+
+| Label | Effect | When to use |
+|-------|--------|-------------|
+| `ci/skip-test` | Skips **all** tests (unit + e2e + container-structure) | Docs-only, comment-only, or non-code PRs where no test can be affected. Never on code changes |
+| `ci/skip-e2e-test` | Skips only e2e tests (unit tests still run) | Changes fully covered by unit tests where slow e2e adds no signal (e.g. isolated pkg refactor, config/CLI text). Don't use if touching xDS gen, policies, KDS, or transparent proxy |
+| `ci/run-full-matrix` | Runs full OS/arch/k8s test matrix instead of the reduced PR matrix | Changes with cross-platform/version risk: transparent proxy, CNI, install/bootstrap, k8s-version-sensitive code, build/packaging. Costly — don't add by default |
+| `ci/verify-stability` | Reruns CI repeatedly to detect flakiness; auto-removed after N consecutive green runs | Suspected flaky test, or a change to e2e/timing-sensitive code where you want confidence it's stable before merge. Add on the PR, let the scheduled stability workflow drive it |
+
+Default (no labels) is correct for most code PRs. Reach for `skip-*` only to save CI on genuinely test-irrelevant changes; reach for `run-full-matrix`/`verify-stability` to add coverage/confidence when the change warrants it.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ git push --no-verify <remote> branch-name    # ALWAYS use --no-verify
 - **Base branch**: `master`
 - **PR template**: `.github/PULL_REQUEST_TEMPLATE.md`
 - **Changelog**: from PR title or `> Changelog: {<desc>,skip}`
-- **CI labels**: MUST set with `gh pr create --label "ci/..."`. Most gate on `pull_request` `opened/synchronize` events, so labels added after creation only take effect on the next push — set them at creation time. See label table below
+- **CI labels**: MUST set with `gh pr create --label "ci/..."`. Most gate on `pull_request` `opened/reopened/synchronize` events, so labels added after creation only take effect on the next new run (usually the next push) — set them at creation time. See label table below
 - **MADR**: `docs/madr/decisions/000-template.md` for features/architecture decisions
 - **Downstream refs**: say "downstream project" or "enterprise fork". Never mention Kong Mesh in PRs/commits (private repo)
 


### PR DESCRIPTION
## Motivation

`CLAUDE.md` mentioned `ci/...` labels only generically, so it was unclear which labels actually change PR CI behavior and when to apply them. This documents the behavior-changing labels so they're used deliberately when opening PRs.

> Changelog: skip

## Implementation information

- Added a "Behavior-changing CI labels" table under **Git & PRs** covering `ci/skip-test`, `ci/skip-e2e-test`, `ci/run-full-matrix`, and `ci/verify-stability` with effect + when-to-use guidance.
- Clarified the existing CI-labels bullet: most labels gate on `pull_request` `opened/synchronize`, so they must be set at creation time.

## Supporting documentation

Derived from `.github/workflows/` (`_test.yaml`, `build-test-distribute.yaml`, `ci-stability.yaml`).
