### PR TITLE
fix(k8s): keep serving inbound when deduplicating

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -200,17 +200,40 @@ func (ic *InboundConverter) inboundInterfacesFor(ctx context.Context, zone strin
 	return ifaces, nil
 }
 
+// inboundServingRank orders inbound states from the most to the least serving.
+func inboundServingRank(state mesh_proto.Dataplane_Networking_Inbound_State) int {
+	switch state {
+	case mesh_proto.Dataplane_Networking_Inbound_Ready:
+		return 0
+	case mesh_proto.Dataplane_Networking_Inbound_NotReady:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// deduplicateInboundsByAddressAndPort collapses inbounds sharing an address:port
+// into the most serving one. With IgnoredServiceSelectorLabels set, a Service that
+// doesn't select the Pod still yields an Ignored inbound on the same port as the
+// one that does; keeping the Ignored one would take the MeshService down (#17142).
 func deduplicateInboundsByAddressAndPort(ifaces []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {
 	inboundKey := func(iface *mesh_proto.Dataplane_Networking_Inbound) string {
 		return fmt.Sprintf("%s:%d", iface.Address, iface.Port)
 	}
 
 	var deduplicatedInbounds []*mesh_proto.Dataplane_Networking_Inbound
-	inboundsPerAddressPort := map[string]*mesh_proto.Dataplane_Networking_Inbound{}
+	indexPerAddressPort := map[string]int{}
 	for _, iface := range ifaces {
-		if inboundsPerAddressPort[inboundKey(iface)] == nil {
-			inboundsPerAddressPort[inboundKey(iface)] = iface
+		key := inboundKey(iface)
+		idx, exists := indexPerAddressPort[key]
+		if !exists {
+			indexPerAddressPort[key] = len(deduplicatedInbounds)
 			deduplicatedInbounds = append(deduplicatedInbounds, iface)
+			continue
+		}
+		// Replace in place to keep port order independent of Service state.
+		if inboundServingRank(iface.State) < inboundServingRank(deduplicatedInbounds[idx].State) {
+			deduplicatedInbounds[idx] = iface
 		}
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -351,6 +351,17 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "overlapping-inbounds.services-for-pod.yaml",
 			dataplane:      "overlapping-inbounds.dataplane.yaml",
 		}),
+		Entry("Deduplication keeps the Ready inbound when an Ignored one comes first", testCase{
+			pod:                 "dedup-keeps-ready-inbound.pod.yaml",
+			servicesForPod:      "dedup-keeps-ready-inbound.services-for-pod.yaml",
+			dataplane:           "dedup-keeps-ready-inbound.dataplane.yaml",
+			inboundTagsDisabled: true,
+		}),
+		Entry("Ignored and Ready inbounds are both kept when inbound tags enabled", testCase{
+			pod:            "overlapping-ignored-ready.pod.yaml",
+			servicesForPod: "overlapping-ignored-ready.services-for-pod.yaml",
+			dataplane:      "overlapping-ignored-ready.dataplane.yaml",
+		}),
 		Entry("31. Pod with workload labels configured matching pod label", testCase{
 			pod:            "31.pod.yaml",
 			servicesForPod: "31.services-for-pod.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/dedup-keeps-ready-inbound.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/dedup-keeps-ready-inbound.dataplane.yaml
@@ -1,0 +1,18 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    rollouts-pod-template-hash: new-revision
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health:
+        ready: true
+      name: main-port
+      port: 7070
+      protocol: tcp

--- a/pkg/plugins/runtime/k8s/controllers/testdata/dedup-keeps-ready-inbound.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/dedup-keeps-ready-inbound.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    rollouts-pod-template-hash: new-revision
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 7070
+          name: main-port
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/dedup-keeps-ready-inbound.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/dedup-keeps-ready-inbound.services-for-pod.yaml
@@ -1,0 +1,29 @@
+---
+# Argo blue-green mid-rollout with IgnoredServiceSelectorLabels=rollouts-pod-template-hash.
+# active still targets the old revision (Ignored) and sorts first; preview targets
+# this Pod's revision (Ready). Both share the container port.
+metadata:
+  namespace: demo
+  name: example-active
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: old-revision
+  ports:
+    - protocol: TCP
+      port: 7000
+      targetPort: 7070
+---
+metadata:
+  namespace: demo
+  name: example-preview
+spec:
+  clusterIP: 192.168.0.2
+  selector:
+    app: example
+    rollouts-pod-template-hash: new-revision
+  ports:
+    - protocol: TCP
+      port: 7001
+      targetPort: 7070

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-ignored-ready.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-ignored-ready.dataplane.yaml
@@ -1,0 +1,41 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    rollouts-pod-template-hash: new-revision
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health: {}
+      name: main-port
+      port: 7070
+      protocol: tcp
+      state: Ignored
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-active
+        k8s.kuma.io/service-port: "7000"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-active_demo_svc_7000
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: new-revision
+    - health:
+        ready: true
+      name: main-port
+      port: 7070
+      protocol: tcp
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-preview
+        k8s.kuma.io/service-port: "7001"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-preview_demo_svc_7001
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: new-revision

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-ignored-ready.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-ignored-ready.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    rollouts-pod-template-hash: new-revision
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 7070
+          name: main-port
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-ignored-ready.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-ignored-ready.services-for-pod.yaml
@@ -1,0 +1,28 @@
+---
+# Same overlap as dedup-keeps-ready-inbound, but with inbound tags enabled the
+# Ignored (active) and Ready (preview) inbounds are both kept, not deduplicated.
+metadata:
+  namespace: demo
+  name: example-active
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: old-revision
+  ports:
+    - protocol: TCP
+      port: 7000
+      targetPort: 7070
+---
+metadata:
+  namespace: demo
+  name: example-preview
+spec:
+  clusterIP: 192.168.0.2
+  selector:
+    app: example
+    rollouts-pod-template-hash: new-revision
+  ports:
+    - protocol: TCP
+      port: 7001
+      targetPort: 7070


### PR DESCRIPTION
## Motivation

Fixes #17142 on `release-2.14`.

In `Exclusive` mode with inbound tags disabled, inbound deduplication by `address:port` kept the *first* inbound and was state-blind. With Argo Rollouts blue-green plus `KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS=rollouts-pod-template-hash`, both the active `<app>` and `<app>-preview` Service match the same Pod. `inboundForService` recomputes state against the full selector, so one inbound is `Ready` and the other `Ignored`, both on the same `address:port`.

Services are sorted by name, so `<app>-preview` sorts before `<app>` and dedup kept the `Ignored` inbound, dropping the `Ready` one. `GetHealthyInbounds()` then found nothing and the backing MeshService flipped to `Unavailable` while Pods were healthy.

## Implementation information

Deduplication now keeps the most serving inbound per `address:port` (`Ready` > `NotReady` > `Ignored`), replacing in place so port order does not depend on which Services select the Pod. Safe because these inbounds carry no tags: MeshService membership is resolved on Dataplane labels, not the inbound, so collapsing duplicates loses no information.

## Supporting documentation

- Issue: #17142
- Dedup origin: #12760
- Direct fix to the release branch (not merged to master; the flag is being removed there, see #17393).

> Changelog: fix(k8s): prevent MeshService going Unavailable during Argo blue-green rollouts