### PR TITLE
ci(renovate): group spire image bumps into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -314,6 +314,15 @@
     },
     {
       "description": [
+        " Group the SPIRE server and agent image bumps (ghcr.io/spiffe/spire-server and",
+        " spire-agent in test/dockerfiles/universal.Dockerfile) into a single PR since they",
+        " are released together and must stay on the same version"
+      ],
+      "matchPackageNames": ["ghcr.io/spiffe/spire-server", "ghcr.io/spiffe/spire-agent"],
+      "groupName": "spire"
+    },
+    {
+      "description": [
         " Apply the 'immediately' helper for all dependencies from the 'kumahq' org (matching both",
         " 'kumahq/*' and 'github.com/kumahq/*') so Renovate proposes updates as soon as they're",
         " available, without waiting for the default release-age delay. This lets us consume our own",


### PR DESCRIPTION
## Motivation

Renovate opens separate PRs for the `spire-server` and `spire-agent` image bumps in `test/dockerfiles/universal.Dockerfile`, even though they are released together and must stay on the same version.

## Implementation information

Add a `packageRules` entry matching `ghcr.io/spiffe/spire-server` and `ghcr.io/spiffe/spire-agent` with a shared `groupName: "spire"`, so both bumps land in a single PR.

## Supporting documentation

The images are defined in `test/dockerfiles/universal.Dockerfile` and picked up by Renovate's `dockerfile` manager.

> Changelog: skip