### PR TITLE
fix(k8s): keep serving inbound when deduplicating

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -200,17 +200,53 @@ func (ic *InboundConverter) inboundInterfacesFor(ctx context.Context, zone strin
 	return ifaces, nil
 }
 
+// inboundStatePrecedence orders inbound states from the most to the least serving.
+// When several Services select the same address:port, that port is serving as long
+// as one of them is Ready, so a Ready inbound has to win deduplication over an
+// Ignored one. Ignored is the least serving: it only says that one particular
+// Service does not select this Pod, which is a membership fact rather than a
+// property of the port itself.
+func inboundStatePrecedence(state mesh_proto.Dataplane_Networking_Inbound_State) int {
+	switch state {
+	case mesh_proto.Dataplane_Networking_Inbound_Ready:
+		return 0
+	case mesh_proto.Dataplane_Networking_Inbound_NotReady:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// deduplicateInboundsByAddressAndPort collapses inbounds that share an address and
+// port into one, keeping the most serving one. Inbounds here carry no tags, so the
+// only thing that distinguishes duplicates is their state and dropping the rest
+// loses no information: which Services select the Pod is resolved by MeshService
+// matching on Dataplane labels, not by the inbound.
+//
+// Keeping the most serving one matters when IgnoredServiceSelectorLabels is
+// configured: a Service is then matched with that label removed, so a Service that
+// does not select this Pod still produces an (Ignored) inbound on the same port as
+// the Service that does. Keeping the Ignored one would leave the Pod with no
+// healthy inbound and take its MeshService down. See #17142.
 func deduplicateInboundsByAddressAndPort(ifaces []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {
 	inboundKey := func(iface *mesh_proto.Dataplane_Networking_Inbound) string {
 		return fmt.Sprintf("%s:%d", iface.Address, iface.Port)
 	}
 
 	var deduplicatedInbounds []*mesh_proto.Dataplane_Networking_Inbound
-	inboundsPerAddressPort := map[string]*mesh_proto.Dataplane_Networking_Inbound{}
+	indexPerAddressPort := map[string]int{}
 	for _, iface := range ifaces {
-		if inboundsPerAddressPort[inboundKey(iface)] == nil {
-			inboundsPerAddressPort[inboundKey(iface)] = iface
+		key := inboundKey(iface)
+		idx, exists := indexPerAddressPort[key]
+		if !exists {
+			indexPerAddressPort[key] = len(deduplicatedInbounds)
 			deduplicatedInbounds = append(deduplicatedInbounds, iface)
+			continue
+		}
+		// Replace in place so that the order of ports does not depend on the
+		// state of the Services that happen to select this Pod.
+		if inboundStatePrecedence(iface.State) < inboundStatePrecedence(deduplicatedInbounds[idx].State) {
+			deduplicatedInbounds[idx] = iface
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -351,6 +351,17 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "overlapping-inbounds.services-for-pod.yaml",
 			dataplane:      "overlapping-inbounds.dataplane.yaml",
 		}),
+		Entry("Deduplication keeps the Ready inbound when an Ignored one comes first", testCase{
+			pod:                 "argo-rollout-inbounds.pod.yaml",
+			servicesForPod:      "argo-rollout-inbounds.services-for-pod.yaml",
+			dataplane:           "argo-rollout-inbounds.dataplane.yaml",
+			inboundTagsDisabled: true,
+		}),
+		Entry("Ignored and Ready inbounds are both kept when inbound tags enabled", testCase{
+			pod:            "argo-rollout-inbounds.pod.yaml",
+			servicesForPod: "argo-rollout-inbounds.services-for-pod.yaml",
+			dataplane:      "argo-rollout-inbounds-tags.dataplane.yaml",
+		}),
 		Entry("31. Pod with workload labels configured matching pod label", testCase{
 			pod:            "31.pod.yaml",
 			servicesForPod: "31.services-for-pod.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds-tags.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds-tags.dataplane.yaml
@@ -1,0 +1,42 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/display-name: ""
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    rollouts-pod-template-hash: new-revision
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health: {}
+      name: main-port
+      port: 7070
+      protocol: tcp
+      state: Ignored
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-active
+        k8s.kuma.io/service-port: "7000"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-active_demo_svc_7000
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: new-revision
+    - health:
+        ready: true
+      name: main-port
+      port: 7070
+      protocol: tcp
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-preview
+        k8s.kuma.io/service-port: "7001"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-preview_demo_svc_7001
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: new-revision

--- a/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds.dataplane.yaml
@@ -1,0 +1,19 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/display-name: ""
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    rollouts-pod-template-hash: new-revision
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health:
+        ready: true
+      name: main-port
+      port: 7070
+      protocol: tcp

--- a/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds.pod.yaml
@@ -1,0 +1,18 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    # Pod belongs to the new revision that the preview Service points at.
+    rollouts-pod-template-hash: new-revision
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 7070
+          name: main-port
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/argo-rollout-inbounds.services-for-pod.yaml
@@ -1,0 +1,36 @@
+---
+# Argo Rollouts blue-green in the middle of a rollout. Both Services select this
+# Pod because the control plane is configured with
+# IgnoredServiceSelectorLabels=rollouts-pod-template-hash, so that label is
+# dropped when matching Services to the Pod. They are ordered by name, the way
+# findMatchingServices returns them.
+#
+# The active Service still points at the old revision, so it does not select this
+# Pod and its inbound ends up Ignored. It sorts first.
+metadata:
+  namespace: demo
+  name: example-active
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: old-revision
+  ports:
+    - protocol: TCP
+      port: 7000
+      targetPort: 7070
+---
+# The preview Service points at the new revision, so it selects this Pod and its
+# inbound is Ready. Both Services target the same container port.
+metadata:
+  namespace: demo
+  name: example-preview
+spec:
+  clusterIP: 192.168.0.2
+  selector:
+    app: example
+    rollouts-pod-template-hash: new-revision
+  ports:
+    - protocol: TCP
+      port: 7001
+      targetPort: 7070


### PR DESCRIPTION
## Motivation

Fixes #17142.

In MeshServices `Exclusive` mode with inbound tags disabled, inbound deduplication by `address:port` (`deduplicateInboundsByAddressAndPort`) kept the *first* inbound and was state-blind.

This bites with Argo Rollouts blue-green plus `KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS=rollouts-pod-template-hash`. That config makes `findMatchingServices` drop the hash when matching Services to a Pod, so both the active `<app>` and the `<app>-preview` Service match the same Pod. `inboundForService` then recomputes state against the *full* selector: the Service that actually selects the Pod produces a `Ready` inbound, the other produces an `Ignored` one, both on the same `address:port`.

Because Services are returned sorted by name, `<app>-preview` sorts before `<app>`, so dedup kept the `Ignored` inbound and dropped the `Ready` one. `GetHealthyInbounds()` then finds nothing, the backing MeshService reports `Healthy: 0` and flips to `Unavailable` while the Pods are healthy and serving.

## Implementation information

Deduplication now keeps the *most serving* inbound for each `address:port` (`Ready` > `NotReady` > `Ignored`) and replaces in place, so the resulting inbound order does not depend on which Services happen to select the Pod. This is safe because in this model inbounds carry no tags: which Services select the Pod is resolved by MeshService matching on Dataplane labels, not by the inbound itself, so collapsing duplicates loses no information and picking the serving one is strictly correct.

## Supporting documentation

- Issue: #17142
- Deduplication origin: #12760 (fixes #12123)

Tests: added a golden fixture reproducing the mid-rollout scenario (two Services on one port, `Ignored` sorting first). Confirmed the new golden fails on the pre-fix code and passes after. A companion fixture pins the tags-enabled path (both inbounds kept, unchanged by this PR).

### Known follow-up (not in this PR)

The tags-enabled path (no MeshIdentity) does not deduplicate, so the same Argo config leaves two inbounds on one `address:port`. Those collide on the Envoy inbound listener name (`inbound:<ip>:<port>`) and `ResourceSet.Add` is last-write-wins, so the surviving listener depends on Service name order rather than inbound state. That is a separate failure surface in the xDS generator and needs its own fix + verification; tracking it separately rather than widening this change.

> Changelog: fix(k8s): prevent MeshService going Unavailable during Argo blue-green rollouts