### PR TITLE
feat(MeshHealthCheck): add unhealthyInterval support

### DIFF
--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -283,6 +283,15 @@ spec:
                             this interval takes precedence over any other. The default value for "no
                             traffic interval" is 60 seconds.
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            The interval used between health checks while an endpoint is considered
+                            unhealthy. When an endpoint becomes unhealthy, Envoy will probe it using
+                            this more frequent interval instead of the normal health check interval.
+                            This allows faster detection of recovery or continued failure. If not
+                            specified, Envoy will use the same interval for both healthy and unhealthy
+                            endpoints.
+                          type: string
                         reuseConnection:
                           description: Reuse health check connection between health
                             checks. Default is true.

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -283,6 +283,15 @@ spec:
                             this interval takes precedence over any other. The default value for "no
                             traffic interval" is 60 seconds.
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            The interval used between health checks while an endpoint is considered
+                            unhealthy. When an endpoint becomes unhealthy, Envoy will probe it using
+                            this more frequent interval instead of the normal health check interval.
+                            This allows faster detection of recovery or continued failure. If not
+                            specified, Envoy will use the same interval for both healthy and unhealthy
+                            endpoints.
+                          type: string
                         reuseConnection:
                           description: Reuse health check connection between health
                             checks. Default is true.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
@@ -82,8 +82,15 @@ type Conf struct {
 	// to using the standard health check interval that is defined. Note that
 	// this interval takes precedence over any other. The default value for "no
 	// traffic interval" is 60 seconds.
-	NoTrafficInterval *k8s.Duration    `json:"noTrafficInterval,omitempty"`
-	Tcp               *TcpHealthCheck  `json:"tcp,omitempty"`
+	NoTrafficInterval *k8s.Duration `json:"noTrafficInterval,omitempty"`
+	// The interval used between health checks while an endpoint is considered
+	// unhealthy. When an endpoint becomes unhealthy, Envoy will probe it using
+	// this more frequent interval instead of the normal health check interval.
+	// This allows faster detection of recovery or continued failure. If not
+	// specified, Envoy will use the same interval for both healthy and unhealthy
+	// endpoints.
+	UnhealthyInterval *k8s.Duration  `json:"unhealthyInterval,omitempty"`
+	Tcp               *TcpHealthCheck `json:"tcp,omitempty"`
 	Http              *HttpHealthCheck `json:"http,omitempty"`
 	Grpc              *GrpcHealthCheck `json:"grpc,omitempty"`
 	// Reuse health check connection between health checks. Default is true.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
@@ -89,8 +89,8 @@ type Conf struct {
 	// This allows faster detection of recovery or continued failure. If not
 	// specified, Envoy will use the same interval for both healthy and unhealthy
 	// endpoints.
-	UnhealthyInterval *k8s.Duration  `json:"unhealthyInterval,omitempty"`
-	Tcp               *TcpHealthCheck `json:"tcp,omitempty"`
+	UnhealthyInterval *k8s.Duration    `json:"unhealthyInterval,omitempty"`
+	Tcp               *TcpHealthCheck  `json:"tcp,omitempty"`
 	Http              *HttpHealthCheck `json:"http,omitempty"`
 	Grpc              *GrpcHealthCheck `json:"grpc,omitempty"`
 	// Reuse health check connection between health checks. Default is true.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -62,6 +62,7 @@ func validateDefault(conf Conf) validators.ValidationError {
 	verr.Add(validators.ValidateIntPercentageOrNil(path.Field("intervalJitterPercent"), conf.IntervalJitterPercent))
 	verr.Add(validators.ValidatePercentageOrNil(path.Field("healthyPanicThreshold"), conf.HealthyPanicThreshold))
 	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("noTrafficInterval"), conf.NoTrafficInterval))
+	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("unhealthyInterval"), conf.UnhealthyInterval))
 	verr.Add(validators.ValidatePathOrNil(path.Field("eventLogPath"), conf.EventLogPath))
 	if conf.Http != nil {
 		verr.Add(validateConfHttp(path.Field("http"), conf.Http))

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.deepcopy.go
@@ -73,6 +73,11 @@ func (in *Conf) DeepCopyInto(out *Conf) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.UnhealthyInterval != nil {
+		in, out := &in.UnhealthyInterval, &out.UnhealthyInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Tcp != nil {
 		in, out := &in.Tcp, &out.Tcp
 		*out = new(TcpHealthCheck)

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -283,6 +283,15 @@ spec:
                             this interval takes precedence over any other. The default value for "no
                             traffic interval" is 60 seconds.
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            The interval used between health checks while an endpoint is considered
+                            unhealthy. When an endpoint becomes unhealthy, Envoy will probe it using
+                            this more frequent interval instead of the normal health check interval.
+                            This allows faster detection of recovery or continued failure. If not
+                            specified, Envoy will use the same interval for both healthy and unhealthy
+                            endpoints.
+                          type: string
                         reuseConnection:
                           description: Reuse health check connection between health
                             checks. Default is true.

--- a/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
@@ -318,6 +318,9 @@ func buildHealthCheck(conf api.Conf) *envoy_core.HealthCheck {
 	if conf.NoTrafficInterval != nil {
 		hc.NoTrafficInterval = util_proto.Duration(conf.NoTrafficInterval.Duration)
 	}
+	if conf.UnhealthyInterval != nil {
+		hc.UnhealthyInterval = util_proto.Duration(conf.UnhealthyInterval.Duration)
+	}
 	if conf.ReuseConnection != nil {
 		hc.ReuseConnection = util_proto.Bool(*conf.ReuseConnection)
 	}

--- a/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer_test.go
@@ -1,8 +1,11 @@
 package xds
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
@@ -170,4 +173,32 @@ var _ = Describe("MeshHealthCheck configurer", func() {
 			expectedHcType: HCNone,
 		}),
 	)
+
+	Describe("buildHealthCheck", func() {
+		It("should set UnhealthyInterval when provided", func() {
+			dur := &k8s.Duration{Duration: 10 * time.Second}
+			conf := v1alpha1.Conf{
+				UnhealthyInterval: dur,
+			}
+			hc := buildHealthCheck(conf)
+			Expect(hc.UnhealthyInterval).NotTo(BeNil())
+			Expect(hc.UnhealthyInterval.AsDuration()).To(Equal(10 * time.Second))
+		})
+
+		It("should not set UnhealthyInterval when nil", func() {
+			conf := v1alpha1.Conf{}
+			hc := buildHealthCheck(conf)
+			Expect(hc.UnhealthyInterval).To(BeNil())
+		})
+
+		It("should set NoTrafficInterval when provided", func() {
+			dur := &k8s.Duration{Duration: 30 * time.Second}
+			conf := v1alpha1.Conf{
+				NoTrafficInterval: dur,
+			}
+			hc := buildHealthCheck(conf)
+			Expect(hc.NoTrafficInterval).NotTo(BeNil())
+			Expect(hc.NoTrafficInterval.AsDuration()).To(Equal(30 * time.Second))
+		})
+	})
 })


### PR DESCRIPTION
## Description

Adds `unhealthyInterval` support to MeshHealthCheck policy, as requested in #17129.

This maps to Envoy's [`health_check.unhealthy_interval`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-field-config-core-v3-healthcheck-unhealthy-interval) field, which allows configuring a separate health check interval used when an endpoint is considered unhealthy.

### Why this matters

When an endpoint becomes unhealthy, Envoy can probe it at a more frequent interval to quickly detect recovery or continued failure. Without this field, users had to use `ProxyTemplate` to access this Envoy feature. With MeshHealthCheck supporting it natively, users migrating from ProxyTemplate can now configure this directly.

### Changes

- Added `UnhealthyInterval` field to `Conf` API type in `meshhealthcheck.go`
- Added xDS mapping in `buildHealthCheck` configurer to pass the value to Envoy's `HealthCheck.UnhealthyInterval`
- Added validation for the new field in `validator.go`
- Updated deepcopy generated code in `zz_generated.deepcopy.go`
- Updated CRD definitions in 3 files

### Testing

- Existing tests continue to pass (field is optional, nil by default)
- No golden file changes needed since existing test cases don't set the field

Fixes #17129
