### PR TITLE
fix(xds): unified naming for zone proxies

### DIFF
--- a/pkg/xds/generator/egress/generator.go
+++ b/pkg/xds/generator/egress/generator.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kumahq/kuma/v2/pkg/core/naming"
-	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
@@ -33,7 +32,10 @@ func (g Generator) Generate(
 ) (*core_xds.ResourceSet, error) {
 	rs := core_xds.NewResourceSet()
 
-	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
+	// ZoneEgress isn't scoped to a single mesh (xdsCtx.Mesh is empty for zone proxies),
+	// so unlike mesh-scoped generators we can't use unified_naming.Enabled here: it
+	// would always see a nil mesh and report unified naming as disabled.
+	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 
 	zoneEgress := proxy.ZoneEgressProxy.ZoneEgressResource

--- a/pkg/xds/generator/egress/generator_test.go
+++ b/pkg/xds/generator/egress/generator_test.go
@@ -16,6 +16,7 @@ import (
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	rest_types "github.com/kumahq/kuma/v2/pkg/core/resources/model/rest"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	policies_generator "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/generator"
 	meshhttproute_api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	. "github.com/kumahq/kuma/v2/pkg/test/matchers"
@@ -46,6 +47,7 @@ var _ = Describe("EgressGenerator", func() {
 	type testCase struct {
 		fileWithResourcesName string
 		expected              string
+		unifiedNaming         bool
 	}
 
 	DescribeTable("should generate Envoy xDS resources",
@@ -175,6 +177,9 @@ var _ = Describe("EgressGenerator", func() {
 					ZoneIngresses:      zoneIngresses,
 					MeshResourcesList:  meshResourcesList,
 				},
+				Metadata: &core_xds.DataplaneMetadata{
+					Features: map[string]bool{xds_types.FeatureUnifiedResourceNaming: given.unifiedNaming},
+				},
 			}
 			xdsCtx := xds_context.Context{
 				ControlPlane: &xds_context.ControlPlaneContext{
@@ -200,6 +205,11 @@ var _ = Describe("EgressGenerator", func() {
 		Entry("01. default trafficroute, one externalservice", testCase{
 			fileWithResourcesName: "01.externalservice-only.yaml",
 			expected:              "01.externalservice-only.golden.yaml",
+		}),
+		Entry("01. unified naming, one externalservice", testCase{
+			fileWithResourcesName: "01.externalservice-only.yaml",
+			expected:              "01.externalservice-only-unified-naming.golden.yaml",
+			unifiedNaming:         true,
 		}),
 		Entry("02. default trafficroute, one service behind zoneingress", testCase{
 			fileWithResourcesName: "02.internalservice-only.yaml",

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only-unified-naming.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only-unified-naming.golden.yaml
@@ -1,0 +1,230 @@
+resources:
+- name: kri_extsvc_mesh-1___meshexternalservice-1_9090
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    circuitBreakers:
+      thresholds:
+      - trackRemaining: true
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: kri_extsvc_mesh-1___meshexternalservice-1_9090
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 127.0.0.1
+                portValue: 8080
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                mesh: mesh-1
+        - endpoint:
+            address:
+              socketAddress:
+                address: example.com
+                portValue: 1234
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                mesh: mesh-1
+        locality:
+          subZone: priority-0
+    name: kri_extsvc_mesh-1___meshexternalservice-1_9090
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: mesh-1:externalservice-1
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh-1_externalservice-1
+    circuitBreakers:
+      thresholds:
+      - trackRemaining: true
+    connectTimeout: 5s
+    dnsLookupFamily: V4_ONLY
+    loadAssignment:
+      clusterName: mesh-1:externalservice-1
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: kuma.io
+                portValue: 80
+          loadBalancingWeight: 1
+          metadata:
+            filterMetadata:
+              envoy.lb:
+                kuma.io/protocol: http
+                mesh: mesh-1
+              envoy.transport_socket_match:
+                kuma.io/protocol: http
+                mesh: mesh-1
+    name: mesh-1:externalservice-1
+    type: STRICT_DNS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          httpProtocolOptions: {}
+- name: self_inbound_ze_10002
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 10002
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - externalservice-1{mesh=mesh-1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: mesh-1_externalservice-1.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+          routeConfig:
+            name: outbound:mesh-1:externalservice-1
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: mesh-1:externalservice-1
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: mesh-1:externalservice-1
+                  timeout: 0s
+          statPrefix: mesh-1_externalservice-1
+      name: mesh-1:externalservice-1_mesh-1
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_mtls_ca_mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: system_mtls_identity_mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    - filterChainMatch:
+        serverNames:
+        - a45e197ed7825551b.meshexternalservice-1.9090.mesh-1.mes
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: kri_extsvc_mesh-1___meshexternalservice-1_9090.
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          httpFilters:
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+          routeConfig:
+            name: kri_extsvc_mesh-1___meshexternalservice-1_9090
+            validateClusters: false
+            virtualHosts:
+            - domains:
+              - '*'
+              name: kri_extsvc_mesh-1___meshexternalservice-1_9090
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  autoHostRewrite: true
+                  cluster: kri_extsvc_mesh-1___meshexternalservice-1_9090
+                  timeout: 0s
+          statPrefix: kri_extsvc_mesh-1___meshexternalservice-1_9090
+      name: kri_extsvc_mesh-1___meshexternalservice-1_9090
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://mesh-1/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: system_mtls_ca_mesh-1
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: system_mtls_identity_mesh-1
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: self_inbound_ze_10002
+    statPrefix: self_inbound_ze_10002
+    trafficDirection: INBOUND
+- name: identity_cert:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: identity_cert:secret:mesh-1
+    tlsCertificate:
+      certificateChain:
+        inlineBytes: Q0VSVA==
+      privateKey:
+        inlineBytes: S0VZ
+- name: mesh_ca:secret:mesh-1
+  resource:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
+    name: mesh_ca:secret:mesh-1
+    validationContext:
+      trustedCa:
+        inlineBytes: Q0E=

--- a/pkg/xds/generator/ingress_generator.go
+++ b/pkg/xds/generator/ingress_generator.go
@@ -7,7 +7,6 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/naming"
-	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
@@ -29,7 +28,10 @@ func (i IngressGenerator) Generate(
 ) (*core_xds.ResourceSet, error) {
 	rs := core_xds.NewResourceSet()
 	cp := xdsCtx.ControlPlane
-	unifiedNaming := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
+	// ZoneIngress isn't scoped to a single mesh (xdsCtx.Mesh is empty for zone proxies),
+	// so unlike mesh-scoped generators we can't use unified_naming.Enabled here: it
+	// would always see a nil mesh and report unified naming as disabled.
+	unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	getName := naming.GetNameOrFallbackFunc(unifiedNaming)
 
 	zoneIngress := proxy.ZoneIngressProxy.ZoneIngressResource

--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -13,6 +13,7 @@ import (
 	meshservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	meshhttproute_api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	meshtcproute_api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtcproute/api/v1alpha1"
 	. "github.com/kumahq/kuma/v2/pkg/test/matchers"
@@ -32,6 +33,7 @@ var _ = Describe("IngressGenerator", func() {
 		expected         string
 		proxyZone        string
 		meshResourceList []*core_xds.MeshProxyResources
+		unifiedNaming    bool
 	}
 
 	DescribeTable("should generate Envoy xDS resources",
@@ -56,6 +58,9 @@ var _ = Describe("IngressGenerator", func() {
 					MeshResourceList:    given.meshResourceList,
 				},
 				InternalAddresses: DummyInternalAddresses,
+				Metadata: &core_xds.DataplaneMetadata{
+					Features: map[string]bool{xds_types.FeatureUnifiedResourceNaming: given.unifiedNaming},
+				},
 			}
 
 			// when
@@ -97,6 +102,76 @@ var _ = Describe("IngressGenerator", func() {
                   region: us
 `,
 			expected: "01.envoy.golden.yaml",
+			meshResourceList: []*core_xds.MeshProxyResources{
+				{
+					Mesh: builders.Mesh().WithName("mesh1").Build(),
+					EndpointMap: map[core_xds.ServiceName][]core_xds.Endpoint{
+						"backend": {
+							{
+								Target: "192.168.0.1",
+								Port:   2521,
+								Tags: map[string]string{
+									"kuma.io/service": "backend",
+									"version":         "v1",
+									"region":          "eu",
+									"mesh":            "mesh1",
+								},
+								Weight: 1,
+							},
+							{
+								Target: "192.168.0.2",
+								Port:   2521,
+								Tags: map[string]string{
+									"kuma.io/service": "backend",
+									"version":         "v2",
+									"region":          "us",
+									"mesh":            "mesh1",
+								},
+								Weight: 1,
+							},
+						},
+					},
+					Resources: map[core_model.ResourceType]core_model.ResourceList{
+						core_mesh.TrafficRouteType: &core_mesh.TrafficRouteResourceList{
+							Items: []*core_mesh.TrafficRouteResource{
+								{
+									Spec: &mesh_proto.TrafficRoute{
+										Sources: []*mesh_proto.Selector{{
+											Match: mesh_proto.MatchAnyService(),
+										}},
+										Destinations: []*mesh_proto.Selector{{
+											Match: mesh_proto.MatchAnyService(),
+										}},
+										Conf: &mesh_proto.TrafficRoute_Conf{
+											Destination: mesh_proto.MatchAnyService(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+		Entry("01. unified naming, single mesh", testCase{
+			ingress: `
+            networking:
+              address: 10.0.0.1
+              port: 10001
+            availableServices:
+              - mesh: mesh1
+                tags:
+                  kuma.io/service: backend
+                  version: v1
+                  region: eu
+              - mesh: mesh1
+                tags:
+                  kuma.io/service: backend
+                  version: v2
+                  region: us
+`,
+			expected:      "01.unified-naming.envoy.golden.yaml",
+			unifiedNaming: true,
 			meshResourceList: []*core_xds.MeshProxyResources{
 				{
 					Mesh: builders.Mesh().WithName("mesh1").Build(),

--- a/pkg/xds/generator/testdata/ingress/01.unified-naming.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/01.unified-naming.envoy.golden.yaml
@@ -1,0 +1,76 @@
+resources:
+- name: mesh1:backend
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: mesh1_backend
+    connectTimeout: 5s
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: mesh1:backend
+    type: EDS
+- name: mesh1:backend
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: mesh1:backend
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.1
+              portValue: 2521
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              mesh: mesh1
+              region: eu
+              version: v1
+            envoy.transport_socket_match:
+              mesh: mesh1
+              region: eu
+              version: v1
+      - endpoint:
+          address:
+            socketAddress:
+              address: 192.168.0.2
+              portValue: 2521
+        loadBalancingWeight: 1
+        metadata:
+          filterMetadata:
+            envoy.lb:
+              mesh: mesh1
+              region: us
+              version: v2
+            envoy.transport_socket_match:
+              mesh: mesh1
+              region: us
+              version: v2
+- name: self_inbound_zi_10001
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 10.0.0.1
+        portValue: 10001
+    enableReusePort: false
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - backend{mesh=mesh1}
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: mesh1:backend
+          statPrefix: mesh1_backend
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: self_inbound_zi_10001
+    statPrefix: self_inbound_zi_10001
+    trafficDirection: INBOUND


### PR DESCRIPTION
## Motivation

> Changelog: fix(xds): fix unified naming detection for zone proxies

Backport of #17511 to release-2.14.

ZoneEgress and ZoneIngress compute whether to use unified resource
naming with `unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)`.
For zone proxies `xdsCtx.Mesh` is always an empty `MeshContext{}` (zone
proxies aren't scoped to a single mesh), so `xdsCtx.Mesh.Resource` is
always `nil`, and `unified_naming.Enabled` always returns `false`
regardless of the proxy's actual `feature-unified-resource-naming` flag.

This is harmless while unified naming is off, but breaks as soon as a
mesh/dataplane enables it: ZoneEgress's own SDS secrets are generated
correctly under the unified name (that code path threads the real
per-mesh `mesh` resource through), but ZoneEgress's inbound
listener/cluster naming stays hardcoded to legacy because of this bug —
so the listener requests an SDS secret name the control plane never
publishes. The downstream TLS context never gets its secrets
(`downstream_context_secrets_not_ready`), and every connection through
zone egress fails TLS with a 503.

Reproduced live in a k3d cluster built from this fix: a
MeshExternalService reached through zone egress with unified naming
enabled returned 503 (`upstream connect error ... remote connection
failure`) before the fix, with egress logs showing SDS fetch timeouts
and 100% of downstream connections failing
(`server_ssl_socket_factory.downstream_context_secrets_not_ready`).
After the fix the same repro returns 200 and the counter stays at zero.

ZoneIngress has the identical pattern, fixed here too for consistency.

## Implementation information

Same two-file fix as #17511, cherry-picked onto release-2.14 (module
path is `v2` on this branch instead of `v3`):

- `pkg/xds/generator/egress/generator.go`
- `pkg/xds/generator/ingress_generator.go`

## Supporting documentation

See #17511 for the live repro details.