### PR TITLE
test(unit): measure race vs non-race timing

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -17,7 +17,7 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
 jobs:
   test_unit:
-    timeout-minutes: 30
+    timeout-minutes: 90
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
@@ -31,8 +31,25 @@ jobs:
           version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - run: |
-          make test
+      # A/B experiment: same runner, same cold cache, only the -race flag differs.
+      - name: "unit tests WITHOUT race"
+        run: |
+          rc=0
+          make test UNIT_RACE= || rc=$?
+          {
+            echo "## Unit test A/B timing";
+            echo "- no-race: ${SECONDS}s (exit=$rc)";
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "no_race_seconds=${SECONDS} exit=$rc"
+          exit $rc
+      - name: "unit tests WITH race"
+        if: ${{ always() }}
+        run: |
+          rc=0
+          make test || rc=$?
+          echo "- race: ${SECONDS}s (exit=$rc)" >> "$GITHUB_STEP_SUMMARY"
+          echo "race_seconds=${SECONDS} exit=$rc"
+          exit $rc
   gen_e2e_matrix:
     timeout-minutes: 2
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,6 +1,9 @@
 UPDATE_GOLDEN_FILES ?=
 TEST_PKG_LIST ?= ./...
 REPORTS_DIR ?= build/reports
+# UNIT_RACE toggles the Go race detector for unit tests (default on).
+# Override with `make test UNIT_RACE=` to measure/skip the race cost.
+UNIT_RACE ?= -race
 # Path to the kumactl binary for Linux. This binary will be uploaded to Docker
 # containers during transparent proxy tests.
 KUMACTL_LINUX_BIN ?= $(BUILD_DIR)/artifacts-linux-$(GOARCH)/kumactl/kumactl
@@ -32,7 +35,7 @@ ifndef TEST_REPORTS
 ifdef CI
 	$(GO) clean -testcache
 endif
-	$(UNIT_TEST_ENV) $(GO) test $(GOFLAGS) $(call LD_FLAGS,$(GOOS),$(GOARCH)) -race $$($(GO) list $(TEST_PKG_LIST) | grep -E -v "test/e2e" | grep -E -v "test/transparentproxy")
+	$(UNIT_TEST_ENV) $(GO) test $(GOFLAGS) $(call LD_FLAGS,$(GOOS),$(GOARCH)) $(UNIT_RACE) $$($(GO) list $(TEST_PKG_LIST) | grep -E -v "test/e2e" | grep -E -v "test/transparentproxy")
 endif
 
 $(REPORTS_DIR):


### PR DESCRIPTION
## Motivation

Throwaway experiment (DO NOT MERGE) to quantify how much the Go race
detector adds to PR unit-test wall-clock.

> Changelog: skip

## Implementation information

`test_unit` runs the unit suite twice on the same runner with the same
cold cache — once with `UNIT_RACE=` (no race) then once with the default
`-race` — and prints each elapsed time to the job summary. Only the
`-race` flag differs, so the delta is the race cost. e2e is skipped via
`ci/skip-e2e-test`; timeout bumped to fit both runs.

## Supporting documentation

N/A — measurement only.