### PR TITLE
fix(kds): attribute zone-to-global synced resources by the connecting zone's client-id

### DIFF
--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -190,10 +190,14 @@ var _ = Describe("Global Sync", func() {
 			Expect(err).ToNot(HaveOccurred())
 			stopCh := make(chan struct{})
 			clientStreams := []*grpc.MockDeltaClientStream{}
-			for _, ss := range serverStreams {
+			zoneNames := []string{}
+			for i, ss := range serverStreams {
 				clientStreams = append(clientStreams, ss.ClientStream(stopCh))
+				// The authenticated client-id equals the zone name in production;
+				// it drives attribution on the global ingest path.
+				zoneNames = append(zoneNames, fmt.Sprintf(zoneName, i))
 			}
-			kds_setup.StartDeltaClient(clientStreams, []model.ResourceType{mesh.DataplaneType}, stopCh, sync_store_v2.GlobalSyncCallback(context.Background(), globalSyncer, false, nil, "kuma-system"))
+			kds_setup.StartDeltaClient(clientStreams, zoneNames, []model.ResourceType{mesh.DataplaneType}, stopCh, sync_store_v2.GlobalSyncCallback(context.Background(), globalSyncer, false, nil, "kuma-system"))
 
 			// Create Zone resources for each Kuma CP Zone
 			for i := range numOfZones {

--- a/pkg/kds/global/components_test.go
+++ b/pkg/kds/global/components_test.go
@@ -193,11 +193,11 @@ var _ = Describe("Global Sync", func() {
 			zoneNames := []string{}
 			for i, ss := range serverStreams {
 				clientStreams = append(clientStreams, ss.ClientStream(stopCh))
-				// The authenticated client-id equals the zone name in production;
+				// The client-id equals the zone name in production;
 				// it drives attribution on the global ingest path.
 				zoneNames = append(zoneNames, fmt.Sprintf(zoneName, i))
 			}
-			kds_setup.StartDeltaClient(clientStreams, zoneNames, []model.ResourceType{mesh.DataplaneType}, stopCh, sync_store_v2.GlobalSyncCallback(context.Background(), globalSyncer, false, nil, "kuma-system"))
+			kds_setup.StartDeltaClient(clientStreams, zoneNames, []model.ResourceType{mesh.DataplaneType}, stopCh, sync_store_v2.GlobalSyncCallback(context.Background(), globalSyncer, false, nil, "kuma-system", nil))
 
 			// Create Zone resources for each Kuma CP Zone
 			for i := range numOfZones {

--- a/pkg/kds/mux/zone_sync.go
+++ b/pkg/kds/mux/zone_sync.go
@@ -227,6 +227,7 @@ func (g *KDSSyncServiceServer) ZoneToGlobalSync(stream mesh_proto.KDSSyncService
 			g.k8sStore,
 			k8s.NewSimpleKubeFactory(),
 			g.systemNamespace,
+			g.metrics.KdsZoneAttributionRewrites,
 		)
 		zoneName := zone
 		cb.OnNACK = func(resourceType core_model.ResourceType) {

--- a/pkg/kds/v2/client/cross_zone_attribution_test.go
+++ b/pkg/kds/v2/client/cross_zone_attribution_test.go
@@ -1,0 +1,281 @@
+// KDS zone-to-global sync attribution guard.
+//
+// The global CP must attribute a synced resource by the authenticated
+// connection identity (the client-id from util.ClientIDFromIncomingCtx, wired
+// into the stream in pkg/kds/mux/zone_sync.go), not by values the sender
+// provides in-band. These tests drive the real global ingest wiring
+// (NewDeltaKDSStream(stream, <authenticated zone>, ...) -> GlobalSyncCallback ->
+// KDSSyncClient.Receive) with a stream whose authenticated client-id ("zone-b")
+// differs from the in-band ControlPlane.Identifier and the in-spec kuma.io/zone
+// tags ("zone-a"), and assert that all attribution resolves to the authenticated
+// client-id.
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/metadata"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	"github.com/kumahq/kuma/v3/pkg/kds"
+	client_v2 "github.com/kumahq/kuma/v3/pkg/kds/v2/client"
+	sync_store_v2 "github.com/kumahq/kuma/v3/pkg/kds/v2/store"
+	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
+	test_grpc "github.com/kumahq/kuma/v3/pkg/test/grpc"
+	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
+)
+
+const (
+	// authenticatedZone is the connection's authenticated identity (client-id),
+	// which zone_sync.go passes to NewDeltaKDSStream and which must drive
+	// attribution.
+	authenticatedZone = "zone-b"
+	// otherZone is a different, already-enrolled zone named by the sender's
+	// in-band ControlPlane.Identifier and in-spec kuma.io/zone tags.
+	otherZone = "zone-a"
+)
+
+// newGlobalSink wires the global-CP KDS zone-to-global ingest as
+// pkg/kds/mux/zone_sync.go does, feeding a memory-backed store. authClientID is
+// the authenticated zone (client-id), intentionally different from the
+// per-message ControlPlane.Identifier and in-spec tags the responses carry.
+func newGlobalSink(t *testing.T, ctx context.Context, authClientID string, typ core_model.ResourceType) (store.ResourceStore, *test_grpc.MockDeltaClientStream, func()) {
+	t.Helper()
+	g := NewWithT(t)
+
+	globalStore := memory.NewStore()
+	// Both zones exist on global, as in any federated mesh.
+	for _, z := range []string{otherZone, authenticatedZone} {
+		err := globalStore.Create(ctx,
+			&system.ZoneResource{Spec: &system_proto.Zone{Enabled: util_proto.Bool(true)}},
+			store.CreateByKey(z, core_model.NoMesh))
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
+	metrics, err := core_metrics.NewMetrics("")
+	g.Expect(err).ToNot(HaveOccurred())
+	syncer, err := sync_store_v2.NewResourceSyncer(core.Log.WithName("crosszone-syncer"), globalStore, store.NoTransactions{}, metrics, context.Background())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	clientStream := test_grpc.NewMockDeltaClientStream()
+	// authClientID is the authenticated zone that must drive attribution, not
+	// the in-band ControlPlane.Identifier.
+	kdsStream := client_v2.NewDeltaKDSStream(clientStream, authClientID, authClientID+"-instance", "", 1)
+	sink := client_v2.NewKDSSyncClient(
+		core.Log.WithName("crosszone-global-sink"),
+		[]core_model.ResourceType{typ},
+		kdsStream,
+		sync_store_v2.GlobalSyncCallback(ctx, syncer, false, nil, "kuma-system"),
+		client_v2.SyncClientConfig{},
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = sink.Receive()
+	}()
+
+	cleanup := func() {
+		close(clientStream.RecvCh)
+		_ = kdsStream.CloseSend()
+		<-done
+	}
+	return globalStore, clientStream, cleanup
+}
+
+// deltaResponse builds a KDS DeltaDiscoveryResponse carrying one resource and a
+// chosen ControlPlane.Identifier - the wire shape a zone CP sends.
+func deltaResponse(t *testing.T, typ core_model.ResourceType, controlPlaneID, name, mesh string, spec core_model.ResourceSpec) *envoy_sd.DeltaDiscoveryResponse {
+	t.Helper()
+	g := NewWithT(t)
+
+	specAny, err := core_model.ToAny(spec)
+	g.Expect(err).ToNot(HaveOccurred())
+	kr := &mesh_proto.KumaResource{
+		Meta: &mesh_proto.KumaResource_Meta{Name: name, Mesh: mesh},
+		Spec: specAny,
+	}
+	krAny, err := util_proto.MarshalAnyDeterministic(kr)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	return &envoy_sd.DeltaDiscoveryResponse{
+		TypeUrl:      string(typ),
+		Nonce:        "nonce-1",
+		ControlPlane: &envoy_core.ControlPlane{Identifier: controlPlaneID},
+		Resources: []*envoy_sd.Resource{{
+			Name:     fmt.Sprintf("%s.%s", name, mesh),
+			Version:  "v1",
+			Resource: krAny,
+		}},
+	}
+}
+
+// dataplaneWithDivergentZoneTags returns a Dataplane whose inbound kuma.io/zone
+// tag names a zone different from the connection's authenticated zone. That tag
+// feeds the global service inventory via createOrUpdateServiceInsight for
+// non-Exclusive meshes, so global ingest must resolve it to the authenticated
+// zone.
+func dataplaneWithDivergentZoneTags() *mesh_proto.Dataplane {
+	return &mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Address: "192.168.0.1",
+			Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
+				Port: 1212,
+				Tags: map[string]string{
+					mesh_proto.ZoneTag:    otherZone,
+					mesh_proto.ServiceTag: "svc-a",
+				},
+			}},
+			Outbound: []*mesh_proto.Dataplane_Networking_Outbound{{
+				Port: 10000,
+				Tags: map[string]string{
+					mesh_proto.ServiceTag:  "web",
+					mesh_proto.ProtocolTag: "http",
+				},
+			}},
+		},
+	}
+}
+
+// gatewayDataplaneWithDivergentZoneTag returns a gateway Dataplane whose gateway
+// kuma.io/zone tag names a zone different from the connection's authenticated
+// zone.
+func gatewayDataplaneWithDivergentZoneTag() *mesh_proto.Dataplane {
+	return &mesh_proto.Dataplane{
+		Networking: &mesh_proto.Dataplane_Networking{
+			Address: "192.168.0.2",
+			Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+				Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
+				Tags: map[string]string{
+					mesh_proto.ZoneTag:    otherZone,
+					mesh_proto.ServiceTag: "gateway-a",
+				},
+			},
+		},
+	}
+}
+
+// zoneIngressWithDivergentZoneTags returns a ZoneIngress whose AvailableServices
+// carry a kuma.io/zone tag naming a zone different from the connection's
+// authenticated zone. That tag drives cross-zone endpoint locality in
+// fillIngressOutbounds, so global ingest must resolve it to the authenticated
+// zone.
+func zoneIngressWithDivergentZoneTags() *mesh_proto.ZoneIngress {
+	return &mesh_proto.ZoneIngress{
+		Zone: authenticatedZone,
+		Networking: &mesh_proto.ZoneIngress_Networking{
+			Address: "10.0.0.1",
+			Port:    10001,
+		},
+		AvailableServices: []*mesh_proto.ZoneIngress_AvailableService{{
+			Tags: map[string]string{
+				mesh_proto.ServiceTag: "svc-a",
+				mesh_proto.ZoneTag:    otherZone,
+			},
+		}},
+	}
+}
+
+// hashSuffixCtx advertises the hash-suffix feature, as every currently
+// supported zone does, so the modern (non-prefixing) global ingest path runs.
+func hashSuffixCtx() context.Context {
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(kds.FeaturesMetadataKey, kds.FeatureHashSuffix))
+}
+
+func storedDataplane(t *testing.T, s store.ResourceStore, ctx context.Context) *core_mesh.DataplaneResource {
+	t.Helper()
+	g := NewWithT(t)
+	var stored *core_mesh.DataplaneResource
+	g.Eventually(func(g Gomega) {
+		list := core_mesh.DataplaneResourceList{}
+		g.Expect(s.List(ctx, &list)).To(Succeed())
+		g.Expect(list.Items).To(HaveLen(1))
+		stored = list.Items[0]
+	}, "5s", "50ms").Should(Succeed())
+	return stored
+}
+
+func storedZoneIngress(t *testing.T, s store.ResourceStore, ctx context.Context) *core_mesh.ZoneIngressResource {
+	t.Helper()
+	g := NewWithT(t)
+	var stored *core_mesh.ZoneIngressResource
+	g.Eventually(func(g Gomega) {
+		list := core_mesh.ZoneIngressResourceList{}
+		g.Expect(s.List(ctx, &list)).To(Succeed())
+		g.Expect(list.Items).To(HaveLen(1))
+		stored = list.Items[0]
+	}, "5s", "50ms").Should(Succeed())
+	return stored
+}
+
+// TestZoneToGlobalSyncAttribution asserts that every zone attribution the global
+// CP derives from a synced resource follows the authenticated client-id, not the
+// sender-provided in-band values. It covers the top-level metadata (kuma.io/zone
+// label, ZoneIngress.Spec.Zone) and the zone tags carried inside the specs
+// (ZoneIngress AvailableServices; Dataplane inbound/gateway), which are consumed
+// downstream for endpoint locality and the global service inventory. The stream
+// authenticates as authenticatedZone while the payload names otherZone
+// throughout; all of it must resolve to authenticatedZone.
+func TestZoneToGlobalSyncAttribution(t *testing.T) {
+	t.Run("Dataplane", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := hashSuffixCtx()
+		globalStore, clientStream, cleanup := newGlobalSink(t, ctx, authenticatedZone, core_mesh.DataplaneType)
+		defer cleanup()
+
+		clientStream.RecvCh <- deltaResponse(t, core_mesh.DataplaneType, otherZone, "dp-1", "default", dataplaneWithDivergentZoneTags())
+
+		stored := storedDataplane(t, globalStore, ctx)
+		zone := stored.GetMeta().GetLabels()[mesh_proto.ZoneTag]
+		g.Expect(zone).To(Equal(authenticatedZone),
+			"kuma.io/zone label must be the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, zone)
+
+		inboundZone := stored.Spec.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]
+		g.Expect(inboundZone).To(Equal(authenticatedZone),
+			"Dataplane inbound kuma.io/zone tag must resolve to the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, inboundZone)
+	})
+
+	t.Run("DataplaneGateway", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := hashSuffixCtx()
+		globalStore, clientStream, cleanup := newGlobalSink(t, ctx, authenticatedZone, core_mesh.DataplaneType)
+		defer cleanup()
+
+		clientStream.RecvCh <- deltaResponse(t, core_mesh.DataplaneType, otherZone, "gw-dp-1", "default", gatewayDataplaneWithDivergentZoneTag())
+
+		stored := storedDataplane(t, globalStore, ctx)
+		gatewayZone := stored.Spec.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
+		g.Expect(gatewayZone).To(Equal(authenticatedZone),
+			"Dataplane gateway kuma.io/zone tag must resolve to the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, gatewayZone)
+	})
+
+	t.Run("ZoneIngress", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := hashSuffixCtx()
+		globalStore, clientStream, cleanup := newGlobalSink(t, ctx, authenticatedZone, core_mesh.ZoneIngressType)
+		defer cleanup()
+
+		clientStream.RecvCh <- deltaResponse(t, core_mesh.ZoneIngressType, otherZone, "zi-1", "", zoneIngressWithDivergentZoneTags())
+
+		stored := storedZoneIngress(t, globalStore, ctx)
+		g.Expect(stored.Spec.GetZone()).To(Equal(authenticatedZone),
+			"ZoneIngress.Spec.Zone must be the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, stored.Spec.GetZone())
+		g.Expect(stored.GetMeta().GetLabels()[mesh_proto.ZoneTag]).To(Equal(authenticatedZone))
+
+		svcZone := stored.Spec.GetAvailableServices()[0].GetTags()[mesh_proto.ZoneTag]
+		g.Expect(svcZone).To(Equal(authenticatedZone),
+			"ZoneIngress AvailableServices kuma.io/zone tag must resolve to the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, svcZone)
+	})
+}

--- a/pkg/kds/v2/client/cross_zone_attribution_test.go
+++ b/pkg/kds/v2/client/cross_zone_attribution_test.go
@@ -1,14 +1,8 @@
-// KDS zone-to-global sync attribution guard.
-//
-// The global CP must attribute a synced resource by the authenticated
-// connection identity (the client-id from util.ClientIDFromIncomingCtx, wired
-// into the stream in pkg/kds/mux/zone_sync.go), not by values the sender
-// provides in-band. These tests drive the real global ingest wiring
-// (NewDeltaKDSStream(stream, <authenticated zone>, ...) -> GlobalSyncCallback ->
-// KDSSyncClient.Receive) with a stream whose authenticated client-id ("zone-b")
-// differs from the in-band ControlPlane.Identifier and the in-spec kuma.io/zone
-// tags ("zone-a"), and assert that all attribution resolves to the authenticated
-// client-id.
+// Tests that the global CP attributes KDS zone-to-global synced resources by the
+// connecting peer's declared client-id, not by sender-provided in-band values.
+// Each case drives the real global ingest with a client-id ("zone-b") that
+// differs from the payload's zone ("zone-a"), and asserts everything resolves to
+// the connecting zone.
 package client_test
 
 import (
@@ -19,6 +13,8 @@ import (
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"google.golang.org/grpc/metadata"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
@@ -38,26 +34,21 @@ import (
 )
 
 const (
-	// authenticatedZone is the connection's authenticated identity (client-id),
-	// which zone_sync.go passes to NewDeltaKDSStream and which must drive
-	// attribution.
-	authenticatedZone = "zone-b"
-	// otherZone is a different, already-enrolled zone named by the sender's
-	// in-band ControlPlane.Identifier and in-spec kuma.io/zone tags.
+	// connectingZone is the client-id the connection presents.
+	connectingZone = "zone-b"
+	// otherZone is the differing zone the sender names in-band.
 	otherZone = "zone-a"
 )
 
-// newGlobalSink wires the global-CP KDS zone-to-global ingest as
-// pkg/kds/mux/zone_sync.go does, feeding a memory-backed store. authClientID is
-// the authenticated zone (client-id), intentionally different from the
-// per-message ControlPlane.Identifier and in-spec tags the responses carry.
-func newGlobalSink(t *testing.T, ctx context.Context, authClientID string, typ core_model.ResourceType) (store.ResourceStore, *test_grpc.MockDeltaClientStream, func()) {
+// newGlobalSink wires the global-CP KDS ingest as pkg/kds/mux/zone_sync.go does,
+// over a memory store; the connecting peer's client-id is connectingZone.
+func newGlobalSink(t *testing.T, ctx context.Context, typ core_model.ResourceType) (store.ResourceStore, *test_grpc.MockDeltaClientStream, *prometheus.CounterVec, func()) {
 	t.Helper()
 	g := NewWithT(t)
 
 	globalStore := memory.NewStore()
 	// Both zones exist on global, as in any federated mesh.
-	for _, z := range []string{otherZone, authenticatedZone} {
+	for _, z := range []string{otherZone, connectingZone} {
 		err := globalStore.Create(ctx,
 			&system.ZoneResource{Spec: &system_proto.Zone{Enabled: util_proto.Bool(true)}},
 			store.CreateByKey(z, core_model.NoMesh))
@@ -69,15 +60,20 @@ func newGlobalSink(t *testing.T, ctx context.Context, authClientID string, typ c
 	syncer, err := sync_store_v2.NewResourceSyncer(core.Log.WithName("crosszone-syncer"), globalStore, store.NoTransactions{}, metrics, context.Background())
 	g.Expect(err).ToNot(HaveOccurred())
 
+	// Counts resources whose zone attribution the global ingest rewrote because
+	// a sender-provided value differed from the connecting zone.
+	rewrites := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "test_kds_zone_attribution_rewrites_total",
+	}, []string{"resource_type"})
+
 	clientStream := test_grpc.NewMockDeltaClientStream()
-	// authClientID is the authenticated zone that must drive attribution, not
-	// the in-band ControlPlane.Identifier.
-	kdsStream := client_v2.NewDeltaKDSStream(clientStream, authClientID, authClientID+"-instance", "", 1)
+	// The client-id drives attribution, not the in-band ControlPlane.Identifier.
+	kdsStream := client_v2.NewDeltaKDSStream(clientStream, connectingZone, connectingZone+"-instance", "", 1)
 	sink := client_v2.NewKDSSyncClient(
 		core.Log.WithName("crosszone-global-sink"),
 		[]core_model.ResourceType{typ},
 		kdsStream,
-		sync_store_v2.GlobalSyncCallback(ctx, syncer, false, nil, "kuma-system"),
+		sync_store_v2.GlobalSyncCallback(ctx, syncer, false, nil, "kuma-system", rewrites),
 		client_v2.SyncClientConfig{},
 	)
 
@@ -92,11 +88,10 @@ func newGlobalSink(t *testing.T, ctx context.Context, authClientID string, typ c
 		_ = kdsStream.CloseSend()
 		<-done
 	}
-	return globalStore, clientStream, cleanup
+	return globalStore, clientStream, rewrites, cleanup
 }
 
-// deltaResponse builds a KDS DeltaDiscoveryResponse carrying one resource and a
-// chosen ControlPlane.Identifier - the wire shape a zone CP sends.
+// deltaResponse builds the one-resource DeltaDiscoveryResponse a zone CP would send.
 func deltaResponse(t *testing.T, typ core_model.ResourceType, controlPlaneID, name, mesh string, spec core_model.ResourceSpec) *envoy_sd.DeltaDiscoveryResponse {
 	t.Helper()
 	g := NewWithT(t)
@@ -122,19 +117,15 @@ func deltaResponse(t *testing.T, typ core_model.ResourceType, controlPlaneID, na
 	}
 }
 
-// dataplaneWithDivergentZoneTags returns a Dataplane whose inbound kuma.io/zone
-// tag names a zone different from the connection's authenticated zone. That tag
-// feeds the global service inventory via createOrUpdateServiceInsight for
-// non-Exclusive meshes, so global ingest must resolve it to the authenticated
-// zone.
-func dataplaneWithDivergentZoneTags() *mesh_proto.Dataplane {
+// dataplaneWithZoneTag returns a Dataplane whose inbound carries the given kuma.io/zone tag.
+func dataplaneWithZoneTag(zone string) *mesh_proto.Dataplane {
 	return &mesh_proto.Dataplane{
 		Networking: &mesh_proto.Dataplane_Networking{
 			Address: "192.168.0.1",
 			Inbound: []*mesh_proto.Dataplane_Networking_Inbound{{
 				Port: 1212,
 				Tags: map[string]string{
-					mesh_proto.ZoneTag:    otherZone,
+					mesh_proto.ZoneTag:    zone,
 					mesh_proto.ServiceTag: "svc-a",
 				},
 			}},
@@ -149,9 +140,10 @@ func dataplaneWithDivergentZoneTags() *mesh_proto.Dataplane {
 	}
 }
 
-// gatewayDataplaneWithDivergentZoneTag returns a gateway Dataplane whose gateway
-// kuma.io/zone tag names a zone different from the connection's authenticated
-// zone.
+func dataplaneWithDivergentZoneTags() *mesh_proto.Dataplane {
+	return dataplaneWithZoneTag(otherZone)
+}
+
 func gatewayDataplaneWithDivergentZoneTag() *mesh_proto.Dataplane {
 	return &mesh_proto.Dataplane{
 		Networking: &mesh_proto.Dataplane_Networking{
@@ -167,14 +159,9 @@ func gatewayDataplaneWithDivergentZoneTag() *mesh_proto.Dataplane {
 	}
 }
 
-// zoneIngressWithDivergentZoneTags returns a ZoneIngress whose AvailableServices
-// carry a kuma.io/zone tag naming a zone different from the connection's
-// authenticated zone. That tag drives cross-zone endpoint locality in
-// fillIngressOutbounds, so global ingest must resolve it to the authenticated
-// zone.
 func zoneIngressWithDivergentZoneTags() *mesh_proto.ZoneIngress {
 	return &mesh_proto.ZoneIngress{
-		Zone: authenticatedZone,
+		Zone: otherZone,
 		Networking: &mesh_proto.ZoneIngress_Networking{
 			Address: "10.0.0.1",
 			Port:    10001,
@@ -220,62 +207,82 @@ func storedZoneIngress(t *testing.T, s store.ResourceStore, ctx context.Context)
 	return stored
 }
 
-// TestZoneToGlobalSyncAttribution asserts that every zone attribution the global
-// CP derives from a synced resource follows the authenticated client-id, not the
-// sender-provided in-band values. It covers the top-level metadata (kuma.io/zone
-// label, ZoneIngress.Spec.Zone) and the zone tags carried inside the specs
-// (ZoneIngress AvailableServices; Dataplane inbound/gateway), which are consumed
-// downstream for endpoint locality and the global service inventory. The stream
-// authenticates as authenticatedZone while the payload names otherZone
-// throughout; all of it must resolve to authenticatedZone.
+// TestZoneToGlobalSyncAttribution asserts the top-level attribution (kuma.io/zone
+// label, ZoneIngress.Spec.Zone) and the in-spec zone tags (ZoneIngress
+// AvailableServices, Dataplane inbound/gateway) all resolve to the connecting
+// zone's client-id, and that a matching zone is a no-op.
 func TestZoneToGlobalSyncAttribution(t *testing.T) {
 	t.Run("Dataplane", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := hashSuffixCtx()
-		globalStore, clientStream, cleanup := newGlobalSink(t, ctx, authenticatedZone, core_mesh.DataplaneType)
+		globalStore, clientStream, rewrites, cleanup := newGlobalSink(t, ctx, core_mesh.DataplaneType)
 		defer cleanup()
 
 		clientStream.RecvCh <- deltaResponse(t, core_mesh.DataplaneType, otherZone, "dp-1", "default", dataplaneWithDivergentZoneTags())
 
 		stored := storedDataplane(t, globalStore, ctx)
 		zone := stored.GetMeta().GetLabels()[mesh_proto.ZoneTag]
-		g.Expect(zone).To(Equal(authenticatedZone),
-			"kuma.io/zone label must be the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, zone)
+		g.Expect(zone).To(Equal(connectingZone),
+			"kuma.io/zone label must be the connecting zone's client-id %q, not the sender-provided zone %q", connectingZone, zone)
 
 		inboundZone := stored.Spec.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]
-		g.Expect(inboundZone).To(Equal(authenticatedZone),
-			"Dataplane inbound kuma.io/zone tag must resolve to the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, inboundZone)
+		g.Expect(inboundZone).To(Equal(connectingZone),
+			"Dataplane inbound kuma.io/zone tag must resolve to the connecting zone's client-id %q, not the sender-provided zone %q", connectingZone, inboundZone)
+
+		g.Expect(testutil.ToFloat64(rewrites.WithLabelValues(string(core_mesh.DataplaneType)))).To(Equal(1.0),
+			"the rewrite must be counted once for the diverging Dataplane")
 	})
 
 	t.Run("DataplaneGateway", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := hashSuffixCtx()
-		globalStore, clientStream, cleanup := newGlobalSink(t, ctx, authenticatedZone, core_mesh.DataplaneType)
+		globalStore, clientStream, rewrites, cleanup := newGlobalSink(t, ctx, core_mesh.DataplaneType)
 		defer cleanup()
 
 		clientStream.RecvCh <- deltaResponse(t, core_mesh.DataplaneType, otherZone, "gw-dp-1", "default", gatewayDataplaneWithDivergentZoneTag())
 
 		stored := storedDataplane(t, globalStore, ctx)
 		gatewayZone := stored.Spec.GetNetworking().GetGateway().GetTags()[mesh_proto.ZoneTag]
-		g.Expect(gatewayZone).To(Equal(authenticatedZone),
-			"Dataplane gateway kuma.io/zone tag must resolve to the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, gatewayZone)
+		g.Expect(gatewayZone).To(Equal(connectingZone),
+			"Dataplane gateway kuma.io/zone tag must resolve to the connecting zone's client-id %q, not the sender-provided zone %q", connectingZone, gatewayZone)
+
+		g.Expect(testutil.ToFloat64(rewrites.WithLabelValues(string(core_mesh.DataplaneType)))).To(Equal(1.0))
 	})
 
 	t.Run("ZoneIngress", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := hashSuffixCtx()
-		globalStore, clientStream, cleanup := newGlobalSink(t, ctx, authenticatedZone, core_mesh.ZoneIngressType)
+		globalStore, clientStream, rewrites, cleanup := newGlobalSink(t, ctx, core_mesh.ZoneIngressType)
 		defer cleanup()
 
 		clientStream.RecvCh <- deltaResponse(t, core_mesh.ZoneIngressType, otherZone, "zi-1", "", zoneIngressWithDivergentZoneTags())
 
 		stored := storedZoneIngress(t, globalStore, ctx)
-		g.Expect(stored.Spec.GetZone()).To(Equal(authenticatedZone),
-			"ZoneIngress.Spec.Zone must be the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, stored.Spec.GetZone())
-		g.Expect(stored.GetMeta().GetLabels()[mesh_proto.ZoneTag]).To(Equal(authenticatedZone))
+		g.Expect(stored.Spec.GetZone()).To(Equal(connectingZone),
+			"ZoneIngress.Spec.Zone must be the connecting zone's client-id %q, not the sender-provided zone %q", connectingZone, stored.Spec.GetZone())
+		g.Expect(stored.GetMeta().GetLabels()[mesh_proto.ZoneTag]).To(Equal(connectingZone))
 
 		svcZone := stored.Spec.GetAvailableServices()[0].GetTags()[mesh_proto.ZoneTag]
-		g.Expect(svcZone).To(Equal(authenticatedZone),
-			"ZoneIngress AvailableServices kuma.io/zone tag must resolve to the authenticated client-id %q, not the sender-provided zone %q", authenticatedZone, svcZone)
+		g.Expect(svcZone).To(Equal(connectingZone),
+			"ZoneIngress AvailableServices kuma.io/zone tag must resolve to the connecting zone's client-id %q, not the sender-provided zone %q", connectingZone, svcZone)
+
+		g.Expect(testutil.ToFloat64(rewrites.WithLabelValues(string(core_mesh.ZoneIngressType)))).To(Equal(1.0))
+	})
+
+	// When the sender's values already match the connecting zone (ordinary
+	// sync), nothing is rewritten and the counter stays at zero.
+	t.Run("MatchingZoneIsNoOp", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := hashSuffixCtx()
+		globalStore, clientStream, rewrites, cleanup := newGlobalSink(t, ctx, core_mesh.DataplaneType)
+		defer cleanup()
+
+		clientStream.RecvCh <- deltaResponse(t, core_mesh.DataplaneType, connectingZone, "dp-ok", "default", dataplaneWithZoneTag(connectingZone))
+
+		stored := storedDataplane(t, globalStore, ctx)
+		g.Expect(stored.Spec.GetNetworking().GetInbound()[0].GetTags()[mesh_proto.ZoneTag]).To(Equal(connectingZone))
+		g.Consistently(func() float64 {
+			return testutil.ToFloat64(rewrites.WithLabelValues(string(core_mesh.DataplaneType)))
+		}, "1s", "100ms").Should(Equal(0.0), "no rewrite must be counted when values already match")
 	})
 }

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -229,12 +229,12 @@ func (s *stream) Receive() (UpstreamResponse, error) {
 		nameToVersion: nameToVersion,
 	}
 	return UpstreamResponse{
-		// Attribute the batch to the authenticated peer (s.clientID), not the
-		// in-band ControlPlane.Identifier the sender provides. On the global
-		// ingest path s.clientID is the zone from util.ClientIDFromIncomingCtx
-		// (see pkg/kds/mux/zone_sync.go); in legitimate zone-to-global sync it
-		// already equals the sender's identifier, so relying on it keeps
-		// attribution consistent with the authenticated zone.
+		// Attribute the batch to the connecting peer's declared client-id
+		// (s.clientID), not the ControlPlane.Identifier in the payload. The
+		// client-id is request metadata the peer declares; verifying it per
+		// connection is the (enterprise) zone-token filter's job, not this
+		// path's. The two match in ordinary sync, so this only changes behavior
+		// when they diverge.
 		ControlPlaneId:      s.clientID,
 		Nonce:               resp.GetNonce(),
 		Type:                rs.GetItemType(),

--- a/pkg/kds/v2/client/stream.go
+++ b/pkg/kds/v2/client/stream.go
@@ -229,7 +229,13 @@ func (s *stream) Receive() (UpstreamResponse, error) {
 		nameToVersion: nameToVersion,
 	}
 	return UpstreamResponse{
-		ControlPlaneId:      resp.GetControlPlane().GetIdentifier(),
+		// Attribute the batch to the authenticated peer (s.clientID), not the
+		// in-band ControlPlane.Identifier the sender provides. On the global
+		// ingest path s.clientID is the zone from util.ClientIDFromIncomingCtx
+		// (see pkg/kds/mux/zone_sync.go); in legitimate zone-to-global sync it
+		// already equals the sender's identifier, so relying on it keeps
+		// attribution consistent with the authenticated zone.
+		ControlPlaneId:      s.clientID,
 		Nonce:               resp.GetNonce(),
 		Type:                rs.GetItemType(),
 		AddedResources:      rs,

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -417,7 +417,7 @@ var _ = Describe("KDSSyncClient logging", func() {
 				"addedResourcesCount",
 				"removedResourcesCount",
 			},
-			// ControlPlaneId now reflects the authenticated client-id ("zone-1"),
+			// ControlPlaneId now reflects the connecting peer's client-id ("zone-1"),
 			// not the in-band "cp-1"; it must not leak into summary logs.
 			[]string{
 				"zone-1",

--- a/pkg/kds/v2/client/zone_sync_test.go
+++ b/pkg/kds/v2/client/zone_sync_test.go
@@ -417,15 +417,17 @@ var _ = Describe("KDSSyncClient logging", func() {
 				"addedResourcesCount",
 				"removedResourcesCount",
 			},
+			// ControlPlaneId now reflects the authenticated client-id ("zone-1"),
+			// not the in-band "cp-1"; it must not leak into summary logs.
 			[]string{
-				"cp-1",
+				"zone-1",
 			},
 		),
 		Entry("full payload logging when enabled",
 			true,
 			[]string{
 				"DeltaDiscoveryResponse received",
-				"cp-1",
+				"zone-1",
 				"nonce-1",
 			},
 			[]string{

--- a/pkg/kds/v2/server/metrics.go
+++ b/pkg/kds/v2/server/metrics.go
@@ -14,10 +14,11 @@ const (
 )
 
 type Metrics struct {
-	KdsGenerations           *prometheus.HistogramVec
-	KdsGenerationErrors      prometheus.Counter
-	KdsZoneActiveConnections *prometheus.GaugeVec
-	KdsNackTotal             *prometheus.CounterVec
+	KdsGenerations             *prometheus.HistogramVec
+	KdsGenerationErrors        prometheus.Counter
+	KdsZoneActiveConnections   *prometheus.GaugeVec
+	KdsNackTotal               *prometheus.CounterVec
+	KdsZoneAttributionRewrites *prometheus.CounterVec
 }
 
 func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
@@ -41,14 +42,20 @@ func NewMetrics(metrics core_metrics.Metrics) (*Metrics, error) {
 		Help: "Total KDS NACKs sent by zone and resource type.",
 	}, []string{"zone_name", "resource_type"})
 
-	if err := metrics.BulkRegister(kdsGenerations, kdsGenerationsErrors, kdsZoneActiveConnections, kdsNackTotal); err != nil {
+	kdsZoneAttributionRewrites := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kds_zone_attribution_rewrites_total",
+		Help: "Total zone-to-global synced resources whose zone attribution was rewritten to the connecting zone's client-id because a sender-provided value differed, by resource type.",
+	}, []string{"resource_type"})
+
+	if err := metrics.BulkRegister(kdsGenerations, kdsGenerationsErrors, kdsZoneActiveConnections, kdsNackTotal, kdsZoneAttributionRewrites); err != nil {
 		return nil, err
 	}
 
 	return &Metrics{
-		KdsGenerations:           kdsGenerations,
-		KdsGenerationErrors:      kdsGenerationsErrors,
-		KdsZoneActiveConnections: kdsZoneActiveConnections,
-		KdsNackTotal:             kdsNackTotal,
+		KdsGenerations:             kdsGenerations,
+		KdsGenerationErrors:        kdsGenerationsErrors,
+		KdsZoneActiveConnections:   kdsZoneActiveConnections,
+		KdsNackTotal:               kdsNackTotal,
+		KdsZoneAttributionRewrites: kdsZoneAttributionRewrites,
 	}, nil
 }

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -30,6 +30,8 @@ import (
 	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
 )
 
+var globalSyncLog = core.Log.WithName("kds-global-sync")
+
 // ResourceSyncer allows to synchronize resources in Store
 type ResourceSyncer interface {
 	// Sync method takes 'upstream' as a basis and synchronize underlying store.
@@ -358,6 +360,7 @@ func GlobalSyncCallback(
 	k8sStore bool,
 	kubeFactory resources_k8s.KubeFactory,
 	systemNamespace string,
+	rewrites *prometheus.CounterVec,
 ) *client_v2.Callbacks {
 	supportsHashSuffixes := kds.ContextHasFeature(ctx, kds.FeatureHashSuffix)
 
@@ -383,32 +386,36 @@ func GlobalSyncCallback(
 				}
 			}
 
-			// Resolve zone attribution to the authenticated zone
-			// (upstream.ControlPlaneId). Besides the top-level Spec.Zone, zone
-			// tags carried inside the specs are consumed downstream - the tag in
-			// ZoneIngress AvailableServices drives cross-zone endpoint locality
-			// (fillIngressOutbounds) and Dataplane inbound/gateway tags feed the
-			// global service inventory (createOrUpdateServiceInsight) - so these
-			// must stay consistent with the authenticated zone too.
+			// In-spec zone tags feed downstream logic too (ZoneIngress
+			// AvailableServices -> cross-zone endpoint locality, Dataplane
+			// inbound/gateway tags -> global service inventory), so pin them
+			// alongside the top-level Spec.Zone.
+			clientID := upstream.ControlPlaneId
 			switch upstream.Type {
 			case core_mesh.ZoneIngressType:
 				for _, zi := range upstream.AddedResources.(*core_mesh.ZoneIngressResourceList).Items {
-					zi.Spec.Zone = upstream.ControlPlaneId
+					var rejected []string
+					rejected = pinZone(&zi.Spec.Zone, clientID, rejected)
 					for _, svc := range zi.Spec.GetAvailableServices() {
-						pinZoneTag(svc.GetTags(), upstream.ControlPlaneId)
+						rejected = pinZoneTag(svc.GetTags(), clientID, rejected)
 					}
+					recordZoneRewrite(rewrites, upstream.Type, zi.GetMeta(), clientID, rejected)
 				}
 			case core_mesh.ZoneEgressType:
 				for _, ze := range upstream.AddedResources.(*core_mesh.ZoneEgressResourceList).Items {
-					ze.Spec.Zone = upstream.ControlPlaneId
+					var rejected []string
+					rejected = pinZone(&ze.Spec.Zone, clientID, rejected)
+					recordZoneRewrite(rewrites, upstream.Type, ze.GetMeta(), clientID, rejected)
 				}
 			case core_mesh.DataplaneType:
 				for _, dp := range upstream.AddedResources.(*core_mesh.DataplaneResourceList).Items {
+					var rejected []string
 					networking := dp.Spec.GetNetworking()
 					for _, inbound := range networking.GetInbound() {
-						pinZoneTag(inbound.GetTags(), upstream.ControlPlaneId)
+						rejected = pinZoneTag(inbound.GetTags(), clientID, rejected)
 					}
-					pinZoneTag(networking.GetGateway().GetTags(), upstream.ControlPlaneId)
+					rejected = pinZoneTag(networking.GetGateway().GetTags(), clientID, rejected)
+					recordZoneRewrite(rewrites, upstream.Type, dp.GetMeta(), clientID, rejected)
 				}
 			}
 
@@ -427,15 +434,47 @@ func GlobalSyncCallback(
 	}
 }
 
-// pinZoneTag rewrites a kuma.io/zone tag to the authenticated zone. It only
-// touches tags that already carry the key, so resources that legitimately omit
-// it are left unchanged - an absent tag names no zone, so there is nothing to
-// reconcile. tags may be nil (e.g. a resource with no gateway); reads on a nil
-// map are safe and the write never runs.
-func pinZoneTag(tags map[string]string, zone string) {
-	if _, ok := tags[mesh_proto.ZoneTag]; ok {
+// pinZone sets *field to zone, recording in rejected any differing value it replaces.
+func pinZone(field *string, zone string, rejected []string) []string {
+	if *field != "" && *field != zone {
+		rejected = append(rejected, *field)
+	}
+	*field = zone
+	return rejected
+}
+
+// pinZoneTag pins an existing kuma.io/zone tag to zone (an absent tag names no
+// zone, so it is left alone), recording any differing value in rejected. A nil
+// map is fine: the read misses and the write never runs.
+func pinZoneTag(tags map[string]string, zone string, rejected []string) []string {
+	if v, ok := tags[mesh_proto.ZoneTag]; ok {
+		if v != "" && v != zone {
+			rejected = append(rejected, v)
+		}
 		tags[mesh_proto.ZoneTag] = zone
 	}
+	return rejected
+}
+
+// recordZoneRewrite reports an attribution rewrite only when it replaced a
+// differing value (in ordinary sync rejected is empty and nothing is recorded).
+// The counter is deliberately labeled only by resource type to stay
+// low-cardinality; the unbounded detail goes to the log line.
+func recordZoneRewrite(rewrites *prometheus.CounterVec, resType core_model.ResourceType, meta core_model.ResourceMeta, clientID string, rejected []string) {
+	if len(rejected) == 0 {
+		return
+	}
+	if rewrites != nil {
+		rewrites.WithLabelValues(string(resType)).Inc()
+	}
+	globalSyncLog.Info(
+		"[WARNING] rewrote synced resource zone attribution to the connecting zone's client-id because a payload value differed",
+		"type", string(resType),
+		"name", meta.GetName(),
+		"mesh", meta.GetMesh(),
+		"clientID", clientID,
+		"replacedValues", rejected,
+	)
 }
 
 func addNamespaceSuffix(kubeFactory resources_k8s.KubeFactory, upstream client_v2.UpstreamResponse, ns string) error {

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -383,14 +383,32 @@ func GlobalSyncCallback(
 				}
 			}
 
+			// Resolve zone attribution to the authenticated zone
+			// (upstream.ControlPlaneId). Besides the top-level Spec.Zone, zone
+			// tags carried inside the specs are consumed downstream - the tag in
+			// ZoneIngress AvailableServices drives cross-zone endpoint locality
+			// (fillIngressOutbounds) and Dataplane inbound/gateway tags feed the
+			// global service inventory (createOrUpdateServiceInsight) - so these
+			// must stay consistent with the authenticated zone too.
 			switch upstream.Type {
 			case core_mesh.ZoneIngressType:
 				for _, zi := range upstream.AddedResources.(*core_mesh.ZoneIngressResourceList).Items {
 					zi.Spec.Zone = upstream.ControlPlaneId
+					for _, svc := range zi.Spec.GetAvailableServices() {
+						pinZoneTag(svc.GetTags(), upstream.ControlPlaneId)
+					}
 				}
 			case core_mesh.ZoneEgressType:
 				for _, ze := range upstream.AddedResources.(*core_mesh.ZoneEgressResourceList).Items {
 					ze.Spec.Zone = upstream.ControlPlaneId
+				}
+			case core_mesh.DataplaneType:
+				for _, dp := range upstream.AddedResources.(*core_mesh.DataplaneResourceList).Items {
+					networking := dp.Spec.GetNetworking()
+					for _, inbound := range networking.GetInbound() {
+						pinZoneTag(inbound.GetTags(), upstream.ControlPlaneId)
+					}
+					pinZoneTag(networking.GetGateway().GetTags(), upstream.ControlPlaneId)
 				}
 			}
 
@@ -406,6 +424,17 @@ func GlobalSyncCallback(
 				return hasOldStylePrefix || hasZoneLabel
 			}), Zone(upstream.ControlPlaneId))
 		},
+	}
+}
+
+// pinZoneTag rewrites a kuma.io/zone tag to the authenticated zone. It only
+// touches tags that already carry the key, so resources that legitimately omit
+// it are left unchanged - an absent tag names no zone, so there is nothing to
+// reconcile. tags may be nil (e.g. a resource with no gateway); reads on a nil
+// map are safe and the write never runs.
+func pinZoneTag(tags map[string]string, zone string) {
+	if _, ok := tags[mesh_proto.ZoneTag]; ok {
+		tags[mesh_proto.ZoneTag] = zone
 	}
 }
 

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -10,16 +10,11 @@ import (
 )
 
 // StartDeltaClient starts a KDS sync client per stream. clientIDs[i] is the
-// authenticated peer identity for clientStreams[i]; in production this is the
-// zone name from util.ClientIDFromIncomingCtx and it drives resource
-// attribution on the global ingest path. If clientIDs is shorter than
-// clientStreams the remaining streams fall back to "client-<i>".
+// client-id for clientStreams[i] (the zone name in production, which drives
+// attribution) and must be provided for every stream.
 func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, clientIDs []string, resourceTypes []model.ResourceType, stopCh chan struct{}, cb *kds_client_v2.Callbacks) {
 	for i := range clientStreams {
-		clientID := fmt.Sprintf("client-%d", i)
-		if i < len(clientIDs) {
-			clientID = clientIDs[i]
-		}
+		clientID := clientIDs[i]
 		item := clientStreams[i]
 		kdsStream := kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes))
 		comp := kds_client_v2.NewKDSSyncClient(

--- a/pkg/test/kds/setup/client.go
+++ b/pkg/test/kds/setup/client.go
@@ -9,9 +9,17 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/test/grpc"
 )
 
-func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, resourceTypes []model.ResourceType, stopCh chan struct{}, cb *kds_client_v2.Callbacks) {
+// StartDeltaClient starts a KDS sync client per stream. clientIDs[i] is the
+// authenticated peer identity for clientStreams[i]; in production this is the
+// zone name from util.ClientIDFromIncomingCtx and it drives resource
+// attribution on the global ingest path. If clientIDs is shorter than
+// clientStreams the remaining streams fall back to "client-<i>".
+func StartDeltaClient(clientStreams []*grpc.MockDeltaClientStream, clientIDs []string, resourceTypes []model.ResourceType, stopCh chan struct{}, cb *kds_client_v2.Callbacks) {
 	for i := range clientStreams {
 		clientID := fmt.Sprintf("client-%d", i)
+		if i < len(clientIDs) {
+			clientID = clientIDs[i]
+		}
 		item := clientStreams[i]
 		kdsStream := kds_client_v2.NewDeltaKDSStream(item, clientID, fmt.Sprintf("cp-%d", i), "", len(resourceTypes))
 		comp := kds_client_v2.NewKDSSyncClient(


### PR DESCRIPTION
## Motivation

On the global control plane, KDS zone-to-global sync derives a synced resource's zone attribution from values the sending zone provides in-band: the `ControlPlane.Identifier` on the `DeltaDiscoveryResponse` (used for the `kuma.io/zone` label, origin, `ZoneIngress`/`ZoneEgress` `Spec.Zone`, the name prefix and the owning `Zone`) and the `kuma.io/zone` tags carried inside the specs (`ZoneIngress` `AvailableServices` and `Dataplane` inbound/gateway tags, consumed downstream for cross-zone endpoint locality and the global service inventory). Those in-band values can diverge from the `client-id` the zone connects with, so attribution is not guaranteed to stay consistent with the connecting peer.

## Implementation information

Attribute all of it by the connecting peer's declared identity (the `client-id` from the KDS stream) instead of the sender-provided in-band values:

- `UpstreamResponse.ControlPlaneId` is taken from the stream's `client-id` rather than the in-band `ControlPlane.Identifier`, so the top-level attribution (`kuma.io/zone` label, origin, `Spec.Zone`, name prefix and owning `Zone`) follows the connecting zone.
- The global ingest callback resolves the `kuma.io/zone` tag inside synced `ZoneIngress` `AvailableServices` and `Dataplane` inbound/gateway specs to that same `client-id`.

The `client-id` is request metadata the peer declares on the stream. Verifying it per connection is the (enterprise) zone-token filter's responsibility, not this path's. In ordinary zone-to-global sync these values already equal the zone name, so the change is a no-op for valid traffic. When a synced payload does carry a differing value, the correction is counted (`kds_zone_attribution_rewrites_total`, labelled by resource type) and logged with the resource and replaced value.

Adds a regression test covering attribution of the `kuma.io/zone` label, `ZoneIngress.Spec.Zone`, `ZoneIngress` `AvailableServices` tags, and `Dataplane` inbound and gateway tags.
