### PR TITLE
test(e2e): wait for all replicas on install

### DIFF
--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -336,7 +336,7 @@ func (k *k8SDeployment) Deploy(cluster framework.Cluster) error {
 	}
 	if k.opts.WaitingToBeReady {
 		funcs = append(funcs,
-			framework.WaitNumPods(k.opts.Namespace, 1, k.Name()),
+			framework.WaitNumPods(k.opts.Namespace, int(k.opts.Replicas), k.Name()),
 			framework.WaitPodsAvailable(k.opts.Namespace, k.Name()),
 		)
 		if k.opts.EnableService {


### PR DESCRIPTION
## Motivation

`Gateway MeshLoadBalancingStrategy should route to only one instance` flakes on `release-2.13` (seen on the `v2.13.9` tag run). The first `Eventually` expects all 3 StatefulSet replicas of `test-server-mlbs` to receive traffic (`HaveLen(3)`) but intermittently sees only 2 — the gateway's cluster carries only 2 of the 3 endpoints because the 3rd replica hasn't come up yet.

Root cause: `testserver` install with `WithStatefulSet` + `WithReplicas(3)` only waits for a hardcoded `1` pod in `WaitNumPods`. StatefulSets start pods sequentially, so `BeforeAll` returns while replicas 1 and 2 are still starting, and the test races the rollout.

## Implementation information

- `WaitNumPods(..., 1, ...)` -> `WaitNumPods(..., int(k.opts.Replicas), ...)` so the install waits for every replica before the test runs. `Replicas` defaults to 1, so single-replica callers are unchanged.

This matches master, where the same line was already corrected in #16269.

## Supporting documentation

> Changelog: skip
