### PR TITLE
feat(helm): configurable zone proxy probes

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -564,8 +564,9 @@ ingress:
       cpu: 1000m
       memory: 512Mi
 
-  # Liveness probe for the Ingress
+  # -- Liveness probe settings for the Ingress proxy
   livenessProbe:
+    # -- Whether to enable the liveness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 60
@@ -573,8 +574,9 @@ ingress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Readiness probe for the Ingress
+  # -- Readiness probe settings for the Ingress proxy
   readinessProbe:
+    # -- Whether to enable the readiness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 1
@@ -582,8 +584,9 @@ ingress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Startup probe for the Ingress
+  # -- Startup probe settings for the Ingress proxy
   startupProbe:
+    # -- Whether to enable the startup probe.
     enabled: false
     failureThreshold: 60
     initialDelaySeconds: 1
@@ -750,8 +753,9 @@ egress:
       cpu: 1000m
       memory: 512Mi
 
-  # Liveness probe for the Egress
+  # -- Liveness probe settings for the Ingress proxy
   livenessProbe:
+    # -- Whether to enable the liveness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 60
@@ -759,8 +763,9 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Readiness probe for the Egress
+  # -- Readiness probe settings for the Ingress proxy
   readinessProbe:
+    # -- Whether to enable the readiness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 1
@@ -768,8 +773,9 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Startup probe for the Egress
+  # -- Startup probe settings for the Ingress proxy
   startupProbe:
+    # -- Whether to enable the startup probe.
     enabled: false
     failureThreshold: 60
     initialDelaySeconds: 1

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -564,6 +564,33 @@ ingress:
       cpu: 1000m
       memory: 512Mi
 
+  # Liveness probe for the Ingress
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Readiness probe for the Ingress
+  readinessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Startup probe for the Ingress
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
   # -- Pod lifecycle settings (useful for adding a preStop hook, when
   # using AWS ALB or NLB)
   lifecycle: {}
@@ -722,6 +749,33 @@ egress:
     limits:
       cpu: 1000m
       memory: 512Mi
+
+  # Liveness probe for the Egress
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Readiness probe for the Egress
+  readinessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Startup probe for the Egress
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
 
   service:
     # -- Whether to create the service object

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -753,7 +753,7 @@ egress:
       cpu: 1000m
       memory: 512Mi
 
-  # -- Liveness probe settings for the Ingress proxy
+  # -- Liveness probe settings for the Egress proxy
   livenessProbe:
     # -- Whether to enable the liveness probe.
     enabled: true
@@ -763,7 +763,7 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # -- Readiness probe settings for the Ingress proxy
+  # -- Readiness probe settings for the Egress proxy
   readinessProbe:
     # -- Whether to enable the readiness probe.
     enabled: true
@@ -773,7 +773,7 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # -- Startup probe settings for the Ingress proxy
+  # -- Startup probe settings for the Egress proxy
   startupProbe:
     # -- Whether to enable the startup probe.
     enabled: false

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyProbes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyProbes.golden.yaml
@@ -1,0 +1,1375 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-system
+  labels:
+    kuma.io/sidecar-injection: "false"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuma-control-plane-config
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+data:
+  config.yaml: |
+    # use this file to override default configuration of `kuma-cp`
+    #
+    # see conf/kuma-cp.conf.yml for available settings
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuma-control-plane
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  # Kubernetes resources
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: # Gateway API
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - referencegrants
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses # ClusterScope
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses/status # ClusterScope
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - kuma.io
+    resources:
+      - dataplanes
+      - dataplaneinsights
+      - meshes
+      - zones
+      - zoneinsights
+      - zoneingresses
+      - zoneingressinsights
+      - zoneegresses
+      - zoneegressinsights
+      - meshinsights
+      - serviceinsights
+      - proxytemplates
+      - ratelimits
+      - trafficpermissions
+      - trafficroutes
+      - timeouts
+      - retries
+      - circuitbreakers
+      - virtualoutbounds
+      - containerpatches
+      - externalservices
+      - faultinjections
+      - healthchecks
+      - trafficlogs
+      - traffictraces
+      - meshgateways
+      - meshgatewayroutes
+      - meshgatewayinstances
+      - meshgatewayconfigs
+      - meshaccesslogs
+      - meshcircuitbreakers
+      - meshfaultinjections
+      - meshhealthchecks
+      - meshhttproutes
+      - meshloadbalancingstrategies
+      - meshmetrics
+      - meshpassthroughs
+      - meshproxypatches
+      - meshratelimits
+      - meshretries
+      - meshtcproutes
+      - meshtimeouts
+      - meshtlses
+      - meshtraces
+      - meshtrafficpermissions
+      - hostnamegenerators
+      - meshexternalservices
+      - meshidentities
+      - meshmultizoneservices
+      - meshopentelemetrybackends
+      - meshservices
+      - meshtrusts
+      - meshzoneaddresses
+      - workloads
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - kuma.io
+    resources:
+      - meshgatewayinstances/status
+      - meshgatewayinstances/finalizers
+      - meshes/finalizers
+      - dataplanes/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  # validate k8s token before issuing mTLS cert
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuma-control-plane-workloads
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+    # required by MeshGateway
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    # required by MeshGateway
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+    # Gateway API
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - referencegrants
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways/status
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane-workloads
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane-workloads
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  # leader-for-life election deletes Pods in some circumstances
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - referencegrants
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways/status
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kuma-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    prometheus.io/port: "5680"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5680
+      name: diagnostics
+      appProtocol: http
+    - port: 5681
+      name: http-api-server
+      appProtocol: http
+    - port: 5682
+      name: https-api-server
+      appProtocol: https
+    - port: 443
+      name: https-admission-server
+      targetPort: 5443
+      appProtocol: https
+    - port: 5676
+      name: mads-server
+      appProtocol: https
+    - port: 5678
+      name: dp-server
+      appProtocol: https
+  selector:
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 10002
+      protocol: TCP
+      targetPort: 10002
+  selector:
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      protocol: TCP
+      targetPort: 10001
+  selector:
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations: 
+    
+spec:
+  replicas: 1
+  minReadySeconds: 0
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-control-plane
+  template:
+    metadata:
+      annotations:
+        checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
+        checksum/tls-secrets: 037b75e7a91465d94401c948c7fb17c9d74e43f2becf66ab2dbadae773b7f1ea
+      labels: 
+        app: kuma-control-plane
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - 'kuma-control-plane'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kuma-control-plane
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+        
+        kubernetes.io/os: linux
+      hostNetwork: false
+      terminationGracePeriodSeconds: 30
+      
+      containers:
+        - name: control-plane
+          image: "docker.io/kumahq/kuma-cp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
+              value: "false"
+            - name: KUMA_API_SERVER_READ_ONLY
+              value: "true"
+            - name: KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET
+              value: "true"
+            - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
+              value: "false"
+            - name: KUMA_DP_SERVER_HDS_ENABLED
+              value: "false"
+            - name: KUMA_ENVIRONMENT
+              value: "kubernetes"
+            - name: KUMA_EXPERIMENTAL_SIDECAR_CONTAINERS
+              value: "true"
+            - name: KUMA_GENERAL_TLS_CERT_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/tls.crt"
+            - name: KUMA_GENERAL_TLS_KEY_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/tls.key"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_IMAGE
+              value: "docker.io/kumahq/kuma-init:0.0.1"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "50M"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "20m"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "20M"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "512Mi"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "50m"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "64Mi"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "50M"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "20m"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "20M"
+            - name: KUMA_MODE
+              value: "zone"
+            - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
+              value: "true"
+            - name: KUMA_PLUGIN_POLICIES_ENABLED
+              value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
+            - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR
+              value: "/var/run/secrets/kuma.io/tls-cert"
+            - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
+              value: "5443"
+            - name: KUMA_RUNTIME_KUBERNETES_ALLOWED_USERS
+              value: "system:serviceaccount:kuma-system:kuma-control-plane"
+            - name: KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME
+              value: "kuma-control-plane"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CA_CERT_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/ca.crt"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CNI_ENABLED
+              value: "false"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IMAGE
+              value: "docker.io/kumahq/kuma-dp:0.0.1"
+            - name: KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE
+              value: "kuma-system"
+            - name: KUMA_STORE_TYPE
+              value: "kubernetes"
+            - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: control-plane
+                  resource: limits.memory
+                  divisor: "1"
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: control-plane
+                  resource: limits.cpu
+                  divisor: "1"
+          args:
+            - run
+            - --log-level=info
+            - --log-output-path=
+            - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
+          ports:
+            - containerPort: 5680
+              name: diagnostics
+              protocol: TCP
+            - containerPort: 5681
+            - containerPort: 5682
+            - containerPort: 5443
+            - containerPort: 5678
+          livenessProbe:
+            timeoutSeconds: 10
+            httpGet:
+              path: /healthy
+              port: 5680
+          readinessProbe:
+            timeoutSeconds: 10
+            httpGet:
+              path: /ready
+              port: 5680
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          
+          volumeMounts:
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/tls.crt
+              subPath: tls.crt
+              readOnly: true
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/tls.key
+              subPath: tls.key
+              readOnly: true
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              subPath: ca.crt
+              readOnly: true
+            - name: kuma-control-plane-config
+              mountPath: /etc/kuma.io/kuma-control-plane
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: general-tls-cert
+          secret:
+            secretName: general-tls-secret
+        - name: kuma-control-plane-config
+          configMap:
+            name: kuma-control-plane-config
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-egress
+  template:
+    metadata:
+      annotations:
+        kuma.io/egress: enabled
+      labels:
+        app: kuma-egress
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - kuma-egress
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsGroup: 5678
+        runAsNonRoot: true
+        runAsUser: 5678
+      serviceAccountName: kuma-egress
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      
+      containers:
+        - name: egress
+          image: "docker.io/kumahq/kuma-dp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUMA_CONTROL_PLANE_URL
+              value: "https://kuma-control-plane.kuma-system:5678"
+            - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
+            - name: KUMA_DATAPLANE_DRAIN_TIME
+              value: 30s
+            - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: KUMA_DATAPLANE_PROXY_TYPE
+              value: "egress"
+          args:
+            - run
+            - --log-level=info
+          ports:
+            - containerPort: 10002
+            - containerPort: 9902
+          readinessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 12
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 60
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources: 
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: control-plane-ca
+          secret:
+            secretName: "general-tls-secret"
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-ingress
+  template:
+    metadata:
+      annotations:
+        kuma.io/ingress: enabled
+      labels:
+        app: kuma-ingress
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - kuma-ingress
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsGroup: 5678
+        runAsNonRoot: true
+        runAsUser: 5678
+      serviceAccountName: kuma-ingress
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+      
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 40
+      
+      containers:
+        - name: ingress
+          image: "docker.io/kumahq/kuma-dp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUMA_CONTROL_PLANE_URL
+              value: "https://kuma-control-plane.kuma-system:5678"
+            - name: KUMA_CONTROL_PLANE_CA_CERT_FILE
+              value: /var/run/secrets/kuma.io/cp-ca/ca.crt
+            - name: KUMA_DATAPLANE_DRAIN_TIME
+              value: 30s
+            - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: KUMA_DATAPLANE_PROXY_TYPE
+              value: "ingress"
+          args:
+            - run
+            - --log-level=info
+          ports:
+            - containerPort: 10001
+            - containerPort: 9902
+          livenessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 6
+            initialDelaySeconds: 90
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 20
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: "/ready"
+              port: 9902
+            failureThreshold: 120
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+          resources: 
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          
+          volumeMounts:
+            - name: control-plane-ca
+              mountPath: /var/run/secrets/kuma.io/cp-ca
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: control-plane-ca
+          secret:
+            secretName: "general-tls-secret"
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - name: tmp
+          emptyDir: { }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kuma-admission-mutating-webhook-configuration
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+webhooks:
+  - name: mesh.defaulter.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /default-kuma-io-v1alpha1-mesh
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - meshes
+          - dataplanes
+          - dataplaneinsights
+          - meshgateways
+          - zoneingresses
+          - zoneingressinsights
+          - zoneegresses
+          - zoneegressinsights
+          - serviceinsights
+          - zone
+          - zoneinsights
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+    sideEffects: None
+  - name: owner-reference.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /owner-reference-kuma-io-v1alpha1
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - circuitbreakers
+          - externalservices
+          - faultinjections
+          - healthchecks
+          - meshgateways
+          - meshgatewayroutes
+          - proxytemplates
+          - ratelimits
+          - retries
+          - timeouts
+          - trafficlogs
+          - trafficpermissions
+          - trafficroutes
+          - traffictraces
+          - virtualoutbounds
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+  
+      
+    sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: In
+          values:
+          - enabled
+          - "true"
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: mesh-zoneproxy-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - kuma-system
+    objectSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: In
+          values:
+            - enabled
+        - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
+          operator: Exists
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kuma-validating-webhook-configuration
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+webhooks:
+  - name: validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-kuma-io-v1alpha1
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - circuitbreakers
+          - dataplanes
+          - externalservices
+          - faultinjections
+          - meshgatewayinstances
+          - healthchecks
+          - meshes
+          - meshgateways
+          - meshgatewayroutes
+          - proxytemplates
+          - ratelimits
+          - retries
+          - trafficlogs
+          - trafficpermissions
+          - trafficroutes
+          - traffictraces
+          - virtualoutbounds
+          - zones
+          - containerpatches
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+    
+      
+    sideEffects: None
+  - name: secret.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1-secret
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - secrets
+    sideEffects: None
+  - name: pod.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    failurePolicy: Fail
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1-pod
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+    sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyProbes.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/zoneProxyProbes.values.yaml
@@ -1,0 +1,19 @@
+ingress:
+  enabled: true
+  livenessProbe:
+    initialDelaySeconds: 90
+    failureThreshold: 6
+  readinessProbe:
+    failureThreshold: 20
+  startupProbe:
+    enabled: true
+    failureThreshold: 120
+    periodSeconds: 10
+egress:
+  enabled: true
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    timeoutSeconds: 5
+  startupProbe:
+    enabled: true

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -160,6 +160,24 @@ A Helm chart for the Kuma Control Plane
 | ingress.logLevel | string | `"info"` | Log level for ingress (available values: off|info|debug) |
 | ingress.restartPolicy | string | `"Always"` | Pod restart policy for the ingress pods |
 | ingress.resources | object | `{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Define the resources to allocate to mesh ingress |
+| ingress.livenessProbe.enabled | bool | `true` |  |
+| ingress.livenessProbe.failureThreshold | int | `12` |  |
+| ingress.livenessProbe.initialDelaySeconds | int | `60` |  |
+| ingress.livenessProbe.periodSeconds | int | `5` |  |
+| ingress.livenessProbe.successThreshold | int | `1` |  |
+| ingress.livenessProbe.timeoutSeconds | int | `3` |  |
+| ingress.readinessProbe.enabled | bool | `true` |  |
+| ingress.readinessProbe.failureThreshold | int | `12` |  |
+| ingress.readinessProbe.initialDelaySeconds | int | `1` |  |
+| ingress.readinessProbe.periodSeconds | int | `5` |  |
+| ingress.readinessProbe.successThreshold | int | `1` |  |
+| ingress.readinessProbe.timeoutSeconds | int | `3` |  |
+| ingress.startupProbe.enabled | bool | `false` |  |
+| ingress.startupProbe.failureThreshold | int | `60` |  |
+| ingress.startupProbe.initialDelaySeconds | int | `1` |  |
+| ingress.startupProbe.periodSeconds | int | `5` |  |
+| ingress.startupProbe.successThreshold | int | `1` |  |
+| ingress.startupProbe.timeoutSeconds | int | `3` |  |
 | ingress.lifecycle | object | `{}` | Pod lifecycle settings (useful for adding a preStop hook, when using AWS ALB or NLB) |
 | ingress.terminationGracePeriodSeconds | int | `40` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
 | ingress.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
@@ -206,6 +224,24 @@ A Helm chart for the Kuma Control Plane
 | egress.resources.requests.memory | string | `"64Mi"` |  |
 | egress.resources.limits.cpu | string | `"1000m"` |  |
 | egress.resources.limits.memory | string | `"512Mi"` |  |
+| egress.livenessProbe.enabled | bool | `true` |  |
+| egress.livenessProbe.failureThreshold | int | `12` |  |
+| egress.livenessProbe.initialDelaySeconds | int | `60` |  |
+| egress.livenessProbe.periodSeconds | int | `5` |  |
+| egress.livenessProbe.successThreshold | int | `1` |  |
+| egress.livenessProbe.timeoutSeconds | int | `3` |  |
+| egress.readinessProbe.enabled | bool | `true` |  |
+| egress.readinessProbe.failureThreshold | int | `12` |  |
+| egress.readinessProbe.initialDelaySeconds | int | `1` |  |
+| egress.readinessProbe.periodSeconds | int | `5` |  |
+| egress.readinessProbe.successThreshold | int | `1` |  |
+| egress.readinessProbe.timeoutSeconds | int | `3` |  |
+| egress.startupProbe.enabled | bool | `false` |  |
+| egress.startupProbe.failureThreshold | int | `60` |  |
+| egress.startupProbe.initialDelaySeconds | int | `1` |  |
+| egress.startupProbe.periodSeconds | int | `5` |  |
+| egress.startupProbe.successThreshold | int | `1` |  |
+| egress.startupProbe.timeoutSeconds | int | `3` |  |
 | egress.service.enabled | bool | `true` | Whether to create the service object |
 | egress.service.type | string | `"ClusterIP"` | Service type of the Egress |
 | egress.service.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -160,24 +160,12 @@ A Helm chart for the Kuma Control Plane
 | ingress.logLevel | string | `"info"` | Log level for ingress (available values: off|info|debug) |
 | ingress.restartPolicy | string | `"Always"` | Pod restart policy for the ingress pods |
 | ingress.resources | object | `{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Define the resources to allocate to mesh ingress |
-| ingress.livenessProbe.enabled | bool | `true` |  |
-| ingress.livenessProbe.failureThreshold | int | `12` |  |
-| ingress.livenessProbe.initialDelaySeconds | int | `60` |  |
-| ingress.livenessProbe.periodSeconds | int | `5` |  |
-| ingress.livenessProbe.successThreshold | int | `1` |  |
-| ingress.livenessProbe.timeoutSeconds | int | `3` |  |
-| ingress.readinessProbe.enabled | bool | `true` |  |
-| ingress.readinessProbe.failureThreshold | int | `12` |  |
-| ingress.readinessProbe.initialDelaySeconds | int | `1` |  |
-| ingress.readinessProbe.periodSeconds | int | `5` |  |
-| ingress.readinessProbe.successThreshold | int | `1` |  |
-| ingress.readinessProbe.timeoutSeconds | int | `3` |  |
-| ingress.startupProbe.enabled | bool | `false` |  |
-| ingress.startupProbe.failureThreshold | int | `60` |  |
-| ingress.startupProbe.initialDelaySeconds | int | `1` |  |
-| ingress.startupProbe.periodSeconds | int | `5` |  |
-| ingress.startupProbe.successThreshold | int | `1` |  |
-| ingress.startupProbe.timeoutSeconds | int | `3` |  |
+| ingress.livenessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Liveness probe settings for the Ingress proxy |
+| ingress.livenessProbe.enabled | bool | `true` | Whether to enable the liveness probe. |
+| ingress.readinessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Readiness probe settings for the Ingress proxy |
+| ingress.readinessProbe.enabled | bool | `true` | Whether to enable the readiness probe. |
+| ingress.startupProbe | object | `{"enabled":false,"failureThreshold":60,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Startup probe settings for the Ingress proxy |
+| ingress.startupProbe.enabled | bool | `false` | Whether to enable the startup probe. |
 | ingress.lifecycle | object | `{}` | Pod lifecycle settings (useful for adding a preStop hook, when using AWS ALB or NLB) |
 | ingress.terminationGracePeriodSeconds | int | `40` | Number of seconds to wait before force killing the pod. Make sure to update this if you add a preStop hook. |
 | ingress.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
@@ -224,24 +212,12 @@ A Helm chart for the Kuma Control Plane
 | egress.resources.requests.memory | string | `"64Mi"` |  |
 | egress.resources.limits.cpu | string | `"1000m"` |  |
 | egress.resources.limits.memory | string | `"512Mi"` |  |
-| egress.livenessProbe.enabled | bool | `true` |  |
-| egress.livenessProbe.failureThreshold | int | `12` |  |
-| egress.livenessProbe.initialDelaySeconds | int | `60` |  |
-| egress.livenessProbe.periodSeconds | int | `5` |  |
-| egress.livenessProbe.successThreshold | int | `1` |  |
-| egress.livenessProbe.timeoutSeconds | int | `3` |  |
-| egress.readinessProbe.enabled | bool | `true` |  |
-| egress.readinessProbe.failureThreshold | int | `12` |  |
-| egress.readinessProbe.initialDelaySeconds | int | `1` |  |
-| egress.readinessProbe.periodSeconds | int | `5` |  |
-| egress.readinessProbe.successThreshold | int | `1` |  |
-| egress.readinessProbe.timeoutSeconds | int | `3` |  |
-| egress.startupProbe.enabled | bool | `false` |  |
-| egress.startupProbe.failureThreshold | int | `60` |  |
-| egress.startupProbe.initialDelaySeconds | int | `1` |  |
-| egress.startupProbe.periodSeconds | int | `5` |  |
-| egress.startupProbe.successThreshold | int | `1` |  |
-| egress.startupProbe.timeoutSeconds | int | `3` |  |
+| egress.livenessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Liveness probe settings for the Ingress proxy |
+| egress.livenessProbe.enabled | bool | `true` | Whether to enable the liveness probe. |
+| egress.readinessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Readiness probe settings for the Ingress proxy |
+| egress.readinessProbe.enabled | bool | `true` | Whether to enable the readiness probe. |
+| egress.startupProbe | object | `{"enabled":false,"failureThreshold":60,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Startup probe settings for the Ingress proxy |
+| egress.startupProbe.enabled | bool | `false` | Whether to enable the startup probe. |
 | egress.service.enabled | bool | `true` | Whether to create the service object |
 | egress.service.type | string | `"ClusterIP"` | Service type of the Egress |
 | egress.service.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -212,11 +212,11 @@ A Helm chart for the Kuma Control Plane
 | egress.resources.requests.memory | string | `"64Mi"` |  |
 | egress.resources.limits.cpu | string | `"1000m"` |  |
 | egress.resources.limits.memory | string | `"512Mi"` |  |
-| egress.livenessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Liveness probe settings for the Ingress proxy |
+| egress.livenessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":60,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Liveness probe settings for the Egress proxy |
 | egress.livenessProbe.enabled | bool | `true` | Whether to enable the liveness probe. |
-| egress.readinessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Readiness probe settings for the Ingress proxy |
+| egress.readinessProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Readiness probe settings for the Egress proxy |
 | egress.readinessProbe.enabled | bool | `true` | Whether to enable the readiness probe. |
-| egress.startupProbe | object | `{"enabled":false,"failureThreshold":60,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Startup probe settings for the Ingress proxy |
+| egress.startupProbe | object | `{"enabled":false,"failureThreshold":60,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3}` | Startup probe settings for the Egress proxy |
 | egress.startupProbe.enabled | bool | `false` | Whether to enable the startup probe. |
 | egress.service.enabled | bool | `true` | Whether to create the service object |
 | egress.service.type | string | `"ClusterIP"` | Service type of the Egress |

--- a/deployments/charts/kuma/templates/egress-deployment.yaml
+++ b/deployments/charts/kuma/templates/egress-deployment.yaml
@@ -91,24 +91,39 @@ spec:
 {{- else }}
             - containerPort: 9901
 {{- end }}
+          {{- if .Values.egress.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: "/ready"
               port: {{ if .Values.experimental.envoyAdminUnixSocket }}9902{{ else }}9901{{ end }}
-            failureThreshold: 12
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            failureThreshold: {{ .Values.egress.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.egress.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.egress.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.egress.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.egress.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.egress.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: "/ready"
               port: {{ if .Values.experimental.envoyAdminUnixSocket }}9902{{ else }}9901{{ end }}
-            failureThreshold: 12
-            initialDelaySeconds: 1
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            failureThreshold: {{ .Values.egress.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.egress.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.egress.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.egress.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.egress.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.egress.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: "/ready"
+              port: {{ if .Values.experimental.envoyAdminUnixSocket }}9902{{ else }}9901{{ end }}
+            failureThreshold: {{ .Values.egress.startupProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.egress.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.egress.startupProbe.periodSeconds }}
+            successThreshold: {{ .Values.egress.startupProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.egress.startupProbe.timeoutSeconds }}
+          {{- end }}
           resources: {{ toYaml .Values.egress.resources | nindent 12 }}
           volumeMounts:
 {{- if not .Values.egress.automountServiceAccountToken }}

--- a/deployments/charts/kuma/templates/ingress-deployment.yaml
+++ b/deployments/charts/kuma/templates/ingress-deployment.yaml
@@ -92,24 +92,39 @@ spec:
 {{- else }}
             - containerPort: 9901
 {{- end }}
+          {{- if .Values.ingress.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: "/ready"
               port: {{ if .Values.experimental.envoyAdminUnixSocket }}9902{{ else }}9901{{ end }}
-            failureThreshold: 12
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            failureThreshold: {{ .Values.ingress.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.ingress.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.ingress.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.ingress.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.ingress.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.ingress.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: "/ready"
               port: {{ if .Values.experimental.envoyAdminUnixSocket }}9902{{ else }}9901{{ end }}
-            failureThreshold: 12
-            initialDelaySeconds: 1
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
+            failureThreshold: {{ .Values.ingress.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.ingress.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.ingress.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.ingress.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.ingress.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.ingress.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: "/ready"
+              port: {{ if .Values.experimental.envoyAdminUnixSocket }}9902{{ else }}9901{{ end }}
+            failureThreshold: {{ .Values.ingress.startupProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.ingress.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.ingress.startupProbe.periodSeconds }}
+            successThreshold: {{ .Values.ingress.startupProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.ingress.startupProbe.timeoutSeconds }}
+          {{- end }}
           resources: {{ toYaml .Values.ingress.resources | nindent 12 }}
           {{ with .Values.ingress.lifecycle}}
           lifecycle: {{ . | toYaml | nindent 12 }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -564,8 +564,9 @@ ingress:
       cpu: 1000m
       memory: 512Mi
 
-  # Liveness probe for the Ingress
+  # -- Liveness probe settings for the Ingress proxy
   livenessProbe:
+    # -- Whether to enable the liveness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 60
@@ -573,8 +574,9 @@ ingress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Readiness probe for the Ingress
+  # -- Readiness probe settings for the Ingress proxy
   readinessProbe:
+    # -- Whether to enable the readiness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 1
@@ -582,8 +584,9 @@ ingress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Startup probe for the Ingress
+  # -- Startup probe settings for the Ingress proxy
   startupProbe:
+    # -- Whether to enable the startup probe.
     enabled: false
     failureThreshold: 60
     initialDelaySeconds: 1
@@ -750,8 +753,9 @@ egress:
       cpu: 1000m
       memory: 512Mi
 
-  # Liveness probe for the Egress
+  # -- Liveness probe settings for the Ingress proxy
   livenessProbe:
+    # -- Whether to enable the liveness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 60
@@ -759,8 +763,9 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Readiness probe for the Egress
+  # -- Readiness probe settings for the Ingress proxy
   readinessProbe:
+    # -- Whether to enable the readiness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 1
@@ -768,8 +773,9 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Startup probe for the Egress
+  # -- Startup probe settings for the Ingress proxy
   startupProbe:
+    # -- Whether to enable the startup probe.
     enabled: false
     failureThreshold: 60
     initialDelaySeconds: 1

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -564,6 +564,33 @@ ingress:
       cpu: 1000m
       memory: 512Mi
 
+  # Liveness probe for the Ingress
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Readiness probe for the Ingress
+  readinessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Startup probe for the Ingress
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
   # -- Pod lifecycle settings (useful for adding a preStop hook, when
   # using AWS ALB or NLB)
   lifecycle: {}
@@ -722,6 +749,33 @@ egress:
     limits:
       cpu: 1000m
       memory: 512Mi
+
+  # Liveness probe for the Egress
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Readiness probe for the Egress
+  readinessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Startup probe for the Egress
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
 
   service:
     # -- Whether to create the service object

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -753,7 +753,7 @@ egress:
       cpu: 1000m
       memory: 512Mi
 
-  # -- Liveness probe settings for the Ingress proxy
+  # -- Liveness probe settings for the Egress proxy
   livenessProbe:
     # -- Whether to enable the liveness probe.
     enabled: true
@@ -763,7 +763,7 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # -- Readiness probe settings for the Ingress proxy
+  # -- Readiness probe settings for the Egress proxy
   readinessProbe:
     # -- Whether to enable the readiness probe.
     enabled: true
@@ -773,7 +773,7 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # -- Startup probe settings for the Ingress proxy
+  # -- Startup probe settings for the Egress proxy
   startupProbe:
     # -- Whether to enable the startup probe.
     enabled: false

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -564,8 +564,9 @@ ingress:
       cpu: 1000m
       memory: 512Mi
 
-  # Liveness probe for the Ingress
+  # -- Liveness probe settings for the Ingress proxy
   livenessProbe:
+    # -- Whether to enable the liveness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 60
@@ -573,8 +574,9 @@ ingress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Readiness probe for the Ingress
+  # -- Readiness probe settings for the Ingress proxy
   readinessProbe:
+    # -- Whether to enable the readiness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 1
@@ -582,8 +584,9 @@ ingress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Startup probe for the Ingress
+  # -- Startup probe settings for the Ingress proxy
   startupProbe:
+    # -- Whether to enable the startup probe.
     enabled: false
     failureThreshold: 60
     initialDelaySeconds: 1
@@ -750,8 +753,9 @@ egress:
       cpu: 1000m
       memory: 512Mi
 
-  # Liveness probe for the Egress
+  # -- Liveness probe settings for the Ingress proxy
   livenessProbe:
+    # -- Whether to enable the liveness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 60
@@ -759,8 +763,9 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Readiness probe for the Egress
+  # -- Readiness probe settings for the Ingress proxy
   readinessProbe:
+    # -- Whether to enable the readiness probe.
     enabled: true
     failureThreshold: 12
     initialDelaySeconds: 1
@@ -768,8 +773,9 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # Startup probe for the Egress
+  # -- Startup probe settings for the Ingress proxy
   startupProbe:
+    # -- Whether to enable the startup probe.
     enabled: false
     failureThreshold: 60
     initialDelaySeconds: 1

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -564,6 +564,33 @@ ingress:
       cpu: 1000m
       memory: 512Mi
 
+  # Liveness probe for the Ingress
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Readiness probe for the Ingress
+  readinessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Startup probe for the Ingress
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
   # -- Pod lifecycle settings (useful for adding a preStop hook, when
   # using AWS ALB or NLB)
   lifecycle: {}
@@ -722,6 +749,33 @@ egress:
     limits:
       cpu: 1000m
       memory: 512Mi
+
+  # Liveness probe for the Egress
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 60
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Readiness probe for the Egress
+  readinessProbe:
+    enabled: true
+    failureThreshold: 12
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
+  # Startup probe for the Egress
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    initialDelaySeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
 
   service:
     # -- Whether to create the service object

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -753,7 +753,7 @@ egress:
       cpu: 1000m
       memory: 512Mi
 
-  # -- Liveness probe settings for the Ingress proxy
+  # -- Liveness probe settings for the Egress proxy
   livenessProbe:
     # -- Whether to enable the liveness probe.
     enabled: true
@@ -763,7 +763,7 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # -- Readiness probe settings for the Ingress proxy
+  # -- Readiness probe settings for the Egress proxy
   readinessProbe:
     # -- Whether to enable the readiness probe.
     enabled: true
@@ -773,7 +773,7 @@ egress:
     successThreshold: 1
     timeoutSeconds: 3
 
-  # -- Startup probe settings for the Ingress proxy
+  # -- Startup probe settings for the Egress proxy
   startupProbe:
     # -- Whether to enable the startup probe.
     enabled: false


### PR DESCRIPTION
## Motivation

Zone Ingress and Egress deployments hardcode their `livenessProbe` and `readinessProbe`, and expose no `startupProbe`. Today the only workaround is a post-render / manual patch, which is awkward for GitOps (Flux/Argo) users who manage everything through Helm values.

## Implementation information

- Add `livenessProbe`, `readinessProbe`, and `startupProbe` blocks under `ingress` and `egress` in the chart values.
- `livenessProbe` and `readinessProbe` gain an `enabled` flag (default `true`) so they can be turned off; all timing fields (`failureThreshold`, `initialDelaySeconds`, `periodSeconds`, `successThreshold`, `timeoutSeconds`) are configurable.
- `startupProbe` is `enabled: false` by default; when enabled it suspends the liveness probe until Envoy is ready, giving slow-warming proxies the time they need.
- Liveness/readiness defaults exactly match the previously-hardcoded values, so existing installs render byte-identical output — no behavior change unless the new values are set.
- The `httpGet` path/port stays templated (respects `experimental.envoyAdminUnixSocket`), so users never need to know the admin port.

Example enabling a 5-minute startup window on the ingress:

```yaml
ingress:
  startupProbe:
    enabled: true
    failureThreshold: 60
    periodSeconds: 5
```

## Supporting documentation

- Chart README regenerated via helm-docs.
- Added a kumactl install golden test (`zoneProxyProbes`) covering enabled startup probes, overridden liveness/readiness fields, and a disabled liveness probe.