### PR TITLE
fix(meshproxypatch): match unified listener names

### DIFF
--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go
@@ -148,7 +148,7 @@ func (h *httpFilterModificator) listenerMatches(resource *core_xds.Resource) boo
 	if h.Match == nil {
 		return true
 	}
-	if h.Match.ListenerName != nil && *h.Match.ListenerName != resource.Name {
+	if h.Match.ListenerName != nil && !listenerNameMatches(*h.Match.ListenerName, resource.Name) {
 		return false
 	}
 	if h.Match.Origin != nil && *h.Match.Origin != string(resource.Origin) {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod_test.go
@@ -315,6 +315,41 @@ var _ = Describe("HTTP Filter modifications", func() {
                 name: inbound:192.168.0.1:8081
                 trafficDirection: INBOUND`,
 		}),
+		Entry("should match listener by legacy name against a unified-naming listener", testCase{
+			listeners: []string{
+				`
+                name: self_transparentproxy_passthrough_outbound_ipv4
+                filterChains:
+                - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                      httpFilters:
+                      - name: envoy.filters.http.router
+                      - name: envoy.filters.http.cors
+                      statPrefix: outbound_passthrough`,
+			},
+			modifications: []string{
+				`
+                httpFilter:
+                   operation: Remove
+                   match:
+                     listenerName: outbound:passthrough:ipv4
+`,
+			},
+			expected: `
+            resources:
+            - name: self_transparentproxy_passthrough_outbound_ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+                filterChains:
+                - filters:
+                  - name: envoy.filters.network.http_connection_manager
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                      statPrefix: outbound_passthrough
+                name: self_transparentproxy_passthrough_outbound_ipv4`,
+		}),
 		Entry("should remove all filters of given name from all listeners", testCase{
 			listeners: []string{
 				`

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod.go
@@ -75,7 +75,7 @@ func (l *listenerModificator) listenerMatches(listener *core_xds.Resource) bool 
 	if l.Match == nil {
 		return true
 	}
-	if l.Match.Name != nil && *l.Match.Name != listener.Name {
+	if l.Match.Name != nil && !listenerNameMatches(*l.Match.Name, listener.Name) {
 		return false
 	}
 	if l.Match.Origin != nil && *l.Match.Origin != string(listener.Origin) {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod_test.go
@@ -178,6 +178,30 @@ var _ = Describe("Listener modifications", func() {
                 name: inbound:192.168.0.1:8081
                 trafficDirection: INBOUND`,
 		}),
+		Entry("should remove listener by legacy name against a unified-naming listener", testCase{
+			listeners: []string{
+				`
+                name: self_transparentproxy_passthrough_outbound_ipv4
+                trafficDirection: OUTBOUND`,
+				`
+                name: inbound:192.168.0.1:8081
+                trafficDirection: INBOUND`,
+			},
+			modifications: []string{
+				`
+                listener:
+                   operation: Remove
+                   match:
+                     name: outbound:passthrough:ipv4`,
+			},
+			expected: `
+            resources:
+            - name: inbound:192.168.0.1:8081
+              resource:
+                '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+                name: inbound:192.168.0.1:8081
+                trafficDirection: INBOUND`,
+		}),
 		Entry("should remove all inbound listeners", testCase{
 			listeners: []string{
 				`

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go
@@ -9,13 +9,39 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/naming"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/jsonpatch"
 	api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshproxypatch/api/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
 	envoy_metadata "github.com/kumahq/kuma/v2/pkg/xds/envoy/metadata/v3"
+	generator_meta "github.com/kumahq/kuma/v2/pkg/xds/generator/metadata"
 )
+
+// systemListenerNameEquivalents pairs up the legacy and unified-resource-naming
+// names of well-known system listeners. Users write MeshProxyPatch's
+// listenerName against whichever naming scheme they know, but the actual
+// listener name depends on whether unified naming is enabled for the proxy -
+// a plain string match on one form would silently never match the other.
+var systemListenerNameEquivalents = [][2]string{
+	{generator_meta.TransparentOutboundNameIPv4, naming.ContextualTransparentProxyName("outbound", 4)},
+	{generator_meta.TransparentOutboundNameIPv6, naming.ContextualTransparentProxyName("outbound", 6)},
+	{generator_meta.TransparentInboundNameIPv4, naming.ContextualTransparentProxyName("inbound", 4)},
+	{generator_meta.TransparentInboundNameIPv6, naming.ContextualTransparentProxyName("inbound", 6)},
+}
+
+func listenerNameMatches(match, actual string) bool {
+	if match == actual {
+		return true
+	}
+	for _, pair := range systemListenerNameEquivalents {
+		if (match == pair[0] && actual == pair[1]) || (match == pair[1] && actual == pair[0]) {
+			return true
+		}
+	}
+	return false
+}
 
 type networkFilterModificator api.NetworkFilterMod
 
@@ -125,7 +151,7 @@ func (n *networkFilterModificator) listenerMatches(resource *core_xds.Resource) 
 	if n.Match == nil {
 		return true
 	}
-	if n.Match.ListenerName != nil && *n.Match.ListenerName != resource.Name {
+	if n.Match.ListenerName != nil && !listenerNameMatches(*n.Match.ListenerName, resource.Name) {
 		return false
 	}
 	if n.Match.Origin != nil && *n.Match.Origin != string(resource.Origin) {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod_test.go
@@ -310,6 +310,34 @@ var _ = Describe("Network Filter modifications", func() {
                       cluster: backend
                 name: inbound:192.168.0.1:8081`,
 		}),
+		Entry("should match listener by legacy name against a unified-naming listener", testCase{
+			listeners: []string{
+				`
+                name: self_transparentproxy_passthrough_outbound_ipv4
+                filterChains:
+                - filters:
+                  - name: envoy.filters.network.tcp_proxy
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                      cluster: backend`,
+			},
+			modifications: []string{
+				`
+                networkFilter:
+                   operation: Remove
+                   match:
+                     listenerName: outbound:passthrough:ipv4
+`,
+			},
+			expected: `
+            resources:
+            - name: self_transparentproxy_passthrough_outbound_ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+                filterChains:
+                - {}
+                name: self_transparentproxy_passthrough_outbound_ipv4`,
+		}),
 		Entry("should remove all filters of given name from all listeners", testCase{
 			listeners: []string{
 				`


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshproxypatch): match unified listener names

Backport of the master fix (unified naming for zone ingress/egress
admin cluster) to release-2.14. `MeshProxyPatch`'s network filter, HTTP
filter, and listener modificators all match a target listener by exact
string equality between the policy's `listenerName`/`name` and the
Envoy resource's `Name`. Well-known system listeners (currently the
transparent-proxy passthrough listeners) are named differently
depending on whether unified resource naming is enabled for the proxy,
e.g. `outbound:passthrough:ipv4` under legacy naming vs.
`self_transparentproxy_passthrough_outbound_ipv4` under unified naming.
A `MeshProxyPatch` written against one naming scheme silently stops
matching once the proxy switches naming scheme, so the patch never
applies without an error.

## Implementation information

- `pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go`:
  added `listenerNameMatches`, which treats the legacy and unified
  names of the transparent-proxy passthrough listeners (inbound and
  outbound, IPv4 and IPv6) as equivalent, in addition to exact string
  equality. Used in place of the plain `!=` comparison.
- `pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/http_filter_mod.go`
  and `.../listener_mod.go`: same fix, reusing `listenerNameMatches`
  (same package) since both had the identical exact-match bug for
  their own `listenerName`/`name` matcher.
- Added test coverage for all three modificators matching a
  unified-naming-named listener via its legacy name.

## Supporting documentation

N/A