### PR TITLE
fix(k8s): include state in inbound dedup key

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -140,7 +140,7 @@ func (i *InboundConverter) LegacyInboundInterfacesFor(ctx context.Context, zone 
 	return i.inboundInterfacesFor(ctx, zone, pod, services)
 }
 
-// InboundInterfacesFor should be used when MeshService mode is Exclusive. This function deduplicates inbounds by address and port.
+// InboundInterfacesFor should be used when MeshService mode is Exclusive. This function deduplicates inbounds by address, port and state.
 // Since MeshService does not need tags we can safely deduplicate inbounds
 func (i *InboundConverter) InboundInterfacesFor(ctx context.Context, zone string, pod *kube_core.Pod, services []*kube_core.Service) ([]*mesh_proto.Dataplane_Networking_Inbound, error) {
 	inbounds, err := i.inboundInterfacesFor(ctx, zone, pod, services)
@@ -181,16 +181,22 @@ func (i *InboundConverter) inboundInterfacesFor(ctx context.Context, zone string
 	return ifaces, nil
 }
 
+// deduplicateInboundsByAddressAndPort collapses inbounds that share an address,
+// a port and a state into the first one. Inbounds differing only by state are
+// kept, because state is not interchangeable: when a Service does not select the
+// Pod its inbound is Ignored, and a Service that does select it yields a Ready
+// inbound on the very same port. Collapsing those two would hide the serving one
+// and take the MeshService down (#17142).
 func deduplicateInboundsByAddressAndPort(ifaces []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {
 	inboundKey := func(iface *mesh_proto.Dataplane_Networking_Inbound) string {
-		return fmt.Sprintf("%s:%d", iface.Address, iface.Port)
+		return fmt.Sprintf("%s:%d:%d", iface.Address, iface.Port, iface.State)
 	}
 
 	var deduplicatedInbounds []*mesh_proto.Dataplane_Networking_Inbound
-	inboundsPerAddressPort := map[string]*mesh_proto.Dataplane_Networking_Inbound{}
+	inboundsPerKey := map[string]*mesh_proto.Dataplane_Networking_Inbound{}
 	for _, iface := range ifaces {
-		if inboundsPerAddressPort[inboundKey(iface)] == nil {
-			inboundsPerAddressPort[inboundKey(iface)] = iface
+		if inboundsPerKey[inboundKey(iface)] == nil {
+			inboundsPerKey[inboundKey(iface)] = iface
 			deduplicatedInbounds = append(deduplicatedInbounds, iface)
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -183,10 +183,11 @@ func (i *InboundConverter) inboundInterfacesFor(ctx context.Context, zone string
 
 // deduplicateInboundsByAddressAndPort collapses inbounds that share an address,
 // a port and a state into the first one. Inbounds differing only by state are
-// kept, because state is not interchangeable: when a Service does not select the
-// Pod its inbound is Ignored, and a Service that does select it yields a Ready
-// inbound on the very same port. Collapsing those two would hide the serving one
-// and take the MeshService down (#17142).
+// kept to fix the Argo Rollouts blue-green problem (#17142): with
+// KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS ignoring the
+// rollouts-pod-template-hash label, both the active Service and the -preview
+// Service match the same Pod on the same port, one Ready and one Ignored.
+// Collapsing those would hide the Ready inbound and mark the MeshService down.
 func deduplicateInboundsByAddressAndPort(ifaces []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {
 	inboundKey := func(iface *mesh_proto.Dataplane_Networking_Inbound) string {
 		return fmt.Sprintf("%s:%d:%d", iface.Address, iface.Port, iface.State)

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -333,6 +333,11 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "duplicated-inbounds.services-for-pod.yaml",
 			dataplane:      "duplicated-inbounds.dataplane.yaml",
 		}),
+		Entry("Multiple services selecting single port with different states", testCase{
+			pod:            "dedup-different-state-inbounds.pod.yaml",
+			servicesForPod: "dedup-different-state-inbounds.services-for-pod.yaml",
+			dataplane:      "dedup-different-state-inbounds.dataplane.yaml",
+		}),
 		Entry("31. Pod with workload labels configured matching pod label", testCase{
 			pod:            "31.pod.yaml",
 			servicesForPod: "31.services-for-pod.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/dedup-different-state-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/dedup-different-state-inbounds.dataplane.yaml
@@ -1,0 +1,39 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/mesh: default
+    kuma.io/proxy-type: sidecar
+    kuma.io/sidecar-injection: enabled
+    rollouts-pod-template-hash: new-revision
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health: {}
+      name: main-port
+      port: 7070
+      state: Ignored
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-active
+        k8s.kuma.io/service-port: "7000"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-active_demo_svc_7000
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: new-revision
+    - health:
+        ready: true
+      name: main-port
+      port: 7070
+      tags:
+        app: example
+        k8s.kuma.io/namespace: demo
+        k8s.kuma.io/service-name: example-preview
+        k8s.kuma.io/service-port: "7001"
+        kuma.io/protocol: tcp
+        kuma.io/service: example-preview_demo_svc_7001
+        kuma.io/zone: zone-1
+        rollouts-pod-template-hash: new-revision

--- a/pkg/plugins/runtime/k8s/controllers/testdata/dedup-different-state-inbounds.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/dedup-different-state-inbounds.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    rollouts-pod-template-hash: new-revision
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 7070
+          name: main-port
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/dedup-different-state-inbounds.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/dedup-different-state-inbounds.services-for-pod.yaml
@@ -1,0 +1,30 @@
+---
+# Argo blue-green mid-rollout with IgnoredServiceSelectorLabels=rollouts-pod-template-hash.
+# active still targets the old revision (Ignored); preview targets this Pod's
+# revision (Ready). Both share the container port, so they only differ by state
+# and both inbounds have to survive deduplication.
+metadata:
+  namespace: demo
+  name: example-active
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: old-revision
+  ports:
+    - protocol: TCP
+      port: 7000
+      targetPort: 7070
+---
+metadata:
+  namespace: demo
+  name: example-preview
+spec:
+  clusterIP: 192.168.0.2
+  selector:
+    app: example
+    rollouts-pod-template-hash: new-revision
+  ports:
+    - protocol: TCP
+      port: 7001
+      targetPort: 7070


### PR DESCRIPTION
## Motivation

Fixes #17142 on `release-2.13`.

In `Exclusive` mode, inbounds are deduplicated by `address:port` and the first one wins. That key is state-blind. With Argo Rollouts blue-green plus `KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS=rollouts-pod-template-hash`, both the active `<app>` and the `<app>-preview` Service match the same Pod. `inboundForService` recomputes state against the full selector, so one inbound comes out `Ready` and the other `Ignored` on the same `address:port`.

Services are sorted by name, so whichever Service sorts first decides the survivor. When that is the `Ignored` one, the `Ready` inbound is dropped, `GetHealthyInbounds()` then finds nothing, and the backing MeshService flips to `Unavailable` while the Pods are healthy.

## Implementation information

`state` is now part of the deduplication key, so two inbounds are only collapsed when they are genuinely interchangeable. Inbounds that differ only by state describe different things — one Service serves this Pod, another does not — and both are kept, so the `Ready` one always survives regardless of Service name ordering. Duplicates that share address, port and state still collapse to the first one, which is what #12760 set out to remove.

This deliberately allows two inbounds on one `address:port` when their states differ. Nothing rejects that: the Dataplane validator has no uniqueness check on `address:port`, and everything that reads inbounds for availability (`GetHealthyInbounds`, MeshService matching and status, `endpoints.go`, `vips_allocator`, insights) filters on state and picks the `Ready` one. The residual is in xDS: `InboundProxyGenerator` iterates every inbound without filtering by state, and listener/cluster names derive from `address:port`, so the two entries resolve to a single Envoy listener via last-write-wins in the `ResourceSet` rather than a conflict. Traffic on the port keeps flowing either way; only the listener's tag metadata depends on which inbound lands last. Filtering `Ignored` inbounds out of the xDS path is the cleaner follow-up, but it is a wider change than a release branch should carry.

## Supporting documentation

- Issue: #17142
- Dedup origin: #12760
- Companion release fix: #17394 (release-2.14). Direct fix to the release branch (not merged to master; the flag is being removed there, see #17393).

> Changelog: fix(k8s): prevent MeshService going Unavailable during Argo blue-green rollouts
