### PR TITLE
test(k8s): fix overlapping-inbounds golden file on master

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
@@ -3,6 +3,7 @@ metadata:
   labels:
     app: example
     k8s.kuma.io/namespace: demo
+    kuma.io/display-name: ""
     kuma.io/mesh: default
     kuma.io/proxy-type: sidecar
     kuma.io/sidecar-injection: enabled


### PR DESCRIPTION
## Motivation

The `test / test_unit` job is failing on `master` after #17162 ("compute `kuma.io/display-name` for all resources"). That PR added `kuma.io/display-name` to the labels computed for every resource but missed regenerating one golden file, so `PodToDataplane` fails on the `overlapping-inbounds` case:

```
first mismatched key: "metadata"."labels"
Rerun the test with UPDATE_GOLDEN_FILES=true flag to update file:
  pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
```

## Implementation information

Regenerated the golden file via `UPDATE_GOLDEN_FILES=true make test TEST_PKG_LIST=./pkg/plugins/runtime/k8s/controllers/...`. The only change is the added `kuma.io/display-name: ""` label, matching the empty value already present in every other `*.dataplane.yaml` golden file in the same directory.

## Supporting documentation

Follow-up to #17162.

> Changelog: skip
