### PR TITLE
fix(xds): kri tag on MeshService outbounds

### DIFF
--- a/pkg/core/xds/types/outbound.go
+++ b/pkg/core/xds/types/outbound.go
@@ -49,6 +49,24 @@ func (o *Outbound) TagsOrNil() map[string]string {
 	return nil
 }
 
+const KRITag = "kuma.io/kri"
+
+// ListenerTags returns tags for listener metadata. For legacy outbounds, it
+// returns the tags from the LegacyOutbound. For real resource outbounds
+// (MeshService, MeshExternalService, MeshMultiZoneService), it returns a tag
+// containing the KRI, enabling MeshProxyPatch to match on it.
+func (o *Outbound) ListenerTags() map[string]string {
+	if o.LegacyOutbound != nil {
+		return o.LegacyOutbound.Tags
+	}
+	if !o.Resource.IsEmpty() {
+		return map[string]string{
+			KRITag: o.Resource.String(),
+		}
+	}
+	return nil
+}
+
 func (o *Outbound) GetPort() uint32 {
 	if o.LegacyOutbound != nil {
 		return o.LegacyOutbound.Port

--- a/pkg/core/xds/types/outbound_test.go
+++ b/pkg/core/xds/types/outbound_test.go
@@ -1,0 +1,81 @@
+package types_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/xds/types"
+)
+
+var _ = Describe("Outbound", func() {
+	Describe("ListenerTags", func() {
+		It("returns legacy tags for legacy outbound", func() {
+			o := &types.Outbound{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Tags: map[string]string{
+						mesh_proto.ServiceTag: "backend",
+						"version":             "v1",
+					},
+				},
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(Equal(map[string]string{
+				mesh_proto.ServiceTag: "backend",
+				"version":             "v1",
+			}))
+		})
+
+		It("returns KRI tag for real resource outbound", func() {
+			id := kri.Identifier{
+				ResourceType: meshservice_api.MeshServiceType,
+				Mesh:         "default",
+				Zone:         "zone-1",
+				Namespace:    "ns",
+				Name:         "backend",
+				SectionName:  "http",
+			}
+			o := &types.Outbound{
+				Resource: id,
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(HaveKey(types.KRITag))
+			Expect(tags[types.KRITag]).To(Equal(id.String()))
+		})
+
+		It("returns nil for empty outbound", func() {
+			o := &types.Outbound{}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(BeNil())
+		})
+
+		It("prefers legacy tags over KRI when both present", func() {
+			id := kri.Identifier{
+				ResourceType: meshservice_api.MeshServiceType,
+				Mesh:         "default",
+				Zone:         "zone-1",
+				Namespace:    "ns",
+				Name:         "backend",
+				SectionName:  "http",
+			}
+			o := &types.Outbound{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Tags: map[string]string{
+						mesh_proto.ServiceTag: "backend",
+					},
+				},
+				Resource: id,
+			}
+
+			tags := o.ListenerTags()
+			Expect(tags).To(Equal(map[string]string{
+				mesh_proto.ServiceTag: "backend",
+			}))
+		})
+	})
+})

--- a/pkg/core/xds/types/types_suite_test.go
+++ b/pkg/core/xds/types/types_suite_test.go
@@ -1,0 +1,11 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestTypes(t *testing.T) {
+	test.RunSpecs(t, "Types Suite")
+}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
@@ -148,6 +148,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshexternalservice-http___extsvc_47777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_extsvc_default___other-meshexternalservice-http_
 name: outbound:127.0.0.1:47777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
@@ -93,6 +93,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -75,7 +75,7 @@ func GenerateOutboundListener(
 		Configure(envoy_listeners.StatPrefix(listenerStatPrefix)).
 		Configure(envoy_listeners.OutboundListener(address, port, core_xds.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.TransparentProxying(transparentProxyEnabled)).
-		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag))).
+		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.ListenerTags()).WithoutTags(mesh_proto.MeshTag))).
 		Configure(envoy_listeners.FilterChain(filterChain))
 
 	resource, err := listener.Build()

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
@@ -61,7 +61,8 @@ resources:
           statPrefix: kri_msvc_default___backend_test-port
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: kri_msvc_default___backend_test-port
     statPrefix: kri_msvc_default___backend_test-port
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -85,6 +85,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
@@ -37,7 +37,8 @@ resources:
           statPrefix: kri_msvc_default___backend_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: kri_msvc_default___backend_80
     statPrefix: kri_msvc_default___backend_80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/gateway-default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -52,6 +52,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default___example_
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: kri_extsvc_default___example_
     statPrefix: kri_extsvc_default___example_
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
@@ -89,6 +89,7 @@ resources:
           statPrefix: default_ms-1_ns-1_zone-1_msvc_27777
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default_zone-1_ns-1_ms-1_
     name: outbound:127.0.0.1:27777
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -39,7 +39,7 @@ func GenerateOutboundListener(
 		tcpProxyStatPrefix = listenerName
 	}
 
-	tags := envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)
+	tags := envoy_tags.Tags(svc.Outbound.ListenerTags()).WithoutTags(mesh_proto.MeshTag)
 
 	filterChain := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 		Configure(envoy_listeners.TCPProxy(tcpProxyStatPrefix, splits...)).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -15,6 +15,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:10.20.20.2:9090
@@ -34,7 +35,8 @@ resources:
           statPrefix: default_example2___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example2_
     name: outbound:10.20.20.2:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -783,7 +783,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -870,7 +872,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -706,7 +706,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -793,7 +795,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -783,7 +783,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -870,7 +872,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.demo-client.golden.json
@@ -706,7 +706,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -793,7 +795,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound.test-server.golden.json
@@ -783,7 +783,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -870,7 +872,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
@@ -879,7 +879,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1087,7 +1089,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
@@ -956,7 +956,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1164,7 +1166,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
@@ -788,7 +788,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -973,7 +975,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
@@ -865,7 +865,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1050,7 +1052,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -713,7 +713,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -835,7 +837,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -790,7 +790,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -912,7 +914,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -779,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -866,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -702,7 +702,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -789,7 +791,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -779,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -866,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -702,7 +702,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -789,7 +791,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -779,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -866,7 +868,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
@@ -732,7 +732,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -819,7 +821,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
@@ -809,7 +809,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -896,7 +898,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -736,7 +736,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -823,7 +825,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -813,7 +813,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -900,7 +902,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -768,7 +770,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
@@ -1059,7 +1059,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1154,7 +1156,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -768,7 +770,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound.test-server.golden.json
@@ -837,7 +837,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -932,7 +934,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
@@ -750,7 +750,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -837,7 +839,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
@@ -700,7 +700,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -787,7 +789,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
@@ -777,7 +777,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -864,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
@@ -701,7 +701,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -795,7 +797,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
@@ -778,7 +778,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -872,7 +874,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
@@ -701,7 +701,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -795,7 +797,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
@@ -778,7 +778,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -872,7 +874,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
@@ -769,7 +769,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -971,7 +973,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
@@ -846,7 +846,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1048,7 +1050,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
@@ -769,7 +769,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -971,7 +973,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
@@ -846,7 +846,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1048,7 +1050,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -932,7 +932,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1019,7 +1021,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -1009,7 +1009,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1096,7 +1098,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -908,7 +908,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -995,7 +997,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -985,7 +985,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1072,7 +1074,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -843,7 +843,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -930,7 +932,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -843,7 +843,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -930,7 +932,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -843,7 +843,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -930,7 +932,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
@@ -750,7 +750,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -837,7 +839,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -760,7 +760,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -897,7 +899,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -837,7 +837,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -974,7 +976,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
@@ -772,7 +772,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -921,7 +923,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
@@ -849,7 +849,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -998,7 +1000,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
@@ -686,7 +686,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -781,7 +783,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
@@ -763,7 +763,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -858,7 +860,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -811,7 +811,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -898,7 +900,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -694,7 +694,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -781,7 +783,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -811,7 +811,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -898,7 +900,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -694,7 +694,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -781,7 +783,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -811,7 +811,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -898,7 +900,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -750,7 +750,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -837,7 +839,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -764,7 +764,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -889,7 +891,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -841,7 +841,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -966,7 +968,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
@@ -764,7 +764,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -889,7 +891,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
@@ -841,7 +841,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -966,7 +968,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -734,7 +734,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -821,7 +823,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -811,7 +811,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -898,7 +900,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -918,7 +918,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1005,7 +1007,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -1241,7 +1241,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1328,7 +1330,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -918,7 +918,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1005,7 +1007,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -1241,7 +1241,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1328,7 +1330,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -728,7 +728,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -815,7 +817,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -805,7 +805,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -892,7 +894,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -728,7 +728,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -815,7 +817,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -805,7 +805,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -892,7 +894,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/from-rules-long.test-server.golden.json
@@ -2423,7 +2423,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -2510,7 +2512,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
@@ -764,7 +764,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -851,7 +853,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
@@ -1013,7 +1013,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1100,7 +1102,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
@@ -1038,7 +1038,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1125,7 +1127,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
@@ -1115,7 +1115,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1202,7 +1204,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
@@ -673,7 +673,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -760,7 +762,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
@@ -750,7 +750,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -837,7 +839,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",


### PR DESCRIPTION
## Motivation

Backport of #17389 to release-2.13.

Enabling MeshService breaks MeshProxyPatch tag-based targeting of outbound listeners. Once an outbound is backed by a MeshService, the generated listener carries empty `io.kuma.tags` metadata because `TagsOrNil()` returns nil for real resource outbounds.

Closes #17369

## Implementation information

- Add `ListenerTags()` method to `Outbound` that returns a `kuma.io/kri` tag containing the KRI for real resource outbounds (MeshService, MeshExternalService, MeshMultiZoneService)
- Update `meshtcproute` and `meshhttproute` listener generation to use `ListenerTags()` instead of `TagsOrNil()`
- With this fix, MeshProxyPatch can match MeshService-backed outbound listeners using:

```yaml
  match:
    tags:
      kuma.io/kri: kri_msvc_<mesh>_<zone>_<ns>_<name>_<port>
```

Needed on 2.13/2.14 only; 3.0 requires unified naming by default.