### PR TITLE
fix(tokens): reject a non-string kid header and recover from dp-server handler panics (backport of #17465)

### DIFF
--- a/pkg/core/tokens/validator.go
+++ b/pkg/core/tokens/validator.go
@@ -46,12 +46,13 @@ var _ Validator = &jwtTokenValidator{}
 
 func (j *jwtTokenValidator) ParseWithValidation(ctx context.Context, rawToken Token, claims Claims) error {
 	token, err := jwt.ParseWithClaims(rawToken, claims, func(token *jwt.Token) (any, error) {
-		var keyID KeyID
 		kid, exists := token.Header[KeyIDHeader]
 		if !exists {
 			return 0, fmt.Errorf("JWT token must have %s header", KeyIDHeader)
-		} else {
-			keyID = kid.(string)
+		}
+		keyID, ok := kid.(string)
+		if !ok {
+			return 0, fmt.Errorf("JWT token %s header must be a string", KeyIDHeader)
 		}
 		switch token.Method.Alg() {
 		case jwt.SigningMethodHS256.Name:

--- a/pkg/core/tokens/validator_kid_test.go
+++ b/pkg/core/tokens/validator_kid_test.go
@@ -1,0 +1,54 @@
+package tokens_test
+
+import (
+	"context"
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	store_config "github.com/kumahq/kuma/v2/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/v2/pkg/core"
+	"github.com/kumahq/kuma/v2/pkg/core/secrets/cipher"
+	secret_manager "github.com/kumahq/kuma/v2/pkg/core/secrets/manager"
+	secret_store "github.com/kumahq/kuma/v2/pkg/core/secrets/store"
+	"github.com/kumahq/kuma/v2/pkg/core/tokens"
+	"github.com/kumahq/kuma/v2/pkg/plugins/resources/memory"
+)
+
+// The JWT header is decoded into a map[string]interface{}, so a "kid" written
+// as a JSON number arrives as a float64. The validator must reject it with a
+// normal error rather than doing an unchecked string type assertion.
+var _ = Describe("Validator with a non-string kid header", func() {
+	var validator tokens.Validator
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		store := memory.NewStore()
+		secretManager := secret_manager.NewGlobalSecretManager(secret_store.NewSecretStore(store), cipher.None())
+		validator = tokens.NewValidator(
+			core.Log.WithName("test"),
+			[]tokens.SigningKeyAccessor{
+				tokens.NewSigningKeyAccessor(secretManager, TestTokenSigningKeyPrefix),
+			},
+			tokens.NewRevocations(secretManager, TokenRevocationsGlobalSecretKey),
+			store_config.MemoryStore,
+		)
+	})
+
+	It("returns an error when kid is a JSON number", func() {
+		// Header {"alg":"HS256","typ":"JWT","kid":1337} - kid is a number.
+		enc := base64.RawURLEncoding.EncodeToString
+		header := enc([]byte(`{"alg":"HS256","typ":"JWT","kid":1337}`))
+		payload := enc([]byte(`{}`))
+		signature := enc([]byte("signature"))
+		token := header + "." + payload + "." + signature
+
+		var err error
+		Expect(func() {
+			err = validator.ParseWithValidation(ctx, token, &TestClaims{})
+		}).ToNot(Panic())
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/core/tokens/validator_kid_test.go
+++ b/pkg/core/tokens/validator_kid_test.go
@@ -50,5 +50,6 @@ var _ = Describe("Validator with a non-string kid header", func() {
 			err = validator.ParseWithValidation(ctx, token, &TestClaims{})
 		}).ToNot(Panic())
 		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("kid header must be a string"))
 	})
 })

--- a/pkg/dp-server/server/recovery.go
+++ b/pkg/dp-server/server/recovery.go
@@ -18,6 +18,11 @@ func recoverGRPCHandler(p any) error {
 	return status.Error(codes.Internal, "internal server error")
 }
 
+// The interceptors below wrap the handler call, so they recover panics that
+// happen synchronously on the handler goroutine (the one gRPC invokes the
+// handler on). Work a handler offloads to a goroutine it starts itself runs
+// outside this wrapper and has to recover on its own.
+
 func recoveryUnaryInterceptor(
 	ctx context.Context,
 	req any,

--- a/pkg/dp-server/server/recovery.go
+++ b/pkg/dp-server/server/recovery.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// recoverGRPCHandler turns a recovered panic into a gRPC error so a single
+// failing call is aborted instead of taking down the whole process. The panic
+// value and stack are logged for debugging.
+func recoverGRPCHandler(p any) error {
+	log.Error(fmt.Errorf("%v", p), "recovered from panic in gRPC handler", "stack", string(debug.Stack()))
+	return status.Error(codes.Internal, "internal server error")
+}
+
+func recoveryUnaryInterceptor(
+	ctx context.Context,
+	req any,
+	_ *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	var resp any
+	var err error
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				err = recoverGRPCHandler(p)
+			}
+		}()
+		resp, err = handler(ctx, req)
+	}()
+	return resp, err
+}
+
+func recoveryStreamInterceptor(
+	srv any,
+	ss grpc.ServerStream,
+	_ *grpc.StreamServerInfo,
+	handler grpc.StreamHandler,
+) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = recoverGRPCHandler(p)
+		}
+	}()
+	return handler(srv, ss)
+}

--- a/pkg/dp-server/server/recovery_test.go
+++ b/pkg/dp-server/server/recovery_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ = Describe("gRPC recovery interceptors", func() {
+	It("recovers from a panic in a unary handler", func() {
+		handler := func(context.Context, any) (any, error) {
+			panic("boom")
+		}
+
+		var err error
+		Expect(func() {
+			_, err = recoveryUnaryInterceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, handler)
+		}).ToNot(Panic())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+	})
+
+	It("recovers from a panic in a stream handler", func() {
+		handler := func(any, grpc.ServerStream) error {
+			panic("boom")
+		}
+
+		var err error
+		Expect(func() {
+			err = recoveryStreamInterceptor(nil, nil, &grpc.StreamServerInfo{}, handler)
+		}).ToNot(Panic())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+	})
+
+	It("passes through when the handler does not panic", func() {
+		unary := func(context.Context, any) (any, error) {
+			return "ok", nil
+		}
+		resp, err := recoveryUnaryInterceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, unary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp).To(Equal("ok"))
+
+		stream := func(any, grpc.ServerStream) error {
+			return nil
+		}
+		Expect(recoveryStreamInterceptor(nil, nil, &grpc.StreamServerInfo{}, stream)).To(Succeed())
+	})
+})

--- a/pkg/dp-server/server/recovery_wiring_test.go
+++ b/pkg/dp-server/server/recovery_wiring_test.go
@@ -56,6 +56,10 @@ var panicServiceDesc = grpc.ServiceDesc{
 	},
 }
 
+// panicService is the registered implementation. The handlers in
+// panicServiceDesc do not use it, but RegisterService wants a non-nil value.
+type panicService struct{}
+
 var _ = Describe("DpServer gRPC recovery wiring", func() {
 	var lis *bufconn.Listener
 	var conn *grpc.ClientConn
@@ -72,7 +76,7 @@ var _ = Describe("DpServer gRPC recovery wiring", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		grpcServer = dpServer.GrpcServer()
-		grpcServer.RegisterService(&panicServiceDesc, nil)
+		grpcServer.RegisterService(&panicServiceDesc, &panicService{})
 
 		lis = bufconn.Listen(1024 * 1024)
 		go func() {

--- a/pkg/dp-server/server/recovery_wiring_test.go
+++ b/pkg/dp-server/server/recovery_wiring_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	dp_server "github.com/kumahq/kuma/v2/pkg/config/dp-server"
+	"github.com/kumahq/kuma/v2/pkg/metrics"
+)
+
+// panicServiceDesc registers a unary and a stream method that always panic, so
+// a call routed through the real DpServer.GrpcServer() exercises the recovery
+// interceptors wired in NewDpServer. It covers the wiring itself: dropping the
+// ChainUnary/StreamInterceptor options makes these expectations fail.
+var panicServiceDesc = grpc.ServiceDesc{
+	ServiceName: "kuma.test.PanicService",
+	HandlerType: (*any)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Unary",
+			Handler: func(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+				in := new(emptypb.Empty)
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				handler := func(context.Context, any) (any, error) {
+					panic("boom")
+				}
+				if interceptor == nil {
+					return handler(ctx, in)
+				}
+				info := &grpc.UnaryServerInfo{Server: srv, FullMethod: "/kuma.test.PanicService/Unary"}
+				return interceptor(ctx, in, info, handler)
+			},
+		},
+	},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName: "Stream",
+			Handler: func(any, grpc.ServerStream) error {
+				panic("boom")
+			},
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+}
+
+var _ = Describe("DpServer gRPC recovery wiring", func() {
+	var lis *bufconn.Listener
+	var conn *grpc.ClientConn
+	var grpcServer *grpc.Server
+
+	BeforeEach(func() {
+		m, err := metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		dpServer, err := NewDpServer(
+			*dp_server.DefaultDpServerConfig(),
+			m,
+			func(http.ResponseWriter, *http.Request) bool { return true },
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		grpcServer = dpServer.GrpcServer()
+		grpcServer.RegisterService(&panicServiceDesc, nil)
+
+		lis = bufconn.Listen(1024 * 1024)
+		go func() {
+			defer GinkgoRecover()
+			_ = grpcServer.Serve(lis)
+		}()
+
+		conn, err = grpc.NewClient(
+			"passthrough:///bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if conn != nil {
+			Expect(conn.Close()).To(Succeed())
+		}
+		if grpcServer != nil {
+			grpcServer.Stop()
+		}
+	})
+
+	It("returns Internal when a unary handler panics", func() {
+		err := conn.Invoke(context.Background(), "/kuma.test.PanicService/Unary", &emptypb.Empty{}, &emptypb.Empty{})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(status.Convert(err).Message()).To(Equal("internal server error"))
+	})
+
+	It("returns Internal when a stream handler panics", func() {
+		stream, err := conn.NewStream(context.Background(), &panicServiceDesc.Streams[0], "/kuma.test.PanicService/Stream")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = stream.RecvMsg(&emptypb.Empty{})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(status.Convert(err).Message()).To(Equal("internal server error"))
+	})
+})

--- a/pkg/dp-server/server/server.go
+++ b/pkg/dp-server/server/server.go
@@ -75,6 +75,10 @@ func NewDpServer(config dp_server.DpServerConfig, metrics metrics.Metrics, filte
 			MinTime:             GrpcKeepAliveTime,
 			PermitWithoutStream: true,
 		}),
+		// Recover from panics in handlers so a single failing call is aborted
+		// instead of bringing down the whole server.
+		grpc.ChainUnaryInterceptor(recoveryUnaryInterceptor),
+		grpc.ChainStreamInterceptor(recoveryStreamInterceptor),
 	}
 	grpcOptions = append(grpcOptions, metrics.GRPCServerInterceptors()...)
 	grpcServer := grpc.NewServer(grpcOptions...)


### PR DESCRIPTION
## Motivation

Backport of #17465 to `release-2.14`.

Two small robustness and correctness gaps in the control plane:

- The dataplane token validator read the JWT `kid` header and asserted it to `string` without checking the type. JWT headers are decoded into a generic map, so a `kid` encoded as a non-string JSON value (for example a number, which decodes to `float64`) was not handled gracefully.
- The dp-server gRPC server installed no panic recovery, so a panic in a stream or unary handler was not contained to that single call.

## Implementation information

- `pkg/core/tokens`: `ParseWithValidation` now type-checks the `kid` header and returns a normal validation error when it is not a string, instead of an unchecked type assertion. Valid string `kid`s behave exactly as before.
- `pkg/dp-server/server`: added unary and stream recovery interceptors, wired into the gRPC server built in `NewDpServer`. A recovered panic is logged with its stack and returned to the caller as `codes.Internal`, so a single failing handler is contained instead of affecting the whole server. The interceptors cover the synchronous handler goroutine (documented inline).
- Tests:
  - `validator_kid_test.go` - a non-string `kid` returns an error rather than an unchecked assertion.
  - `recovery_test.go` - the recovery interceptors turn a handler panic into an error and pass non-panicking calls through untouched.
  - `recovery_wiring_test.go` - an in-process test that dials the real `DpServer.GrpcServer()` and asserts a panicking handler surfaces to the client as `codes.Internal`, so the interceptor wiring itself is covered.

Backport notes: cherry-picked the four commits from #17465 and adapted the new test files to this branch's module path (`kuma/v3` -> `kuma/v2`). The production changes in `validator.go` and `server.go` applied cleanly; `grpc.ChainUnaryInterceptor`/`ChainStreamInterceptor` are available on this branch's gRPC version and all referenced test helpers already exist here, so no other changes were needed.
