### PR TITLE
build(docs): skip protoc when DOCS_PROTOS is empty

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -27,11 +27,13 @@ docs/generated/raw: docs/generated/raw/rbac.yaml
 	mkdir -p $@/crds
 	for f in $$(find deployments/charts -name '*.yaml' | grep '/crds/'); do command cp $$f $@/crds/; done
 
+ifneq ($(strip $(DOCS_PROTOS)),)
 	mkdir -p $@/protos
 	$(PROTOC) \
 		--jsonschema_out=$@/protos \
 		--plugin=protoc-gen-jsonschema=$(PROTOC_GEN_JSONSCHEMA) \
 		$(DOCS_PROTOS)
+endif
 
 .PHONY: docs/generated/raw/rbac.yaml
 docs/generated/raw/rbac.yaml:


### PR DESCRIPTION
> Changelog: skip

## Motivation

Distributions that build on Kuma's makefiles (Kong Mesh, for one) may have no protos left to document as JSON schema, and today they cannot opt out of the protoc step in `docs/generated/raw`. Setting `DOCS_PROTOS` to an empty value makes protoc fail with `Missing input file.`, and leaving it at the default points the build at `api/mesh/v1alpha1/*.proto`, which does not exist downstream, so the target fails there too. The only workaround is neutering `PROTOC` with a target-scoped variable or copy-pasting the whole recipe downstream, which then drifts whenever this recipe changes.

## Implementation information

Wrap the `mkdir -p $@/protos` and protoc invocation in `ifneq ($(strip $(DOCS_PROTOS)),)`. The conditional is evaluated at parse time, so an empty `DOCS_PROTOS` drops those two lines from the recipe and nothing else about the target changes. Kuma itself keeps the default `DOCS_PROTOS ?= api/mesh/v1alpha1/*.proto`, so its own behaviour is untouched — verified with `make -n docs/generated/raw` (protoc still runs) and `make -n docs/generated/raw DOCS_PROTOS=` (protoc and the empty `protos/` directory are skipped, the config/helm-values/crds copies still run).

## Supporting documentation

Downstream trigger: Kong Mesh removed its last documented proto (the legacy `OPAPolicy` API, superseded by `MeshOPA`) and `make docs` now breaks on this recipe. With this change it can simply leave `DOCS_PROTOS` unset instead of carrying a local workaround.