### PR TITLE
fix(xds): use unified name for probe local cluster

### DIFF
--- a/pkg/xds/generator/probe_generator.go
+++ b/pkg/xds/generator/probe_generator.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kumahq/kuma/v2/pkg/core/naming"
+	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	model "github.com/kumahq/kuma/v2/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
@@ -19,7 +21,7 @@ import (
 
 type ProbeProxyGenerator struct{}
 
-func (g ProbeProxyGenerator) Generate(_ context.Context, _ *model.ResourceSet, _ xds_context.Context, proxy *model.Proxy) (*model.ResourceSet, error) {
+func (g ProbeProxyGenerator) Generate(_ context.Context, _ *model.ResourceSet, xdsCtx xds_context.Context, proxy *model.Proxy) (*model.ResourceSet, error) {
 	// if app probe proxy is enabled for this DP, Virtual Probes are not needed
 	appProbeProxyEnabled := proxy.Metadata.GetAppProbeProxyEnabled()
 	if appProbeProxyEnabled {
@@ -31,11 +33,13 @@ func (g ProbeProxyGenerator) Generate(_ context.Context, _ *model.ResourceSet, _
 		return nil, nil
 	}
 
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
 	virtualHostBuilder := envoy_virtual_hosts.NewVirtualHostBuilder(proxy.APIVersion, "probe")
 
-	portSet := map[uint32]bool{}
+	inboundNameByPort := map[uint32]string{}
 	for _, inbound := range proxy.Dataplane.Spec.Networking.Inbound {
-		portSet[proxy.Dataplane.Spec.Networking.ToInboundInterface(inbound).WorkloadPort] = true
+		iface := proxy.Dataplane.Spec.Networking.ToInboundInterface(inbound)
+		inboundNameByPort[iface.WorkloadPort] = iface.InboundName
 	}
 	for _, endpoint := range probes.Endpoints {
 		matchURL, err := url.Parse(endpoint.Path)
@@ -46,9 +50,13 @@ func (g ProbeProxyGenerator) Generate(_ context.Context, _ *model.ResourceSet, _
 		if err != nil {
 			return nil, err
 		}
-		if portSet[endpoint.InboundPort] {
+		if inboundName, ok := inboundNameByPort[endpoint.InboundPort]; ok {
+			localClusterName := names.GetLocalClusterName(endpoint.InboundPort)
+			if unifiedNaming {
+				localClusterName = naming.MustContextualInboundName(proxy.Dataplane, inboundName)
+			}
 			virtualHostBuilder.Configure(
-				envoy_virtual_hosts.Route(matchURL.Path, newURL.Path, names.GetLocalClusterName(endpoint.InboundPort), true))
+				envoy_virtual_hosts.Route(matchURL.Path, newURL.Path, localClusterName, true))
 		} else {
 			// On Kubernetes we are overriding probes for every container, but there is no guarantee that given
 			// probe will have an equivalent in inbound interface (ex. sidecar that is not selected by any service).

--- a/pkg/xds/generator/probe_generator_test.go
+++ b/pkg/xds/generator/probe_generator_test.go
@@ -10,6 +10,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	. "github.com/kumahq/kuma/v2/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
@@ -23,6 +24,7 @@ var _ = Describe("ProbeGenerator", func() {
 		dataplane            string
 		expected             string
 		appProbeProxyEnabled bool
+		unifiedNaming        bool
 	}
 
 	DescribeTable("should generate Envoy xDS resources",
@@ -42,14 +44,28 @@ var _ = Describe("ProbeGenerator", func() {
 				Metadata: &core_xds.DataplaneMetadata{
 					AppProbeProxyEnabled: given.appProbeProxyEnabled,
 					IPv6Enabled:          true,
+					Features:             map[string]bool{xds_types.FeatureUnifiedResourceNaming: given.unifiedNaming},
 				},
 				APIVersion: envoy_common.APIV3,
 				// internal addresses are set to "localhost" addresses to the "probe" listener
 				InternalAddresses: DummyInternalAddresses,
 			}
 
+			xdsCtx := xds_context.Context{
+				Mesh: xds_context.MeshContext{
+					Resource: &core_mesh.MeshResource{
+						Meta: &test_model.ResourceMeta{Name: "default"},
+						Spec: &mesh_proto.Mesh{
+							MeshServices: &mesh_proto.Mesh_MeshServices{
+								Mode: mesh_proto.Mesh_MeshServices_Exclusive,
+							},
+						},
+					},
+				},
+			}
+
 			// when
-			rs, err := gen.Generate(context.Background(), nil, xds_context.Context{}, proxy)
+			rs, err := gen.Generate(context.Background(), nil, xdsCtx, proxy)
 			// then
 			Expect(err).ToNot(HaveOccurred())
 
@@ -110,6 +126,21 @@ var _ = Describe("ProbeGenerator", func() {
                 path: /8080/healthz/probe?param1=value1&param2=value2
 `,
 			expected: "04.envoy.golden.yaml",
+		}),
+		Entry("base probes with unified naming", testCase{
+			dataplane: `
+            networking:
+              inbound:
+              - port: 8080
+            probes:
+              port: 9000
+              endpoints:
+              - inboundPort: 8080
+                inboundPath: /healthz/probe
+                path: /8080/healthz/probe
+`,
+			unifiedNaming: true,
+			expected:      "06.envoy.golden.yaml",
 		}),
 		Entry("skip probes listener with application probe proxy enabled ", testCase{
 			dataplane: `

--- a/pkg/xds/generator/testdata/probe/06.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/probe/06.envoy.golden.yaml
@@ -1,0 +1,45 @@
+resources:
+- name: probe:listener
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        portValue: 9000
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          routeConfig:
+            name: probe:route_configuration
+            virtualHosts:
+            - domains:
+              - '*'
+              name: probe
+              routes:
+              - match:
+                  headers:
+                  - name: :method
+                    stringMatch:
+                      exact: GET
+                  path: /8080/healthz/probe
+                route:
+                  cluster: self_inbound_dp_8080
+                  regexRewrite:
+                    pattern:
+                      regex: .*
+                    substitution: /healthz/probe
+          statPrefix: probe_listener
+    name: probe:listener
+    trafficDirection: INBOUND


### PR DESCRIPTION
## Motivation

`ProbeProxyGenerator` builds the virtual-probe fallback route's target
cluster with the legacy local cluster name unconditionally. When a
dataplane has `unifiedResourceNaming` enabled (and the mesh's
`meshServices.mode` is `Exclusive`, required on this branch),
`InboundProxyGenerator` creates the actual local/self inbound cluster
under the unified name instead, so the probe route ends up pointing at
a cluster that doesn't exist. This breaks the
app-probe-proxy-disabled virtual-probes fallback for anyone who has
already opted into `unifiedResourceNaming` on 2.14.

> Changelog: fix(xds): probe fallback route uses unified cluster name

## Implementation information

- `ProbeProxyGenerator` now checks `unified_naming.Enabled` and builds
  the probe route's target cluster with the same contextual unified
  name `InboundProxyGenerator` already uses for that cluster.
- Added a golden-file test case with unified naming (and Exclusive
  mesh services mode) enabled to cover the regression.

## Supporting documentation

Direct fix for release-2.14, not a backport — found while investigating
unrelated e2e failures on master for #17483 (defaulting
`unifiedResourceNaming` to `true`), but the bug predates and is
independent of that work. Users need this fixed on 2.14 ahead of
migrating to the 3.0 default. Companion fix for master: #17498.