### PR TITLE
refactor(e2e): relocate MeshLoadBalancingStrategy field

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshloadbalancingstrategy.go
@@ -57,13 +57,12 @@ spec:
         kind: MeshService
         name: test-server_%[2]s_svc_80
       default:
+        hashPolicies:
+          - type: Header
+            header:
+              name: x-header
         loadBalancer:
           type: RingHash
-          ringHash:
-            hashPolicies:
-              - type: Header
-                header:
-                  name: x-header
 `, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
 
 			Eventually(func(g Gomega) {

--- a/test/e2e_env/universal/meshloadbalancingstrategy/policy.go
+++ b/test/e2e_env/universal/meshloadbalancingstrategy/policy.go
@@ -67,13 +67,12 @@ spec:
         kind: MeshService
         name: test-server
       default:
+        hashPolicies:
+          - type: Header
+            header:
+              name: x-header
         loadBalancer:
           type: RingHash
-          ringHash:
-            hashPolicies:
-              - type: Header
-                header:
-                  name: x-header
 `)(universal.Cluster)).To(Succeed())
 
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
## Motivation

> Changelog: skip

Split out of #17387. Modernizes e2e test specs using
`MeshLoadBalancingStrategy`'s relocated `hashPolicies` field
(deprecated in its old location by the 3.0 preflight audit).

## Implementation information

- `refactor(e2e): relocate MeshLoadBalancingStrategy hashPolicies`

Pure test-spec changes, no product code touched. Also drops a
built-in-gateway test file master already deleted
(`kubernetes/gateway/gateway.go`), which the rebase onto current
master otherwise conflicts with. Verified `go build` and `gofmt`
clean.

## Supporting documentation

Part of the larger e2e modernization effort tracked in #17387.