### PR TITLE
fix(xds): fix inbound cluster name lookup

### DIFF
--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go
@@ -6,6 +6,8 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
+	"github.com/kumahq/kuma/v2/pkg/core/naming"
+	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/destinationname"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
@@ -65,7 +67,8 @@ func (p plugin) Apply(
 		return nil
 	}
 
-	if err := applyToInbounds(policies.FromRules, clusters.Inbound, proxy.Dataplane); err != nil {
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)
+	if err := applyToInbounds(policies.FromRules, clusters.Inbound, proxy.Dataplane, unifiedNaming); err != nil {
 		return err
 	}
 
@@ -94,7 +97,9 @@ func applyToInbounds(
 	fromRules core_rules.FromRules,
 	inboundClusters map[string]*envoy_cluster.Cluster,
 	dataplane *core_mesh.DataplaneResource,
+	unifiedNaming bool,
 ) error {
+	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 	for _, inbound := range dataplane.Spec.Networking.GetInbound() {
 		iface := dataplane.Spec.Networking.ToInboundInterface(inbound)
 
@@ -103,7 +108,9 @@ func applyToInbounds(
 			Port:    iface.DataplanePort,
 		}
 
-		cluster, ok := inboundClusters[envoy_names.GetInboundClusterName(inbound.ServicePort, iface.DataplanePort)]
+		legacyClusterName := envoy_names.GetInboundClusterName(inbound.ServicePort, iface.DataplanePort)
+		clusterName := getName(naming.MustContextualInboundName(dataplane, iface.InboundName), legacyClusterName)
+		cluster, ok := inboundClusters[clusterName]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin_test.go
@@ -17,6 +17,7 @@ import (
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
+	"github.com/kumahq/kuma/v2/pkg/core/naming"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
@@ -65,6 +66,7 @@ var _ = Describe("MeshCircuitBreaker", func() {
 		toRules         core_rules.ToRules
 		fromRules       core_rules.FromRules
 		withoutPolicy   bool
+		unifiedNaming   bool
 		expectedCluster []string
 	}
 
@@ -127,6 +129,11 @@ var _ = Describe("MeshCircuitBreaker", func() {
 			resourceSet.Add(given.resources...)
 
 			context := xds_samples.SampleContext()
+			if given.unifiedNaming {
+				context = *xds_builders.Context().WithMeshBuilder(
+					samples.MeshDefaultBuilder().WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive),
+				).Build()
+			}
 
 			proxy := xds_builders.Proxy().
 				WithDataplane(
@@ -150,6 +157,11 @@ var _ = Describe("MeshCircuitBreaker", func() {
 						},
 					}},
 				})
+			if given.unifiedNaming {
+				proxy = proxy.WithMetadata(&core_xds.DataplaneMetadata{
+					Features: xds_types.Features{xds_types.FeatureUnifiedResourceNaming: true},
+				})
+			}
 			if !given.withoutPolicy {
 				proxy = proxy.WithPolicies(
 					xds_builders.MatchedPolicies().WithPolicy(api.MeshCircuitBreakerType, given.toRules, given.fromRules),
@@ -328,6 +340,34 @@ var _ = Describe("MeshCircuitBreaker", func() {
 				},
 			},
 			expectedCluster: []string{"inbound_cluster_connection_limits.golden.yaml"},
+		}),
+		Entry("basic inbound cluster with connection limits (unified naming)", sidecarTestCase{
+			unifiedNaming: true,
+			resources: []*core_xds.Resource{
+				{
+					Name:     "inbound",
+					Origin:   metadata.OriginInbound,
+					Resource: test_xds.ClusterWithName(naming.MustContextualInboundName(core_mesh.NewDataplaneResource(), builders.FirstInboundPort)),
+				},
+			},
+			fromRules: core_rules.FromRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: []*core_rules.Rule{
+						{
+							Subset: subsetutils.Subset{},
+							Conf: api.Conf{
+								ConnectionLimits: genConnectionLimits(),
+							},
+						},
+					},
+				},
+				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
+					{Address: "127.0.0.1", Port: builders.FirstInboundPort}: {{
+						Conf: api.Conf{ConnectionLimits: genConnectionLimits()},
+					}},
+				},
+			},
+			expectedCluster: []string{"inbound_cluster_connection_limits_unified_naming.golden.yaml"},
 		}),
 		Entry("basic inbound cluster with outlier detection", sidecarTestCase{
 			resources: []*core_xds.Resource{

--- a/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits_unified_naming.golden.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/testdata/inbound_cluster_connection_limits_unified_naming.golden.yaml
@@ -1,0 +1,9 @@
+circuitBreakers:
+  thresholds:
+  - maxConnectionPools: 1111
+    maxConnections: 2222
+    maxPendingRequests: 3333
+    maxRequests: 4444
+    maxRetries: 5555
+    trackRemaining: true
+name: self_inbound_dp_80

--- a/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_inbound_cluster_unified_naming.golden.yaml
+++ b/pkg/plugins/policies/meshtimeout/plugin/testdata/basic_inbound_cluster_unified_naming.golden.yaml
@@ -1,0 +1,9 @@
+connectTimeout: 10s
+name: self_inbound_dp_80
+typedExtensionProtocolOptions:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    commonHttpProtocolOptions:
+      idleTimeout: 3600s
+      maxConnectionDuration: 600s
+      maxStreamDuration: 600s

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v2/pkg/core/metadata"
 	"github.com/kumahq/kuma/v2/pkg/core/naming"
+	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -60,7 +61,8 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	clusters := xds.GatherClusters(rs)
 	routes := xds.GatherRoutes(rs)
 
-	if err := applyToInbounds(policies.FromRules, listeners.Inbound, clusters.Inbound, proxy.Dataplane); err != nil {
+	unifiedNaming := unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)
+	if err := applyToInbounds(policies.FromRules, listeners.Inbound, clusters.Inbound, proxy.Dataplane, unifiedNaming); err != nil {
 		return err
 	}
 	if err := applyToZoneProxyListeners(policies, listeners, clusters, proxy); err != nil {
@@ -97,7 +99,8 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	return nil
 }
 
-func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_rules.InboundListener]*envoy_listener.Listener, inboundClusters map[string]*envoy_cluster.Cluster, dataplane *core_mesh.DataplaneResource) error {
+func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_rules.InboundListener]*envoy_listener.Listener, inboundClusters map[string]*envoy_cluster.Cluster, dataplane *core_mesh.DataplaneResource, unifiedNaming bool) error {
+	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 	for _, inbound := range dataplane.Spec.Networking.GetInbound() {
 		iface := dataplane.Spec.Networking.ToInboundInterface(inbound)
 
@@ -126,7 +129,9 @@ func applyToInbounds(fromRules core_rules.FromRules, inboundListeners map[core_r
 			return err
 		}
 
-		cluster, ok := inboundClusters[envoy_names.GetInboundClusterName(inbound.ServicePort, listenerKey.Port)]
+		legacyClusterName := envoy_names.GetInboundClusterName(inbound.ServicePort, listenerKey.Port)
+		clusterName := getName(naming.MustContextualInboundName(dataplane, iface.InboundName), legacyClusterName)
+		cluster, ok := inboundClusters[clusterName]
 		if !ok {
 			continue
 		}

--- a/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin_test.go
@@ -72,6 +72,7 @@ var _ = Describe("MeshTimeout", func() {
 		resources         []core_xds.Resource
 		toRules           core_rules.ToRules
 		fromRules         core_rules.FromRules
+		unifiedNaming     bool
 		expectedListeners []string
 		expectedClusters  []string
 	}
@@ -83,13 +84,17 @@ var _ = Describe("MeshTimeout", func() {
 			resourceSet.Add(&r)
 		}
 
+		meshBuilder := samples.MeshDefaultBuilder()
+		if given.unifiedNaming {
+			meshBuilder = meshBuilder.WithMeshServicesEnabled(mesh_proto.Mesh_MeshServices_Exclusive)
+		}
 		context := *xds_builders.Context().
-			WithMeshBuilder(samples.MeshDefaultBuilder()).
+			WithMeshBuilder(meshBuilder).
 			WithResources(xds_context.NewResources()).
 			AddServiceProtocol("other-service", core_meta.ProtocolHTTP).
 			AddServiceProtocol("second-service", core_meta.ProtocolTCP).
 			Build()
-		proxy := xds_builders.Proxy().
+		proxyBuilder := xds_builders.Proxy().
 			WithDataplane(builders.Dataplane().
 				WithName("backend").
 				WithMesh("default").
@@ -120,8 +125,13 @@ var _ = Describe("MeshTimeout", func() {
 			).
 			WithPolicies(
 				xds_builders.MatchedPolicies().WithPolicy(api.MeshTimeoutType, given.toRules, given.fromRules),
-			).
-			Build()
+			)
+		if given.unifiedNaming {
+			proxyBuilder = proxyBuilder.WithMetadata(&core_xds.DataplaneMetadata{
+				Features: xds_types.Features{xds_types.FeatureUnifiedResourceNaming: true},
+			})
+		}
+		proxy := proxyBuilder.Build()
 
 		// when
 		plugin := v1alpha1.NewPlugin().(core_plugins.PolicyPlugin)
@@ -269,6 +279,62 @@ var _ = Describe("MeshTimeout", func() {
 				},
 			},
 			expectedClusters:  []string{"basic_inbound_cluster.golden.yaml"},
+			expectedListeners: []string{"basic_inbound_listener.golden.yaml"},
+		}),
+		Entry("basic inbound route (unified naming)", sidecarTestCase{
+			unifiedNaming: true,
+			resources: []core_xds.Resource{
+				{
+					Name:     "inbound",
+					Origin:   metadata.OriginInbound,
+					Resource: httpInboundListenerWith(),
+				},
+				{
+					Name:     "inbound",
+					Origin:   metadata.OriginInbound,
+					Resource: test_xds.ClusterWithName(naming.MustContextualInboundName(core_mesh.NewDataplaneResource(), uint32(80))),
+				},
+			},
+			fromRules: core_rules.FromRules{
+				Rules: map[core_rules.InboundListener]core_rules.Rules{
+					{
+						Address: "127.0.0.1",
+						Port:    80,
+					}: []*core_rules.Rule{
+						{
+							Subset: subsetutils.Subset{},
+							Conf: api.Conf{
+								ConnectionTimeout: test.ParseDuration("10s"),
+								IdleTimeout:       test.ParseDuration("1h"),
+								Http: &api.Http{
+									RequestTimeout:        test.ParseDuration("5s"),
+									StreamIdleTimeout:     test.ParseDuration("1s"),
+									MaxStreamDuration:     test.ParseDuration("10m"),
+									MaxConnectionDuration: test.ParseDuration("10m"),
+								},
+							},
+						},
+					},
+				},
+				InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
+					{
+						Address: "127.0.0.1",
+						Port:    80,
+					}: {{
+						Conf: api.Conf{
+							ConnectionTimeout: test.ParseDuration("10s"),
+							IdleTimeout:       test.ParseDuration("1h"),
+							Http: &api.Http{
+								RequestTimeout:        test.ParseDuration("5s"),
+								StreamIdleTimeout:     test.ParseDuration("1s"),
+								MaxStreamDuration:     test.ParseDuration("10m"),
+								MaxConnectionDuration: test.ParseDuration("10m"),
+							},
+						},
+					}},
+				},
+			},
+			expectedClusters:  []string{"basic_inbound_cluster_unified_naming.golden.yaml"},
 			expectedListeners: []string{"basic_inbound_listener.golden.yaml"},
 		}),
 		Entry("basic inbound route without defaults", sidecarTestCase{


### PR DESCRIPTION
## Motivation

> Changelog: fix(xds): fix inbound cluster name lookup

`MeshTimeout` and `MeshCircuitBreaker` resolve the inbound Envoy cluster to attach cluster-level config (idle/stream/connection timeouts, connection limits, outlier detection) by looking it up with the legacy cluster name only (`envoy_names.GetInboundClusterName(...)`). When unified resource naming is enabled, the actual cluster is named via the contextual scheme (`self_inbound_<shortname>_<sectionName>`), so the lookup always misses and the cluster-level config is silently never applied — while listener-level config (which is keyed by address/port, not name) still works.

`MeshTLS` already handles this correctly by branching on `unified_naming.Enabled(...)` and picking between the contextual name and the legacy fallback; this PR applies the same pattern to `MeshTimeout` and `MeshCircuitBreaker`. This is a manual backport of #17504 (master), adjusted for this branch's module path and its `unified_naming.Enabled` signature, which additionally requires `MeshServices` `Exclusive` mode.

## Implementation information

- `pkg/plugins/policies/meshcircuitbreaker/plugin/v1alpha1/plugin.go`: `applyToInbounds` now resolves the cluster name via `naming.GetNameOrFallbackFunc(unifiedNaming)` instead of the legacy name only.
- `pkg/plugins/policies/meshtimeout/plugin/v1alpha1/plugin.go`: same fix in its `applyToInbounds`.
- Added a regression test per plugin (`... (unified naming)` entry) with a matching golden file, verified to fail before the fix and pass after.

## Supporting documentation

N/A