### PR TITLE
refactor(policy): restrict to[].targetRef kinds in outbound

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator.go
@@ -23,7 +23,7 @@ func (r *MeshAccessLogResource) validate() error {
 		verr.AddViolationAt(path, "at least one of 'from', 'to' or 'rules' has to be defined")
 	}
 	if r.Spec.To != nil {
-		verr.AddErrorAt(path, validateTo(r.Spec.GetTargetRef().Kind, pointer.Deref(r.Spec.To)))
+		verr.AddErrorAt(path, validateTo(pointer.Deref(r.Spec.To)))
 	}
 	if r.Spec.From != nil {
 		verr.AddErrorAt(path, validateFrom(pointer.Deref(r.Spec.From)))
@@ -81,28 +81,19 @@ func validateMatches(field string, matches []common_api.Match) validators.Valida
 	return verr
 }
 
-func validateTo(topLevelKind common_api.TargetRefKind, to []To) validators.ValidationError {
+func validateTo(to []To) validators.ValidationError {
 	var verr validators.ValidationError
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)
 
-		var supportedKinds []common_api.TargetRefKind
-		switch topLevelKind {
-		case common_api.MeshGateway:
-			supportedKinds = []common_api.TargetRefKind{
-				common_api.Mesh,
-			}
-		default:
-			supportedKinds = []common_api.TargetRefKind{
+		verr.AddErrorAt(path.Field("targetRef"), mesh.ValidateTargetRef(toItem.GetTargetRef(), &mesh.ValidateTargetRefOpts{
+			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshExternalService,
 				common_api.MeshMultiZoneService,
 				common_api.MeshHTTPRoute,
-			}
-		}
-		verr.AddErrorAt(path.Field("targetRef"), mesh.ValidateTargetRef(toItem.GetTargetRef(), &mesh.ValidateTargetRefOpts{
-			SupportedKinds: supportedKinds,
+			},
 		}))
 
 		defaultField := path.Field("default")

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/validator_test.go
@@ -643,9 +643,7 @@ to:
 				expected: `
 violations:
 - field: spec.targetRef.kind
-  message: value 'MeshGateway' is not supported
-- field: spec.to[0].targetRef.kind
-  message: value 'MeshService' is not supported`,
+  message: value 'MeshGateway' is not supported`,
 			}),
 		)
 	})

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -37,33 +37,13 @@ func validateTo(topTargetRef common_api.TargetRef, to []To) validators.Validatio
 	var verr validators.ValidationError
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)
-		var supportedKinds []common_api.TargetRefKind
-		var supportedKindsError string
-		switch topTargetRef.Kind {
-		case common_api.MeshGateway:
-			if toItem.Default.LoadBalancer != nil {
-				supportedKindsError = fmt.Sprintf("value '%s' is not supported, only %s is allowed if loadBalancer is set", topTargetRef.Kind, common_api.Mesh)
-				supportedKinds = []common_api.TargetRefKind{
-					common_api.Mesh,
-				}
-			} else {
-				supportedKinds = []common_api.TargetRefKind{
-					common_api.Mesh,
-					common_api.MeshService,
-					common_api.MeshMultiZoneService,
-				}
-			}
-		default:
-			supportedKinds = []common_api.TargetRefKind{
+		errs := mesh.ValidateTargetRef(toItem.TargetRef, &mesh.ValidateTargetRefOpts{
+			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshMultiZoneService,
 				common_api.MeshHTTPRoute,
-			}
-		}
-		errs := mesh.ValidateTargetRef(toItem.TargetRef, &mesh.ValidateTargetRefOpts{
-			SupportedKinds:      supportedKinds,
-			SupportedKindsError: supportedKindsError,
+			},
 		})
 		verr.AddErrorAt(path.Field("targetRef"), errs)
 		if toItem.TargetRef.Kind == common_api.MeshExternalService && topTargetRef.Kind != common_api.Mesh {

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator.go
@@ -17,7 +17,7 @@ func (r *MeshRetryResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef))
-	verr.AddErrorAt(path, validateTo(pointer.Deref(r.Spec.To), pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh})))
+	verr.AddErrorAt(path, validateTo(pointer.Deref(r.Spec.To)))
 	return verr.OrNil()
 }
 
@@ -44,33 +44,22 @@ func (r *MeshRetryResource) validateTop(targetRef *common_api.TargetRef) validat
 	}
 }
 
-func validateTo(to []To, topLevelKind common_api.TargetRef) validators.ValidationError {
+func validateTo(to []To) validators.ValidationError {
 	var verr validators.ValidationError
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)
-
-		var supportedKinds []common_api.TargetRefKind
-		switch topLevelKind.Kind {
-		case common_api.MeshGateway, common_api.MeshHTTPRoute:
-			supportedKinds = []common_api.TargetRefKind{
-				common_api.Mesh,
-				common_api.MeshExternalService,
-			}
-		default:
-			supportedKinds = []common_api.TargetRefKind{
-				common_api.Mesh,
-				common_api.MeshService,
-				common_api.MeshExternalService,
-				common_api.MeshMultiZoneService,
-				common_api.MeshHTTPRoute,
-			}
-		}
 
 		verr.AddErrorAt(
 			path.Field("targetRef"),
 			mesh.ValidateTargetRef(
 				toItem.TargetRef,
-				&mesh.ValidateTargetRefOpts{SupportedKinds: supportedKinds},
+				&mesh.ValidateTargetRefOpts{SupportedKinds: []common_api.TargetRefKind{
+					common_api.Mesh,
+					common_api.MeshService,
+					common_api.MeshExternalService,
+					common_api.MeshMultiZoneService,
+					common_api.MeshHTTPRoute,
+				}},
 			),
 		)
 		verr.AddErrorAt(path.Field("default"), validateDefault(toItem.Default))

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/validator_test.go
@@ -520,9 +520,7 @@ to:
 				expected: `
 violations:
   - field: spec.targetRef.kind
-    message: value 'MeshHTTPRoute' is not supported
-  - field: spec.to[0].targetRef.kind
-    message: value 'MeshService' is not supported`,
+    message: value 'MeshHTTPRoute' is not supported`,
 			}),
 			Entry("top-level targetRef MeshHTTPRoute with valid to", testCase{
 				inputYaml: `

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
@@ -15,7 +15,7 @@ func (r *MeshTCPRouteResource) validate() error {
 	path := validators.RootedAt("spec")
 
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef))
-	verr.AddErrorAt(path, validateTo(pointer.DerefOr(r.Spec.TargetRef, common_api.TargetRef{Kind: common_api.Mesh}), pointer.Deref(r.Spec.To)))
+	verr.AddErrorAt(path, validateTo(pointer.Deref(r.Spec.To)))
 
 	return verr.OrNil()
 }
@@ -43,32 +43,23 @@ func (r *MeshTCPRouteResource) validateTop(targetRef *common_api.TargetRef) vali
 	}
 }
 
-func validateToRef(topTargetRef, targetRef common_api.TargetRef) validators.ValidationError {
-	switch topTargetRef.Kind {
-	case common_api.MeshGateway:
-		return mesh.ValidateTargetRef(targetRef, &mesh.ValidateTargetRefOpts{
-			SupportedKinds: []common_api.TargetRefKind{
-				common_api.Mesh,
-			},
-		})
-	default:
-		return mesh.ValidateTargetRef(targetRef, &mesh.ValidateTargetRefOpts{
-			SupportedKinds: []common_api.TargetRefKind{
-				common_api.MeshService,
-				common_api.MeshExternalService,
-				common_api.MeshMultiZoneService,
-			},
-		})
-	}
+func validateToRef(targetRef common_api.TargetRef) validators.ValidationError {
+	return mesh.ValidateTargetRef(targetRef, &mesh.ValidateTargetRefOpts{
+		SupportedKinds: []common_api.TargetRefKind{
+			common_api.MeshService,
+			common_api.MeshExternalService,
+			common_api.MeshMultiZoneService,
+		},
+	})
 }
 
-func validateTo(topTargetRef common_api.TargetRef, to []To) validators.ValidationError {
+func validateTo(to []To) validators.ValidationError {
 	var verr validators.ValidationError
 
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)
 
-		verr.AddErrorAt(path.Field("targetRef"), validateToRef(topTargetRef, toItem.TargetRef))
+		verr.AddErrorAt(path.Field("targetRef"), validateToRef(toItem.TargetRef))
 		verr.AddErrorAt(path.Field("rules"), validateRules(toItem.Rules))
 	}
 

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
@@ -85,25 +85,14 @@ func validateTo(to []To, topLevelKind common_api.TargetRefKind) validators.Valid
 	for idx, toItem := range to {
 		path := validators.RootedAt("to").Index(idx)
 
-		var supportedKinds []common_api.TargetRefKind
-		switch topLevelKind {
-		case common_api.MeshHTTPRoute, common_api.MeshGateway:
-			supportedKinds = []common_api.TargetRefKind{
-				common_api.Mesh,
-				common_api.MeshExternalService,
-			}
-		default:
-			supportedKinds = []common_api.TargetRefKind{
+		verr.AddErrorAt(path.Field("targetRef"), mesh.ValidateTargetRef(toItem.GetTargetRef(), &mesh.ValidateTargetRefOpts{
+			SupportedKinds: []common_api.TargetRefKind{
 				common_api.Mesh,
 				common_api.MeshService,
 				common_api.MeshExternalService,
 				common_api.MeshMultiZoneService,
 				common_api.MeshHTTPRoute,
-			}
-		}
-
-		verr.AddErrorAt(path.Field("targetRef"), mesh.ValidateTargetRef(toItem.GetTargetRef(), &mesh.ValidateTargetRefOpts{
-			SupportedKinds: supportedKinds,
+			},
 		}))
 
 		defaultField := path.Field("default")

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
@@ -314,8 +314,6 @@ violations:
     message: value 'MeshHTTPRoute' is not supported
   - field: spec.from
     message: must not be defined
-  - field: spec.to[0].targetRef.kind
-    message: value 'MeshService' is not supported
   - field: spec.to[0].default.connectionTimeout
     message: can't be specified when top-level TargetRef is referencing MeshHTTPRoute
   - field: spec.to[0].default.idleTimeout


### PR DESCRIPTION
## Motivation

Part of #17243. Restrict the allowed target kinds in outbound policy `to[]` rules to the set of kinds that are actually supported, removing MeshGateway and other subset kinds from validation.

## Implementation information

- Updated `validateTo` and `SupportedKinds` in outbound policies to restrict allowed kinds
- Removed MeshGateway and subset kinds from validation
- Kept supported kinds: Mesh, Mesh*Service, MeshHTTPRoute
- Updated to-rules test data to reflect new validation rules

Closes https://github.com/kumahq/kuma/issues/17305

_Generated by Sybra harness_