### PR TITLE
fix(xds): kri tag on MeshService outbounds

### DIFF
--- a/pkg/core/xds/types/outbound.go
+++ b/pkg/core/xds/types/outbound.go
@@ -49,6 +49,24 @@ func (o *Outbound) TagsOrNil() map[string]string {
 	return nil
 }
 
+const KRITag = "kuma.io/kri"
+
+// ListenerTags returns tags for listener metadata. For legacy outbounds, it
+// returns the tags from the LegacyOutbound. For real resource outbounds
+// (MeshService, MeshExternalService, MeshMultiZoneService), it returns a tag
+// containing the KRI, enabling MeshProxyPatch to match on it.
+func (o *Outbound) ListenerTags() map[string]string {
+	if o.LegacyOutbound != nil {
+		return o.LegacyOutbound.Tags
+	}
+	if !o.Resource.IsEmpty() {
+		return map[string]string{
+			KRITag: o.Resource.String(),
+		}
+	}
+	return nil
+}
+
 func (o *Outbound) GetPort() uint32 {
 	if o.LegacyOutbound != nil {
 		return o.LegacyOutbound.Port

--- a/pkg/core/xds/types/outbound_test.go
+++ b/pkg/core/xds/types/outbound_test.go
@@ -1,0 +1,81 @@
+package types_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/xds/types"
+)
+
+var _ = Describe("Outbound", func() {
+	Describe("ListenerTags", func() {
+		It("returns legacy tags for legacy outbound", func() {
+			o := &types.Outbound{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Tags: map[string]string{
+						mesh_proto.ServiceTag: "backend",
+						"version":             "v1",
+					},
+				},
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(Equal(map[string]string{
+				mesh_proto.ServiceTag: "backend",
+				"version":             "v1",
+			}))
+		})
+
+		It("returns KRI tag for real resource outbound", func() {
+			id := kri.Identifier{
+				ResourceType: meshservice_api.MeshServiceType,
+				Mesh:         "default",
+				Zone:         "zone-1",
+				Namespace:    "ns",
+				Name:         "backend",
+				SectionName:  "http",
+			}
+			o := &types.Outbound{
+				Resource: id,
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(HaveKey(types.KRITag))
+			Expect(tags[types.KRITag]).To(Equal(id.String()))
+		})
+
+		It("returns nil for empty outbound", func() {
+			o := &types.Outbound{}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(BeNil())
+		})
+
+		It("prefers legacy tags over KRI when both present", func() {
+			id := kri.Identifier{
+				ResourceType: meshservice_api.MeshServiceType,
+				Mesh:         "default",
+				Zone:         "zone-1",
+				Namespace:    "ns",
+				Name:         "backend",
+				SectionName:  "http",
+			}
+			o := &types.Outbound{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Tags: map[string]string{
+						mesh_proto.ServiceTag: "backend",
+					},
+				},
+				Resource: id,
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(Equal(map[string]string{
+				mesh_proto.ServiceTag: "backend",
+			}))
+		})
+	})
+})

--- a/pkg/core/xds/types/types_suite_test.go
+++ b/pkg/core/xds/types/types_suite_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestTypes(t *testing.T) {
+	test.RunSpecs(t, "Types Suite")
+}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
@@ -148,6 +148,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshexternalservice-http___extsvc_47777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_extsvc_default___other-meshexternalservice-http_
 name: outbound:127.0.0.1:47777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
@@ -93,6 +93,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_workload_identity.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
@@ -82,6 +82,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -75,7 +75,7 @@ func GenerateOutboundListener(
 		Configure(envoy_listeners.StatPrefix(listenerStatPrefix)).
 		Configure(envoy_listeners.OutboundListener(address, port, core_xds.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.TransparentProxying(transparentProxyEnabled)).
-		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag))).
+		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.ListenerTags()).WithoutTags(mesh_proto.MeshTag))).
 		Configure(envoy_listeners.FilterChain(filterChain))
 
 	resource, err := listener.Build()

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
@@ -61,7 +61,8 @@ resources:
           statPrefix: kri_msvc_default___backend_test-port
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: kri_msvc_default___backend_test-port
     statPrefix: kri_msvc_default___backend_test-port
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -85,6 +85,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default_remote-zone__ext-backend_9000
     name: kri_extsvc_default_remote-zone__ext-backend_9000
     statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend__remote-zone_msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default_remote-zone__backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
@@ -37,7 +37,8 @@ resources:
           statPrefix: kri_msvc_default___backend_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: kri_msvc_default___backend_80
     statPrefix: kri_msvc_default___backend_80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -52,6 +52,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default___example_
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: kri_extsvc_default___example_
     statPrefix: kri_extsvc_default___example_
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
@@ -89,6 +89,7 @@ resources:
           statPrefix: default_ms-1_ns-1_zone-1_msvc_27777
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default_zone-1_ns-1_ms-1_
     name: outbound:127.0.0.1:27777
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -39,7 +39,7 @@ func GenerateOutboundListener(
 		tcpProxyStatPrefix = listenerName
 	}
 
-	tags := envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)
+	tags := envoy_tags.Tags(svc.Outbound.ListenerTags()).WithoutTags(mesh_proto.MeshTag)
 
 	filterChain := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 		Configure(envoy_listeners.TCPProxy(tcpProxyStatPrefix, splits...)).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -15,6 +15,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:10.20.20.2:9090
@@ -34,7 +35,8 @@ resources:
           statPrefix: default_example2___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example2_
     name: outbound:10.20.20.2:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -868,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -955,7 +957,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -791,7 +791,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -878,7 +880,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -868,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -955,7 +957,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
@@ -791,7 +791,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -878,7 +880,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
@@ -868,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -955,7 +957,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
@@ -964,7 +964,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1172,7 +1174,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
@@ -1041,7 +1041,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1249,7 +1251,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
@@ -873,7 +873,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1058,7 +1060,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
@@ -950,7 +950,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1135,7 +1137,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -798,7 +798,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -920,7 +922,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -875,7 +875,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -997,7 +999,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -866,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -953,7 +955,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -789,7 +789,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -876,7 +878,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -866,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -953,7 +955,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -789,7 +789,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -876,7 +878,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -866,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -953,7 +955,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
@@ -817,7 +817,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -904,7 +906,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
@@ -894,7 +894,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -981,7 +983,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -821,7 +821,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -908,7 +910,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -898,7 +898,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -985,7 +987,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -853,7 +855,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
@@ -1144,7 +1144,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1239,7 +1241,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -853,7 +855,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
@@ -922,7 +922,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1017,7 +1019,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
@@ -835,7 +835,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -922,7 +924,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
@@ -789,7 +789,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -876,7 +878,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
@@ -866,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -953,7 +955,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
@@ -786,7 +786,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -880,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
@@ -863,7 +863,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -957,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
@@ -786,7 +786,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -880,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
@@ -863,7 +863,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -957,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
@@ -854,7 +854,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1056,7 +1058,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
@@ -931,7 +931,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1133,7 +1135,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
@@ -854,7 +854,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1056,7 +1058,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
@@ -931,7 +931,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1133,7 +1135,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -1007,7 +1007,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1094,7 +1096,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -1084,7 +1084,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1171,7 +1173,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -983,7 +983,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1070,7 +1072,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -1060,7 +1060,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1147,7 +1149,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -928,7 +928,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1015,7 +1017,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -928,7 +928,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1015,7 +1017,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -928,7 +928,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1015,7 +1017,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
@@ -835,7 +835,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -922,7 +924,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -845,7 +845,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -982,7 +984,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -922,7 +922,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1059,7 +1061,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
@@ -857,7 +857,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1006,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
@@ -934,7 +934,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1083,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
@@ -771,7 +771,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -866,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
@@ -848,7 +848,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -943,7 +945,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -896,7 +896,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -983,7 +985,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -779,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -866,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -896,7 +896,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -983,7 +985,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -779,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -866,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -896,7 +896,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -983,7 +985,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -835,7 +835,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -922,7 +924,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -849,7 +849,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -974,7 +976,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -926,7 +926,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1051,7 +1053,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
@@ -849,7 +849,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -974,7 +976,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
@@ -926,7 +926,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1051,7 +1053,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -819,7 +819,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -906,7 +908,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -896,7 +896,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -983,7 +985,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -1003,7 +1003,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1090,7 +1092,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -1326,7 +1326,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1413,7 +1415,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -1003,7 +1003,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1090,7 +1092,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -1326,7 +1326,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1413,7 +1415,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -813,7 +813,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -900,7 +902,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -890,7 +890,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -977,7 +979,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -813,7 +813,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -900,7 +902,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -890,7 +890,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -977,7 +979,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
@@ -2508,7 +2508,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -2595,7 +2597,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
@@ -847,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -934,7 +936,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
@@ -974,7 +974,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1061,7 +1063,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
@@ -849,7 +849,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -936,7 +938,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
@@ -1098,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1185,7 +1187,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
@@ -993,7 +993,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1080,7 +1082,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
@@ -1070,7 +1070,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1157,7 +1159,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
@@ -1123,7 +1123,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1210,7 +1212,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
@@ -1200,7 +1200,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1287,7 +1289,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -845,7 +847,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
@@ -835,7 +835,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -922,7 +924,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
@@ -1008,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
@@ -1036,7 +1036,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1132,7 +1134,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1113,7 +1113,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1209,7 +1211,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
@@ -1113,7 +1113,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1209,7 +1211,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
@@ -1008,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
@@ -1233,7 +1233,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1321,7 +1323,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1310,7 +1310,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1398,7 +1400,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
@@ -1310,7 +1310,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1398,7 +1400,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
@@ -1023,7 +1023,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1111,7 +1113,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1100,7 +1100,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1188,7 +1190,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
@@ -1100,7 +1100,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1188,7 +1190,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
@@ -1019,7 +1019,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1107,7 +1109,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1096,7 +1096,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1184,7 +1186,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
@@ -1096,7 +1096,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1184,7 +1186,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
@@ -1008,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-demo-client.golden.json
@@ -1008,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/sni.zone-proxy-test-server.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
@@ -1008,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
@@ -1153,7 +1153,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1241,7 +1243,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1302,7 +1302,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1390,7 +1392,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
@@ -1302,7 +1302,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1390,7 +1392,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-demo-client.golden.json
@@ -1177,7 +1177,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1265,7 +1267,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1334,7 +1334,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1422,7 +1424,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/otel.zone-proxy-test-server.golden.json
@@ -1334,7 +1334,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1422,7 +1424,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
@@ -1159,7 +1159,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1247,7 +1249,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1314,7 +1314,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1402,7 +1404,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
@@ -1314,7 +1314,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1402,7 +1404,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
@@ -1008,7 +1008,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
@@ -1085,7 +1085,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1173,7 +1175,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",


### PR DESCRIPTION
## Motivation

Backport of #17389 to release-2.14.

Enabling MeshService breaks MeshProxyPatch tag-based targeting of outbound listeners. Once an outbound is backed by a MeshService, the generated listener carries empty `io.kuma.tags` metadata because `TagsOrNil()` returns nil for real resource outbounds.

Closes #17369

## Implementation information

- Add `ListenerTags()` method to `Outbound` that returns a `kuma.io/kri` tag containing the KRI for real resource outbounds (MeshService, MeshExternalService, MeshMultiZoneService)
- Update `meshtcproute` and `meshhttproute` listener generation to use `ListenerTags()` instead of `TagsOrNil()`
- With this fix, MeshProxyPatch can match MeshService-backed outbound listeners using:

```yaml
  match:
    tags:
      kuma.io/kri: kri_msvc_<mesh>_<zone>_<ns>_<name>_<port>
```

Needed on 2.13/2.14 only; 3.0 requires unified naming by default.