### PR TITLE
ci(build-test-distribute): add fail-hard green-SHA gate before release

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -45,7 +45,7 @@ jobs:
           WORKFLOW="build-test-distribute.yaml"
 
           runs_ndjson="$(mktemp)"
-          if ! gh api "/repos/${REPO}/actions/workflows/${WORKFLOW}/runs" \
+          if ! gh api --method GET "/repos/${REPO}/actions/workflows/${WORKFLOW}/runs" \
               -f head_sha="${SHA}" -f status=completed -f event=push \
               --jq '.workflow_runs[] | {id, conclusion, created_at, html_url}' \
               > "${runs_ndjson}" 2>gate_runs_err.log; then
@@ -72,7 +72,7 @@ jobs:
           run_url="$(jq -r '.html_url' <<<"${selected_run}")"
 
           jobs_ndjson="$(mktemp)"
-          if ! gh api "/repos/${REPO}/actions/runs/${run_id}/jobs" -f per_page=100 --paginate \
+          if ! gh api --method GET "/repos/${REPO}/actions/runs/${run_id}/jobs" -f per_page=100 --paginate \
               --jq '.jobs[] | {name, conclusion}' \
               > "${jobs_ndjson}" 2>gate_jobs_err.log; then
             echo "::error title=release_sha_gate::gate could not query GitHub Actions for jobs of run ${run_url}: $(cat gate_jobs_err.log)"

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -46,7 +46,7 @@ jobs:
 
           runs_ndjson="$(mktemp)"
           if ! gh api --method GET "/repos/${REPO}/actions/workflows/${WORKFLOW}/runs" \
-              -f head_sha="${SHA}" -f status=completed -f event=push \
+              -f head_sha="${SHA}" -f status=completed -f event=push -f per_page=100 --paginate \
               --jq '.workflow_runs[] | {id, conclusion, created_at, html_url}' \
               > "${runs_ndjson}" 2>gate_runs_err.log; then
             echo "::error title=release_sha_gate::gate could not query GitHub Actions for prior runs of ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_err.log)"

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -21,7 +21,93 @@ concurrency:
   group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, github.event_name == 'push' && github.sha || github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
 jobs:
+  release_sha_gate:
+    timeout-minutes: 5
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: "Verify tagged SHA has a trusted green push run"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${REF_TYPE}" != "tag" ]]; then
+            echo "Not a tag push; skipping release SHA gate."
+            exit 0
+          fi
+
+          WORKFLOW="build-test-distribute.yaml"
+
+          runs_ndjson="$(mktemp)"
+          if ! gh api "/repos/${REPO}/actions/workflows/${WORKFLOW}/runs" \
+              -f head_sha="${SHA}" -f status=completed -f event=push \
+              --jq '.workflow_runs[] | {id, conclusion, created_at, html_url}' \
+              > "${runs_ndjson}" 2>gate_runs_err.log; then
+            echo "::error title=release_sha_gate::gate could not query GitHub Actions for prior runs of ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_err.log)"
+            exit 1
+          fi
+
+          if ! selected_run="$(jq -s -r '
+              map(select(.conclusion == "success"))
+              | sort_by(.created_at)
+              | last
+              // empty
+            ' "${runs_ndjson}" 2>gate_runs_jq_err.log)"; then
+            echo "::error title=release_sha_gate::gate could not parse GitHub Actions run data for ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_jq_err.log)"
+            exit 1
+          fi
+
+          if [[ -z "${selected_run}" ]]; then
+            echo "::error title=release_sha_gate::No successful completed push run of ${WORKFLOW} found for tagged SHA ${SHA}. Every tag push requires a prior green branch push CI run for the tagged commit. Recovery: re-run the branch push CI on this SHA (re-tests and re-publishes the preview), then re-tag."
+            exit 1
+          fi
+
+          run_id="$(jq -r '.id' <<<"${selected_run}")"
+          run_url="$(jq -r '.html_url' <<<"${selected_run}")"
+
+          jobs_ndjson="$(mktemp)"
+          if ! gh api "/repos/${REPO}/actions/runs/${run_id}/jobs" -f per_page=100 --paginate \
+              --jq '.jobs[] | {name, conclusion}' \
+              > "${jobs_ndjson}" 2>gate_jobs_err.log; then
+            echo "::error title=release_sha_gate::gate could not query GitHub Actions for jobs of run ${run_url}: $(cat gate_jobs_err.log)"
+            exit 1
+          fi
+
+          if ! missing="$(jq -s -r '
+              def has_success($jobs; $pattern):
+                ($jobs | any(.[]; (.name | test($pattern)) and .conclusion == "success"));
+
+              . as $jobs
+              | [
+                  {label: "test / test_unit", pattern: "^test / test_unit$"},
+                  {label: "test / e2e ...", pattern: "^test / e2e"},
+                  {label: "build_publish / digest-images", pattern: "^build_publish / digest-images$"},
+                  {label: "build_publish / build-binaries", pattern: "^build_publish / build-binaries$"},
+                  {label: "build_publish / build-images ...", pattern: "^build_publish / build-images"},
+                  {label: "build_publish / publish-helm", pattern: "^build_publish / publish-helm$"}
+                ]
+              | map(select(has_success($jobs; .pattern) | not))
+              | map(.label)
+              | join(", ")
+            ' "${jobs_ndjson}" 2>gate_jobs_jq_err.log)"; then
+            echo "::error title=release_sha_gate::gate could not parse GitHub Actions job data for run ${run_url}: $(cat gate_jobs_jq_err.log)"
+            exit 1
+          fi
+
+          if [[ -n "${missing}" ]]; then
+            echo "::error title=release_sha_gate::Selected run ${run_url} is missing required successful job(s): ${missing}. Recovery: re-run the branch push CI on SHA ${SHA}, then re-tag."
+            exit 1
+          fi
+
+          echo "Trusted source run: ${run_url}"
   meta:
+    needs: ["release_sha_gate"]
     timeout-minutes: 5
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
@@ -31,6 +117,7 @@ jobs:
     steps:
       - run: echo "FULL_MATRIX=${{ env.FULL_MATRIX }}"
   build_check:
+    needs: ["release_sha_gate"]
     timeout-minutes: 20
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
@@ -53,6 +140,7 @@ jobs:
             go-build-${{ runner.os }}-
       - run: go build ./...
   check:
+    needs: ["release_sha_gate"]
     permissions:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
@@ -229,7 +317,7 @@ jobs:
       NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
       IMAGE_DIGESTS: ${{ needs.build_publish.outputs.IMAGE_DIGESTS }}
   distributions:
-    needs: ["build_publish", "check", "test", "provenance"]
+    needs: ["release_sha_gate", "build_publish", "check", "test", "provenance"]
     permissions:
       id-token: write
     timeout-minutes: 10


### PR DESCRIPTION
## Motivation

Release tags currently skip CI without confirming the tagged commit is green and published. This risks releasing broken or incomplete artifacts.

## Implementation information

Added a guard job that validates the tagged SHA before releasing:

- Queries prior successful push-event runs for the tagged commit
- Confirms all required jobs are present and succeeded: `test_unit`, `test_e2e*`, `digest-images`, `build-binaries`, `build-images`, `publish-helm`
- Fails the pipeline if validation fails, directing users to re-publish from the branch and re-tag for recovery

Closes https://github.com/kumahq/kuma/issues/17233

_Generated by Sybra harness_