### PR TITLE
docs(upgrade): reference SO_REUSEPORT note under 2.13.7

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,7 +54,7 @@ A new explicit flag preserves the previous insecure behavior:
 
 Do not use this in production.
 
-### Inbound listeners now use SO_REUSEPORT by default
+### Rolling-upgrade note: inbound listeners use SO_REUSEPORT by default
 
 See [Inbound listeners now use SO_REUSEPORT by default](#inbound-listeners-now-use-so_reuseport-by-default).
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,6 +54,10 @@ A new explicit flag preserves the previous insecure behavior:
 
 Do not use this in production.
 
+### Inbound listeners now use SO_REUSEPORT by default
+
+See [Inbound listeners now use SO_REUSEPORT by default](#inbound-listeners-now-use-so_reuseport-by-default).
+
 ## Upgrade to `2.12.11`
 
 See [Insecure TLS fallback removed when no CA cert is provided](#insecure-tls-fallback-removed-when-no-ca-cert-is-provided).


### PR DESCRIPTION
## Motivation

The `2.14.x` "Inbound listeners now use SO_REUSEPORT by default" note already states the change applies to `2.13.7`+, but the `2.13.7` section did not surface it. Readers upgrading to `2.13.7` could miss the rolling-upgrade guidance.

## Implementation information

Added a subsection under `Upgrade to 2.13.7` that links to the existing `2.14.x` section via anchor, matching the reference pattern already used by the other patch-release sections (2.12.11, 2.11.14, etc.). The section is not duplicated.

## Supporting documentation

N/A

<!--
> Changelog: skip
-->