### PR TITLE
ci(build-publish): assert built binary reports tag version

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -66,6 +66,10 @@ jobs:
         name: Image tag
         run: |
           echo "::notice title=Image tag::$(make build/info/version)"
+      - name: Assert built binary reports tag version
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          make build/assert-tag-version
       - run: |
           make -j build/distributions
       - id: inspect-binary-output

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -44,27 +44,30 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   assert-tag-version:
-    # Runs before build-binaries/build-images/publish-helm so a tag whose
-    # binary reports the wrong version can't slip through to a publish step
-    # in a job that doesn't depend on build-binaries.
-    if: ${{ github.ref_type == 'tag' }}
+    # Tag check lives on the steps, not the job, so this job always reports
+    # success/failure and never "skipped". That lets build-binaries and
+    # build-images depend on it with a plain `needs:` and GitHub's default
+    # job-status semantics, which correctly cascade to digest-images and
+    # publish-helm further down the chain and correctly stop on cancellation.
     timeout-minutes: 10
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: ${{ github.ref_type == 'tag' }}
         with:
           persist-credentials: false
           fetch-depth: 0
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        if: ${{ github.ref_type == 'tag' }}
         with:
           # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
           version: 2026.5.7
       - name: Assert built binary reports tag version
+        if: ${{ github.ref_type == 'tag' }}
         run: |
           make build/assert-tag-version
   build-binaries:
     needs: [assert-tag-version]
-    if: ${{ always() && (needs.assert-tag-version.result == 'success' || needs.assert-tag-version.result == 'skipped') }}
     timeout-minutes: 70
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
@@ -120,7 +123,6 @@ jobs:
           make publish/pulp
   build-images:
     needs: [assert-tag-version]
-    if: ${{ always() && (needs.assert-tag-version.result == 'success' || needs.assert-tag-version.result == 'skipped') }}
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -43,7 +43,28 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
+  assert-tag-version:
+    # Runs before build-binaries/build-images/publish-helm so a tag whose
+    # binary reports the wrong version can't slip through to a publish step
+    # in a job that doesn't depend on build-binaries.
+    if: ${{ github.ref_type == 'tag' }}
+    timeout-minutes: 10
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
+      - name: Assert built binary reports tag version
+        run: |
+          make build/assert-tag-version
   build-binaries:
+    needs: [assert-tag-version]
+    if: ${{ always() && (needs.assert-tag-version.result == 'success' || needs.assert-tag-version.result == 'skipped') }}
     timeout-minutes: 70
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
@@ -66,10 +87,6 @@ jobs:
         name: Image tag
         run: |
           echo "::notice title=Image tag::$(make build/info/version)"
-      - name: Assert built binary reports tag version
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          make build/assert-tag-version
       - run: |
           make -j build/distributions
       - id: inspect-binary-output
@@ -102,6 +119,8 @@ jobs:
         run: |
           make publish/pulp
   build-images:
+    needs: [assert-tag-version]
+    if: ${{ always() && (needs.assert-tag-version.result == 'success' || needs.assert-tag-version.result == 'skipped') }}
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -73,8 +73,8 @@ build/info/version:
 
 .PHONY: build/assert-tag-version
 build/assert-tag-version: ## Dev: Assert the built kuma-cp binary reports the tag version
-	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$2}'); \
-	if [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
+	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$NF}'); \
+	if [ -z "$$actual" ] || [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
 		echo "kuma-cp binary reports version '$$actual', expected tag version '$(BUILD_INFO_VERSION)'"; \
 		exit 1; \
 	fi; \

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -72,7 +72,7 @@ build/info/version:
 	@echo $(BUILD_INFO_VERSION)
 
 .PHONY: build/assert-tag-version
-build/assert-tag-version: ## Dev: Assert the built kuma-cp binary reports the tag version
+build/assert-tag-version: build/kuma-cp ## Dev: Assert the built kuma-cp binary reports the tag version
 	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$NF}'); \
 	if [ -z "$$actual" ] || [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
 		echo "kuma-cp binary reports version '$$actual', expected tag version '$(BUILD_INFO_VERSION)'"; \

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -71,6 +71,15 @@ build/info/short:
 build/info/version:
 	@echo $(BUILD_INFO_VERSION)
 
+.PHONY: build/assert-tag-version
+build/assert-tag-version: ## Dev: Assert the built kuma-cp binary reports the tag version
+	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$2}'); \
+	if [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
+		echo "kuma-cp binary reports version '$$actual', expected tag version '$(BUILD_INFO_VERSION)'"; \
+		exit 1; \
+	fi; \
+	echo "kuma-cp binary correctly reports tag version '$(BUILD_INFO_VERSION)'"
+
 .PHONY: build
 build: build/release build/test ## Dev: Build all binaries
 


### PR DESCRIPTION
## Motivation

Tag builds inject a release version (X.Y.Z) via ldflags, whereas branch builds use X.Y.Z-preview.<hash>. We need to verify this version injection is working correctly on release builds.

## Implementation information

Added an assertion in the build pipeline to verify the freshly-built binary reports the correct tag version (e.g., via `make build/info/version` or `kuma-cp --version`). The existing container-structure tests on the built image are preserved. This is the only tag-specific validation needed—the green branch CI already covers general correctness.

Closes https://github.com/kumahq/kuma/issues/17234

_Generated by Sybra harness_