### PR TITLE
test(e2e): slim image for in-cluster workloads

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -11,7 +11,7 @@ $(addsuffix :$(BUILD_INFO_VERSION)$(if $(2),-$(2)),$(addprefix $(DOCKER_REGISTRY
 endef
 
 IMAGES_RELEASE += kuma-cp kuma-dp kumactl kuma-init kuma-cni
-IMAGES_TEST += kuma-universal
+IMAGES_TEST += kuma-universal kuma-test-app
 KUMA_IMAGES = $(call build_image,$(IMAGES_RELEASE) $(IMAGES_TEST))
 
 # Always use Docker BuildKit, see
@@ -66,6 +66,10 @@ image/kuma-cni/$(1): image/base-root/$(1) build/artifacts-linux-$(1)/kuma-cni bu
 .PHONY: image/kuma-universal/$(1)
 image/kuma-universal/$(1): image/envoy/$(1) build/artifacts-linux-$(1)/kuma-cp build/artifacts-linux-$(1)/kuma-dp build/artifacts-linux-$(1)/kumactl build/artifacts-linux-$(1)/kumactl build/artifacts-linux-$(1)/test-server build/artifacts-linux-$(1)/coredns
 	docker build $(DOCKER_BUILD_OPTS) -t $$(call build_image,kuma-universal,$(1)) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(KUMA_DIR)/test/dockerfiles/universal.Dockerfile .
+
+.PHONY: image/kuma-test-app/$(1)
+image/kuma-test-app/$(1): image/envoy/$(1) build/artifacts-linux-$(1)/kuma-dp build/artifacts-linux-$(1)/test-server build/artifacts-linux-$(1)/coredns
+	docker build $(DOCKER_BUILD_OPTS) -t $$(call build_image,kuma-test-app,$(1)) --build-arg ARCH=$(1) --platform=linux/$(1) -f $(KUMA_DIR)/test/dockerfiles/test-app.Dockerfile .
 endef
 $(foreach goarch,$(SUPPORTED_GOARCHES),$(eval $(call IMAGE_TARGETS_BY_ARCH,$(goarch))))
 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -146,12 +146,16 @@ K3D_CLUSTER_START_RETRIES ?= 3
 K3D_IMAGE_IMPORT_VERBOSE ?= true
 K3D_IMAGE_IMPORT_VERBOSE_FLAG := $(if $(filter true 1,$(K3D_IMAGE_IMPORT_VERBOSE)),--verbose,)
 
+# Import release images + the slim kuma-test-app; the fat kuma-universal is only
+# needed by host-docker universal clusters, so k3d skips it.
+K3D_IMPORT_IMAGES ?= $(call build_image,$(IMAGES_RELEASE) kuma-test-app)
+
 # The import command, factored out so the retry wrapper stays generic
 _k3d_import = $(K3D) image import \
   --mode $(K3D_IMAGE_IMPORT_MODE) \
   --cluster $(CLUSTER_NAME) \
   $(K3D_IMAGE_IMPORT_VERBOSE_FLAG) \
-  $(KUMA_IMAGES)
+  $(K3D_IMPORT_IMAGES)
 
 .PHONY: k3d/cluster/load/images
 k3d/cluster/load/images:

--- a/test/dockerfiles/test-app.Dockerfile
+++ b/test/dockerfiles/test-app.Dockerfile
@@ -1,0 +1,20 @@
+ARG ARCH
+FROM kumahq/envoy:no-push-$ARCH AS envoy
+FROM ghcr.io/kumahq/ubuntu-netools:main@sha256:71653eb9e17fd6529df13a404c4ffac2b14ec260dd13db5bfa10d83ba7d56f9d
+
+ARG ARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -u 5678 -U kuma-dp
+
+RUN mkdir /kuma
+
+ADD /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp /usr/bin
+COPY --from=envoy /envoy /usr/bin/envoy
+ADD /build/artifacts-linux-$ARCH/coredns/coredns /usr/bin
+ADD /build/artifacts-linux-$ARCH/test-server/test-server /usr/bin
+ADD /test/server/certs/server.crt /kuma
+ADD /test/server/certs/server.key /kuma

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -46,6 +46,7 @@ type E2eConfig struct {
 	KumaInitImageRepo                 string            `json:"initImageRepo,omitempty" envconfig:"KUMA_INIT_IMAGE_REPOSITORY"`
 	KumaCNIImageRepo                  string            `json:"cniImageRepo,omitempty" envconfig:"KUMA_CNI_IMAGE_REPOSITORY"`
 	KumaUniversalImageRepo            string            `json:"universalImageRepo,omitempty"`
+	KumaTestAppImageRepo              string            `json:"testAppImageRepo,omitempty"`
 	XDSApiVersion                     string            `json:"xdsVersion,omitempty" envconfig:"API_VERSION"`
 	K8sType                           K8sType           `json:"k8sType,omitempty" envconfig:"KUMA_K8S_TYPE"`
 	IPV6                              bool              `json:"ipv6,omitempty" envconfig:"IPV6"`
@@ -181,6 +182,17 @@ func (c E2eConfig) GetUniversalImage() string {
 	}
 }
 
+// GetTestAppImage returns the slim in-cluster workload image (test-server,
+// demo-client, curl jobs, zone proxies) — the universal image without
+// kuma-cp/kumactl/spire, so k3d doesn't import those binaries every run.
+func (c E2eConfig) GetTestAppImage() string {
+	if c.KumaImageTag != "" {
+		return fmt.Sprintf("%s/%s:%s", c.KumaImageRegistry, c.KumaTestAppImageRepo, c.KumaImageTag)
+	} else {
+		return fmt.Sprintf("%s/%s", c.KumaImageRegistry, c.KumaTestAppImageRepo)
+	}
+}
+
 var defaultConf = E2eConfig{
 	HelmChartName:                 "kuma/kuma",
 	HelmChartPath:                 "../../../deployments/charts/kuma",
@@ -198,6 +210,7 @@ var defaultConf = E2eConfig{
 	KumaImageRegistry:      "kumahq",
 	KumaImageTag:           kuma_version.Build.Version,
 	KumaUniversalImageRepo: "kuma-universal",
+	KumaTestAppImageRepo:   "kuma-test-app",
 	KumaCPImageRepo:        "kuma-cp",
 	KumaDPImageRepo:        "kuma-dp",
 	KumaInitImageRepo:      "kuma-init",

--- a/test/framework/deployments/democlient/kubernetes.go
+++ b/test/framework/deployments/democlient/kubernetes.go
@@ -54,7 +54,7 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 				{
 					Name:            k.Name(),
 					ImagePullPolicy: "IfNotPresent",
-					Image:           framework.Config.GetUniversalImage(),
+					Image:           framework.Config.GetTestAppImage(),
 					Ports: []corev1.ContainerPort{
 						{ContainerPort: 3000, Name: "main"},
 					},

--- a/test/framework/deployments/testserver/kubernetes.go
+++ b/test/framework/deployments/testserver/kubernetes.go
@@ -217,7 +217,7 @@ func (k *k8SDeployment) podSpec() corev1.PodTemplateSpec {
 					ReadinessProbe:  readinessProbe,
 					LivenessProbe:   livenessProbe,
 					StartupProbe:    startupProbe,
-					Image:           framework.Config.GetUniversalImage(),
+					Image:           framework.Config.GetTestAppImage(),
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: int32(containerPort),

--- a/test/framework/deployments/zoneproxy/kubernetes.go
+++ b/test/framework/deployments/zoneproxy/kubernetes.go
@@ -60,7 +60,7 @@ func (d *k8sDeployment) ingressDeployment() *appsv1.Deployment {
 		Containers: []corev1.Container{
 			{
 				Name:            name,
-				Image:           framework.Config.GetUniversalImage(),
+				Image:           framework.Config.GetTestAppImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/usr/bin/sleep"},
 				Args:            []string{"3600"},
@@ -154,7 +154,7 @@ func (d *k8sDeployment) egressDeployment() *appsv1.Deployment {
 		Containers: []corev1.Container{
 			{
 				Name:            name,
-				Image:           framework.Config.GetUniversalImage(),
+				Image:           framework.Config.GetTestAppImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/usr/bin/sleep"},
 				Args:            []string{"3600"},

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -711,7 +711,7 @@ func DemoClientJobK8s(namespace, mesh, destination string) InstallFunc {
 					Containers: []corev1.Container{
 						{
 							Name:            name,
-							Image:           Config.GetUniversalImage(),
+							Image:           Config.GetTestAppImage(),
 							ImagePullPolicy: "IfNotPresent",
 							Command:         []string{"curl"},
 							Args:            []string{"-v", "-m", "3", "--fail", destination},


### PR DESCRIPTION
## Motivation

Prototype (measuring impact) to cut the ~3-min per-job e2e image-import.
Today every k3d cluster imports the fat `kuma-universal` image (ubuntu-netools
+ envoy + spire-server/agent + kuma-cp/dp/coredns/kumactl/test-server), because
the in-cluster test workloads reuse it. Most of that is unused in-cluster.

> Changelog: skip

## Implementation information

- New `kuma-test-app` image = `kuma-universal` **minus** kuma-cp/kumactl/spire
  (~250 MB of binaries), same `ubuntu-netools` base so all shell tools
  (curl/ncat/sleep) are unchanged.
- Repoint in-cluster (k3d) consumers to it: test-server, demo-client, the curl
  Job in `setup.go`, and zone proxies. k8s SPIRE uses upstream spiffe charts
  (unaffected); universal-mode container zones keep `kuma-universal` on host docker.
- `K3D_IMPORT_IMAGES` drops `kuma-universal` from the k3d import (release +
  test-app only). Kind still loads everything (correctness preserved).

Measuring: k3d image-import + cluster-setup time on multizone/kubernetes vs the
baseline. Not for merge as-is — validating the approach + delta.

## Supporting documentation

Follow-up to the CI e2e long-pole analysis.