### PR TITLE
ci(e2e): stop running gatewayapi conformance suite

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -81,7 +81,6 @@ jobs:
                   {"k8sVersion": "${{ env.K8S_MIN_VERSION }}", "target": "multizone", "arch": "amd64"},
                   {"k8sVersion": "${{ env.K8S_MIN_VERSION }}", "target": "kubernetes", "arch": "amd64"},
                   {"k8sVersion": "kind", "target": "universal", "arch": "arm64"},
-                  {"k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "gatewayapi", "arch": "amd64"},
                   {"cniNetworkPlugin": "calico", "k8sVersion": "${{ env.K8S_MAX_VERSION }}", "target": "multizone", "arch": "amd64"}
                 ]
               }


### PR DESCRIPTION
## Motivation

The `gatewayapi` conformance e2e suite has been failing on **every** master run since 2026-07-13, keeping CI permanently red and masking real regressions in unrelated PRs. The failure is deterministic (conformance backend pod never becomes ready), not a flake, and needs a proper fix — but until then the suite should not block all of CI.

> Changelog: skip

## Implementation information

Remove the `gatewayapi` entry from the e2e matrix `include` in `_test.yaml` so no separate gatewayapi job is spawned. All other e2e targets (kubernetes, universal, multizone) are unchanged.

## Supporting documentation

Follow-up work is needed to re-enable the suite once the underlying conformance regression is fixed.