### PR TITLE
chore(deps): track coredns-builds via renovate

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -28,6 +28,7 @@ export PATH := $(BUILD_KUMACTL_DIR):$(PATH)
 
 # An optional extension to the coredns packages
 COREDNS_EXT ?=
+# renovate: datasource=github-tags depName=coredns packageName=kumahq/coredns-builds versioning=semver
 COREDNS_VERSION = v1.14.2
 
 # List of binaries that we have build/release build rules for.


### PR DESCRIPTION
## Motivation

Renovate already tracks Envoy releases from [kumahq/envoy-builds](https://github.com/kumahq/envoy-builds) via a hint comment above `ENVOY_VERSION` in `mk/dev.mk`. `COREDNS_VERSION` had no equivalent, so CoreDNS builds from [kumahq/coredns-builds](https://github.com/kumahq/coredns-builds) had to be bumped manually.

## Implementation information

Added the same Renovate hint comment convention above `COREDNS_VERSION` in `mk/build.mk`. No `renovate.json` changes needed: `customManagers:makefileVersions` (pulled in transitively via the `Kong/public-shared-renovate` default preset, and not present in `renovate.json`'s `ignorePresets`) already scans `*.mk` files for this comment convention.

Verified locally that the Renovate regex correctly extracts `datasource=github-tags`, `depName=coredns`, `packageName=kumahq/coredns-builds`, `currentValue=v1.14.2` from the new comment, and that `kumahq/coredns-builds` tags follow the same `vX.Y.Z` format already used by `COREDNS_VERSION`.

## Supporting documentation

See `mk/dev.mk` for the equivalent, pre-existing `ENVOY_VERSION` Renovate hint this mirrors.

> Changelog: skip