### PR TITLE
refactor(mesh): drop MeshMetric backend endpoints for BackendRef

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -609,6 +609,20 @@ use, rotate them (generate new tokens with the current control plane)
 before upgrading — they will be rejected as using an unsupported
 algorithm afterward.
 
+### `MeshMetric` OpenTelemetry backend no longer accepts an inline `endpoint`
+
+The deprecated `default.backends[].openTelemetry.endpoint` field has been
+removed from the `MeshMetric` policy. `backendRef`, pointing at a
+`MeshOpenTelemetryBackend` resource, is now the only way to configure an
+OpenTelemetry metrics backend.
+
+**Action required**
+
+If any `MeshMetric` policy still sets `openTelemetry.endpoint`, create a
+`MeshOpenTelemetryBackend` resource with the equivalent endpoint and update
+the policy to reference it via `openTelemetry.backendRef` before upgrading.
+Policies that still set `openTelemetry.endpoint` will fail validation.
+
 ## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2366,7 +2366,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -2383,13 +2383,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2366,7 +2366,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -2383,13 +2383,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2386,7 +2386,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -2403,13 +2403,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -5296,7 +5296,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -5313,13 +5313,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -92,7 +92,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -109,13 +109,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -11969,8 +11969,7 @@ components:
                               BackendRef is a reference to a
                               MeshOpenTelemetryBackend resource that
 
-                              defines the collector endpoint. Mutually exclusive
-                              with Endpoint.
+                              defines the collector endpoint.
                             properties:
                               kind:
                                 description: Kind of the backend resource.
@@ -11989,13 +11988,6 @@ components:
                             required:
                               - kind
                             type: object
-                          endpoint:
-                            default: ''
-                            description: |-
-                              Endpoint for OpenTelemetry collector.
-
-                              Deprecated: use BackendRef instead.
-                            type: string
                           refreshInterval:
                             description: >-
                               RefreshInterval defines how frequent metrics

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -92,7 +92,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -109,13 +109,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
@@ -2,16 +2,8 @@ package v1alpha1
 
 import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 func (t *MeshMetricResource) Deprecations() []string {
-	var deprecations []string
-	for _, backend := range pointer.Deref(t.Spec.Default.Backends) {
-		if backend.OpenTelemetry != nil && backend.OpenTelemetry.Endpoint != "" && backend.OpenTelemetry.BackendRef == nil {
-			deprecations = append(deprecations, "openTelemetry.endpoint is deprecated, use openTelemetry.backendRef with a MeshOpenTelemetryBackend resource instead")
-			break
-		}
-	}
-	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/meshmetric.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/meshmetric.go
@@ -134,14 +134,8 @@ type PrometheusTls struct {
 }
 
 type OpenTelemetryBackend struct {
-	// Endpoint for OpenTelemetry collector.
-	//
-	// Deprecated: use BackendRef instead.
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=""
-	Endpoint string `json:"endpoint"`
 	// BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-	// defines the collector endpoint. Mutually exclusive with Endpoint.
+	// defines the collector endpoint.
 	BackendRef *common_api.BackendResourceRef `json:"backendRef,omitempty"`
 	// RefreshInterval defines how frequent metrics should be pushed to collector
 	RefreshInterval *k8s.Duration `json:"refreshInterval,omitempty"`

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -191,7 +191,7 @@ components:
                           backendRef:
                             description: |-
                               BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                              defines the collector endpoint. Mutually exclusive with Endpoint.
+                              defines the collector endpoint.
                             properties:
                               kind:
                                 description: Kind of the backend resource.
@@ -208,13 +208,6 @@ components:
                             required:
                               - kind
                             type: object
-                          endpoint:
-                            default: ""
-                            description: |-
-                              Endpoint for OpenTelemetry collector.
-
-                              Deprecated: use BackendRef instead.
-                            type: string
                           refreshInterval:
                             description: RefreshInterval defines how frequent metrics should be pushed to collector
                             type: string

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
@@ -133,11 +133,12 @@ func validateBackend(backends *[]Backend) validators.ValidationError {
 				verr.Add(validators.ValidatePort(path.Field("port"), backend.Prometheus.Port))
 			}
 		case OpenTelemetryBackendType:
-			if backend.OpenTelemetry == nil {
+			switch {
+			case backend.OpenTelemetry == nil:
 				verr.AddViolationAt(path.Field("openTelemetry"), validators.MustBeDefined)
-			} else if backend.OpenTelemetry.BackendRef == nil {
+			case backend.OpenTelemetry.BackendRef == nil:
 				verr.AddViolationAt(path.Field("openTelemetry").Field("backendRef"), validators.MustBeDefined)
-			} else {
+			default:
 				verr.AddErrorAt(path.Field("openTelemetry").Field("backendRef"), validators.ValidateBackendResourceRef(backend.OpenTelemetry.BackendRef))
 			}
 		default:

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"net"
 	"regexp"
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
@@ -136,30 +135,15 @@ func validateBackend(backends *[]Backend) validators.ValidationError {
 		case OpenTelemetryBackendType:
 			if backend.OpenTelemetry == nil {
 				verr.AddViolationAt(path.Field("openTelemetry"), validators.MustBeDefined)
+			} else if backend.OpenTelemetry.BackendRef == nil {
+				verr.AddViolationAt(path.Field("openTelemetry").Field("backendRef"), validators.MustBeDefined)
 			} else {
-				// validateOtelEndpointHostPort maintains backward compatibility:
-				// MeshMetric required host:port before backendRef was introduced.
-				verr.AddErrorAt(path.Field("openTelemetry"), validators.ValidateOtelBackendRefOrEndpoint(
-					backend.OpenTelemetry.Endpoint,
-					backend.OpenTelemetry.BackendRef,
-					validateOtelEndpointHostPort,
-				))
+				verr.AddErrorAt(path.Field("openTelemetry").Field("backendRef"), validators.ValidateBackendResourceRef(backend.OpenTelemetry.BackendRef))
 			}
 		default:
 			verr.AddViolationAt(path, "unrecognized type")
 		}
 	}
 
-	return verr
-}
-
-// validateOtelEndpointHostPort enforces host:port format for MeshMetric
-// endpoints. MeshMetric required a URL-like endpoint before backendRef was
-// introduced, so we keep the port requirement for backward compatibility.
-func validateOtelEndpointHostPort(endpoint string) validators.ValidationError {
-	var verr validators.ValidationError
-	if _, _, err := net.SplitHostPort(endpoint); err != nil {
-		verr.AddViolationAt(validators.RootedAt("endpoint"), "must be in host:port format")
-	}
 	return verr
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/validator_test.go
@@ -43,7 +43,10 @@ default:
           mode: "ProvidedTLS"
     - type: OpenTelemetry
       openTelemetry:
-        endpoint: otel-collector:4778
+        backendRef:
+          kind: MeshOpenTelemetryBackend
+          labels:
+            kuma.io/display-name: my-otel
 `),
 		Entry("openTelemetry with backendRef", `
 type: MeshMetric
@@ -171,46 +174,10 @@ default:
         - name: not_supported
 `),
 		ErrorCase(
-			"invalid endpoint missing port",
+			"openTelemetry backendRef missing",
 			validators.Violation{
-				Field:   "spec.default.backends.backend[0].openTelemetry.endpoint",
-				Message: "must be in host:port format",
-			},
-			`
-type: MeshMetric
-mesh: mesh-1
-name: metrics-1
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: "asdasd123"
-`),
-		ErrorCase(
-			"invalid endpoint with URL scheme",
-			validators.Violation{
-				Field:   "spec.default.backends.backend[0].openTelemetry.endpoint",
-				Message: "must be in host:port format, not a URL",
-			},
-			`
-type: MeshMetric
-mesh: mesh-1
-name: metrics-1
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: "http://endpoint:8023"
-`),
-		ErrorCase(
-			"openTelemetry neither endpoint nor backendRef",
-			validators.Violation{
-				Field:   "spec.default.backends.backend[0].openTelemetry",
-				Message: "openTelemetry must have exactly one defined: endpoint, backendRef",
+				Field:   "spec.default.backends.backend[0].openTelemetry.backendRef",
+				Message: "must be defined",
 			},
 			`
 type: MeshMetric
@@ -222,28 +189,6 @@ default:
   backends:
     - type: OpenTelemetry
       openTelemetry: {}
-`),
-		ErrorCase(
-			"openTelemetry both endpoint and backendRef",
-			validators.Violation{
-				Field:   "spec.default.backends.backend[0].openTelemetry",
-				Message: "openTelemetry must have only one type defined: endpoint, backendRef",
-			},
-			`
-type: MeshMetric
-mesh: mesh-1
-name: metrics-1
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: otel-collector:4778
-        backendRef:
-          kind: MeshOpenTelemetryBackend
-          labels:
-            kuma.io/display-name: my-otel
 `),
 		ErrorCase(
 			"openTelemetry backendRef no labels",

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -92,7 +92,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -109,13 +109,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Endpoint for OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              type: string
                             refreshInterval:
                               description: RefreshInterval defines how frequent metrics
                                 should be pushed to collector

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -146,7 +146,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		inboundTagsDisabled = ctx.ControlPlane.InboundTagsDisabled
 	}
 
-	if err := configureDynamicDPPConfig(rs, proxy, ctx.Mesh, conf, prometheusBackends, envoyBackends, inboundTagsDisabled); err != nil {
+	if err := configureDynamicDPPConfig(rs, proxy, ctx.Mesh, conf, prometheusBackends, envoyBackends, inboundTagsDisabled, ctx.Mesh.Resources); err != nil {
 		return err
 	}
 
@@ -228,7 +228,7 @@ func configureOpenTelemetryBackend(rs *core_xds.ResourceSet, proxy *core_xds.Pro
 
 	resolved := policies_xds.ResolveOtelBackend(
 		openTelemetryBackend.BackendRef,
-		openTelemetryBackend.Endpoint,
+		"",
 		policies_xds.ParseOtelEndpoint,
 		backendNameFrom,
 		resources,
@@ -283,8 +283,9 @@ func configureDynamicDPPConfig(
 	prometheusBackends []*api.PrometheusBackend,
 	openTelemetryBackends []*api.OpenTelemetryBackend,
 	inboundTagsDisabled bool,
+	resources xds_context.Resources,
 ) error {
-	dpConfig := createDynamicConfig(conf, proxy, meshCtx.Resource, prometheusBackends, openTelemetryBackends, inboundTagsDisabled)
+	dpConfig := createDynamicConfig(conf, proxy, meshCtx.Resource, prometheusBackends, openTelemetryBackends, inboundTagsDisabled, resources)
 	marshal, err := json.Marshal(dpConfig)
 	if err != nil {
 		return err
@@ -313,6 +314,7 @@ func createDynamicConfig(
 	prometheusBackends []*api.PrometheusBackend,
 	openTelemetryBackends []*api.OpenTelemetryBackend,
 	inboundTagsDisabled bool,
+	resources xds_context.Resources,
 ) dpapi.MeshMetricDpConfig {
 	var applications []dpapi.Application
 	for _, app := range pointer.Deref(conf.Applications) {
@@ -331,7 +333,17 @@ func createDynamicConfig(
 		})
 	}
 	for _, backend := range openTelemetryBackends {
-		backendName := backendNameFrom(backend.Endpoint)
+		resolved := policies_xds.ResolveOtelBackend(
+			backend.BackendRef,
+			"",
+			policies_xds.ParseOtelEndpoint,
+			backendNameFrom,
+			resources,
+		)
+		if resolved == nil {
+			continue
+		}
+		backendName := resolved.Name
 		backends = append(backends, dpapi.Backend{
 			Type: string(api.OpenTelemetryBackendType),
 			Name: &backendName,
@@ -424,7 +436,7 @@ func addOtelToAccumulator(proxy *core_xds.Proxy, openTelemetryBackends []*api.Op
 
 		resolved := policies_xds.ResolveOtelBackend(
 			backend.BackendRef,
-			backend.Endpoint,
+			"",
 			policies_xds.ParseOtelEndpoint,
 			backendNameFrom,
 			ctx.Mesh.Resources,

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -75,7 +75,7 @@ func zoneIngressOnlyDataplane(name string) *builders.DataplaneBuilder {
 		})
 }
 
-func otelBackendResource(name, address string, port int32) *motb_api.MeshOpenTelemetryBackendResource {
+func otelBackendResource(name, address string) *motb_api.MeshOpenTelemetryBackendResource {
 	motb := motb_api.NewMeshOpenTelemetryBackendResource()
 	motb.SetMeta(&test_model.ResourceMeta{
 		Mesh:   "default",
@@ -84,7 +84,7 @@ func otelBackendResource(name, address string, port int32) *motb_api.MeshOpenTel
 	})
 	motb.Spec.Endpoint = &motb_api.Endpoint{
 		Address: new(address),
-		Port:    new(port),
+		Port:    new(int32(4317)),
 	}
 	motb.Spec.Protocol = new(motb_api.ProtocolGRPC)
 	return motb
@@ -246,7 +246,7 @@ var _ = Describe("MeshMetric", func() {
 		}),
 		Entry("openTelemetry", testCase{
 			context: *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).
-				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317)}).
+				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc")}).
 				Build(),
 			proxy: xds_builders.Proxy().
 				WithID(*core_xds.BuildProxyId("default", "backend")).
@@ -324,7 +324,7 @@ var _ = Describe("MeshMetric", func() {
 			context: *xds_builders.Context().WithMeshBuilder(
 				samples.MeshDefaultBuilder(),
 			).
-				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317)}).
+				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc")}).
 				Build(),
 			proxy: xds_builders.Proxy().
 				WithID(*core_xds.BuildProxyId("default", "backend")).
@@ -380,7 +380,7 @@ var _ = Describe("MeshMetric", func() {
 			context: *xds_builders.Context().WithMeshBuilder(
 				samples.MeshDefaultBuilder(),
 			).
-				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317)}).
+				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc")}).
 				Build(),
 			proxy: xds_builders.Proxy().
 				WithID(*core_xds.BuildProxyId("default", "backend")).
@@ -440,8 +440,8 @@ var _ = Describe("MeshMetric", func() {
 		Entry("multiple_otel", testCase{
 			context: *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).
 				WithMeshLocalResources([]core_model.Resource{
-					otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317),
-					otelBackendResource("second-collector", "second-collector.observability.svc", 4317),
+					otelBackendResource("otel-collector", "otel-collector.observability.svc"),
+					otelBackendResource("second-collector", "second-collector.observability.svc"),
 				}).
 				Build(),
 			proxy: xds_builders.Proxy().
@@ -781,7 +781,6 @@ var _ = Describe("MeshMetric", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(clusters)).ToNot(ContainSubstring("_kuma:metrics:opentelemetry:"))
 		})
-
 	})
 
 	DescribeTable("deriveProxyRole",

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -75,6 +75,28 @@ func zoneIngressOnlyDataplane(name string) *builders.DataplaneBuilder {
 		})
 }
 
+func otelBackendResource(name, address string, port int32) *motb_api.MeshOpenTelemetryBackendResource {
+	motb := motb_api.NewMeshOpenTelemetryBackendResource()
+	motb.SetMeta(&test_model.ResourceMeta{
+		Mesh:   "default",
+		Name:   name,
+		Labels: map[string]string{mesh_proto.DisplayName: name},
+	})
+	motb.Spec.Endpoint = &motb_api.Endpoint{
+		Address: new(address),
+		Port:    new(port),
+	}
+	motb.Spec.Protocol = new(motb_api.ProtocolGRPC)
+	return motb
+}
+
+func otelBackendRef(name string) *common_api.BackendResourceRef {
+	return &common_api.BackendResourceRef{
+		Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+		Labels: map[string]string{mesh_proto.DisplayName: name},
+	}
+}
+
 var _ = Describe("MeshMetric", func() {
 	type testCase struct {
 		proxy   *core_xds.Proxy
@@ -223,7 +245,9 @@ var _ = Describe("MeshMetric", func() {
 				Build(),
 		}),
 		Entry("openTelemetry", testCase{
-			context: *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).Build(),
+			context: *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).
+				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317)}).
+				Build(),
 			proxy: xds_builders.Proxy().
 				WithID(*core_xds.BuildProxyId("default", "backend")).
 				WithDataplane(
@@ -247,7 +271,7 @@ var _ = Describe("MeshMetric", func() {
 										{
 											Type: api.OpenTelemetryBackendType,
 											OpenTelemetry: &api.OpenTelemetryBackend{
-												Endpoint:        "otel-collector.observability.svc:4317",
+												BackendRef:      otelBackendRef("otel-collector"),
 												RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
 											},
 										},
@@ -299,7 +323,9 @@ var _ = Describe("MeshMetric", func() {
 		Entry("otel_and_prometheus", testCase{
 			context: *xds_builders.Context().WithMeshBuilder(
 				samples.MeshDefaultBuilder(),
-			).Build(),
+			).
+				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317)}).
+				Build(),
 			proxy: xds_builders.Proxy().
 				WithID(*core_xds.BuildProxyId("default", "backend")).
 				WithDataplane(
@@ -339,7 +365,7 @@ var _ = Describe("MeshMetric", func() {
 										{
 											Type: api.OpenTelemetryBackendType,
 											OpenTelemetry: &api.OpenTelemetryBackend{
-												Endpoint: "otel-collector.observability.svc:4317",
+												BackendRef: otelBackendRef("otel-collector"),
 											},
 										},
 									},
@@ -353,7 +379,9 @@ var _ = Describe("MeshMetric", func() {
 		Entry("otel_and_prometheus_unified_naming", testCase{
 			context: *xds_builders.Context().WithMeshBuilder(
 				samples.MeshDefaultBuilder(),
-			).Build(),
+			).
+				WithMeshLocalResources([]core_model.Resource{otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317)}).
+				Build(),
 			proxy: xds_builders.Proxy().
 				WithID(*core_xds.BuildProxyId("default", "backend")).
 				WithDataplane(
@@ -398,7 +426,7 @@ var _ = Describe("MeshMetric", func() {
 										{
 											Type: api.OpenTelemetryBackendType,
 											OpenTelemetry: &api.OpenTelemetryBackend{
-												Endpoint: "otel-collector.observability.svc:4317",
+												BackendRef: otelBackendRef("otel-collector"),
 											},
 										},
 									},
@@ -410,7 +438,12 @@ var _ = Describe("MeshMetric", func() {
 				Build(),
 		}),
 		Entry("multiple_otel", testCase{
-			context: *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).Build(),
+			context: *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).
+				WithMeshLocalResources([]core_model.Resource{
+					otelBackendResource("otel-collector", "otel-collector.observability.svc", 4317),
+					otelBackendResource("second-collector", "second-collector.observability.svc", 4317),
+				}).
+				Build(),
 			proxy: xds_builders.Proxy().
 				WithDataplane(
 					samples.DataplaneBackendBuilder().
@@ -436,13 +469,13 @@ var _ = Describe("MeshMetric", func() {
 										{
 											Type: api.OpenTelemetryBackendType,
 											OpenTelemetry: &api.OpenTelemetryBackend{
-												Endpoint: "otel-collector.observability.svc:4317",
+												BackendRef: otelBackendRef("otel-collector"),
 											},
 										},
 										{
 											Type: api.OpenTelemetryBackendType,
 											OpenTelemetry: &api.OpenTelemetryBackend{
-												Endpoint: "second-collector.observability.svc:4317",
+												BackendRef: otelBackendRef("second-collector"),
 											},
 										},
 									},
@@ -706,35 +739,6 @@ var _ = Describe("MeshMetric", func() {
 			return proxy
 		}
 
-		It("inline endpoint should not add to pipe accumulator", func() {
-			backends := &[]api.Backend{{
-				Type: api.OpenTelemetryBackendType,
-				OpenTelemetry: &api.OpenTelemetryBackend{
-					Endpoint:        "otel-collector.observability.svc:4317",
-					RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
-				},
-			}}
-
-			proxy := pipeProxy(backends)
-			resources := core_xds.NewResourceSet()
-			plugin := v1alpha1.NewPlugin().(core_plugins.PolicyPlugin)
-
-			Expect(plugin.Apply(resources, *xds_builders.Context().
-				WithMeshBuilder(samples.MeshDefaultBuilder()).Build(), proxy)).To(Succeed())
-
-			// Accumulator stays empty - inline endpoints don't use pipe
-			Expect(proxy.OtelPipeBackends.Empty()).To(BeTrue())
-
-			// Envoy-side OTel resources still created
-			listeners, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ListenerType)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(listeners)).To(ContainSubstring("_kuma:metrics:opentelemetry:"))
-
-			clusters, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ClusterType)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(clusters)).To(ContainSubstring("_kuma:metrics:opentelemetry:"))
-		})
-
 		It("backendRef should add to pipe accumulator and skip Envoy OTel resources", func() {
 			motb := newMotb()
 			backends := &[]api.Backend{{
@@ -778,56 +782,6 @@ var _ = Describe("MeshMetric", func() {
 			Expect(string(clusters)).ToNot(ContainSubstring("_kuma:metrics:opentelemetry:"))
 		})
 
-		It("mixed inline + backendRef should handle each correctly", func() {
-			motb := newMotb()
-			backends := &[]api.Backend{
-				{
-					Type: api.OpenTelemetryBackendType,
-					OpenTelemetry: &api.OpenTelemetryBackend{
-						Endpoint:        "inline-collector.svc:4317",
-						RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
-					},
-				},
-				{
-					Type: api.OpenTelemetryBackendType,
-					OpenTelemetry: &api.OpenTelemetryBackend{
-						BackendRef: &common_api.BackendResourceRef{
-							Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
-							Labels: map[string]string{mesh_proto.DisplayName: backendName},
-						},
-						RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
-					},
-				},
-			}
-
-			proxy := pipeProxy(backends)
-			resources := core_xds.NewResourceSet()
-			plugin := v1alpha1.NewPlugin().(core_plugins.PolicyPlugin)
-
-			ctx := xds_builders.Context().
-				WithMeshBuilder(samples.MeshDefaultBuilder()).
-				WithMeshLocalResources([]core_model.Resource{motb}).
-				Build()
-
-			Expect(plugin.Apply(resources, *ctx, proxy)).To(Succeed())
-
-			// Only backendRef in accumulator
-			Expect(proxy.OtelPipeBackends.Empty()).To(BeFalse())
-			pipeBackends := proxy.OtelPipeBackends.All()
-			Expect(pipeBackends).To(HaveLen(1))
-			Expect(pipeBackends[0].Endpoint).To(Equal("collector.mesh:4317"))
-			Expect(pipeBackends[0].Metrics).ToNot(BeNil())
-
-			// Envoy-side resources created for inline only
-			listeners, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ListenerType)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(listeners)).To(ContainSubstring("inline-collector"))
-			Expect(string(listeners)).ToNot(ContainSubstring("_kuma:metrics:opentelemetry:" + backendName))
-
-			clusters, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ClusterType)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(clusters)).To(ContainSubstring("inline-collector"))
-		})
 	})
 
 	DescribeTable("deriveProxyRole",

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_otel-collector_observability_svc-4317
+    altStatName: _kuma_metrics_opentelemetry_otel-collector
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+      clusterName: _kuma:metrics:opentelemetry:otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -14,21 +14,21 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+    name: _kuma:metrics:opentelemetry:otel-collector
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:second-collector
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_second-collector_observability_svc-4317
+    altStatName: _kuma_metrics_opentelemetry_second-collector
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
+      clusterName: _kuma:metrics:opentelemetry:second-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -36,7 +36,7 @@ resources:
               socketAddress:
                 address: second-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
+    name: _kuma:metrics:opentelemetry:second-collector
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/multiple_otel.listeners.golden.yaml
@@ -19,7 +19,7 @@ resources:
             - addressPrefix: 127.0.0.1
               prefixLen: 32
           routeConfig:
-            maxDirectResponseBodySizeBytes: 697
+            maxDirectResponseBodySizeBytes: 605
             virtualHosts:
             - domains:
               - '*'
@@ -31,11 +31,11 @@ resources:
                   headers:
                   - name: If-None-Match
                     stringMatch:
-                      exact: cdb5ae821d62ba49a5f7ca1b8f8c5ef9ceba9e3354bc5b594bf1211c1b2be710
+                      exact: 41e600dc2beb025d9f731cf9b9c5638509cb1f4aad2133cfcb3f5e395a6f6266
                   path: /meshmetric
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc-4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc-4317.sock","refreshInterval":"1m0s"}},{"type":"OpenTelemetry","name":"second-collector.observability.svc-4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-second-collector.observability.svc-4317.sock","refreshInterval":"1m0s"}}],"sidecar":{"includeUnused":false},"extraLabels":{"dataplane":"dp-1","kuma.proxy_role":"sidecar","kuma.workload":"backend","kuma_io_service":"backend","kuma_io_services":",backend,","mesh":"default","zone":"zone-1"}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.sock","refreshInterval":"1m0s"}},{"type":"OpenTelemetry","name":"second-collector","openTelemetry":{"endpoint":"/tmp/kuma-otel-second-collector.sock","refreshInterval":"1m0s"}}],"sidecar":{"includeUnused":false},"extraLabels":{"dataplane":"dp-1","kuma.proxy_role":"sidecar","kuma.workload":"backend","kuma_io_service":"backend","kuma_io_services":",backend,","mesh":"default","zone":"zone-1"}}}}'
                   status: 200
                 match:
                   path: /meshmetric
@@ -43,15 +43,15 @@ resources:
                 responseHeadersToAdd:
                 - header:
                     key: Etag
-                    value: cdb5ae821d62ba49a5f7ca1b8f8c5ef9ceba9e3354bc5b594bf1211c1b2be710
+                    value: 41e600dc2beb025d9f731cf9b9c5638509cb1f4aad2133cfcb3f5e395a6f6266
           statPrefix: _kuma_dynamicconfig
     name: _kuma:dynamicconfig
-- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc-4317.sock
+        path: /tmp/kuma-otel-otel-collector.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -74,20 +74,20 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+              name: _kuma:metrics:opentelemetry:otel-collector
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
-          statPrefix: _kuma_metrics_opentelemetry_otel-collector_observability_svc-4317
-    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
-- name: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
+                  cluster: _kuma:metrics:opentelemetry:otel-collector
+          statPrefix: _kuma_metrics_opentelemetry_otel-collector
+    name: _kuma:metrics:opentelemetry:otel-collector
+- name: _kuma:metrics:opentelemetry:second-collector
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-second-collector.observability.svc-4317.sock
+        path: /tmp/kuma-otel-second-collector.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -110,11 +110,11 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
+              name: _kuma:metrics:opentelemetry:second-collector
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
-          statPrefix: _kuma_metrics_opentelemetry_second-collector_observability_svc-4317
-    name: _kuma:metrics:opentelemetry:second-collector.observability.svc-4317
+                  cluster: _kuma:metrics:opentelemetry:second-collector
+          statPrefix: _kuma_metrics_opentelemetry_second-collector
+    name: _kuma:metrics:opentelemetry:second-collector

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_otel-collector_observability_svc-4317
+    altStatName: _kuma_metrics_opentelemetry_otel-collector
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+      clusterName: _kuma:metrics:opentelemetry:otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -14,7 +14,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+    name: _kuma:metrics:opentelemetry:otel-collector
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/openTelemetry.listeners.golden.yaml
@@ -19,7 +19,7 @@ resources:
             - addressPrefix: 127.0.0.1
               prefixLen: 32
           routeConfig:
-            maxDirectResponseBodySizeBytes: 472
+            maxDirectResponseBodySizeBytes: 426
             virtualHosts:
             - domains:
               - '*'
@@ -31,11 +31,11 @@ resources:
                   headers:
                   - name: If-None-Match
                     stringMatch:
-                      exact: aa8bc73d3398765ac177775325beeb539537fcdd5b5684bc66b01db7aed8137d
+                      exact: 0e84b169bd3a8f5cb7b08cfa0ee96d0b903216709cef5f419be14495ee345f8d
                   path: /meshmetric
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector.observability.svc-4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc-4317.sock","refreshInterval":"10s"}}],"extraLabels":{"dataplane":"dp-1","kuma.proxy_role":"sidecar","kuma.workload":"backend","kuma_io_service":"backend","kuma_io_services":",backend,","mesh":"default","zone":"zone-1"}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"OpenTelemetry","name":"otel-collector","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.sock","refreshInterval":"10s"}}],"extraLabels":{"dataplane":"dp-1","kuma.proxy_role":"sidecar","kuma.workload":"backend","kuma_io_service":"backend","kuma_io_services":",backend,","mesh":"default","zone":"zone-1"}}}}'
                   status: 200
                 match:
                   path: /meshmetric
@@ -43,15 +43,15 @@ resources:
                 responseHeadersToAdd:
                 - header:
                     key: Etag
-                    value: aa8bc73d3398765ac177775325beeb539537fcdd5b5684bc66b01db7aed8137d
+                    value: 0e84b169bd3a8f5cb7b08cfa0ee96d0b903216709cef5f419be14495ee345f8d
           statPrefix: _kuma_dynamicconfig
     name: _kuma:dynamicconfig
-- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc-4317.sock
+        path: /tmp/kuma-otel-otel-collector.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -74,11 +74,11 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+              name: _kuma:metrics:opentelemetry:otel-collector
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
-          statPrefix: _kuma_metrics_opentelemetry_otel-collector_observability_svc-4317
-    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+                  cluster: _kuma:metrics:opentelemetry:otel-collector
+          statPrefix: _kuma_metrics_opentelemetry_otel-collector
+    name: _kuma:metrics:opentelemetry:otel-collector

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.clusters.golden.yaml
@@ -14,14 +14,14 @@ resources:
                 path: /tmp/kuma-mh-backend-default.sock
     name: _kuma:metrics:hijacker
     type: STATIC
-- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: _kuma_metrics_opentelemetry_otel-collector_observability_svc-4317
+    altStatName: _kuma_metrics_opentelemetry_otel-collector
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+      clusterName: _kuma:metrics:opentelemetry:otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -29,7 +29,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+    name: _kuma:metrics:opentelemetry:otel-collector
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus.listeners.golden.yaml
@@ -19,7 +19,7 @@ resources:
             - addressPrefix: 127.0.0.1
               prefixLen: 32
           routeConfig:
-            maxDirectResponseBodySizeBytes: 541
+            maxDirectResponseBodySizeBytes: 495
             virtualHosts:
             - domains:
               - '*'
@@ -31,11 +31,11 @@ resources:
                   headers:
                   - name: If-None-Match
                     stringMatch:
-                      exact: 4e853f3936f6da69b5f64b4d797df565af89dc0a5b986a028570bd95c79e02f2
+                      exact: c086225ed512de347203b18cbb0d1d8a29523d2cbd280a069a576c75dd970591
                   path: /meshmetric
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector.observability.svc-4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc-4317.sock","refreshInterval":"1m0s"}}],"sidecar":{"includeUnused":false},"extraLabels":{"dataplane":"dp-1","kuma.proxy_role":"sidecar","kuma.workload":"backend","kuma_io_service":"backend","kuma_io_services":",backend,","mesh":"default","zone":"zone-1"}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.sock","refreshInterval":"1m0s"}}],"sidecar":{"includeUnused":false},"extraLabels":{"dataplane":"dp-1","kuma.proxy_role":"sidecar","kuma.workload":"backend","kuma_io_service":"backend","kuma_io_services":",backend,","mesh":"default","zone":"zone-1"}}}}'
                   status: 200
                 match:
                   path: /meshmetric
@@ -43,15 +43,15 @@ resources:
                 responseHeadersToAdd:
                 - header:
                     key: Etag
-                    value: 4e853f3936f6da69b5f64b4d797df565af89dc0a5b986a028570bd95c79e02f2
+                    value: c086225ed512de347203b18cbb0d1d8a29523d2cbd280a069a576c75dd970591
           statPrefix: _kuma_dynamicconfig
     name: _kuma:dynamicconfig
-- name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+- name: _kuma:metrics:opentelemetry:otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc-4317.sock
+        path: /tmp/kuma-otel-otel-collector.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -74,14 +74,14 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+              name: _kuma:metrics:opentelemetry:otel-collector
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
-          statPrefix: _kuma_metrics_opentelemetry_otel-collector_observability_svc-4317
-    name: _kuma:metrics:opentelemetry:otel-collector.observability.svc-4317
+                  cluster: _kuma:metrics:opentelemetry:otel-collector
+          statPrefix: _kuma_metrics_opentelemetry_otel-collector
+    name: _kuma:metrics:opentelemetry:otel-collector
 - name: _kuma:metrics:prometheus:default-backend
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus_unified_naming.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus_unified_naming.clusters.golden.yaml
@@ -1,11 +1,11 @@
 resources:
-- name: system_meshmetric_otel_otel-collector-observability-svc-4317
+- name: system_meshmetric_otel_otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
     dnsLookupFamily: V4_ONLY
     loadAssignment:
-      clusterName: system_meshmetric_otel_otel-collector-observability-svc-4317
+      clusterName: system_meshmetric_otel_otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -13,7 +13,7 @@ resources:
               socketAddress:
                 address: otel-collector.observability.svc
                 portValue: 4317
-    name: system_meshmetric_otel_otel-collector-observability-svc-4317
+    name: system_meshmetric_otel_otel-collector
     type: STRICT_DNS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus_unified_naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/testdata/otel_and_prometheus_unified_naming.listeners.golden.yaml
@@ -19,7 +19,7 @@ resources:
             - addressPrefix: 127.0.0.1
               prefixLen: 32
           routeConfig:
-            maxDirectResponseBodySizeBytes: 463
+            maxDirectResponseBodySizeBytes: 417
             virtualHosts:
             - domains:
               - '*'
@@ -31,12 +31,12 @@ resources:
                   headers:
                   - name: If-None-Match
                     stringMatch:
-                      exact: 073ccd03f48381a4494cf883c93edae3183a52cee1aaa3479add9c56d00ae0f1
+                      exact: 0ac3eb71dd44a32cd57cedc6b84e89a5bc4e34cd70c3ed448c1c9625b88985c2
                   path: /meshmetric
                 name: system_dynamicconfig_meshmetric_not_modified
               - directResponse:
                   body:
-                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector.observability.svc-4317","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.observability.svc-4317.sock","refreshInterval":"1m0s"}}],"sidecar":{"includeUnused":false},"extraLabels":{"kuma.proxy_role":"sidecar","kuma.workload":"backend","mesh":"default","zone":"zone-1"}}}}'
+                    inlineString: '{"observability":{"metrics":{"applications":[{"path":"/metrics","port":8080,"address":""}],"backends":[{"type":"Prometheus","name":null},{"type":"OpenTelemetry","name":"otel-collector","openTelemetry":{"endpoint":"/tmp/kuma-otel-otel-collector.sock","refreshInterval":"1m0s"}}],"sidecar":{"includeUnused":false},"extraLabels":{"kuma.proxy_role":"sidecar","kuma.workload":"backend","mesh":"default","zone":"zone-1"}}}}'
                   status: 200
                 match:
                   path: /meshmetric
@@ -44,16 +44,16 @@ resources:
                 responseHeadersToAdd:
                 - header:
                     key: Etag
-                    value: 073ccd03f48381a4494cf883c93edae3183a52cee1aaa3479add9c56d00ae0f1
+                    value: 0ac3eb71dd44a32cd57cedc6b84e89a5bc4e34cd70c3ed448c1c9625b88985c2
           statPrefix: system_dynamicconfig
     name: system_dynamicconfig
     statPrefix: system_dynamicconfig
-- name: system_meshmetric_otel_otel-collector-observability-svc-4317
+- name: system_meshmetric_otel_otel-collector
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
       pipe:
-        path: /tmp/kuma-otel-otel-collector.observability.svc-4317.sock
+        path: /tmp/kuma-otel-otel-collector.sock
     filterChains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -76,15 +76,15 @@ resources:
             virtualHosts:
             - domains:
               - '*'
-              name: system_meshmetric_otel_otel-collector-observability-svc-4317
+              name: system_meshmetric_otel_otel-collector
               routes:
               - match:
                   prefix: /
                 route:
-                  cluster: system_meshmetric_otel_otel-collector-observability-svc-4317
-          statPrefix: system_meshmetric_otel_otel-collector-observability-svc-4317
-    name: system_meshmetric_otel_otel-collector-observability-svc-4317
-    statPrefix: system_meshmetric_otel_otel-collector-observability-svc-4317
+                  cluster: system_meshmetric_otel_otel-collector
+          statPrefix: system_meshmetric_otel_otel-collector
+    name: system_meshmetric_otel_otel-collector
+    statPrefix: system_meshmetric_otel_otel-collector
 - name: system_meshmetric_prometheus_default-backend
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener


### PR DESCRIPTION
## Motivation

As part of #17240, consolidate MeshMetric to require `BackendRef` instead of supporting inline backend endpoints.

## Implementation information

- Removed inline backend endpoint support from MeshMetric
- Updated the API specification to require `BackendRef`
- Updated validator rules to enforce the new requirement
- Updated plugin implementation
- Updated golden test files to reflect the new schema

Closes https://github.com/kumahq/kuma/issues/17267

_Generated by Sybra harness_