### PR TITLE
feat(meshhealthcheck): add unhealthyInterval support

### DIFF
--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -314,6 +314,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            If specified, Envoy will use this interval between health checks when a
+                            host is marked unhealthy. This allows unhealthy hosts to be checked more
+                            frequently, so they can be marked healthy again sooner. If not specified,
+                            the standard interval is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -11443,6 +11443,19 @@ components:
                           Maximum time to wait for a health check response.
                           If not specified then the default value is 15s
                         type: string
+                      unhealthyInterval:
+                        description: >-
+                          If specified, Envoy will use this interval between
+                          health checks when a
+
+                          host is marked unhealthy. This allows unhealthy hosts
+                          to be checked more
+
+                          frequently, so they can be marked healthy again
+                          sooner. If not specified,
+
+                          the standard interval is used.
+                        type: string
                       unhealthyThreshold:
                         description: >-
                           Number of consecutive unhealthy checks before

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -314,6 +314,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            If specified, Envoy will use this interval between health checks when a
+                            host is marked unhealthy. This allows unhealthy hosts to be checked more
+                            frequently, so they can be marked healthy again sooner. If not specified,
+                            the standard interval is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
@@ -33,6 +33,11 @@ type Conf struct {
 	// Interval between consecutive health checks.
 	// If not specified then the default value is 1m
 	Interval *k8s.Duration `json:"interval,omitempty"`
+	// If specified, Envoy will use this interval between health checks when a
+	// host is marked unhealthy. This allows unhealthy hosts to be checked more
+	// frequently, so they can be marked healthy again sooner. If not specified,
+	// the standard interval is used.
+	UnhealthyInterval *k8s.Duration `json:"unhealthyInterval,omitempty"`
 	// Maximum time to wait for a health check response.
 	// If not specified then the default value is 15s
 	Timeout *k8s.Duration `json:"timeout,omitempty"`

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -409,6 +409,13 @@ components:
                           Maximum time to wait for a health check response.
                           If not specified then the default value is 15s
                         type: string
+                      unhealthyInterval:
+                        description: |-
+                          If specified, Envoy will use this interval between health checks when a
+                          host is marked unhealthy. This allows unhealthy hosts to be checked more
+                          frequently, so they can be marked healthy again sooner. If not specified,
+                          the standard interval is used.
+                        type: string
                       unhealthyThreshold:
                         description: |-
                           Number of consecutive unhealthy checks before considering a host

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -50,6 +50,7 @@ func validateDefault(conf Conf) validators.ValidationError {
 	var verr validators.ValidationError
 	path := validators.RootedAt("default")
 	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("interval"), conf.Interval))
+	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("unhealthyInterval"), conf.UnhealthyInterval))
 	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("timeout"), conf.Timeout))
 	verr.Add(validators.ValidateValueGreaterThanZeroOrNil(path.Field("unhealthyThreshold"), conf.UnhealthyThreshold))
 	verr.Add(validators.ValidateValueGreaterThanZeroOrNil(path.Field("healthyThreshold"), conf.HealthyThreshold))

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -34,6 +34,7 @@ to:
       name: web-backend
     default:
       interval: 10s
+      unhealthyInterval: 1s # optional
       timeout: 2s
       unhealthyThreshold: 3
       healthyThreshold: 1
@@ -185,6 +186,7 @@ to:
       name: web-backend
     default:
       interval: -10s
+      unhealthyInterval: -1s
       timeout: -2s
       initialJitter: -5s
       intervalJitter: -6s
@@ -196,6 +198,8 @@ to:
 				expected: `
 violations:
   - field: spec.to[0].default.interval
+    message: must be greater than zero when defined
+  - field: spec.to[0].default.unhealthyInterval
     message: must be greater than zero when defined
   - field: spec.to[0].default.timeout
     message: must be greater than zero when defined

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.deepcopy.go
@@ -18,6 +18,11 @@ func (in *Conf) DeepCopyInto(out *Conf) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.UnhealthyInterval != nil {
+		in, out := &in.UnhealthyInterval, &out.UnhealthyInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -314,6 +314,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            If specified, Envoy will use this interval between health checks when a
+                            host is marked unhealthy. This allows unhealthy hosts to be checked more
+                            frequently, so they can be marked healthy again sooner. If not specified,
+                            the standard interval is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -155,6 +155,7 @@ var _ = Describe("MeshHealthCheck", func() {
 						Subset: subsetutils.Subset{},
 						Conf: api.Conf{
 							Interval:                     test.ParseDuration("10s"),
+							UnhealthyInterval:            test.ParseDuration("5s"),
 							Timeout:                      test.ParseDuration("2s"),
 							UnhealthyThreshold:           pointer.To[int32](3),
 							HealthyThreshold:             pointer.To[int32](1),

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
@@ -35,5 +35,6 @@ healthChecks:
   noTrafficInterval: 16s
   reuseConnection: true
   timeout: 2s
+  unhealthyInterval: 5s
   unhealthyThreshold: 3
 name: echo-http

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
@@ -35,5 +35,6 @@ healthChecks:
   noTrafficInterval: 16s
   reuseConnection: true
   timeout: 2s
+  unhealthyInterval: 5s
   unhealthyThreshold: 3
 name: echo-http-_0_

--- a/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
@@ -318,6 +318,9 @@ func buildHealthCheck(conf api.Conf) *envoy_core.HealthCheck {
 	if conf.NoTrafficInterval != nil {
 		hc.NoTrafficInterval = util_proto.Duration(conf.NoTrafficInterval.Duration)
 	}
+	if conf.UnhealthyInterval != nil {
+		hc.UnhealthyInterval = util_proto.Duration(conf.UnhealthyInterval.Duration)
+	}
 	if conf.ReuseConnection != nil {
 		hc.ReuseConnection = util_proto.Bool(*conf.ReuseConnection)
 	}


### PR DESCRIPTION
## Motivation

`MeshHealthCheck` supported `interval`, `intervalJitter`, `intervalJitterPercent`
and `noTrafficInterval`, but not `unhealthyInterval`. Envoy already exposes an
`unhealthy_interval` that lets a separate (usually shorter) interval be used
while an endpoint is unhealthy, so it can recover to healthy faster. This was
configurable via `ProxyTemplate` before, but the capability was missing after
migrating to `MeshHealthCheck`.

## Implementation information

Added an `unhealthyInterval` field to the `MeshHealthCheck` `Conf`, validated it
the same way as the other duration fields (must be greater than zero when
defined), and wired it into the generated Envoy health check config, mirroring
the existing `noTrafficInterval` handling. Regenerated the dependent files and
added unit test coverage.

## Supporting documentation

Fix #17129