### PR TITLE
feat(api-server): add pluggable per-route metadata provider

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/api-server/authn"
 	api_server_types "github.com/kumahq/kuma/v3/pkg/api-server/types"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
@@ -86,6 +87,14 @@ func typeToLegacyOverviewPath(resourceType core_model.ResourceType) string {
 	}
 }
 
+// reservedRouteMetadataKeys are route metadata keys Kuma interprets itself, so a
+// RouteMetadataProvider must not set them. If it does, route drops the value to
+// stop an embedder from changing Kuma's own routing behavior (e.g. disabling
+// authn via authn.MetadataAuthKey).
+var reservedRouteMetadataKeys = map[string]struct{}{
+	authn.MetadataAuthKey: {},
+}
+
 // route builds the RouteBuilder for a CRUD method/path and applies any provider
 // metadata, naming the verb once so ws.<VERB> and the metadata can't desync.
 func (r *resourceEndpoints) route(ws *restful.WebService, method, path string) *restful.RouteBuilder {
@@ -102,6 +111,10 @@ func (r *resourceEndpoints) route(ws *restful.WebService, method, path string) *
 	}
 	if r.routeMetadataProvider != nil {
 		for k, v := range r.routeMetadataProvider(r.descriptor, method) {
+			if _, reserved := reservedRouteMetadataKeys[k]; reserved {
+				log.Info("ignoring reserved route metadata key from provider", "key", k, "type", r.descriptor.Name, "method", method)
+				continue
+			}
 			rb = rb.Metadata(k, v)
 		}
 	}

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
 	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v3/pkg/core/rest/errors/types"
+	"github.com/kumahq/kuma/v3/pkg/core/runtime"
 	"github.com/kumahq/kuma/v3/pkg/core/user"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -48,11 +49,12 @@ const (
 
 // resourceEndpointsContext holds the dependencies shared by the resource handlers.
 type resourceEndpointsContext struct {
-	mode           config_core.CpMode
-	zoneName       string
-	resManager     manager.ResourceManager
-	descriptor     core_model.ResourceTypeDescriptor
-	resourceAccess access.ResourceAccess
+	mode                  config_core.CpMode
+	zoneName              string
+	resManager            manager.ResourceManager
+	descriptor            core_model.ResourceTypeDescriptor
+	resourceAccess        access.ResourceAccess
+	routeMetadataProvider runtime.RouteMetadataProvider
 }
 
 type resourceEndpoints struct {
@@ -84,8 +86,30 @@ func typeToLegacyOverviewPath(resourceType core_model.ResourceType) string {
 	}
 }
 
+// route builds the RouteBuilder for a CRUD method/path and applies any provider
+// metadata, naming the verb once so ws.<VERB> and the metadata can't desync.
+func (r *resourceEndpoints) route(ws *restful.WebService, method, path string) *restful.RouteBuilder {
+	var rb *restful.RouteBuilder
+	switch method {
+	case http.MethodGet:
+		rb = ws.GET(path)
+	case http.MethodPut:
+		rb = ws.PUT(path)
+	case http.MethodDelete:
+		rb = ws.DELETE(path)
+	default:
+		panic(fmt.Sprintf("resource endpoints: unsupported method %q", method))
+	}
+	if r.routeMetadataProvider != nil {
+		for k, v := range r.routeMetadataProvider(r.descriptor, method) {
+			rb = rb.Metadata(k, v)
+		}
+	}
+	return rb
+}
+
 func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
-	ws.Route(ws.GET(pathPrefix+"/{name}").To(r.findResource(false)).
+	ws.Route(r.route(ws, http.MethodGet, pathPrefix+"/{name}").To(r.findResource(false)).
 		Doc(fmt.Sprintf("Get a %s", r.descriptor.WsPath)).
 		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 		Returns(200, "OK", nil).
@@ -259,7 +283,7 @@ func formatResource(resource core_model.Resource, format string, k8sMapper k8s.R
 }
 
 func (r *resourceEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix string) {
-	ws.Route(ws.GET(pathPrefix).To(r.listResources(false)).
+	ws.Route(r.route(ws, http.MethodGet, pathPrefix).To(r.listResources(false)).
 		Doc(fmt.Sprintf("List of %s", r.descriptor.Name)).
 		Param(ws.QueryParameter("size", "size of page").DataType("int")).
 		Param(ws.QueryParameter("offset", "offset of page to list").DataType("string")).
@@ -373,11 +397,11 @@ func (r *resourceEndpoints) MergeInOverview(resources core_model.ResourceList, i
 
 func (r *resourceEndpoints) addCreateOrUpdateEndpoint(ws *restful.WebService, pathPrefix string) {
 	if r.descriptor.ReadOnly {
-		ws.Route(ws.PUT(pathPrefix+"/{name}").To(r.methodNotAllowed(r.readOnlyMessage())).
+		ws.Route(r.route(ws, http.MethodPut, pathPrefix+"/{name}").To(r.methodNotAllowed(r.readOnlyMessage())).
 			Doc("Not allowed in read-only mode.").
 			Returns(http.StatusMethodNotAllowed, "Not allowed in read-only mode.", restful.ServiceError{}))
 	} else {
-		ws.Route(ws.PUT(pathPrefix+"/{name}").To(r.createOrUpdateResource).
+		ws.Route(r.route(ws, http.MethodPut, pathPrefix+"/{name}").To(r.createOrUpdateResource).
 			Doc(fmt.Sprintf("Updates a %s", r.descriptor.WsPath)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of the %s", r.descriptor.WsPath)).DataType("string")).
 			Returns(200, "OK", nil).
@@ -578,11 +602,11 @@ func (r *resourceEndpoints) updateResource(
 
 func (r *resourceEndpoints) addDeleteEndpoint(ws *restful.WebService, pathPrefix string) {
 	if r.descriptor.ReadOnly {
-		ws.Route(ws.DELETE(pathPrefix+"/{name}").To(r.methodNotAllowed(r.readOnlyMessage())).
+		ws.Route(r.route(ws, http.MethodDelete, pathPrefix+"/{name}").To(r.methodNotAllowed(r.readOnlyMessage())).
 			Doc("Not allowed in read-only mode.").
 			Returns(http.StatusMethodNotAllowed, "Not allowed in read-only mode.", restful.ServiceError{}))
 	} else {
-		ws.Route(ws.DELETE(pathPrefix+"/{name}").To(r.deleteResource).
+		ws.Route(r.route(ws, http.MethodDelete, pathPrefix+"/{name}").To(r.deleteResource).
 			Doc(fmt.Sprintf("Deletes a %s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil))

--- a/pkg/api-server/route_metadata_test.go
+++ b/pkg/api-server/route_metadata_test.go
@@ -1,0 +1,69 @@
+package api_server
+
+import (
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/core/runtime"
+)
+
+var _ = Describe("route metadata provider", func() {
+	descriptor := core_model.ResourceTypeDescriptor{
+		Name:   "MeshTrafficPermission",
+		WsPath: "meshtrafficpermissions",
+	}
+
+	putRoute := func(ws *restful.WebService) *restful.Route {
+		for i := range ws.Routes() {
+			if ws.Routes()[i].Method == http.MethodPut {
+				return &ws.Routes()[i]
+			}
+		}
+		return nil
+	}
+
+	It("attaches provider metadata to the generated PUT route", func() {
+		provider := func(core_model.ResourceTypeDescriptor, string) map[string]string {
+			return map[string]string{"x-test": "v"}
+		}
+		endpoints := resourceEndpoints{
+			resourceEndpointsContext: resourceEndpointsContext{
+				descriptor:            descriptor,
+				routeMetadataProvider: provider,
+			},
+		}
+		ws := new(restful.WebService)
+
+		endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+descriptor.WsPath)
+
+		put := putRoute(ws)
+		Expect(put).ToNot(BeNil())
+		Expect(put.Metadata).To(HaveKeyWithValue("x-test", "v"))
+	})
+
+	It("attaches no metadata when the provider is nil", func() {
+		endpoints := resourceEndpoints{
+			resourceEndpointsContext: resourceEndpointsContext{
+				descriptor:            descriptor,
+				routeMetadataProvider: nil,
+			},
+		}
+		ws := new(restful.WebService)
+
+		endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+descriptor.WsPath)
+
+		put := putRoute(ws)
+		Expect(put).ToNot(BeNil())
+		Expect(put.Metadata).ToNot(HaveKey("x-test"))
+	})
+
+	It("is satisfied by the runtime RouteMetadataProvider type", func() {
+		var _ runtime.RouteMetadataProvider = func(core_model.ResourceTypeDescriptor, string) map[string]string {
+			return nil
+		}
+	})
+})

--- a/pkg/api-server/route_metadata_test.go
+++ b/pkg/api-server/route_metadata_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kumahq/kuma/v3/pkg/api-server/authn"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/runtime"
 )
@@ -59,6 +60,26 @@ var _ = Describe("route metadata provider", func() {
 		put := putRoute(ws)
 		Expect(put).ToNot(BeNil())
 		Expect(put.Metadata).ToNot(HaveKey("x-test"))
+	})
+
+	It("drops reserved keys but keeps the rest", func() {
+		provider := func(core_model.ResourceTypeDescriptor, string) map[string]string {
+			return map[string]string{authn.MetadataAuthKey: authn.MetadataAuthSkip, "x-ok": "v"}
+		}
+		endpoints := resourceEndpoints{
+			resourceEndpointsContext: resourceEndpointsContext{
+				descriptor:            descriptor,
+				routeMetadataProvider: provider,
+			},
+		}
+		ws := new(restful.WebService)
+
+		endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+descriptor.WsPath)
+
+		put := putRoute(ws)
+		Expect(put).ToNot(BeNil())
+		Expect(put.Metadata).To(HaveKeyWithValue("x-ok", "v"))
+		Expect(put.Metadata).ToNot(HaveKey(authn.MetadataAuthKey))
 	})
 
 	It("is satisfied by the runtime RouteMetadataProvider type", func() {

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -157,6 +157,7 @@ func NewApiServer(
 		rt.GlobalInsightService(),
 		meshContextBuilder,
 		xdsHooks,
+		rt.RouteMetadataProvider(),
 	)
 	addPoliciesWsEndpoints(ws, cfg.Mode == config_core.Global, cfg.IsFederatedZoneCP(), cfg.ApiServer.ReadOnly, defs)
 	addInspectEndpoints(ws, cfg, meshContextBuilder, rt.ResourceManager(), rt.Access().ResourceAccess)
@@ -262,6 +263,7 @@ func addResourcesEndpoints(
 	globalInsightService globalinsight.GlobalInsightService,
 	meshContextBuilder xds_context.MeshContextBuilder,
 	xdsHooks []hooks.ResourceSetHook,
+	routeMetadataProvider runtime.RouteMetadataProvider,
 ) {
 	globalInsightsEndpoints := globalInsightsEndpoints{
 		resManager:     resManager,
@@ -296,10 +298,11 @@ func addResourcesEndpoints(
 			definition.ReadOnly = definition.IsReadOnly(cfg.Mode == config_core.Global, cfg.IsFederatedZoneCP())
 		}
 		endpointsCtx := resourceEndpointsContext{
-			mode:           cfg.Mode,
-			resManager:     resManager,
-			descriptor:     definition,
-			resourceAccess: resourceAccess,
+			mode:                  cfg.Mode,
+			resManager:            resManager,
+			descriptor:            definition,
+			resourceAccess:        resourceAccess,
+			routeMetadataProvider: routeMetadataProvider,
 		}
 		if cfg.Mode == config_core.Zone && cfg.Multizone != nil && cfg.Multizone.Zone != nil {
 			endpointsCtx.zoneName = cfg.Multizone.Zone.Name

--- a/pkg/core/runtime/builder.go
+++ b/pkg/core/runtime/builder.go
@@ -104,6 +104,7 @@ type Builder struct {
 	pgxConfigCustomizationFn config.PgxConfigCustomization
 	tenants                  multitenant.Tenants
 	apiWebServiceCustomize   []func(*restful.WebService) error
+	routeMetadataProvider    RouteMetadataProvider
 	identityProviders        providers.IdentityProviders
 }
 
@@ -293,6 +294,14 @@ func (b *Builder) WithAPIWebServiceCustomize(customize func(*restful.WebService)
 	return b
 }
 
+// WithRouteMetadataProvider sets the route-metadata provider. Unlike
+// WithAPIWebServiceCustomize it does not compose: a second call replaces the
+// first, as there is intentionally a single metadata authority.
+func (b *Builder) WithRouteMetadataProvider(provider RouteMetadataProvider) *Builder {
+	b.routeMetadataProvider = provider
+	return b
+}
+
 func (b *Builder) WithIdentityProviders(name string, identityProviders providers.IdentityProvider) *Builder {
 	b.identityProviders[name] = identityProviders
 	return b
@@ -413,6 +422,7 @@ func (b *Builder) Build() (Runtime, error) {
 			tenants:                  b.tenants,
 			identityProviders:        b.identityProviders,
 			apiWebServiceCustomize:   b.apiWebServiceCustomize,
+			routeMetadataProvider:    b.routeMetadataProvider,
 		},
 		Manager: b.cm,
 	}, nil
@@ -552,6 +562,10 @@ func (b *Builder) Tenants() multitenant.Tenants {
 
 func (b *Builder) APIWebServiceCustomize() []func(*restful.WebService) error {
 	return b.apiWebServiceCustomize
+}
+
+func (b *Builder) RouteMetadataProvider() RouteMetadataProvider {
+	return b.routeMetadataProvider
 }
 
 func (b *Builder) IdentityProviders() providers.IdentityProviders {

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	resources_access "github.com/kumahq/kuma/v3/pkg/core/resources/access"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshidentity/providers"
 	core_manager "github.com/kumahq/kuma/v3/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/v3/pkg/core/resources/store"
 	"github.com/kumahq/kuma/v3/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/v3/pkg/core/secrets/store"
@@ -95,6 +96,7 @@ type RuntimeContext interface {
 	PgxConfigCustomizationFn() config.PgxConfigCustomization
 	Tenants() multitenant.Tenants
 	APIWebServiceCustomize() func(ws *restful.WebService) error
+	RouteMetadataProvider() RouteMetadataProvider
 	IdentityProviders() providers.IdentityProviders
 }
 
@@ -112,6 +114,16 @@ type ResourceValidators struct {
 }
 
 type ExtraReportsFn func(Runtime) (map[string]string, error)
+
+// RouteMetadataProvider supplies metadata to attach to the auto-generated CRUD
+// routes (find, list, create-or-update, delete) of each resource type, keyed by
+// resource descriptor and HTTP verb; sub-routes (_overview, _config, _policies,
+// _rules, inspect, legacy overview) are not passed to it. It runs synchronously
+// while the API server is built at startup, so a panic fails the boot by design.
+// Kuma does not interpret the values, but the metadata namespace is shared with
+// route gates such as authn's reserved "auth":"skip" (pkg/api-server/authn), so
+// providers must not emit reserved keys. A nil provider attaches nothing.
+type RouteMetadataProvider func(desc core_model.ResourceTypeDescriptor, method string) map[string]string
 
 var _ Runtime = &runtime{}
 
@@ -204,6 +216,7 @@ type runtimeContext struct {
 	pgxConfigCustomizationFn config.PgxConfigCustomization
 	tenants                  multitenant.Tenants
 	apiWebServiceCustomize   []func(*restful.WebService) error
+	routeMetadataProvider    RouteMetadataProvider
 	identityProviders        providers.IdentityProviders
 }
 
@@ -349,4 +362,8 @@ func (rc *runtimeContext) APIWebServiceCustomize() func(*restful.WebService) err
 
 		return err
 	}
+}
+
+func (rc *runtimeContext) RouteMetadataProvider() RouteMetadataProvider {
+	return rc.routeMetadataProvider
 }

--- a/pkg/core/runtime/runtime.go
+++ b/pkg/core/runtime/runtime.go
@@ -121,8 +121,9 @@ type ExtraReportsFn func(Runtime) (map[string]string, error)
 // _rules, inspect, legacy overview) are not passed to it. It runs synchronously
 // while the API server is built at startup, so a panic fails the boot by design.
 // Kuma does not interpret the values, but the metadata namespace is shared with
-// route gates such as authn's reserved "auth":"skip" (pkg/api-server/authn), so
-// providers must not emit reserved keys. A nil provider attaches nothing.
+// route gates such as authn's reserved "auth":"skip" (pkg/api-server/authn);
+// keys Kuma reserves are dropped rather than attached. A nil provider attaches
+// nothing.
 type RouteMetadataProvider func(desc core_model.ResourceTypeDescriptor, method string) map[string]string
 
 var _ Runtime = &runtime{}

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -206,6 +206,10 @@ func (t *testRuntimeContext) APIWebServiceCustomize() func(*restful.WebService) 
 	return func(*restful.WebService) error { return nil }
 }
 
+func (t *testRuntimeContext) RouteMetadataProvider() runtime.RouteMetadataProvider {
+	return nil
+}
+
 func (t *testRuntimeContext) Ready() bool {
 	for _, c := range t.components {
 		if rc, ok := c.(component.ReadyComponent); ok && !rc.Ready() {

--- a/pkg/test/runtime/runtime.go
+++ b/pkg/test/runtime/runtime.go
@@ -323,6 +323,10 @@ func (r *TestRuntime) APIWebServiceCustomize() func(ws *restful.WebService) erro
 	return func(*restful.WebService) error { return nil }
 }
 
+func (r *TestRuntime) RouteMetadataProvider() core_runtime.RouteMetadataProvider {
+	return nil
+}
+
 func (r *TestRuntime) Extensions() context.Context {
 	return context.Background()
 }


### PR DESCRIPTION
## Motivation

The api-server auto-generates the REST CRUD routes for every registered resource type in one loop. Today there is no way for an embedder (a downstream build that composes Kuma) to attach metadata to those generated routes — only hand-registered WebServices can call `.Metadata(...)`. That metadata is useful for cross-cutting concerns such as authorization or observability middleware that need per-route, per-method context on the generated resource endpoints.

## Implementation information

Add a provider-neutral `RouteMetadataProvider` hook, plumbed the same way as the existing `APIWebServiceCustomize` hook on the runtime builder and interface:

- `runtime.RouteMetadataProvider` — `func(desc model.ResourceTypeDescriptor, method string) map[string]string`
- `Builder.WithRouteMetadataProvider(...)` setter + `Runtime.RouteMetadataProvider()` getter
- `NewApiServer` threads it into the resource-endpoint context; a small `applyRouteMetadata` helper attaches the returned key/values to the generated find / list / create-or-update / delete routes via the `restful` `RouteBuilder.Metadata`.

Kuma stays neutral — it attaches whatever the provider returns without interpreting it. A nil provider is a no-op, so existing behavior is unchanged.

## Supporting documentation

Added `pkg/api-server/route_metadata_test.go` asserting the generated `PUT /{name}` route carries provider metadata, and none when the provider is nil.
