### PR TITLE
fix(xds): unified naming for zone-proxy admin

### DIFF
--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -63,8 +63,8 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 		return nil, errors.New("ReadinessPort has to be in (0, 65535] range")
 	}
 	// AdminProxyGenerator also runs for zone ingress/egress, which aren't mesh-scoped
-	// (xdsCtx.Mesh is nil for them), so unlike mesh-scoped generators we can't use
-	// unified_naming.Enabled here: it would always see a nil mesh and report unified
+	// (xdsCtx.Mesh.Resource is nil for them), so unlike mesh-scoped generators we can't
+	// use unified_naming.Enabled here: it would always see a nil mesh and report unified
 	// naming as disabled for zone proxies.
 	// TODO(unified-resource-naming): adjust when legacy naming is removed
 	unifiedNamingEnabled := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)

--- a/pkg/xds/generator/admin_proxy_generator.go
+++ b/pkg/xds/generator/admin_proxy_generator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 
-	unified_naming "github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	core_system_names "github.com/kumahq/kuma/v2/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
@@ -63,8 +62,12 @@ func (g AdminProxyGenerator) Generate(ctx context.Context, _ *core_xds.ResourceS
 	if readinessPort == 0 {
 		return nil, errors.New("ReadinessPort has to be in (0, 65535] range")
 	}
+	// AdminProxyGenerator also runs for zone ingress/egress, which aren't mesh-scoped
+	// (xdsCtx.Mesh is nil for them), so unlike mesh-scoped generators we can't use
+	// unified_naming.Enabled here: it would always see a nil mesh and report unified
+	// naming as disabled for zone proxies.
 	// TODO(unified-resource-naming): adjust when legacy naming is removed
-	unifiedNamingEnabled := unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)
+	unifiedNamingEnabled := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
 	// We assume that Admin API must be available on a loopback interface (while users
 	// can override the default value `127.0.0.1` in the Bootstrap Server section of `kuma-cp` config,
 	// the only reasonable alternatives are `::1`, `0.0.0.0` or `::`).

--- a/pkg/xds/generator/admin_proxy_generator_test.go
+++ b/pkg/xds/generator/admin_proxy_generator_test.go
@@ -215,4 +215,60 @@ var _ = Describe("AdminProxyGenerator", func() {
 			readinessPort: 0,
 		}),
 	)
+
+	// Zone ingress/egress aren't mesh-scoped, so xdsCtx.Mesh.Resource is always nil
+	// for them. AdminProxyGenerator must still honor the unified naming feature flag
+	// in that case instead of silently falling back to legacy naming.
+	DescribeTable("should name the envoy admin cluster for zone proxies based on the unified naming feature",
+		func(unifiedNaming bool, expectedClusterName string) {
+			metadata := &xds.DataplaneMetadata{
+				AdminPort:     9901,
+				ReadinessPort: 9902,
+				Features: map[string]bool{
+					xds_types.FeatureUnifiedResourceNaming: unifiedNaming,
+				},
+			}
+			ctx := xds_context.Context{}
+
+			zoneIngressProxy := &xds.Proxy{
+				Id:         *xds.BuildProxyId("default", "zone-ingress"),
+				APIVersion: envoy_common.APIV3,
+				ZoneIngressProxy: &xds.ZoneIngressProxy{
+					ZoneIngressResource: &core_mesh.ZoneIngressResource{
+						Meta: &test_model.ResourceMeta{Name: "zone-ingress"},
+						Spec: &mesh_proto.ZoneIngress{
+							Networking: &mesh_proto.ZoneIngress_Networking{Address: "10.0.0.1"},
+						},
+					},
+				},
+				Metadata: metadata,
+			}
+			zoneEgressProxy := &xds.Proxy{
+				Id:         *xds.BuildProxyId("default", "zone-egress"),
+				APIVersion: envoy_common.APIV3,
+				ZoneEgressProxy: &xds.ZoneEgressProxy{
+					ZoneEgressResource: &core_mesh.ZoneEgressResource{
+						Meta: &test_model.ResourceMeta{Name: "zone-egress"},
+						Spec: &mesh_proto.ZoneEgress{
+							Networking: &mesh_proto.ZoneEgress_Networking{Address: "10.0.0.2"},
+						},
+					},
+				},
+				Metadata: metadata,
+			}
+
+			for _, proxy := range []*xds.Proxy{zoneIngressProxy, zoneEgressProxy} {
+				resources, err := generator.Generate(context.Background(), nil, ctx, proxy)
+				Expect(err).ToNot(HaveOccurred())
+
+				var clusterNames []string
+				for _, resource := range resources.List() {
+					clusterNames = append(clusterNames, resource.Name)
+				}
+				Expect(clusterNames).To(ContainElement(expectedClusterName))
+			}
+		},
+		Entry("legacy naming", false, "kuma:envoy:admin"),
+		Entry("unified naming", true, "system_envoy_admin"),
+	)
 })

--- a/pkg/xds/generator/admin_proxy_generator_test.go
+++ b/pkg/xds/generator/admin_proxy_generator_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -262,7 +263,7 @@ var _ = Describe("AdminProxyGenerator", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				var clusterNames []string
-				for _, resource := range resources.List() {
+				for _, resource := range resources.ListOf(envoy_resource.ClusterType) {
 					clusterNames = append(clusterNames, resource.Name)
 				}
 				Expect(clusterNames).To(ContainElement(expectedClusterName))


### PR DESCRIPTION
## Motivation

> Changelog: fix(xds): unified naming for zone-proxy admin cluster

Backport of the master fix (unified naming for zone ingress/egress
admin cluster) to release-2.14. `AdminProxyGenerator` computed whether
to use unified resource naming with
`unified_naming.Enabled(proxy.Metadata, xdsCtx.Mesh.Resource)`. For zone
proxies `xdsCtx.Mesh` is always an empty `MeshContext{}` (zone proxies
aren't scoped to a single mesh), so `xdsCtx.Mesh.Resource` is always
`nil`, and `unified_naming.Enabled` always returns `false` regardless
of the proxy's actual `feature-unified-resource-naming` flag. As a
result, a zone ingress/egress's Envoy admin cluster/listener stays
named `kuma:envoy:admin` instead of `system_envoy_admin` even when
unified naming is enabled.

## Implementation information

- `pkg/xds/generator/admin_proxy_generator.go`: compute
  `unifiedNamingEnabled` from `proxy.Metadata.HasFeature(...)` directly
  instead of the always-nil-mesh `unified_naming.Enabled` call.
- Added test coverage generating the admin proxy resources for zone
  ingress and zone egress proxies with unified naming on/off.

## Supporting documentation

N/A