### PR TITLE
fix(kuma-dp): fix dataplane token write when WorkDir is missing

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -589,7 +589,7 @@ func getApplicationsToScrape(kumaSidecarConfiguration *types.KumaSidecarConfigur
 }
 
 func writeFile(filename string, data []byte, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(filename), perm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), 0o711); err != nil {
 		return err
 	}
 	return os.WriteFile(filename, data, perm)

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -413,6 +413,32 @@ var _ = Describe("run", func() {
 		Expect(err.Error()).To(ContainSubstring("--name and --mesh cannot be specified"))
 	})
 
+	It("should create the dataplane token in a missing work dir", func() {
+		// given
+		rootCtx := DefaultRootContext()
+		cfg := rootCtx.Config
+		token, err := os.ReadFile(filepath.Join("testdata", "token"))
+		Expect(err).ToNot(HaveOccurred())
+		cfg.Dataplane.Name = "example"
+		cfg.DataplaneRuntime.Token = string(token)
+		cfg.DataplaneRuntime.WorkDir = filepath.Join(tmpDir, "missing-work-dir")
+
+		// when
+		_, err = defaultDataplaneTokenGenerator(cfg)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.DataplaneRuntime.TokenPath).To(Equal(filepath.Join(cfg.DataplaneRuntime.WorkDir, "example")))
+		Expect(cfg.DataplaneRuntime.TokenPath).To(BeARegularFile())
+		data, err := os.ReadFile(cfg.DataplaneRuntime.TokenPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(token))
+
+		info, err := os.Stat(cfg.DataplaneRuntime.TokenPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+	})
+
 	It("should fail when the proxy type is unknown", func() {
 		// given
 		cmd := NewRootCmd(opts, DefaultRootContext())


### PR DESCRIPTION
## Changes

- Fixed `kuma-dp` failing to write an inline dataplane token when `WorkDir` does not exist.
- Changed `writeFile` to create parent directories with directory permissions `0711` instead of reusing the token file permission `0600`.
- Added a regression test for missing `WorkDir`, verifying the token is created and the token file remains `0600`.