### PR TITLE
refactor(e2e): modernize MeshCircuitBreaker fields

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
@@ -61,6 +61,9 @@ spec:
       default:
         outlierDetection:
           healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100
 `, config.CpNamespace, config.Mesh)
 
 		BeforeAll(func() {

--- a/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhealthcheck.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	meshcircuitbreaker_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/test/framework"
 	"github.com/kumahq/kuma/v3/test/framework/client"
@@ -38,13 +39,33 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
-        http: 
+        http:
           path: %s
-          expectedStatuses: 
+          expectedStatuses:
           - %s`, config.CpNamespace, config.Mesh, path, status)
 		}
+
+		circuitBreaker := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshCircuitBreaker
+metadata:
+  name: mcb-disable-panic
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+spec:
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0
+`, config.CpNamespace, config.Mesh)
+
+		BeforeAll(func() {
+			Expect(framework.YamlK8s(circuitBreaker)(kubernetes.Cluster)).To(Succeed())
+		})
 
 		framework.AfterEachFailure(func() {
 			framework.DebugKube(kubernetes.Cluster, config.Mesh, config.Namespace, config.ObservabilityDeploymentName)
@@ -55,6 +76,11 @@ spec:
 				kubernetes.Cluster,
 				config.Mesh,
 				v1alpha1.MeshHealthCheckResourceTypeDescriptor,
+			)).To(Succeed())
+			Expect(framework.DeleteMeshResources(
+				kubernetes.Cluster,
+				config.Mesh,
+				meshcircuitbreaker_api.MeshCircuitBreakerResourceTypeDescriptor,
 			)).To(Succeed())
 		})
 

--- a/test/e2e_env/kubernetes/meshhealthcheck/api.go
+++ b/test/e2e_env/kubernetes/meshhealthcheck/api.go
@@ -64,7 +64,6 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
         http:
           path: /

--- a/test/e2e_env/multizone/meshservice/policies.go
+++ b/test/e2e_env/multizone/meshservice/policies.go
@@ -8,6 +8,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	meshcircuitbreaker_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
 	meshfaultinjection_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshfaultinjection/api/v1alpha1"
 	meshhealthcheck_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhealthcheck/api/v1alpha1"
 	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -104,6 +105,7 @@ spec:
 		Expect(DeleteMeshResources(multizone.KubeZone1, meshName, meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(multizone.KubeZone1, meshName, meshtcproute_api.MeshTCPRouteResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(multizone.KubeZone1, meshName, meshhealthcheck_api.MeshHealthCheckResourceTypeDescriptor)).To(Succeed())
+		Expect(DeleteMeshResources(multizone.KubeZone1, meshName, meshcircuitbreaker_api.MeshCircuitBreakerResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(multizone.KubeZone1, meshName, core_mesh.ExternalServiceResourceTypeDescriptor)).To(Succeed())
 		Expect(DeleteMeshResources(multizone.KubeZone2, meshName, meshfaultinjection_api.MeshFaultInjectionResourceTypeDescriptor)).To(Succeed())
 	})
@@ -403,14 +405,34 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
         http:
           path: /are-you-healthy
           expectedStatuses:
           - 500`, Config.KumaNamespace, meshName, Kuma2)
-		// update HealthCheck policy to check for another status code
+		circuitBreaker := fmt.Sprintf(`
+apiVersion: kuma.io/v1alpha1
+kind: MeshCircuitBreaker
+metadata:
+  name: mcb-for-ms-in-kuma-2
+  namespace: %s
+  labels:
+    kuma.io/mesh: %s
+    kuma.io/origin: zone
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        labels:
+          kuma.io/display-name: test-server
+          kuma.io/zone: %s
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0
+`, Config.KumaNamespace, meshName, Kuma2)
+		// update HealthCheck policy to check for another status code, and disable panic mode
 		Expect(YamlK8s(healthCheck)(multizone.KubeZone1)).To(Succeed())
+		Expect(YamlK8s(circuitBreaker)(multizone.KubeZone1)).To(Succeed())
 
 		// check that test-server is unhealthy
 		Eventually(func(g Gomega) {

--- a/test/e2e_env/multizone/meshservice/policies.go
+++ b/test/e2e_env/multizone/meshservice/policies.go
@@ -429,6 +429,9 @@ spec:
       default:
         outlierDetection:
           healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100
 `, Config.KumaNamespace, meshName, Kuma2)
 		// update HealthCheck policy to check for another status code, and disable panic mode
 		Expect(YamlK8s(healthCheck)(multizone.KubeZone1)).To(Succeed())

--- a/test/e2e_env/universal/meshhealthcheck/panic.go
+++ b/test/e2e_env/universal/meshhealthcheck/panic.go
@@ -47,7 +47,10 @@ spec:
         name: test-server
       default:
         outlierDetection:
-          healthyPanicThreshold: 61`, meshName)
+          healthyPanicThreshold: 61
+          detectors:
+            totalFailures:
+              consecutive: 100`, meshName)
 
 	dp := func(idx int) string {
 		return fmt.Sprintf(`

--- a/test/e2e_env/universal/meshhealthcheck/panic.go
+++ b/test/e2e_env/universal/meshhealthcheck/panic.go
@@ -32,10 +32,22 @@ spec:
         timeout: 2s
         unhealthyThreshold: 3
         healthyThreshold: 1
-        healthyPanicThreshold: 61
         failTrafficOnPanic: true
         http:
           path: "/"`, meshName)
+
+	circuitBreaker := fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: mcb-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 61`, meshName)
 
 	dp := func(idx int) string {
 		return fmt.Sprintf(`
@@ -61,6 +73,7 @@ networking:
 		err := NewClusterSetup().
 			Install(ResourceUniversal(samples.MeshDefaultBuilder().WithName(meshName).WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Disabled).Build())).
 			Install(YamlUniversal(healthCheck)).
+			Install(YamlUniversal(circuitBreaker)).
 			Setup(universal.Cluster)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -57,7 +57,10 @@ spec:
         name: test-server
       default:
         outlierDetection:
-          healthyPanicThreshold: 0`, mesh)
+          healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100`, mesh)
 		}
 		BeforeAll(func() {
 			err := NewClusterSetup().
@@ -150,7 +153,10 @@ spec:
         name: test-server
       default:
         outlierDetection:
-          healthyPanicThreshold: 0`, mesh)
+          healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100`, mesh)
 		}
 
 		BeforeAll(func() {
@@ -251,7 +257,10 @@ spec:
         name: %s
       default:
         outlierDetection:
-          healthyPanicThreshold: 0`, mesh, serviceName)
+          healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100`, mesh, serviceName)
 		}
 		meshName := "meshhealthcheck-tcp"
 		BeforeAll(func() {
@@ -357,7 +366,10 @@ spec:
         name: %s
       default:
         outlierDetection:
-          healthyPanicThreshold: 0`, mesh, serviceName)
+          healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100`, mesh, serviceName)
 		}
 		meshName := "meshhealthcheck-mtls-permissive-tcp"
 		BeforeAll(func() {
@@ -448,7 +460,10 @@ spec:
         name: test-server
       default:
         outlierDetection:
-          healthyPanicThreshold: 0`, mesh)
+          healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100`, mesh)
 		}
 		BeforeAll(func() {
 			err := NewClusterSetup().
@@ -559,7 +574,10 @@ spec:
         name: test-server
       default:
         outlierDetection:
-          healthyPanicThreshold: 0`, mesh)
+          healthyPanicThreshold: 0
+          detectors:
+            totalFailures:
+              consecutive: 100`, mesh)
 		}
 
 		meshHttpRoute := fmt.Sprintf(`

--- a/test/e2e_env/universal/meshhealthcheck/policy.go
+++ b/test/e2e_env/universal/meshhealthcheck/policy.go
@@ -39,17 +39,31 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
-        http: 
+        http:
           path: /%s
-          expectedStatuses: 
+          expectedStatuses:
           - %s`, mesh, method, status)
+		}
+		disablePanic := func(mesh string) string {
+			return fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: everything-to-backend-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0`, mesh)
 		}
 		BeforeAll(func() {
 			err := NewClusterSetup().
 				Install(MeshUniversal(meshName)).
 				Install(YamlUniversal(healthCheck(meshName, "health", "200"))).
+				Install(YamlUniversal(disablePanic(meshName))).
 				Install(DemoClientUniversal("dp-demo-client", meshName,
 					WithTransparentProxy(true)),
 				).
@@ -118,12 +132,25 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
-        http: 
+        http:
           path: /%s
-          expectedStatuses: 
+          expectedStatuses:
           - %s`, mesh, method, status)
+		}
+		disablePanic := func(mesh string) string {
+			return fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: everything-to-backend-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0`, mesh)
 		}
 
 		BeforeAll(func() {
@@ -133,6 +160,7 @@ spec:
 					WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
 				)).
 				Install(YamlUniversal(healthCheck(meshName, "health", "200"))).
+				Install(YamlUniversal(disablePanic(meshName))).
 				Install(DemoClientUniversal("dp-demo-client", meshName,
 					WithTransparentProxy(true)),
 				).
@@ -205,17 +233,31 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
-        tcp: 
+        tcp:
           send: %s
           receive:
           - %s`, mesh, serviceName, sendBase64, recvBase64)
+		}
+		disablePanic := func(mesh, serviceName string) string {
+			return fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: everything-to-backend-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: %s
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0`, mesh, serviceName)
 		}
 		meshName := "meshhealthcheck-tcp"
 		BeforeAll(func() {
 			err := NewClusterSetup().
 				Install(MeshUniversal(meshName)).
+				Install(YamlUniversal(disablePanic(meshName, "test-server"))).
 				Install(DemoClientUniversal("dp-demo-client", meshName,
 					WithTransparentProxy(true)),
 				).
@@ -297,17 +339,31 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
-        tcp: 
+        tcp:
           send: %s
           receive:
             - %s`, mesh, serviceName, sendBase64, recvBase64)
+		}
+		disablePanic := func(mesh, serviceName string) string {
+			return fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: gateway-to-backend-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: %s
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0`, mesh, serviceName)
 		}
 		meshName := "meshhealthcheck-mtls-permissive-tcp"
 		BeforeAll(func() {
 			err := NewClusterSetup().
 				Install(mtlsPermissiveMesh(meshName)).
+				Install(YamlUniversal(disablePanic(meshName, "test-server-mtls"))).
 				Install(DemoClientUniversal("dp-demo-client-mtls", meshName,
 					WithTransparentProxy(true)),
 				).
@@ -377,15 +433,29 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
         grpc: {}`, mesh)
+		}
+		disablePanic := func(mesh string) string {
+			return fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: everything-to-backend-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0`, mesh)
 		}
 		BeforeAll(func() {
 			err := NewClusterSetup().
 				Install(MeshUniversal(meshName)).
 				Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
 				Install(YamlUniversal(healthCheck(meshName))).
+				Install(YamlUniversal(disablePanic(meshName))).
 				Install(TestServerUniversal("test-client", meshName,
 					WithServiceName("test-client"),
 					WithArgs([]string{"grpc", "client", "--address", "test-server.svc.mesh.local:80"}),
@@ -471,12 +541,25 @@ spec:
         healthyThreshold: 1
         failTrafficOnPanic: true
         noTrafficInterval: 1s
-        healthyPanicThreshold: 0
         reuseConnection: true
-        http: 
+        http:
           path: /%s
-          expectedStatuses: 
+          expectedStatuses:
           - %s`, mesh, method, status)
+		}
+		disablePanic := func(mesh string) string {
+			return fmt.Sprintf(`
+type: MeshCircuitBreaker
+mesh: %s
+name: everything-to-backend-panic
+spec:
+  to:
+    - targetRef:
+        kind: MeshService
+        name: test-server
+      default:
+        outlierDetection:
+          healthyPanicThreshold: 0`, mesh)
 		}
 
 		meshHttpRoute := fmt.Sprintf(`
@@ -517,6 +600,7 @@ spec:
 			err := NewClusterSetup().
 				Install(ResourceUniversal(samples.MeshDefaultBuilder().WithName(meshName).WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Disabled).Build())).
 				Install(YamlUniversal(healthCheck(meshName, "health", "200"))).
+				Install(YamlUniversal(disablePanic(meshName))).
 				Install(DemoClientUniversal("dp-demo-client", meshName,
 					WithTransparentProxy(true)),
 				).


### PR DESCRIPTION
## Motivation

> Changelog: skip

Split out of #17387. Modernizes e2e test specs using
`MeshCircuitBreaker`'s relocated `healthyPanicThreshold` field, and
fixes specs that set `healthyPanicThreshold` without the now-mandatory
`outlierDetection.detectors` field (validator requires it whenever
`outlierDetection` is set; omitting it fails with "detectors: must be
defined").

## Implementation information

- `refactor(e2e): move healthyPanicThreshold to MeshCircuitBreaker`
- `fix(e2e): add MeshCircuitBreaker detectors`

Pure test-spec changes, no product code touched. Verified `go build`
and `gofmt` clean on top of current master.

## Supporting documentation

Part of the larger e2e modernization effort tracked in #17387.