### PR TITLE
test(gatewayapi): pin conformance to mesh-ns fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	sigs.k8s.io/controller-tools v0.21.0
 	// When updating this also update version in: test/framework/k8s.go
 	sigs.k8s.io/gateway-api v1.6.0
-	sigs.k8s.io/gateway-api/conformance v1.6.0
+	sigs.k8s.io/gateway-api/conformance v0.0.0-20260603141352-8f69037cd891
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,8 @@ sigs.k8s.io/controller-tools v0.21.0 h1:KXDQza3bgjlPY6xLR63tI/40gzjhyUAvkCrwzd2/
 sigs.k8s.io/controller-tools v0.21.0/go.mod h1:DLIypi3Q2+azVAP8jr/mHXJgveYYHFjhnNOUuBJ10JE=
 sigs.k8s.io/gateway-api v1.6.0 h1:735YBRj5NXFrOGX0GoSjwzUIzbz8kiEOfADsqHFmHgE=
 sigs.k8s.io/gateway-api v1.6.0/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
-sigs.k8s.io/gateway-api/conformance v1.6.0 h1:jyH7Jtx46hEeBQnmSErn2cbp0k4OmT3FLRBnu77c4Ko=
-sigs.k8s.io/gateway-api/conformance v1.6.0/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
+sigs.k8s.io/gateway-api/conformance v0.0.0-20260603141352-8f69037cd891 h1:foDqd0jTO5sGOjd+lAEr70y80T+Hy1GHgZqQxTmf7Wg=
+sigs.k8s.io/gateway-api/conformance v0.0.0-20260603141352-8f69037cd891/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=


### PR DESCRIPTION
## Motivation

The `gatewayapi` e2e job has failed on **every** master run since #17195 - deterministic, not flaky.

#17195 dropped the north-south Gateway conformance profile, so the suite no longer applies its base manifests (which deploy the `gateway-conformance-app-backend` / `gateway-conformance-web-backend` backends). But the mesh profile's `Setup` still waited for those two namespaces to have ready pods, so it blocked until the 300s namespace-readiness timeout and failed the job.

## Implementation information

Upstream removed `app-backend`/`web-backend` from the mesh readiness wait in https://github.com/kubernetes-sigs/gateway-api/pull/4934, leaving only `mesh`/`mesh-consumer`. That fix isn't in any release: `v1.6.0` predates the divergence and `release-1.6` wasn't backported - it exists only on `main`.

So pin the conformance module to that commit (`8f69037cd`). It still compiles against `gateway-api v1.6.0`, which stays unchanged, so production controllers are unaffected. One line in `go.mod`, no test-code change.

## Supporting documentation

- Upstream fix: https://github.com/kubernetes-sigs/gateway-api/pull/4934
- The pin is a pseudo-version (`v0.0.0-20260603141352-8f69037cd891`) on the `main` lineage, diverged from `v1.6.0` (behind ~30 commits), so the mesh tests run are early-June `main`'s set. API/CRDs stay `v1.6.0`, so schema-compatible.
- Follow-up: replace the pin with a real tag once a release (v1.6.1/v1.7.0) or a `release-1.6` backport includes the fix.

> Changelog: skip