### PR TITLE
test(unit): reuse test cache on PRs

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -20,6 +20,9 @@ jobs:
     timeout-minutes: 30
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    env:
+      # PRs reuse cached test results for speed; pushes run everything fresh.
+      UNIT_CLEAN_TESTCACHE: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -31,6 +34,16 @@ jobs:
           version: 2026.5.7
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Cache Go build and test results
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            go-test-race-${{ runner.os }}-
       - run: |
           make test
   gen_e2e_matrix:

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,6 +1,9 @@
 UPDATE_GOLDEN_FILES ?=
 TEST_PKG_LIST ?= ./...
 REPORTS_DIR ?= build/reports
+# Wipe the Go test cache before running. Kept on master/release pushes so CI
+# always runs everything fresh; PRs set it false to reuse cached results.
+UNIT_CLEAN_TESTCACHE ?= true
 # Path to the kumactl binary for Linux. This binary will be uploaded to Docker
 # containers during transparent proxy tests.
 KUMACTL_LINUX_BIN ?= $(BUILD_DIR)/artifacts-linux-$(GOARCH)/kumactl/kumactl
@@ -30,7 +33,9 @@ ifdef TEST_REPORTS
 endif
 ifndef TEST_REPORTS
 ifdef CI
+ifeq ($(UNIT_CLEAN_TESTCACHE),true)
 	$(GO) clean -testcache
+endif
 endif
 	$(UNIT_TEST_ENV) $(GO) test $(GOFLAGS) $(call LD_FLAGS,$(GOOS),$(GOARCH)) -race $$($(GO) list $(TEST_PKG_LIST) | grep -E -v "test/e2e" | grep -E -v "test/transparentproxy")
 endif


### PR DESCRIPTION
## Motivation

Prototype (measuring). CI runs `go clean -testcache` then `go test ./...`, so
all ~700 packages recompile + rerun every PR with no cache. Reusing the Go
build/test cache lets unchanged packages return cached results.

> Changelog: skip

## Implementation information

- `UNIT_CLEAN_TESTCACHE` make var gates `go clean -testcache`; `test_unit` sets
  it `false` on PRs, `true` on push (master/release run fresh, unchanged).
- Add `actions/cache` for `~/.cache/go-build` + `~/go/pkg/mod` to `test_unit`.
- Race stays on. Safety net: master still cleans + runs `-race` fresh.

Measuring: run 1 cold (populate cache), then a 1-package change for run 2 (warm)
to see the realistic small-PR unit time.

## Supporting documentation

N/A