### PR TITLE
ci(build-test-distribute): skip check validation steps on tag

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -234,8 +234,9 @@ jobs:
           only-new-issues: false
 
       # Lint and "make check" are redundant on a tag: release_sha_gate already
-      # requires a green branch push run for this exact tree/SHA. We still run
-      # metadata and SCA so release tags continue publishing security assets.
+      # requires a green branch push run for this exact tree/SHA. We
+      # intentionally keep metadata and SBOM/SCA on tag refs so release tags
+      # continue publishing security assets.
       - if: ${{ github.ref_type != 'tag' }}
         run: |
           make clean

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -234,7 +234,8 @@ jobs:
           only-new-issues: false
 
       # Lint and "make check" are redundant on a tag: release_sha_gate already
-      # requires a green branch push run for this exact tree/SHA.
+      # requires a green branch push run for this exact tree/SHA. We still run
+      # metadata and SCA so release tags continue publishing security assets.
       - if: ${{ github.ref_type != 'tag' }}
         run: |
           make clean
@@ -260,11 +261,9 @@ jobs:
       # and should be ignored. Since we currently can't change the working directory
       # for the SCA step, it must run after "make check." Instead, we clean ./build
       # after "make check" to exclude tool binaries from the SBOM.
-      - if: ${{ github.ref_type != 'tag' }}
-        run: |
+      - run: |
           make clean/build
       - name: "Generate SBOM and CVE report (Software Composition Analysis)"
-        if: ${{ github.ref_type != 'tag' }}
         id: sca-project
         uses: Kong/public-shared-actions/security-actions/sca@4cb2f03c59d51085256a1405c81e0dd7e9a91fe9 # v6.0.2
         env:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -225,7 +225,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        if: steps.changes.outputs.code == 'true'
+        if: ${{ steps.changes.outputs.code == 'true' && github.ref_type != 'tag' }}
         env:
           GOGC: "80" # run GC more aggressively
         with:
@@ -233,9 +233,13 @@ jobs:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           only-new-issues: false
 
-      - run: |
+      # Lint and "make check" are redundant on a tag: release_sha_gate already
+      # requires a green branch push run for this exact tree/SHA.
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make clean
-      - run: |
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make check
       - name: "Set metadata for downstream jobs"
         id: metadata
@@ -256,9 +260,11 @@ jobs:
       # and should be ignored. Since we currently can't change the working directory
       # for the SCA step, it must run after "make check." Instead, we clean ./build
       # after "make check" to exclude tool binaries from the SBOM.
-      - run: |
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make clean/build
       - name: "Generate SBOM and CVE report (Software Composition Analysis)"
+        if: ${{ github.ref_type != 'tag' }}
         id: sca-project
         uses: Kong/public-shared-actions/security-actions/sca@4cb2f03c59d51085256a1405c81e0dd7e9a91fe9 # v6.0.2
         env:


### PR DESCRIPTION
## Motivation

The `check` job runs lint and `make check` on tag refs even though the tree is identical to the green branch SHA that triggered the initial build. Those validation steps are redundant and waste CI time. The job's metadata outputs are still needed downstream by the `build_publish` job, and SBOM/SCA intentionally stays enabled on tag runs so release security assets continue to publish.

## Implementation information

- Retain the metadata outputs step so `build_publish` receives its required inputs
- Skip lint and `make check` when `ref_type == 'tag'`
- Keep SBOM/SCA on tag refs so release security assets still publish

Closes https://github.com/kumahq/kuma/issues/17235

_Generated by Sybra harness_
