### PR TITLE
test(zoneegress): drop dead FaultInjection case

### DIFF
--- a/test/e2e_env/universal/zoneegress/external_services.go
+++ b/test/e2e_env/universal/zoneegress/external_services.go
@@ -144,40 +144,6 @@ func ExternalServices() {
 		})
 	})
 
-	Context("Fault Injection", func() {
-		AfterEach(func() {
-			Expect(DeleteMeshResources(universal.Cluster, meshName, core_mesh.FaultInjectionResourceTypeDescriptor)).To(Succeed())
-		})
-
-		It("should inject faults for external service", func() {
-			Expect(YamlUniversal(`
-type: FaultInjection
-mesh: ze-external-services
-name: fi1
-sources:
-   - match:
-       kuma.io/service: demo-client
-destinations:
-   - match:
-       kuma.io/service: external-service
-       kuma.io/protocol: http
-       version: v2
-conf:
-   abort:
-     httpStatus: 401
-     percentage: 100`)(universal.Cluster)).To(Succeed())
-
-			Eventually(func(g Gomega) {
-				response, err := client.CollectFailure(
-					universal.Cluster, "demo-client", "external-service.mesh",
-					client.WithMaxTime(8),
-				)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(response.ResponseCode).To(Equal(401))
-			}, "30s", "1s").Should(Succeed())
-		})
-	})
-
 	Context("MeshFaultInjection", func() {
 		AfterEach(func() {
 			Expect(DeleteMeshResources(universal.Cluster, meshName, meshfaultinjection_api.MeshFaultInjectionResourceTypeDescriptor)).To(Succeed())


### PR DESCRIPTION
## Motivation

> Changelog: skip

Legacy `FaultInjection` xDS generation was dropped from inbound/egress
proxy builders, but the e2e suite still had a case exercising the
legacy `FaultInjection` resource against zone egress traffic, expecting
a 401 abort. Since the xDS wiring is gone, the request now succeeds
(200) and the assertion fails — this is currently breaking
`test / e2e (universal, kind, amd64)` on master and any PR built on top
of it (e.g. https://github.com/kumahq/kuma/pull/17320).

The `FaultInjection` resource type, CRUD, and validation are untouched;
only the xDS-generation path was removed, and `MeshFaultInjection` is
the intended replacement. The equivalent `MeshFaultInjection` case in
the same suite still exercises that coverage.

## Implementation information

- Remove the `Fault Injection` (legacy) `Context` block from
  `test/e2e_env/universal/zoneegress/external_services.go`.

## Supporting documentation

N/A