### PR TITLE
test(meshproxy): avoid cross-mesh workload clash

### DIFF
--- a/test/e2e_env/multizone/meshproxy/migration.go
+++ b/test/e2e_env/multizone/meshproxy/migration.go
@@ -27,7 +27,8 @@ import (
 )
 
 func Migration() {
-	namespace := "meshproxy-migration"
+	namespaceRed := "meshproxy-migration-red"
+	namespaceBlue := "meshproxy-migration-blue"
 
 	const (
 		redMeshName  = "meshproxymig-red"
@@ -45,6 +46,7 @@ func Migration() {
 		clientName        string
 		destinationServer string
 		expectedInstance  string
+		namespace         string
 	}
 
 	redTraffic := trafficCheck{
@@ -52,12 +54,14 @@ func Migration() {
 		clientName:        redClientZone1,
 		destinationServer: redServerZone2,
 		expectedInstance:  redServerZone2,
+		namespace:         namespaceRed,
 	}
 	blueTraffic := trafficCheck{
 		meshName:          blueMeshName,
 		clientName:        blueClientZone1,
 		destinationServer: blueServerZone2,
 		expectedInstance:  blueServerZone2,
+		namespace:         namespaceBlue,
 	}
 
 	var (
@@ -65,7 +69,7 @@ func Migration() {
 		collectInstances            func(check trafficCheck, requests int) (map[string]int, error)
 		assertCrossZoneTraffic      func(g Gomega, check trafficCheck)
 		assertTrafficForBothMeshes  func()
-		deployMeshScopedZoneProxies func(meshName string)
+		deployMeshScopedZoneProxies func(meshName, namespace string)
 		assertMeshScopedProxyUsed   func(check trafficCheck)
 		runDuringMigration          func(ctx context.Context, checks []trafficCheck, do func())
 		setupMeshIdentity           func(meshName string)
@@ -91,31 +95,33 @@ func Migration() {
 
 		group := errgroup.Group{}
 		NewClusterSetup().
-			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(NamespaceWithSidecarInjection(namespaceRed)).
+			Install(NamespaceWithSidecarInjection(namespaceBlue)).
 			Install(Parallel(
 				democlient.Install(
-					democlient.WithNamespace(namespace),
+					democlient.WithNamespace(namespaceRed),
 					democlient.WithMesh(redMeshName),
 					democlient.WithName(redClientZone1),
 				),
 				democlient.Install(
-					democlient.WithNamespace(namespace),
+					democlient.WithNamespace(namespaceBlue),
 					democlient.WithMesh(blueMeshName),
 					democlient.WithName(blueClientZone1),
 				),
 			)).
 			SetupInGroup(multizone.KubeZone1, &group)
 		NewClusterSetup().
-			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(NamespaceWithSidecarInjection(namespaceRed)).
+			Install(NamespaceWithSidecarInjection(namespaceBlue)).
 			Install(Parallel(
 				testserver.Install(
-					testserver.WithNamespace(namespace),
+					testserver.WithNamespace(namespaceRed),
 					testserver.WithMesh(redMeshName),
 					testserver.WithName(redServerZone2),
 					testserver.WithEchoArgs("echo", "--instance", redServerZone2),
 				),
 				testserver.Install(
-					testserver.WithNamespace(namespace),
+					testserver.WithNamespace(namespaceBlue),
 					testserver.WithMesh(blueMeshName),
 					testserver.WithName(blueServerZone2),
 					testserver.WithEchoArgs("echo", "--instance", blueServerZone2),
@@ -134,15 +140,17 @@ func Migration() {
 	AfterEachFailure(func() {
 		DebugUniversal(multizone.Global, redMeshName)
 		DebugUniversal(multizone.Global, blueMeshName)
-		DebugKube(multizone.KubeZone1, redMeshName, namespace)
-		DebugKube(multizone.KubeZone1, blueMeshName, namespace)
-		DebugKube(multizone.KubeZone2, redMeshName, namespace)
-		DebugKube(multizone.KubeZone2, blueMeshName, namespace)
+		DebugKube(multizone.KubeZone1, redMeshName, namespaceRed)
+		DebugKube(multizone.KubeZone1, blueMeshName, namespaceBlue)
+		DebugKube(multizone.KubeZone2, redMeshName, namespaceRed)
+		DebugKube(multizone.KubeZone2, blueMeshName, namespaceBlue)
 	})
 
 	E2EAfterAll(func() {
-		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
-		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespaceRed)).To(Succeed())
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespaceBlue)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespaceRed)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespaceBlue)).To(Succeed())
 		Expect(multizone.Global.DeleteMesh(redMeshName)).To(Succeed())
 		Expect(multizone.Global.DeleteMesh(blueMeshName)).To(Succeed())
 	})
@@ -151,7 +159,7 @@ func Migration() {
 		assertTrafficForBothMeshes()
 
 		runDuringMigration(ctx, []trafficCheck{redTraffic, blueTraffic}, func() {
-			deployMeshScopedZoneProxies(redMeshName)
+			deployMeshScopedZoneProxies(redMeshName, namespaceRed)
 			assertTrafficForBothMeshes()
 			assertMeshScopedProxyUsed(redTraffic)
 		})
@@ -161,7 +169,7 @@ func Migration() {
 		assertTrafficForBothMeshes()
 
 		runDuringMigration(ctx, []trafficCheck{redTraffic, blueTraffic}, func() {
-			deployMeshScopedZoneProxies(blueMeshName)
+			deployMeshScopedZoneProxies(blueMeshName, namespaceBlue)
 			assertTrafficForBothMeshes()
 			assertMeshScopedProxyUsed(blueTraffic)
 		})
@@ -173,7 +181,7 @@ func Migration() {
 		return fmt.Sprintf(
 			"http://%s.%s.svc.%s.mesh.local:80",
 			check.destinationServer,
-			namespace,
+			check.namespace,
 			multizone.KubeZone2.ZoneName(),
 		)
 	}
@@ -185,7 +193,7 @@ func Migration() {
 			multizone.KubeZone1,
 			check.clientName,
 			crossZoneAddress(check),
-			client.FromKubernetesPod(namespace, check.clientName),
+			client.FromKubernetesPod(check.namespace, check.clientName),
 			client.WithNumberOfRequests(uint(requests)),
 		)
 	}
@@ -214,7 +222,7 @@ func Migration() {
 		}, "60s", "1s").MustPassRepeatedly(3).Should(Succeed())
 	}
 
-	deployMeshScopedZoneProxies = func(meshName string) {
+	deployMeshScopedZoneProxies = func(meshName string, namespace string) {
 		GinkgoHelper()
 
 		const ingressPort = uint32(11001)
@@ -253,13 +261,13 @@ func Migration() {
 			"cluster.kri_msvc_%s_%s_%s_%s_main.upstream_rq_total",
 			check.meshName,
 			multizone.KubeZone2.ZoneName(),
-			namespace,
+			check.namespace,
 			check.destinationServer,
 		)
 
 		Eventually(func(g Gomega) {
 			assertCrossZoneTraffic(g, check)
-			stat, err := multizone.KubeZone2.GetEnvoyAdminTunnel(ingressApp, namespace).GetStats(ingressFilter)
+			stat, err := multizone.KubeZone2.GetEnvoyAdminTunnel(ingressApp, check.namespace).GetStats(ingressFilter)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(stat).To(stats.BeGreaterThanZero())
 		}, "60s", "1s").Should(Succeed())


### PR DESCRIPTION
## Motivation

The MeshProxy Migration multizone E2E deployed both meshes (meshproxymig-red and meshproxymig-blue) into a single meshproxy-migration namespace. Both the red and blue client/server pods run under the default ServiceAccount, and computeWorkloadName falls back to the ServiceAccount name when no workload label is set. So both meshes share workload default in the same namespace, which WorkloadReconciler explicitly rejects:

    ERROR controllers.Workload namespace has dataplanes in multiple meshes for same workload
      workload=default namespace=meshproxy-migration meshCount=2 error=multiple meshes detected

The reconciler logs this on every reconcile and skips Workload generation, so the test exercised an unsupported two-meshes / one-namespace / one-workload configuration.

## Implementation information

Split the shared namespace into per-mesh meshproxy-migration-red and meshproxy-migration-blue, threaded through a namespace field on trafficCheck and the deployMeshScopedZoneProxies helper. Each namespace now holds a single mesh's dataplanes, so workload default no longer collides across meshes and the test models a supported topology.

Scope is the workload/namespace collision only. The separate cross-zone request truncation seen during proxy rollout (a 200 with an empty body while old shared zone ingress/egress endpoints drain) is not addressed here.

## Supporting documentation

Follow-up to #17167, which unskipped this migration test.
Might fix: https://github.com/kumahq/kuma/issues/17407

> Changelog: skip