### PR TITLE
fix(meshaccesslog): match rule-scoped route ids

### DIFF
--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -578,11 +578,14 @@ func buildRoutesMap(l *envoy_listener.Listener, svcCtx *outbound.ResourceContext
 
 		id, _ := kri.FromString(route.Name)
 
-		routeCtx := svcCtx.
-			WithID(kri.NoSectionName(id)).
-			WithID(id)
-
-		if conf, isDirect := routeCtx.DirectConf(); isDirect {
+		// A MeshAccessLog can target either the specific MeshHTTPRoute rule that
+		// produced this route (id, which under unified naming carries a "rule_N"
+		// section name) or the whole MeshHTTPRoute resource (no section name).
+		// DirectConf only ever looks at the most specific id, so both candidates
+		// have to be checked individually rather than chained through WithID.
+		if conf, isDirect := svcCtx.WithID(id).DirectConf(); isDirect {
+			routes[id] = conf
+		} else if conf, isDirect := svcCtx.WithID(kri.NoSectionName(id)).DirectConf(); isDirect {
 			routes[id] = conf
 		}
 	}); err != nil {

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -289,6 +289,65 @@ var _ = Describe("MeshAccessLog", func() {
 			},
 			expectedListeners: []string{"basic_outbound_meshhttproute.listener.golden.yaml"},
 		}),
+		Entry("matches MeshHTTPRoute policy when route name carries a unified-naming rule section", sidecarTestCase{
+			resources: []core_xds.Resource{
+				outboundRealServiceHTTPListener(*otherMeshServiceHTTP, 27777, []meshhttproute_xds.OutboundRoute{
+					{
+						Name: routeKRI("route-1").String(),
+						Match: meshhttproute_api.Match{
+							Path: &meshhttproute_api.PathMatch{Type: meshhttproute_api.PathPrefix, Value: "/route-1"},
+						},
+						Split: []envoy_common.Split{
+							xds.NewSplitBuilder().WithClusterName(serviceName(*otherMeshServiceHTTP, 27777)).Build(),
+						},
+					},
+					{
+						// Under unified naming, a real-resource route carries a
+						// "rule_N" section name identifying the specific
+						// MeshHTTPRoute rule that produced it.
+						Name: kri.WithSectionName(routeKRI("route-2"), "rule_0").String(),
+						Match: meshhttproute_api.Match{
+							Path: &meshhttproute_api.PathMatch{Type: meshhttproute_api.PathPrefix, Value: "/route-2"},
+						},
+						Split: []envoy_common.Split{
+							xds.NewSplitBuilder().WithClusterName(serviceName(*otherMeshServiceHTTP, 27777)).Build(),
+						},
+					},
+				}),
+			},
+			toRules: core_rules.ToRules{
+				ResourceRules: map[kri.Identifier]outbound.ResourceRule{
+					*otherMeshServiceHTTP: {
+						Conf: []any{
+							api.Conf{
+								Backends: &[]api.Backend{{
+									Type: api.FileBackendType,
+									File: &api.FileBackend{
+										Path: "/tmp/meshservice/log",
+									},
+								}},
+							},
+						},
+					},
+					// This MeshAccessLog targets the whole MeshHTTPRoute
+					// resource (no rule section), which must still match
+					// route-2's rule-scoped name.
+					routeKRI("route-2"): {
+						Conf: []any{
+							api.Conf{
+								Backends: &[]api.Backend{{
+									Type: api.FileBackendType,
+									File: &api.FileBackend{
+										Path: "/tmp/route-2/log",
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			expectedListeners: []string{"basic_outbound_meshhttproute_unified_naming.listener.golden.yaml"},
+		}),
 		Entry("disable MAL for MeshHTTPRoute", sidecarTestCase{
 			resources: []core_xds.Resource{
 				outboundRealServiceHTTPListener(*otherMeshServiceHTTP, 27777, []meshhttproute_xds.OutboundRoute{

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute_unified_naming.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute_unified_naming.listener.golden.yaml
@@ -1,0 +1,115 @@
+address:
+  socketAddress:
+    address: 127.0.0.1
+    portValue: 27777
+filterChains:
+- filters:
+  - name: envoy.filters.network.http_connection_manager
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      accessLog:
+      - filter:
+          metadataFilter:
+            matchIfKeyNotFound: true
+            matcher:
+              filter: kuma.routes
+              path:
+              - key: route_kri
+              value:
+                nullMatch: {}
+        name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "backend" "other-meshservice-http" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/meshservice/log
+      - filter:
+          metadataFilter:
+            matchIfKeyNotFound: false
+            matcher:
+              filter: kuma.routes
+              path:
+              - key: route_kri
+              value:
+                stringMatch:
+                  exact: kri_mhttpr_default___route-2_rule0
+        name: envoy.access_loggers.file
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          logFormat:
+            textFormatSource:
+              inlineString: |
+                [%START_TIME%] default "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-B3-TRACEID?X-DATADOG-TRACEID)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "backend" "other-meshservice-http" "127.0.0.1" "%UPSTREAM_HOST%"
+          path: /tmp/route-2/log
+      httpFilters:
+      - name: envoy.filters.http.lua
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+          defaultSourceCode:
+            inlineString: |
+              function envoy_on_request(handle)
+                local meta = handle:metadata():get("route_kri")
+                if meta ~= nil then
+                  handle:streamInfo():dynamicMetadata():set("kuma.routes", "route_kri", meta)
+                end
+              end
+      - name: envoy.filters.http.router
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      internalAddressConfig:
+        cidrRanges:
+        - addressPrefix: 127.0.0.1
+          prefixLen: 32
+      normalizePath: true
+      routeConfig:
+        name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+        requestHeadersToAdd:
+        - header:
+            key: x-kuma-tags
+            value: '&kuma.io/service=backend&'
+        validateClusters: false
+        virtualHosts:
+        - domains:
+          - '*'
+          name: default_other-meshservice-http_other-ns_zone-1_msvc_27777
+          routes:
+          - match:
+              path: /route-1
+            name: kri_mhttpr_default___route-1_
+            route:
+              cluster: default_other-meshservice-http_other-ns_zone-1_msvc_27777
+              timeout: 0s
+          - match:
+              prefix: /route-1/
+            name: kri_mhttpr_default___route-1_
+            route:
+              cluster: default_other-meshservice-http_other-ns_zone-1_msvc_27777
+              timeout: 0s
+          - match:
+              path: /route-2
+            metadata:
+              filterMetadata:
+                envoy.filters.http.lua:
+                  route_kri: kri_mhttpr_default___route-2_rule0
+            name: kri_mhttpr_default___route-2_rule_0
+            route:
+              cluster: default_other-meshservice-http_other-ns_zone-1_msvc_27777
+              timeout: 0s
+          - match:
+              prefix: /route-2/
+            metadata:
+              filterMetadata:
+                envoy.filters.http.lua:
+                  route_kri: kri_mhttpr_default___route-2_rule0
+            name: kri_mhttpr_default___route-2_rule_0
+            route:
+              cluster: default_other-meshservice-http_other-ns_zone-1_msvc_27777
+              timeout: 0s
+      statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
+metadata:
+  filterMetadata:
+    io.kuma.tags: {}
+name: outbound:127.0.0.1:27777
+trafficDirection: OUTBOUND


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshaccesslog): match rule-scoped route ids

Backport of the master fix to release-2.14. Under unified resource
naming, a real-resource `MeshHTTPRoute` outbound route's Envoy
`Route.Name` carries a `rule_N` section name identifying the specific
rule that produced it. A `MeshAccessLog` policy that targets the whole
`MeshHTTPRoute` resource (no specific rule) is keyed in `ResourceRules`
without that section name.

`MeshAccessLog`'s `buildRoutesMap` tried to check both the rule-scoped
id and the section-less id by chaining
`svcCtx.WithID(sectionLess).WithID(id)` and calling `DirectConf()`
once, but `DirectConf()` only ever looks at the single most specific
id. Under legacy naming the two ids happened to be identical, so the
bug was masked; once unified naming is on they diverge, and the
section-less id chained via `WithID` is never actually consulted. The
result: a `MeshAccessLog` targeting the whole `MeshHTTPRoute` resource
silently never matches, and the per-route access log entry is skipped
in favor of the more general fallback ("common") config.

## Implementation information

- `pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go`
  `buildRoutesMap`: check the rule-scoped id and the section-less id as
  two separate `DirectConf()` calls (most specific first) instead of
  chaining them through `WithID` and relying on `DirectConf()`'s
  single-id lookup.
- Added a golden-file test case verifying a route name carrying a
  `rule_N` section resolves to the section-less `MeshAccessLog`
  policy's backend rather than falling back to the mesh-service-level
  default.

## Supporting documentation

N/A