### PR TITLE
fix(xds): emit KRI tag on MeshService outbounds

### DIFF
--- a/pkg/core/xds/types/outbound.go
+++ b/pkg/core/xds/types/outbound.go
@@ -49,6 +49,24 @@ func (o *Outbound) TagsOrNil() map[string]string {
 	return nil
 }
 
+const KRITag = "kuma.io/kri"
+
+// ListenerTags returns tags for listener metadata. For legacy outbounds, it
+// returns the tags from the LegacyOutbound. For real resource outbounds
+// (MeshService, MeshExternalService, MeshMultiZoneService), it returns a tag
+// containing the KRI, enabling MeshProxyPatch to match on it.
+func (o *Outbound) ListenerTags() map[string]string {
+	if o.LegacyOutbound != nil {
+		return o.LegacyOutbound.Tags
+	}
+	if !o.Resource.IsEmpty() {
+		return map[string]string{
+			KRITag: o.Resource.String(),
+		}
+	}
+	return nil
+}
+
 func (o *Outbound) GetPort() uint32 {
 	if o.LegacyOutbound != nil {
 		return o.LegacyOutbound.Port

--- a/pkg/core/xds/types/outbound_test.go
+++ b/pkg/core/xds/types/outbound_test.go
@@ -1,8 +1,6 @@
 package types_test
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -10,12 +8,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/xds/types"
-	"github.com/kumahq/kuma/v3/pkg/test"
 )
-
-func TestOutbound(t *testing.T) {
-	test.RunSpecs(t, "Outbound Types Suite")
-}
 
 var _ = Describe("Outbound", func() {
 	Describe("ListenerTags", func() {

--- a/pkg/core/xds/types/outbound_test.go
+++ b/pkg/core/xds/types/outbound_test.go
@@ -1,0 +1,88 @@
+package types_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/xds/types"
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestOutbound(t *testing.T) {
+	test.RunSpecs(t, "Outbound Types Suite")
+}
+
+var _ = Describe("Outbound", func() {
+	Describe("ListenerTags", func() {
+		It("returns legacy tags for legacy outbound", func() {
+			o := &types.Outbound{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Tags: map[string]string{
+						mesh_proto.ServiceTag: "backend",
+						"version":             "v1",
+					},
+				},
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(Equal(map[string]string{
+				mesh_proto.ServiceTag: "backend",
+				"version":             "v1",
+			}))
+		})
+
+		It("returns KRI tag for real resource outbound", func() {
+			id := kri.Identifier{
+				ResourceType: meshservice_api.MeshServiceType,
+				Mesh:         "default",
+				Zone:         "zone-1",
+				Namespace:    "ns",
+				Name:         "backend",
+				SectionName:  "http",
+			}
+			o := &types.Outbound{
+				Resource: id,
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(HaveKey(types.KRITag))
+			Expect(tags[types.KRITag]).To(Equal(id.String()))
+		})
+
+		It("returns nil for empty outbound", func() {
+			o := &types.Outbound{}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(BeNil())
+		})
+
+		It("prefers legacy tags over KRI when both present", func() {
+			id := kri.Identifier{
+				ResourceType: meshservice_api.MeshServiceType,
+				Mesh:         "default",
+				Zone:         "zone-1",
+				Namespace:    "ns",
+				Name:         "backend",
+				SectionName:  "http",
+			}
+			o := &types.Outbound{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Tags: map[string]string{
+						mesh_proto.ServiceTag: "backend",
+					},
+				},
+				Resource: id,
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(Equal(map[string]string{
+				mesh_proto.ServiceTag: "backend",
+			}))
+		})
+	})
+})

--- a/pkg/core/xds/types/types_suite_test.go
+++ b/pkg/core/xds/types/types_suite_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestTypes(t *testing.T) {
+	test.RunSpecs(t, "Types Suite")
+}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -9,7 +9,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
-	"github.com/kumahq/kuma/v3/pkg/core/naming/unified-naming"
+	unified_naming "github.com/kumahq/kuma/v3/pkg/core/naming/unified-naming"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
@@ -75,7 +75,7 @@ func GenerateOutboundListener(
 		Configure(envoy_listeners.StatPrefix(listenerStatPrefix)).
 		Configure(envoy_listeners.OutboundListener(address, port, core_xds.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.TransparentProxying(transparentProxyEnabled)).
-		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag))).
+		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.ListenerTags()).WithoutTags(mesh_proto.MeshTag))).
 		Configure(envoy_listeners.FilterChain(filterChain))
 
 	resource, err := listener.Build()

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
@@ -61,7 +61,8 @@ resources:
           statPrefix: kri_msvc_default___backend_test-port
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: kri_msvc_default___backend_test-port
     statPrefix: kri_msvc_default___backend_test-port
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -85,6 +85,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default_remote-zone__ext-backend_9000
     name: kri_extsvc_default_remote-zone__ext-backend_9000
     statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend__remote-zone_msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default_remote-zone__backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
@@ -37,7 +37,8 @@ resources:
           statPrefix: kri_msvc_default___backend_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: kri_msvc_default___backend_80
     statPrefix: kri_msvc_default___backend_80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -52,6 +52,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default___example_
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: kri_extsvc_default___example_
     statPrefix: kri_extsvc_default___example_
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -4,7 +4,7 @@ import (
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
-	"github.com/kumahq/kuma/v3/pkg/core/naming/unified-naming"
+	unified_naming "github.com/kumahq/kuma/v3/pkg/core/naming/unified-naming"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	"github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
@@ -39,7 +39,7 @@ func GenerateOutboundListener(
 		tcpProxyStatPrefix = listenerName
 	}
 
-	tags := envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)
+	tags := envoy_tags.Tags(svc.Outbound.ListenerTags()).WithoutTags(mesh_proto.MeshTag)
 
 	filterChain := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 		Configure(envoy_listeners.TCPProxy(tcpProxyStatPrefix, splits...)).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -15,6 +15,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:10.20.20.2:9090
@@ -34,7 +35,8 @@ resources:
           statPrefix: default_example2___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example2_
     name: outbound:10.20.20.2:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001


### PR DESCRIPTION
## Motivation

Enabling MeshService breaks MeshProxyPatch tag-based targeting of outbound listeners. Once an outbound is backed by a MeshService, the generated listener carries empty `io.kuma.tags` metadata because `TagsOrNil()` returns nil for real resource outbounds.

Closes #17369

## Implementation information

- Add `ListenerTags()` method to `Outbound` that returns a `kuma.io/kri` tag containing the KRI for real resource outbounds (MeshService, MeshExternalService, MeshMultiZoneService)
- Update `meshtcproute` and `meshhttproute` listener generation to use `ListenerTags()` instead of `TagsOrNil()`
- With this fix, MeshProxyPatch can match MeshService-backed outbound listeners using:
```yaml
  match:
    tags:
      kuma.io/kri: kri_msvc_<mesh>_<zone>_<ns>_<name>_<port>
```

I think it should be only on <= 2.14 as in 3.0 we require unified naming