### PR TITLE
fix(k8s): dedup inbounds only when tags disabled

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -149,8 +149,8 @@ func (ic *InboundConverter) inboundForServiceless(zone string, pod *kube_core.Po
 	}
 }
 
-// Deprecated: LegacyInboundInterfacesFor is currently only used for delegated gateway and Mesh without MeshService exclusive
-// to not change order of inbounds.
+// Deprecated: LegacyInboundInterfacesFor is used for delegated gateway, Mesh without MeshService exclusive,
+// and MeshService exclusive while inbound tags are still enabled, to not change order of inbounds.
 // For gateway we pick first inbound to take tags from. Delegated gateway identity relies on this.
 // For Dataplanes when MeshService is disabled we base identity and routing on inbound tags
 // TODO: We should revisit this when we rework identity. More in https://github.com/kumahq/kuma/issues/3339
@@ -158,8 +158,9 @@ func (ic *InboundConverter) LegacyInboundInterfacesFor(ctx context.Context, zone
 	return ic.inboundInterfacesFor(ctx, zone, pod, services)
 }
 
-// InboundInterfacesFor should be used when MeshService mode is Exclusive. This function deduplicates inbounds by address and port.
-// Since MeshService does not need tags we can safely deduplicate inbounds
+// InboundInterfacesFor should be used when MeshService mode is Exclusive and inbound tags are disabled.
+// This function deduplicates inbounds by address and port.
+// Since inbounds carry no tags in that model we can safely deduplicate them.
 func (ic *InboundConverter) InboundInterfacesFor(ctx context.Context, zone string, pod *kube_core.Pod, services []*kube_core.Service) ([]*mesh_proto.Dataplane_Networking_Inbound, error) {
 	inbounds, err := ic.inboundInterfacesFor(ctx, zone, pod, services)
 	if err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -315,7 +315,15 @@ func (p *PodConverter) dataplaneFor(
 		if len(regularServices) > 0 || len(zoneProxyServices) == 0 {
 			var ifaces []*mesh_proto.Dataplane_Networking_Inbound
 			var err error
-			if msMode == mesh_proto.Mesh_MeshServices_Exclusive {
+			// Deduplicating inbounds by address:port is only safe when inbound
+			// tags are disabled: identity and MeshService matching then rely on
+			// the workload rather than per-service inbound tags, so collapsing
+			// several services that select the same port loses nothing. When
+			// inbound tags are enabled each service produces a distinctly tagged
+			// inbound with its own Ready/Ignored state; deduplication would drop
+			// one of them (e.g. keep an Ignored inbound over a Ready one), so we
+			// keep every inbound like the non-Exclusive path does.
+			if msMode == mesh_proto.Mesh_MeshServices_Exclusive && p.InboundConverter.InboundTagsDisabled {
 				ifaces, err = p.InboundConverter.InboundInterfacesFor(ctx, p.Zone, pod, regularServices)
 				if err != nil {
 					return nil, err

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -340,10 +340,16 @@ var _ = Describe("PodToDataplane(..)", func() {
 			otherServices:     "update-dataplane.other-services.yaml",
 			dataplane:         "update-dataplane.dataplane.yaml",
 		}),
-		Entry("Multiples services selecting single port", testCase{
-			pod:            "duplicated-inbounds.pod.yaml",
-			servicesForPod: "duplicated-inbounds.services-for-pod.yaml",
-			dataplane:      "duplicated-inbounds.dataplane.yaml",
+		Entry("Multiples services selecting single port deduplicated when inbound tags disabled", testCase{
+			pod:                 "duplicated-inbounds.pod.yaml",
+			servicesForPod:      "duplicated-inbounds.services-for-pod.yaml",
+			dataplane:           "duplicated-inbounds.dataplane.yaml",
+			inboundTagsDisabled: true,
+		}),
+		Entry("Multiples services selecting single port keep all inbounds when inbound tags enabled", testCase{
+			pod:            "overlapping-inbounds.pod.yaml",
+			servicesForPod: "overlapping-inbounds.services-for-pod.yaml",
+			dataplane:      "overlapping-inbounds.dataplane.yaml",
 		}),
 		Entry("31. Pod with workload labels configured matching pod label", testCase{
 			pod:            "31.pod.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -340,13 +340,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			otherServices:     "update-dataplane.other-services.yaml",
 			dataplane:         "update-dataplane.dataplane.yaml",
 		}),
-		Entry("Multiples services selecting single port deduplicated when inbound tags disabled", testCase{
+		Entry("Multiple services selecting a single port deduplicated when inbound tags disabled", testCase{
 			pod:                 "duplicated-inbounds.pod.yaml",
 			servicesForPod:      "duplicated-inbounds.services-for-pod.yaml",
 			dataplane:           "duplicated-inbounds.dataplane.yaml",
 			inboundTagsDisabled: true,
 		}),
-		Entry("Multiples services selecting single port keep all inbounds when inbound tags enabled", testCase{
+		Entry("Multiple services selecting a single port keeps all inbounds when inbound tags enabled", testCase{
 			pod:            "overlapping-inbounds.pod.yaml",
 			servicesForPod: "overlapping-inbounds.services-for-pod.yaml",
 			dataplane:      "overlapping-inbounds.dataplane.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/duplicated-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/duplicated-inbounds.dataplane.yaml
@@ -16,26 +16,8 @@ spec:
       name: main-port
       port: 7070
       protocol: tcp
-      tags:
-        app: example
-        k8s.kuma.io/namespace: demo
-        k8s.kuma.io/service-name: example
-        k8s.kuma.io/service-port: "7000"
-        kuma.io/protocol: tcp
-        kuma.io/service: example_demo_svc_7000
-        kuma.io/zone: zone-1
-        version: "0.1"
     - health:
         ready: true
       name: metrics
       port: 6060
       protocol: tcp
-      tags:
-        app: example
-        k8s.kuma.io/namespace: demo
-        k8s.kuma.io/service-name: example
-        k8s.kuma.io/service-port: "6000"
-        kuma.io/protocol: tcp
-        kuma.io/service: example_demo_svc_6000
-        kuma.io/zone: zone-1
-        version: "0.1"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
@@ -1,0 +1,41 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    rollouts-pod-template-hash: active-hash
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health: {}
+      name: grpc
+      port: 9000
+      protocol: tcp
+      state: Ignored
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-preview
+        k8s.kuma.io/service-port: "9000"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-preview_demo_svc_9000
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: active-hash
+    - health:
+        ready: true
+      name: grpc
+      port: 9000
+      protocol: tcp
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example
+        k8s.kuma.io/service-port: "9000"
+        kuma.io/protocol: tcp
+        kuma.io/service: example_demo_svc_9000
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: active-hash

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    rollouts-pod-template-hash: active-hash
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 9000
+          name: grpc
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.services-for-pod.yaml
@@ -1,0 +1,26 @@
+---
+metadata:
+  namespace: demo
+  name: example-preview
+spec:
+  clusterIP: 192.168.0.1
+  ports:
+    - protocol: TCP
+      port: 9000
+      targetPort: 9000
+  selector:
+    app: example
+    rollouts-pod-template-hash: preview-hash
+---
+metadata:
+  namespace: demo
+  name: example
+spec:
+  clusterIP: 192.168.0.1
+  ports:
+    - protocol: TCP
+      port: 9000
+      targetPort: 9000
+  selector:
+    app: example
+    rollouts-pod-template-hash: active-hash

--- a/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-for-pod-ms.golden.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/pod_controller/dataplane-for-pod-ms.golden.yaml
@@ -47,3 +47,15 @@ spec:
         kuma.io/protocol: tcp
         kuma.io/service: example-ms-1_demo_svc_6061
         kuma.io/zone: zone-1
+    - health: {}
+      port: 8080
+      protocol: http
+      state: NotReady
+      tags:
+        app: sample-ms
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-ms-2
+        k8s.kuma.io/service-port: "80"
+        kuma.io/protocol: http
+        kuma.io/service: example-ms-2_demo_svc_80
+        kuma.io/zone: zone-1


### PR DESCRIPTION
## Motivation

In MeshServices `Exclusive` mode, inbound deduplication by `address:port` (`deduplicateInboundsByAddressAndPort`) keeps the first inbound and is state-blind. With Argo Rollouts blue-green, `IgnoredServiceSelectorLabels` (e.g. `rollouts-pod-template-hash`) makes both the active `<app>` and the `<app>-preview` Service match the same pod. `inboundForService` then recomputes state against the full selector: active -> `Ready`, preview -> `Ignored`. Dedup can keep the `Ignored` preview inbound over the `Ready` active one, so `GetHealthyInbounds` finds nothing and the MeshService goes `Unavailable` while the pods are healthy. Non-Exclusive modes keep both inbounds and work fine.

Fixes #17142

## Implementation information

Inbound listeners are keyed by `address:port` (`GetInboundListenerName`), so dedup was introduced (#12760) to keep Dataplane inbounds correlated 1:1 with Envoy resources. That deduplication is only safe in the tagless model where identity comes from the workload rather than per-service inbound tags. This gates dedup on `InboundTagsDisabled`: the tags-enabled Exclusive path now uses `LegacyInboundInterfacesFor` and keeps every inbound, exactly like the non-Exclusive path. Active inbound stays `Ready` (MeshService `Available`); preview stays `Ignored` (correctly `Unavailable` for that pod).

Trade-off: for tags-enabled Exclusive, two Services on one port again share a single `inbound:addr:port` Envoy listener (the pre-#12760 behaviour). The phantom inbound is inert for MeshService status.

## Supporting documentation

- Issue: #17142
- Deduplication origin: #12760 (fixes #12123)