### PR TITLE
test(e2e): diagnose stuck-init flake on cni zone

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -96,6 +96,11 @@ runs:
           export KUMA_DEFAULT_TIMEOUT="6s"
         fi
 
+        # investigation-only: test whether serial specs (--procs 1) avoid the init-hang I/O wave
+        if [[ "$GITHUB_HEAD_REF" == "test/e2e-init-hang-diagnostics" ]]; then
+          export GINKGO_OPTS="--procs 1 --github-output --output-interceptor-mode=none"
+        fi
+
         NODE_TELEMETRY_DIR="${GITHUB_WORKSPACE}/build/reports/e2e-debug-node-telemetry"
         mkdir -p "${NODE_TELEMETRY_DIR}"
         ./.github/workflows/scripts/e2e-node-telemetry.sh "${NODE_TELEMETRY_DIR}" &

--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -96,10 +96,18 @@ runs:
           export KUMA_DEFAULT_TIMEOUT="6s"
         fi
 
+        NODE_TELEMETRY_DIR="${GITHUB_WORKSPACE}/build/reports/e2e-debug-node-telemetry"
+        mkdir -p "${NODE_TELEMETRY_DIR}"
+        ./.github/workflows/scripts/e2e-node-telemetry.sh "${NODE_TELEMETRY_DIR}" &
+        TELEMETRY_PID=$!
+
         function on_exit()
         {
-          docker logout docker.io
+          kill "${TELEMETRY_PID}" 2>/dev/null || true
+          wait "${TELEMETRY_PID}" 2>/dev/null || true
+          docker logout docker.io 2>/dev/null || true
         }
+        trap "on_exit" EXIT
 
         # we pull a few images during the E2E run, sometimes we get rate-limited by docker hub
         # to prevent this, we support specifying a pull credential here
@@ -107,7 +115,6 @@ runs:
           DOCKER_USER=$(echo "$DOCKERHUB_PULL_CREDENTIAL" | cut -d ':' -f 1)
           DOCKER_PWD=$(echo "$DOCKERHUB_PULL_CREDENTIAL" | cut -d ':' -f 2)
           echo -n "$DOCKER_PWD" | docker login -u "$DOCKER_USER" --password-stdin
-          trap "on_exit" EXIT
         fi
 
         if [[ "$E2E_TARGET" != "" ]]; then

--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -96,20 +96,24 @@ runs:
           export KUMA_DEFAULT_TIMEOUT="6s"
         fi
 
-        # investigation-only: test whether serial specs (--procs 1) avoid the init-hang I/O wave
-        if [[ "$GITHUB_HEAD_REF" == "test/e2e-init-hang-diagnostics" ]]; then
-          export GINKGO_OPTS="--procs 1 --github-output --output-interceptor-mode=none"
-        fi
 
         NODE_TELEMETRY_DIR="${GITHUB_WORKSPACE}/build/reports/e2e-debug-node-telemetry"
         mkdir -p "${NODE_TELEMETRY_DIR}"
         ./.github/workflows/scripts/e2e-node-telemetry.sh "${NODE_TELEMETRY_DIR}" &
         TELEMETRY_PID=$!
 
+        # investigation-only: prototype the page-cache prewarm fix for kumahq/kuma#17426
+        PREWARM_PID=""
+        if [[ "$GITHUB_HEAD_REF" == "test/e2e-init-hang-diagnostics" ]]; then
+          ./.github/workflows/scripts/e2e-prewarm-layers.sh &
+          PREWARM_PID=$!
+        fi
+
         function on_exit()
         {
           kill "${TELEMETRY_PID}" 2>/dev/null || true
           wait "${TELEMETRY_PID}" 2>/dev/null || true
+          [[ -n "${PREWARM_PID}" ]] && { kill "${PREWARM_PID}" 2>/dev/null || true; wait "${PREWARM_PID}" 2>/dev/null || true; }
           docker logout docker.io 2>/dev/null || true
         }
         trap "on_exit" EXIT

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -21,7 +21,8 @@ env:
 jobs:
   test_unit:
     timeout-minutes: 30
-    if: false # investigation-only: disabled on test/e2e-init-hang-diagnostics
+    # investigation-only: disabled on the init-hang data-gathering branch
+    if: ${{ github.head_ref != 'test/e2e-init-hang-diagnostics' }}
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       UNIT_CLEAN_TESTCACHE: ${{ inputs.IS_PULL_REQUEST && 'false' || 'true' }}

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   test_unit:
     timeout-minutes: 30
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+    if: false # investigation-only: disabled on test/e2e-init-hang-diagnostics
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       UNIT_CLEAN_TESTCACHE: ${{ inputs.IS_PULL_REQUEST && 'false' || 'true' }}
@@ -67,7 +67,7 @@ jobs:
                 "cniNetworkPlugin": ["flannel"]
               },
               "test_e2e_env": {
-                "target": ["kubernetes", "universal", "multizone"],
+                "target": ["kubernetes", "multizone"],
                 "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MAX_VERSION }}"],
                 "arch": ["amd64"],
                 "parallelism": [1],

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -53,7 +53,8 @@ jobs:
             go-build-${{ runner.os }}-
       - run: go build ./...
   check:
-    if: false # investigation-only: disabled on test/e2e-init-hang-diagnostics
+    # investigation-only: disabled on the init-hang data-gathering branch
+    if: ${{ github.head_ref != 'test/e2e-init-hang-diagnostics' }}
     permissions:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -53,6 +53,7 @@ jobs:
             go-build-${{ runner.os }}-
       - run: go build ./...
   check:
+    if: false # investigation-only: disabled on test/e2e-init-hang-diagnostics
     permissions:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs

--- a/.github/workflows/scripts/e2e-node-telemetry.sh
+++ b/.github/workflows/scripts/e2e-node-telemetry.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Background node-runtime telemetry sampler for e2e jobs.
+#
+# Why: the "pod stuck initializing" flake self-heals, so by the time a test
+# dumps state the evidence is gone. This samples host/node pressure and the
+# kernel state of watched init processes while they are stuck, so the next
+# occurrence leaves a trace (IO-wait vs CPU starvation vs container-runtime
+# stall). It is best effort and must never fail the job.
+
+OUT="${1:?usage: e2e-node-telemetry.sh <output-dir>}"
+INTERVAL="${E2E_TELEMETRY_INTERVAL:-3}"
+SLOW_EVERY="${E2E_TELEMETRY_SLOW_EVERY:-4}"
+WATCH_CONTAINERS_RE='kuma-init|kuma-validation|kuma-sidecar'
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+node_containers() {
+  docker ps --format '{{.Names}}' 2>/dev/null \
+    | grep -E '(-server-[0-9]+|-agent-[0-9]+|-control-plane$|-worker[0-9]*$)' \
+    | grep -vE 'serverlb|registry'
+}
+
+crictl_exec() {
+  local node="$1"
+  shift
+  docker exec "$node" sh -c "crictl $* 2>/dev/null || k3s crictl $* 2>/dev/null"
+}
+
+sample_host() {
+  {
+    echo "=== $(ts) ==="
+    echo "# loadavg"
+    cat /proc/loadavg 2>/dev/null
+    for resource in cpu io memory; do
+      echo "# pressure/${resource}"
+      cat "/proc/pressure/${resource}" 2>/dev/null
+    done
+    echo "# meminfo"
+    grep -E '^(MemTotal|MemFree|MemAvailable|Dirty|Writeback):' /proc/meminfo 2>/dev/null
+    echo "# disk free"
+    df -h / /var/lib/docker 2>/dev/null
+  } >> "${OUT}/host.log"
+}
+
+sample_docker_stats() {
+  {
+    echo "=== $(ts) ==="
+    docker stats --no-stream \
+      --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.BlockIO}}\t{{.PIDs}}' 2>/dev/null
+  } >> "${OUT}/docker-stats.log"
+}
+
+sample_watched_procs() {
+  local node="$1"
+  local ids id pid
+  ids=$(crictl_exec "$node" ps -a | grep -E "${WATCH_CONTAINERS_RE}" | awk '{print $1}')
+  for id in ${ids}; do
+    pid=$(crictl_exec "$node" inspect "$id" | grep -m1 '"pid"' | grep -oE '[0-9]+' | head -1)
+    [ -n "${pid}" ] && [ "${pid}" != "0" ] || continue
+    {
+      echo "=== $(ts) node=${node} ctr=${id} pid=${pid} ==="
+      docker exec "$node" sh -c "grep -E '^(Name|State|Threads|VmRSS|voluntary_ctxt_switches|nonvoluntary_ctxt_switches):' /proc/${pid}/status 2>/dev/null"
+      echo "# wchan"
+      docker exec "$node" sh -c "cat /proc/${pid}/wchan 2>/dev/null; echo"
+      echo "# stack"
+      docker exec "$node" sh -c "cat /proc/${pid}/stack 2>/dev/null"
+    } >> "${OUT}/node-${node}-watched-procs.log"
+  done
+}
+
+sample_nodes() {
+  local node
+  for node in $(node_containers); do
+    {
+      echo "=== $(ts) node=${node} ==="
+      crictl_exec "$node" ps -a
+    } >> "${OUT}/node-${node}-crictl.log"
+    sample_watched_procs "$node"
+  done
+}
+
+final_capture() {
+  local node
+  sudo dmesg --ctime 2>/dev/null | tail -500 > "${OUT}/host-dmesg.log" 2>/dev/null
+  for node in $(node_containers); do
+    docker logs --tail 5000 "$node" > "${OUT}/node-${node}-runtime.log" 2>&1
+    crictl_exec "$node" ps -a > "${OUT}/node-${node}-crictl-final.log" 2>/dev/null
+    docker exec "$node" sh -c 'dmesg --ctime 2>/dev/null | tail -300' > "${OUT}/node-${node}-dmesg.log" 2>/dev/null
+  done
+}
+
+stop() {
+  final_capture
+  exit 0
+}
+trap stop TERM INT
+
+mkdir -p "${OUT}"
+echo "node telemetry sampler started at $(ts), interval=${INTERVAL}s" > "${OUT}/sampler.log"
+
+tick=0
+while true; do
+  mkdir -p "${OUT}"
+  sample_host
+  if [ $((tick % SLOW_EVERY)) -eq 0 ]; then
+    sample_docker_stats
+    sample_nodes
+  fi
+  tick=$((tick + 1))
+  sleep "${INTERVAL}"
+done

--- a/.github/workflows/scripts/e2e-node-telemetry.sh
+++ b/.github/workflows/scripts/e2e-node-telemetry.sh
@@ -11,7 +11,6 @@
 OUT="${1:?usage: e2e-node-telemetry.sh <output-dir>}"
 INTERVAL="${E2E_TELEMETRY_INTERVAL:-3}"
 SLOW_EVERY="${E2E_TELEMETRY_SLOW_EVERY:-4}"
-WATCH_CONTAINERS_RE='kuma-init|kuma-validation|kuma-sidecar'
 
 ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
@@ -53,20 +52,25 @@ sample_docker_stats() {
 
 sample_watched_procs() {
   local node="$1"
-  local ids id pid
-  ids=$(crictl_exec "$node" ps -a | grep -E "${WATCH_CONTAINERS_RE}" | awk '{print $1}')
-  for id in ${ids}; do
-    pid=$(crictl_exec "$node" inspect "$id" | grep -m1 '"pid"' | grep -oE '[0-9]+' | head -1)
-    [ -n "${pid}" ] && [ "${pid}" != "0" ] || continue
-    {
-      echo "=== $(ts) node=${node} ctr=${id} pid=${pid} ==="
-      docker exec "$node" sh -c "grep -E '^(Name|State|Threads|VmRSS|voluntary_ctxt_switches|nonvoluntary_ctxt_switches):' /proc/${pid}/status 2>/dev/null"
-      echo "# wchan"
-      docker exec "$node" sh -c "cat /proc/${pid}/wchan 2>/dev/null; echo"
-      echo "# stack"
-      docker exec "$node" sh -c "cat /proc/${pid}/stack 2>/dev/null"
-    } >> "${OUT}/node-${node}-watched-procs.log"
-  done
+  local out
+  out=$(docker exec "$node" sh -c '
+    for p in /proc/[0-9]*; do
+      [ -r "$p/cmdline" ] || continue
+      cmd=$(tr "\0" " " < "$p/cmdline" 2>/dev/null)
+      case "$cmd" in
+        *kumactl*|*"kuma-dp run"*|*"/usr/bin/envoy"*) : ;;
+        *) continue ;;
+      esac
+      pid=${p#/proc/}
+      echo "--- pid=$pid cmd=$cmd"
+      grep -E "^(State|VmRSS|Threads|voluntary_ctxt_switches|nonvoluntary_ctxt_switches):" "$p/status" 2>/dev/null
+      printf "wchan="; cat "$p/wchan" 2>/dev/null; echo
+      echo "stack:"; cat "$p/stack" 2>/dev/null
+    done
+  ' 2>/dev/null)
+  if [ -n "$out" ]; then
+    { echo "=== $(ts) node=${node} ==="; echo "$out"; } >> "${OUT}/node-${node}-watched-procs.log"
+  fi
 }
 
 sample_nodes() {

--- a/.github/workflows/scripts/e2e-prewarm-layers.sh
+++ b/.github/workflows/scripts/e2e-prewarm-layers.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Background page-cache prewarmer for e2e nodes.
+#
+# Why: the init-hang flake is cold binary page-in (State-D filemap_fault) off a
+# saturated disk during the pod-startup wave. Reading the imported image overlay
+# layers keeps them resident in the shared host page cache, so container exec
+# faults become cache hits instead of disk reads. Best effort; must never fail
+# the job. Prototype for kumahq/kuma#17426.
+
+INTERVAL="${E2E_PREWARM_INTERVAL:-30}"
+
+node_containers() {
+  docker ps --format '{{.Names}}' 2>/dev/null \
+    | grep -E '(-server-[0-9]+|-agent-[0-9]+|-control-plane$|-worker[0-9]*$)' \
+    | grep -vE 'serverlb|registry'
+}
+
+warm() {
+  docker exec "$1" sh -c '
+    for d in /var/lib/rancher/k3s/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots \
+             /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots; do
+      [ -d "$d" ] && find "$d" -type f -print0 2>/dev/null | xargs -0 -r cat >/dev/null 2>&1
+    done
+  ' 2>/dev/null
+}
+
+while true; do
+  for n in $(node_containers); do warm "$n"; done
+  sleep "$INTERVAL"
+done

--- a/test/e2e_env/multizone/meshservice/policies.go
+++ b/test/e2e_env/multizone/meshservice/policies.go
@@ -98,6 +98,7 @@ spec:
 	AfterEachFailure(func() {
 		DebugUniversal(multizone.Global, meshName)
 		DebugKube(multizone.KubeZone1, meshName)
+		DebugKube(multizone.KubeZone2, meshName)
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e_env/multizone/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/multizone/meshtimeout/meshtimeout.go
@@ -92,6 +92,7 @@ spec:
 	AfterEachFailure(func() {
 		DebugUniversal(multizone.Global, mesh)
 		DebugKube(multizone.KubeZone1, mesh, k8sZoneNamespace)
+		DebugKube(multizone.KubeZone2, mesh, k8sZoneNamespace)
 	})
 
 	E2EAfterEach(func() {

--- a/test/e2e_env/multizone/reachablebackends/reachablebackends.go
+++ b/test/e2e_env/multizone/reachablebackends/reachablebackends.go
@@ -205,6 +205,7 @@ spec:
 	AfterEachFailure(func() {
 		DebugUniversal(multizone.Global, meshName)
 		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
 	})
 
 	E2EAfterAll(func() {

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"go.uber.org/multierr"
+	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/v3/test/framework/kumactl"
@@ -215,8 +216,83 @@ func debugKube(cluster Cluster, mesh string, namespaces ...string) error {
 		if err := debugKubeNamespace(cluster, namespace); err != nil {
 			errs = multierr.Combine(errs, fmt.Errorf("failed to debug namespace %s, %w", namespace, err))
 		}
+		if err := debugStuckPods(cluster, namespace); err != nil {
+			errs = multierr.Combine(errs, fmt.Errorf("failed to debug stuck pods in namespace %s, %w", namespace, err))
+		}
+	}
+	debugKubeCNILogs(cluster)
+	return errs
+}
+
+func podFullyReady(pod *kube_core.Pod) bool {
+	if pod.Status.Phase == kube_core.PodSucceeded {
+		return true
+	}
+	if pod.Status.Phase != kube_core.PodRunning {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+func debugStuckPods(cluster Cluster, namespace string) error {
+	kubeOptions := *cluster.GetKubectlOptions(namespace)
+	kubeOptions.Logger = logger.Discard
+	pods, err := k8s.ListPodsContextE(cluster.GetTesting(), context.Background(), &kubeOptions, kube_meta.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list pods, %w", err)
+	}
+	var errs error
+	for i := range pods {
+		pod := &pods[i]
+		if podFullyReady(pod) {
+			continue
+		}
+		out, err := k8s.RunKubectlAndGetOutputContextE(cluster.GetTesting(), context.Background(), &kubeOptions, "describe", "pod", pod.Name)
+		if err != nil {
+			errs = multierr.Append(errs, fmt.Errorf("failed to describe pod %s, %w", pod.Name, err))
+		} else {
+			report.AddFileToReportEntry(path.Join(cluster.Name(), "k8s", namespace, fmt.Sprintf("stuck-pod-%s-describe.txt", pod.Name)), out)
+		}
+
+		var containers []string
+		for _, c := range pod.Spec.InitContainers {
+			containers = append(containers, c.Name)
+		}
+		for _, c := range pod.Spec.Containers {
+			containers = append(containers, c.Name)
+		}
+		for _, container := range containers {
+			for _, previous := range []bool{false, true} {
+				args := []string{"logs", pod.Name, "-c", container}
+				suffix := ""
+				if previous {
+					args = append(args, "--previous")
+					suffix = "-previous"
+				}
+				logs, err := k8s.RunKubectlAndGetOutputContextE(cluster.GetTesting(), context.Background(), &kubeOptions, args...)
+				if err != nil || strings.TrimSpace(logs) == "" {
+					continue
+				}
+				report.AddFileToReportEntry(path.Join(cluster.Name(), "k8s", namespace, fmt.Sprintf("stuck-pod-%s-%s%s.log", pod.Name, container, suffix)), logs)
+			}
+		}
 	}
 	return errs
+}
+
+func debugKubeCNILogs(cluster Cluster) {
+	kubeOptions := *cluster.GetKubectlOptions(Config.KumaNamespace)
+	kubeOptions.Logger = logger.Discard
+	out, err := k8s.RunKubectlAndGetOutputContextE(cluster.GetTesting(), context.Background(), &kubeOptions, "logs", "daemonset/kuma-cni-node", "--all-containers", "--prefix", "--tail=2000")
+	if err != nil {
+		return
+	}
+	report.AddFileToReportEntry(path.Join(cluster.Name(), "k8s", "kuma-cni-node.log"), out)
 }
 
 func debugKubeNamespace(cluster Cluster, namespace string) error {

--- a/test/framework/k8s.go
+++ b/test/framework/k8s.go
@@ -259,10 +259,12 @@ func ExtractDeploymentDetails(testingT testing.TestingT,
 	}
 	for i := range pods {
 		deployDetails.Pods = append(deployDetails.Pods, &ObjectDetails{
-			Name:       pods[i].Name,
-			Conditions: fromPodCondition(pods[i].Status.Conditions),
-			Events:     getObjectEvents(testingT, kubectlOptions, "Pod", pods[i].Name),
-			Logs:       getPodLogs(testingT, kubectlOptions, &pods[i]),
+			Name:            pods[i].Name,
+			Phase:           string(pods[i].Status.Phase),
+			Conditions:      fromPodCondition(pods[i].Status.Conditions),
+			Events:          getObjectEvents(testingT, kubectlOptions, "Pod", pods[i].Name),
+			ContainerStates: fromPodContainerStatuses(&pods[i]),
+			Logs:            getPodLogs(testingT, kubectlOptions, &pods[i]),
 		})
 	}
 	return &deployDetails
@@ -277,27 +279,75 @@ func ExtractPodDetails(testingT testing.TestingT,
 		return &ObjectDetails{RetrievalError: err}
 	}
 	return &ObjectDetails{
-		Name:       podObject.Name,
-		Namespace:  kubectlOptions.Namespace,
-		Kind:       "Pod",
-		Conditions: fromPodCondition(podObject.Status.Conditions),
-		Events:     getObjectEvents(testingT, kubectlOptions, "Pod", podObject.Name),
-		Phase:      string(podObject.Status.Phase),
-		Logs:       getPodLogs(testingT, kubectlOptions, podObject),
+		Name:            podObject.Name,
+		Namespace:       kubectlOptions.Namespace,
+		Kind:            "Pod",
+		Conditions:      fromPodCondition(podObject.Status.Conditions),
+		Events:          getObjectEvents(testingT, kubectlOptions, "Pod", podObject.Name),
+		Phase:           string(podObject.Status.Phase),
+		ContainerStates: fromPodContainerStatuses(podObject),
+		Logs:            getPodLogs(testingT, kubectlOptions, podObject),
 	}
 }
 
 type ObjectDetails struct {
-	RetrievalError error              `json:"retrievalError,omitempty"`
-	Kind           string             `json:"kind,omitempty"`
-	Namespace      string             `json:"namespace,omitempty"`
-	Name           string             `json:"name,omitempty"`
-	Phase          string             `json:"phase,omitempty"`
-	Logs           map[string]string  `json:"logs,omitempty"`
-	Conditions     []*objectCondition `json:"conditions,omitempty"`
-	Events         []*simplifiedEvent `json:"events,omitempty"`
-	ReplicaSets    []*ObjectDetails   `json:"replicaSets,omitempty"`
-	Pods           []*ObjectDetails   `json:"pods,omitempty"`
+	RetrievalError  error              `json:"retrievalError,omitempty"`
+	Kind            string             `json:"kind,omitempty"`
+	Namespace       string             `json:"namespace,omitempty"`
+	Name            string             `json:"name,omitempty"`
+	Phase           string             `json:"phase,omitempty"`
+	Logs            map[string]string  `json:"logs,omitempty"`
+	Conditions      []*objectCondition `json:"conditions,omitempty"`
+	ContainerStates []*containerState  `json:"containerStates,omitempty"`
+	Events          []*simplifiedEvent `json:"events,omitempty"`
+	ReplicaSets     []*ObjectDetails   `json:"replicaSets,omitempty"`
+	Pods            []*ObjectDetails   `json:"pods,omitempty"`
+}
+
+type containerState struct {
+	Name         string `json:"name"`
+	Init         bool   `json:"init,omitempty"`
+	State        string `json:"state,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	Message      string `json:"message,omitempty"`
+	ExitCode     *int32 `json:"exitCode,omitempty"`
+	Started      *bool  `json:"started,omitempty"`
+	Ready        bool   `json:"ready"`
+	RestartCount int32  `json:"restartCount,omitempty"`
+}
+
+func fromPodContainerStatuses(pod *v1.Pod) []*containerState {
+	var out []*containerState
+	collect := func(statuses []v1.ContainerStatus, init bool) {
+		for i := range statuses {
+			s := statuses[i]
+			cs := &containerState{
+				Name:         s.Name,
+				Init:         init,
+				Ready:        s.Ready,
+				RestartCount: s.RestartCount,
+				Started:      s.Started,
+			}
+			switch {
+			case s.State.Waiting != nil:
+				cs.State = "waiting"
+				cs.Reason = s.State.Waiting.Reason
+				cs.Message = s.State.Waiting.Message
+			case s.State.Running != nil:
+				cs.State = "running"
+			case s.State.Terminated != nil:
+				cs.State = "terminated"
+				cs.Reason = s.State.Terminated.Reason
+				cs.Message = s.State.Terminated.Message
+				exitCode := s.State.Terminated.ExitCode
+				cs.ExitCode = &exitCode
+			}
+			out = append(out, cs)
+		}
+	}
+	collect(pod.Status.InitContainerStatuses, true)
+	collect(pod.Status.ContainerStatuses, false)
+	return out
 }
 
 type objectCondition struct {


### PR DESCRIPTION
## Motivation

We keep hitting an intermittent multizone e2e failure where a pod on the
CNI-enabled zone (`kuma-2`) stays `Pending` with init containers
`[kuma-validation kuma-sidecar]` incomplete, and it usually recovers on a
re-run. Root-causing it has been blocked by missing data:

- The failing zone is never dumped. `meshtimeout`, `meshservice/policies`
  and `reachablebackends` deploy to `KubeZone2` but their
  `AfterEachFailure` only debugged `Global` + `KubeZone1`, so the stuck
  pod's own logs and state on `kuma-2` were never collected.
- Per-container `State`/`Reason` is not recorded anywhere, so we cannot
  tell whether `kuma-validation` never started (`Waiting`) or started but
  never made progress (`Running`).
- Nothing captures node-runtime state (PSI, containerd/kubelet, process
  kernel stacks). Because the flake self-heals, that state has to be
  sampled while the pod is still stuck.

The earlier investigation (#16455) pointed at disk-I/O contention during
container init but could not prove it. This change adds the instrumentation
to capture the smoking gun the next time it happens.

> Changelog: skip

## Implementation information

- Debug `KubeZone2` in the three multizone tests that deployed there but
  skipped it on failure.
- Record per-container states in `ObjectDetails` (shown both inline in the
  failure message and in the dump). For not-ready pods, dump `describe`
  plus every container's logs (including `--previous`) and the
  `kuma-cni-node` daemonset logs.
- Add `.github/workflows/scripts/e2e-node-telemetry.sh`, a best-effort
  background sampler wired into the `run-e2e` action. It records host and
  node PSI, `docker stats`, `crictl` container states, and the kernel
  `stack`/`wchan` of stuck `kuma-init` / `kuma-validation` / `kuma-sidecar`
  processes, so we can tell IO-wait from CPU starvation from a
  container-runtime stall. Output lands in the existing `e2e-debug*`
  artifact.

This is primarily a diagnostics change. `ci/verify-stability` is set so CI
re-runs and tries to reproduce the flake with the new instrumentation in
place.

## Supporting documentation

Failing run: https://github.com/kumahq/kuma/actions/runs/29398805956
(multizone, k8s `v1.35.3-k3s1`).
