### PR TITLE
refactor(targetRef): remove subset resolution from dataplane matcher

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
@@ -157,9 +156,9 @@ func DppSelectedByPolicy(
 	switch ref.Kind {
 	case common_api.Mesh:
 		if isSupportedProxyType(pointer.Deref(ref.ProxyTypes), resolveDataplaneProxyType(dpp)) {
-			inbounds, gateway := inboundsSelectedByTags(nil, dpp)
+			inbounds := allInboundListeners(dpp)
 			inbounds = append(inbounds, embeddedListenersAsInboundListeners(dpp)...)
-			return inbounds, gateway, nil
+			return inbounds, dpp.Spec.IsDelegatedGateway(), nil
 		}
 		return []core_rules.InboundListener{}, false, nil
 	case common_api.Dataplane:
@@ -182,24 +181,6 @@ func DppSelectedByPolicy(
 			return inbounds, dpp.Spec.IsDelegatedGateway(), nil
 		}
 		return []core_rules.InboundListener{}, false, nil
-	case common_api.MeshSubset:
-		if isSupportedProxyType(pointer.Deref(ref.ProxyTypes), resolveDataplaneProxyType(dpp)) {
-			inbounds, gateway := inboundsSelectedByTags(pointer.Deref(ref.Tags), dpp)
-			return inbounds, gateway, nil
-		}
-		return []core_rules.InboundListener{}, false, nil
-	case common_api.MeshService:
-		inbounds, gateway := inboundsSelectedByTags(map[string]string{
-			mesh_proto.ServiceTag: pointer.Deref(ref.Name),
-		}, dpp)
-		return inbounds, gateway, nil
-	case common_api.MeshServiceSubset:
-		tags := map[string]string{
-			mesh_proto.ServiceTag: pointer.Deref(ref.Name),
-		}
-		maps.Copy(tags, pointer.Deref(ref.Tags))
-		inbounds, gateway := inboundsSelectedByTags(tags, dpp)
-		return inbounds, gateway, nil
 	case common_api.MeshHTTPRoute:
 		mhr := resolveMeshHTTPRouteRef(meta, pointer.Deref(ref.Name), referencableResources.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType))
 		if mhr == nil {
@@ -293,21 +274,17 @@ func isSupportedProxyType(supportedTypes []common_api.TargetRefProxyType, dppTyp
 	return len(supportedTypes) == 0 || slices.Contains(supportedTypes, dppType)
 }
 
-// inboundsSelectedByTags returns which inbounds are selected and whether a
-// delegated gateway is selected
-func inboundsSelectedByTags(tagsSelector mesh_proto.TagSelector, dpp *core_mesh.DataplaneResource) ([]core_rules.InboundListener, bool) {
+// allInboundListeners returns every inbound of the dataplane as an InboundListener
+func allInboundListeners(dpp *core_mesh.DataplaneResource) []core_rules.InboundListener {
 	inbounds := []core_rules.InboundListener{}
 	for _, inbound := range dpp.Spec.GetNetworking().GetInbound() {
-		if tagsSelector.Matches(inbound.Tags) {
-			intf := dpp.Spec.GetNetworking().ToInboundInterface(inbound)
-			inbounds = append(inbounds, core_rules.InboundListener{
-				Address: intf.DataplaneIP,
-				Port:    intf.DataplanePort,
-			})
-		}
+		intf := dpp.Spec.GetNetworking().ToInboundInterface(inbound)
+		inbounds = append(inbounds, core_rules.InboundListener{
+			Address: intf.DataplaneIP,
+			Port:    intf.DataplanePort,
+		})
 	}
-	delegatedGatewaySelected := dpp.Spec.IsDelegatedGateway() && tagsSelector.Matches(dpp.Spec.GetNetworking().GetGateway().Tags)
-	return inbounds, delegatedGatewaySelected
+	return inbounds
 }
 
 func SortByTargetRef(rl core_model.ResourceList) core_model.ResourceList {

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -28,7 +28,8 @@ func PolicyMatches(resource core_model.Resource, dpp *core_mesh.DataplaneResourc
 		return false, errors.New("resource is not a targetRef policy")
 	}
 	selectedInbounds, delegatedGateway, err := DppSelectedByPolicy(resource.GetMeta(), refPolicy.GetTargetRef(), dpp, referencableResources)
-	return len(selectedInbounds) != 0 || delegatedGateway, err
+	selectedGatewayInbounds := builtinGatewayListenersSelectedByPolicy(resource.GetMeta(), refPolicy.GetTargetRef(), dpp)
+	return len(selectedInbounds) != 0 || len(selectedGatewayInbounds) != 0 || delegatedGateway, err
 }
 
 // MatchedPolicies match policies using the standard matchers using targetRef (madr-005)
@@ -52,6 +53,7 @@ func MatchedPolicies(
 	var warnings []string
 
 	matchedPoliciesByInbound := map[core_rules.InboundListener]core_model.ResourceList{}
+	matchedPoliciesByGatewayInbound := map[core_rules.InboundListener]core_model.ResourceList{}
 	matchedPoliciesByGatewayListener := map[core_rules.InboundListenerHostname]core_model.ResourceList{}
 	dpPolicies, err := registry.Global().NewList(rType)
 	if err != nil {
@@ -65,6 +67,7 @@ func MatchedPolicies(
 
 		refPolicy := policy.GetSpec().(core_model.Policy)
 		selectedInbounds, delegatedGatewaySelected, err := DppSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp, resources)
+		selectedGatewayInbounds := builtinGatewayListenersSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp)
 		if err != nil {
 			warnings = append(warnings,
 				fmt.Sprintf("unable to resolve TargetRef on policy: mesh:%s name:%s error:%q",
@@ -72,7 +75,7 @@ func MatchedPolicies(
 				),
 			)
 		}
-		if len(selectedInbounds) == 0 && !delegatedGatewaySelected {
+		if len(selectedInbounds) == 0 && len(selectedGatewayInbounds) == 0 && !delegatedGatewaySelected {
 			// DPP is not matched by the policy
 			continue
 		}
@@ -92,12 +95,26 @@ func MatchedPolicies(
 				return core_xds.TypedMatchingPolicies{}, err
 			}
 		}
+		for _, inbound := range append(selectedInbounds, selectedGatewayInbounds...) {
+			if _, ok := matchedPoliciesByGatewayInbound[inbound]; !ok {
+				matchedPoliciesByGatewayInbound[inbound], err = registry.Global().NewList(rType)
+				if err != nil {
+					return core_xds.TypedMatchingPolicies{}, err
+				}
+			}
+			if err := matchedPoliciesByGatewayInbound[inbound].AddItem(policy); err != nil {
+				return core_xds.TypedMatchingPolicies{}, err
+			}
+		}
 	}
 
 	dpPolicies = SortByTargetRef(dpPolicies)
 
 	for inbound, ps := range matchedPoliciesByInbound {
 		matchedPoliciesByInbound[inbound] = SortByTargetRef(ps)
+	}
+	for inbound, ps := range matchedPoliciesByGatewayInbound {
+		matchedPoliciesByGatewayInbound[inbound] = SortByTargetRef(ps)
 	}
 
 	fr, err := core_rules.BuildFromRules(matchedPoliciesByInbound)
@@ -111,7 +128,7 @@ func MatchedPolicies(
 	}
 
 	gr, err := core_rules.BuildGatewayRules(
-		matchedPoliciesByInbound,
+		matchedPoliciesByGatewayInbound,
 		matchedPoliciesByGatewayListener,
 		resources,
 	)
@@ -272,6 +289,28 @@ func resolveDataplaneProxyType(dpp *core_mesh.DataplaneResource) common_api.Targ
 
 func isSupportedProxyType(supportedTypes []common_api.TargetRefProxyType, dppType common_api.TargetRefProxyType) bool {
 	return len(supportedTypes) == 0 || slices.Contains(supportedTypes, dppType)
+}
+
+func builtinGatewayListenersSelectedByPolicy(
+	meta core_model.ResourceMeta,
+	ref common_api.TargetRef,
+	dpp *core_mesh.DataplaneResource,
+) []core_rules.InboundListener {
+	if ref.Kind != common_api.Mesh {
+		return nil
+	}
+	if !dppSelectedByZone(meta, dpp) || !dppSelectedByNamespace(meta, dpp) {
+		return nil
+	}
+	if !isSupportedProxyType(pointer.Deref(ref.ProxyTypes), resolveDataplaneProxyType(dpp)) {
+		return nil
+	}
+	if !dpp.Spec.IsBuiltinGateway() {
+		return nil
+	}
+	return []core_rules.InboundListener{{
+		Address: dpp.Spec.GetNetworking().GetAddress(),
+	}}
 }
 
 // allInboundListeners returns every inbound of the dataplane as an InboundListener

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -94,8 +94,9 @@ func MatchedPolicies(
 			if err := matchedPoliciesByInbound[inbound].AddItem(policy); err != nil {
 				return core_xds.TypedMatchingPolicies{}, err
 			}
+			matchedPoliciesByGatewayInbound[inbound] = matchedPoliciesByInbound[inbound]
 		}
-		for _, inbound := range append(selectedInbounds, selectedGatewayInbounds...) {
+		for _, inbound := range selectedGatewayInbounds {
 			if _, ok := matchedPoliciesByGatewayInbound[inbound]; !ok {
 				matchedPoliciesByGatewayInbound[inbound], err = registry.Global().NewList(rType)
 				if err != nil {

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -28,8 +28,7 @@ func PolicyMatches(resource core_model.Resource, dpp *core_mesh.DataplaneResourc
 		return false, errors.New("resource is not a targetRef policy")
 	}
 	selectedInbounds, delegatedGateway, err := DppSelectedByPolicy(resource.GetMeta(), refPolicy.GetTargetRef(), dpp, referencableResources)
-	selectedGatewayInbounds := builtinGatewayListenersSelectedByPolicy(resource.GetMeta(), refPolicy.GetTargetRef(), dpp)
-	return len(selectedInbounds) != 0 || len(selectedGatewayInbounds) != 0 || delegatedGateway, err
+	return len(selectedInbounds) != 0 || delegatedGateway, err
 }
 
 // MatchedPolicies match policies using the standard matchers using targetRef (madr-005)
@@ -53,7 +52,6 @@ func MatchedPolicies(
 	var warnings []string
 
 	matchedPoliciesByInbound := map[core_rules.InboundListener]core_model.ResourceList{}
-	matchedPoliciesByGatewayInbound := map[core_rules.InboundListener]core_model.ResourceList{}
 	matchedPoliciesByGatewayListener := map[core_rules.InboundListenerHostname]core_model.ResourceList{}
 	dpPolicies, err := registry.Global().NewList(rType)
 	if err != nil {
@@ -67,7 +65,6 @@ func MatchedPolicies(
 
 		refPolicy := policy.GetSpec().(core_model.Policy)
 		selectedInbounds, delegatedGatewaySelected, err := DppSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp, resources)
-		selectedGatewayInbounds := builtinGatewayListenersSelectedByPolicy(policy.GetMeta(), refPolicy.GetTargetRef(), dpp)
 		if err != nil {
 			warnings = append(warnings,
 				fmt.Sprintf("unable to resolve TargetRef on policy: mesh:%s name:%s error:%q",
@@ -75,7 +72,7 @@ func MatchedPolicies(
 				),
 			)
 		}
-		if len(selectedInbounds) == 0 && len(selectedGatewayInbounds) == 0 && !delegatedGatewaySelected {
+		if len(selectedInbounds) == 0 && !delegatedGatewaySelected {
 			// DPP is not matched by the policy
 			continue
 		}
@@ -94,18 +91,6 @@ func MatchedPolicies(
 			if err := matchedPoliciesByInbound[inbound].AddItem(policy); err != nil {
 				return core_xds.TypedMatchingPolicies{}, err
 			}
-			matchedPoliciesByGatewayInbound[inbound] = matchedPoliciesByInbound[inbound]
-		}
-		for _, inbound := range selectedGatewayInbounds {
-			if _, ok := matchedPoliciesByGatewayInbound[inbound]; !ok {
-				matchedPoliciesByGatewayInbound[inbound], err = registry.Global().NewList(rType)
-				if err != nil {
-					return core_xds.TypedMatchingPolicies{}, err
-				}
-			}
-			if err := matchedPoliciesByGatewayInbound[inbound].AddItem(policy); err != nil {
-				return core_xds.TypedMatchingPolicies{}, err
-			}
 		}
 	}
 
@@ -113,9 +98,6 @@ func MatchedPolicies(
 
 	for inbound, ps := range matchedPoliciesByInbound {
 		matchedPoliciesByInbound[inbound] = SortByTargetRef(ps)
-	}
-	for inbound, ps := range matchedPoliciesByGatewayInbound {
-		matchedPoliciesByGatewayInbound[inbound] = SortByTargetRef(ps)
 	}
 
 	fr, err := core_rules.BuildFromRules(matchedPoliciesByInbound)
@@ -129,7 +111,7 @@ func MatchedPolicies(
 	}
 
 	gr, err := core_rules.BuildGatewayRules(
-		matchedPoliciesByGatewayInbound,
+		matchedPoliciesByInbound,
 		matchedPoliciesByGatewayListener,
 		resources,
 	)
@@ -290,28 +272,6 @@ func resolveDataplaneProxyType(dpp *core_mesh.DataplaneResource) common_api.Targ
 
 func isSupportedProxyType(supportedTypes []common_api.TargetRefProxyType, dppType common_api.TargetRefProxyType) bool {
 	return len(supportedTypes) == 0 || slices.Contains(supportedTypes, dppType)
-}
-
-func builtinGatewayListenersSelectedByPolicy(
-	meta core_model.ResourceMeta,
-	ref common_api.TargetRef,
-	dpp *core_mesh.DataplaneResource,
-) []core_rules.InboundListener {
-	if ref.Kind != common_api.Mesh {
-		return nil
-	}
-	if !dppSelectedByZone(meta, dpp) || !dppSelectedByNamespace(meta, dpp) {
-		return nil
-	}
-	if !isSupportedProxyType(pointer.Deref(ref.ProxyTypes), resolveDataplaneProxyType(dpp)) {
-		return nil
-	}
-	if !dpp.Spec.IsBuiltinGateway() {
-		return nil
-	}
-	return []core_rules.InboundListener{{
-		Address: dpp.Spec.GetNetworking().GetAddress(),
-	}}
 }
 
 // allInboundListeners returns every inbound of the dataplane as an InboundListener

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -6,12 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -6,22 +6,81 @@ import (
 	"path/filepath"
 	"strings"
 
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/matchers"
+	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	meshtls_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtls/api/v1alpha1"
 	meshtrafficpermission_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	test_matchers "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	test_resources "github.com/kumahq/kuma/v3/pkg/test/resources"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 )
 
 var _ = Describe("MatchedPolicies", func() {
+	It("returns GatewayRules for mesh-wide policy on a legacy built-in gateway with no inbounds", func() {
+		// given
+		dpp := &core_mesh.DataplaneResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: "mesh-1",
+				Name: "builtin-gateway",
+			},
+			Spec: &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "192.0.2.1",
+					Gateway: &mesh_proto.Dataplane_Networking_Gateway{
+						Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
+						Tags: map[string]string{
+							mesh_proto.ServiceTag: "gateway",
+						},
+					},
+				},
+			},
+		}
+
+		mode := meshtls_api.ModeStrict
+		policy := meshtls_api.NewMeshTLSResource()
+		policy.Meta = &test_model.ResourceMeta{
+			Mesh: "mesh-1",
+			Name: "mesh-wide",
+		}
+		policy.Spec.TargetRef = &common_api.TargetRef{Kind: common_api.Mesh}
+		policy.Spec.Rules = &[]meshtls_api.Rule{{
+			Default: meshtls_api.Conf{
+				Mode: &mode,
+			},
+		}}
+		resources := xds_context.NewResources()
+		resources.MeshLocalResources[meshtls_api.MeshTLSType] = &meshtls_api.MeshTLSResourceList{
+			Items: []*meshtls_api.MeshTLSResource{policy},
+		}
+
+		// when
+		matches, err := matchers.PolicyMatches(policy, dpp, resources)
+		Expect(err).ToNot(HaveOccurred())
+		policies, err := matchers.MatchedPolicies(meshtls_api.MeshTLSType, dpp, resources)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(matches).To(BeTrue())
+		Expect(policies.DataplanePolicies).To(ConsistOf(policy))
+		Expect(policies.FromRules.InboundRules).To(BeEmpty())
+		Expect(policies.GatewayRules.InboundRules).To(HaveKey(core_rules.InboundListener{
+			Address: "192.0.2.1",
+		}))
+	})
+
 	type testCase struct {
 		testName     string
 		dppFile      string

--- a/pkg/plugins/policies/core/matchers/dataplane_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_test.go
@@ -10,77 +10,18 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 
-	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
-	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/matchers"
-	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	meshtls_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtls/api/v1alpha1"
 	meshtrafficpermission_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	test_matchers "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	test_resources "github.com/kumahq/kuma/v3/pkg/test/resources"
-	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
-	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 )
 
 var _ = Describe("MatchedPolicies", func() {
-	It("returns GatewayRules for mesh-wide policy on a legacy built-in gateway with no inbounds", func() {
-		// given
-		dpp := &core_mesh.DataplaneResource{
-			Meta: &test_model.ResourceMeta{
-				Mesh: "mesh-1",
-				Name: "builtin-gateway",
-			},
-			Spec: &mesh_proto.Dataplane{
-				Networking: &mesh_proto.Dataplane_Networking{
-					Address: "192.0.2.1",
-					Gateway: &mesh_proto.Dataplane_Networking_Gateway{
-						Type: mesh_proto.Dataplane_Networking_Gateway_BUILTIN,
-						Tags: map[string]string{
-							mesh_proto.ServiceTag: "gateway",
-						},
-					},
-				},
-			},
-		}
-
-		mode := meshtls_api.ModeStrict
-		policy := meshtls_api.NewMeshTLSResource()
-		policy.Meta = &test_model.ResourceMeta{
-			Mesh: "mesh-1",
-			Name: "mesh-wide",
-		}
-		policy.Spec.TargetRef = &common_api.TargetRef{Kind: common_api.Mesh}
-		policy.Spec.Rules = &[]meshtls_api.Rule{{
-			Default: meshtls_api.Conf{
-				Mode: &mode,
-			},
-		}}
-		resources := xds_context.NewResources()
-		resources.MeshLocalResources[meshtls_api.MeshTLSType] = &meshtls_api.MeshTLSResourceList{
-			Items: []*meshtls_api.MeshTLSResource{policy},
-		}
-
-		// when
-		matches, err := matchers.PolicyMatches(policy, dpp, resources)
-		Expect(err).ToNot(HaveOccurred())
-		policies, err := matchers.MatchedPolicies(meshtls_api.MeshTLSType, dpp, resources)
-
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(matches).To(BeTrue())
-		Expect(policies.DataplanePolicies).To(ConsistOf(policy))
-		Expect(policies.FromRules.InboundRules).To(BeEmpty())
-		Expect(policies.GatewayRules.InboundRules).To(HaveKey(core_rules.InboundListener{
-			Address: "192.0.2.1",
-		}))
-	})
-
 	type testCase struct {
 		testName     string
 		dppFile      string

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -64,7 +64,7 @@ var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
 						Name: "route-2",
 					},
 					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.TargetRefService("web")),
+						TargetRef: pointer.To(builders.TargetRefDataplaneName("web-01")),
 						To: &[]api.To{{
 							TargetRef: builders.TargetRefService("backend"),
 							Rules: []api.Rule{{

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -104,7 +104,7 @@ var _ = Describe("MeshTCPRoute", func() {
 									Name: "route-2",
 								},
 								Spec: &api.MeshTCPRoute{
-									TargetRef: pointer.To(builders.TargetRefService("web")),
+									TargetRef: pointer.To(builders.TargetRefDataplaneName("web-01")),
 									To: &[]api.To{
 										{
 											TargetRef: builders.TargetRefService("backend"),


### PR DESCRIPTION
## Motivation

Remove subset resolution logic from the dataplane matcher to simplify targetRef matching.

## Implementation information

- Removed MeshSubset, MeshServiceSubset, and MeshService-selector cases from `DppSelectedByPolicy` in `policies/core/matchers/dataplane.go`
- Deleted the `inboundsSelectedByTags` helper function
- Updated matchers testdata to reflect the removals

Closes https://github.com/kumahq/kuma/issues/17306

_Generated by Sybra harness_