### PR TITLE
fix(ServiceInsight): keep delegated gateways when meshServices.mode is Exclusive

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -478,10 +478,6 @@ func (r *resyncer) createOrUpdateServiceInsight(
 	insight := &mesh_proto.ServiceInsight{
 		Services: map[string]*mesh_proto.ServiceInsight_Service{},
 	}
-	if exclusiveMeshServices {
-		// set ServiceInsight with empty Services map
-		return r.upsertServiceInsight(ctx, mesh, insight)
-	}
 
 	zonesMap := map[string]map[string]struct{}{}
 	addSvcToZones := func(svc, zone string) {
@@ -506,8 +502,19 @@ func (r *resyncer) createOrUpdateServiceInsight(
 			case mesh_proto.Dataplane_Networking_Gateway_DELEGATED:
 				svcType = mesh_proto.ServiceInsight_Service_gateway_delegated
 			}
-			populateInsight(svcType, insight, gw.GetTags()[mesh_proto.ServiceTag], status, backend, "")
-			addSvcToZones(gw.GetTags()[mesh_proto.ServiceTag], gw.GetTags()[mesh_proto.ZoneTag])
+			// In Exclusive mode kuma.io/service based services are replaced by
+			// MeshService, except delegated gateways which are never turned into
+			// MeshService and so must still be reported here.
+			if !exclusiveMeshServices || svcType == mesh_proto.ServiceInsight_Service_gateway_delegated {
+				populateInsight(svcType, insight, gw.GetTags()[mesh_proto.ServiceTag], status, backend, "")
+				addSvcToZones(gw.GetTags()[mesh_proto.ServiceTag], gw.GetTags()[mesh_proto.ZoneTag])
+			}
+			continue
+		}
+
+		if exclusiveMeshServices {
+			// internal services are represented by MeshService in Exclusive mode
+			continue
 		}
 
 		for _, inbound := range networking.GetInbound() {
@@ -520,9 +527,12 @@ func (r *resyncer) createOrUpdateServiceInsight(
 		}
 	}
 
-	for _, es := range externalServices {
-		populateInsight(mesh_proto.ServiceInsight_Service_external, insight, es.Spec.GetService(), "", "", es.Spec.Networking.GetAddress())
-		addSvcToZones(es.Spec.GetService(), es.Spec.GetTags()[mesh_proto.ZoneTag])
+	if !exclusiveMeshServices {
+		// external services are represented by MeshExternalService in Exclusive mode
+		for _, es := range externalServices {
+			populateInsight(mesh_proto.ServiceInsight_Service_external, insight, es.Spec.GetService(), "", "", es.Spec.Networking.GetAddress())
+			addSvcToZones(es.Spec.GetService(), es.Spec.GetTags()[mesh_proto.ZoneTag])
+		}
 	}
 
 	for svcName, svc := range insight.Services {

--- a/pkg/insights/resyncer_test.go
+++ b/pkg/insights/resyncer_test.go
@@ -605,13 +605,14 @@ var _ = Describe("Insight Persistence", func() {
 		}).Should(Succeed())
 	})
 
-	It("should not compute services when meshServices.mode is Exclusive", func() {
+	It("should only compute delegated gateways when meshServices.mode is Exclusive", func() {
 		// given a mesh with meshServices.mode=Exclusive
 		mesh := core_mesh.NewMeshResource()
 		mesh.Spec.MeshServices = &mesh_proto.Mesh_MeshServices{Mode: mesh_proto.Mesh_MeshServices_Exclusive}
 		err := rm.Create(context.Background(), mesh, store.CreateByKey("mesh-1", model.NoMesh))
 		Expect(err).ToNot(HaveOccurred())
 
+		// an inbound-based service, represented by MeshService in Exclusive mode
 		dp1 := core_mesh.NewDataplaneResource()
 		dp1.Spec = &mesh_proto.Dataplane{
 			Networking: &mesh_proto.Dataplane_Networking{
@@ -627,6 +628,34 @@ var _ = Describe("Insight Persistence", func() {
 			},
 		}
 		err = rm.Create(context.Background(), dp1, store.CreateByKey("dp1", "mesh-1"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// a delegated gateway, which is never turned into a MeshService
+		delegatedGw := core_mesh.NewDataplaneResource()
+		delegatedGw.Spec = &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "10.0.0.2",
+				Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+					Tags: map[string]string{"kuma.io/service": "delegated-gw"},
+					Type: mesh_proto.Dataplane_Networking_Gateway_DELEGATED,
+				},
+			},
+		}
+		err = rm.Create(context.Background(), delegatedGw, store.CreateByKey("dp2", "mesh-1"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// a builtin gateway, which is not reported in Exclusive mode
+		builtinGw := core_mesh.NewDataplaneResource()
+		builtinGw.Spec = &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "10.0.0.3",
+				Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+					Tags: map[string]string{"kuma.io/service": "builtin-gw"},
+					Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
+				},
+			},
+		}
+		err = rm.Create(context.Background(), builtinGw, store.CreateByKey("dp3", "mesh-1"))
 		Expect(err).ToNot(HaveOccurred())
 
 		externalService := core_mesh.NewExternalServiceResource()
@@ -649,10 +678,17 @@ var _ = Describe("Insight Persistence", func() {
 			g.Expect(meshInsight.Spec.Services).To(BeNil())
 		}).Should(Succeed())
 
-		// and no ServiceInsight is created since the empty insight equals the default spec
-		serviceInsight := core_mesh.NewServiceInsightResource()
-		err = rm.Get(context.Background(), serviceInsight, store.GetBy(insights.ServiceInsightKey("mesh-1")))
-		Expect(store.IsNotFound(err)).To(BeTrue())
+		// and the ServiceInsight only contains the delegated gateway
+		Eventually(func(g Gomega) {
+			serviceInsight := core_mesh.NewServiceInsightResource()
+			err := rm.Get(context.Background(), serviceInsight, store.GetBy(insights.ServiceInsightKey("mesh-1")))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(serviceInsight.Spec.Services).To(HaveKey("delegated-gw"))
+			g.Expect(serviceInsight.Spec.Services["delegated-gw"].ServiceType).To(Equal(mesh_proto.ServiceInsight_Service_gateway_delegated))
+			g.Expect(serviceInsight.Spec.Services).ToNot(HaveKey("backend"))
+			g.Expect(serviceInsight.Spec.Services).ToNot(HaveKey("builtin-gw"))
+			g.Expect(serviceInsight.Spec.Services).ToNot(HaveKey("external-service"))
+		}).Should(Succeed())
 	})
 
 	It("should not create a service insight entry for inbounds without a kuma.io/service tag", func() {


### PR DESCRIPTION
## Motivation

When `meshServices.mode: Exclusive`, `ServiceInsight` was computed with an empty `Services` map, so delegated gateways disappeared from the GUI. Delegated gateways are never turned into `MeshService` resources (the MeshService controller explicitly ignores gateway Pods), so nothing replaces them — they must be reported regardless of the mode.

## Implementation information

- Remove the Exclusive-mode short-circuit in `createOrUpdateServiceInsight`.
- Report only `gateway_delegated` entries in Exclusive mode; skip inbound (internal) and external services, which are replaced by `MeshService`/`MeshExternalService`.
- `MeshInsight.Services` counter behavior is unchanged (stays nil in Exclusive mode).

## Supporting documentation

Fixes #17430
