### PR TITLE
fix(helm): anti-affinity for ingress/egress pods using custom kuma.name

### DIFF
--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -660,7 +660,7 @@ ingress:
               - key: app
                 operator: In
                 values:
-                  - kuma-ingress
+                  - '{{ include "kuma.name" . }}-ingress'
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Mesh Ingress pods.
@@ -819,7 +819,7 @@ egress:
               - key: app
                 operator: In
                 values:
-                  - kuma-egress
+                  - '{{ include "kuma.name" . }}-egress'
           topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rule for the Kuma Egress pods.


### PR DESCRIPTION
Uses custom kuma.name instead of hardcoding 'kuma' for egress and ingress anti-affinity label selector.

## Motivation

Anti affinity does not work for ingress and egress pods when using a custom chart name.

## Implementation information

Makes use of the `kuma.name` variable instead of hardcoding the "kuma" chart name.

## Supporting documentation

https://github.com/kumahq/kuma/issues/17359

Fix #17359
