### PR TITLE
fix(meshhttproute): allow MeshGateway target

### DIFF
--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -34,6 +34,7 @@ func (r *MeshHTTPRouteResource) validateTop(targetRef *common_api.TargetRef) val
 		return mesh.ValidateTargetRef(*targetRef, &mesh.ValidateTargetRefOpts{
 			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
+				common_api.MeshGateway,
 				common_api.Dataplane,
 			},
 			GatewayListenerTagsAllowed: true,
@@ -42,6 +43,7 @@ func (r *MeshHTTPRouteResource) validateTop(targetRef *common_api.TargetRef) val
 		return mesh.ValidateTargetRef(*targetRef, &mesh.ValidateTargetRefOpts{
 			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
+				common_api.MeshGateway,
 				common_api.Dataplane,
 			},
 		})

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -53,14 +53,11 @@ to:
 - targetRef:
     kind: Mesh
 `),
-		ErrorCases("spec.to.targetRef MeshService not allowed with top MeshGateway",
-			[]validators.Violation{{
-				Field:   `spec.targetRef.kind`,
-				Message: `value 'MeshGateway' is not supported`,
-			}, {
+		ErrorCase("spec.to.targetRef MeshService not allowed with top MeshGateway",
+			validators.Violation{
 				Field:   `spec.to[0].targetRef.kind`,
 				Message: `value 'MeshService' is not supported`,
-			}}, `
+			}, `
 type: MeshHTTPRoute
 mesh: mesh-1
 name: route-1
@@ -356,14 +353,11 @@ to:
           - kind: MeshService
             name: backend
 `),
-		ErrorCases("top level MeshGateway requires backendRefs",
-			[]validators.Violation{{
-				Field:   `spec.targetRef.kind`,
-				Message: `value 'MeshGateway' is not supported`,
-			}, {
+		ErrorCase("top level MeshGateway requires backendRefs",
+			validators.Violation{
 				Field:   `spec.to[0].rules[0].default.backendRefs`,
 				Message: `must not be empty`,
-			}}, `
+			}, `
 type: MeshHTTPRoute
 mesh: mesh-1
 name: route-1
@@ -568,10 +562,10 @@ to:
             urlRewrite:
               hostname: a23456789-a23456789-a234567890.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a23456789.a2345678.com.
 `),
-		ErrorCase("top-level MeshGateway is rejected even with an otherwise valid gateway route", validators.Violation{
-			Field:   `spec.targetRef.kind`,
-			Message: `value 'MeshGateway' is not supported`,
-		}, `
+	)
+	DescribeValidCases(
+		api.NewMeshHTTPRouteResource,
+		Entry("MeshGateway to Mesh allowed", `
 type: MeshHTTPRoute
 mesh: mesh-1
 name: route-1
@@ -595,10 +589,7 @@ to:
           - kind: MeshService
             name: backend
 `),
-		ErrorCase("top-level MeshGateway is rejected even with hostnames", validators.Violation{
-			Field:   `spec.targetRef.kind`,
-			Message: `value 'MeshGateway' is not supported`,
-		}, `
+		Entry("MeshGateway with hostnames allowed", `
 type: MeshHTTPRoute
 mesh: mesh-1
 name: route-1
@@ -620,9 +611,6 @@ to:
           - kind: MeshService
             name: backend
 `),
-	)
-	DescribeValidCases(
-		api.NewMeshHTTPRouteResource,
 		Entry("accepts valid resource", `
 type: MeshHTTPRoute
 mesh: mesh-1


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshhttproute): allow MeshGateway target

Master CI is red: the multizone `kindIpv6` e2e job fails in
`Advanced LocalityAwareness with MeshLoadBalancingStrategy with Gateway`
(`locality_aware_multizone_hybrid_gateway.go`) with `install yaml
resource unsuccessful after 30 retries`.

A same-day refactor restricted every policy's top-level
`spec.targetRef.kind` to `Mesh`/`Dataplane`, dropping `MeshGateway`
from MeshHTTPRoute's allowlist along with several selector-style kinds
that were genuinely being deprecated. A sibling PR landed ~20 minutes
later replacing the legacy `MeshGatewayRoute` fallback with a
`MeshHTTPRoute` that targets `kind: MeshGateway` at the top level —
exactly the shape that was just rejected, so every attempt to install
that resource in the e2e test fails validation and the `BeforeAll`
retries out.

## Implementation information

Top-level `targetRef.kind: MeshGateway` is not vestigial: the shared
policy matcher (`DppSelectedByPolicy` in
`pkg/plugins/policies/core/matchers/dataplane.go`) has a dedicated,
still-live case for it that resolves the referenced `MeshGateway`
resource and scopes the policy to that gateway's listeners, and a
non-validation xDS-generation unit test builds this exact shape
directly against the Go struct (bypassing API validation), proving the
runtime path is real. It was also previously covered by
`DescribeValidCases` entries ("MeshGateway to Mesh allowed" /
"MeshGateway with hostnames allowed") that the same-day refactor
turned into rejection cases.

This PR restores `common_api.MeshGateway` to MeshHTTPRoute's
`validateTop` allowlist and reverts the corresponding validation test
cases back to their previous (valid) shape. It does not touch the
other ~12 policies the refactor also updated, or revisit the
intentional removal of `MeshSubset`/`MeshService`/`MeshServiceSubset`
as top-level kinds — that broader restriction stands; only the
`MeshGateway` regression is reverted here.

## Supporting documentation