### PR TITLE
refactor(meshtrace)!: drop OTel Endpoint in favor of BackendRef

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -635,6 +635,20 @@ If any `MeshMetric` policy still sets `openTelemetry.endpoint`, create a
 the policy to reference it via `openTelemetry.backendRef` before upgrading.
 Policies that still set `openTelemetry.endpoint` will fail validation.
 
+### `MeshTrace` OpenTelemetry backend no longer accepts an inline `endpoint`
+
+The deprecated `default.backends[].openTelemetry.endpoint` field has been
+removed from the `MeshTrace` policy. `backendRef`, pointing at a
+`MeshOpenTelemetryBackend` resource, is now the only way to configure an
+OpenTelemetry tracing backend.
+
+**Action required**
+
+If any `MeshTrace` policy still sets `openTelemetry.endpoint`, create a
+`MeshOpenTelemetryBackend` resource with the equivalent endpoint and update
+the policy to reference it via `openTelemetry.backendRef` before upgrading.
+Policies that still set `openTelemetry.endpoint` will fail validation.
+
 ## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -6040,7 +6040,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -6057,14 +6057,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -6040,7 +6040,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -6057,14 +6057,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -6060,7 +6060,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -6077,14 +6077,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -9243,7 +9243,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -9260,14 +9260,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -94,7 +94,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -111,14 +111,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -16066,8 +16066,7 @@ components:
                               BackendRef is a reference to a
                               MeshOpenTelemetryBackend resource that
 
-                              defines the collector endpoint. Mutually exclusive
-                              with Endpoint.
+                              defines the collector endpoint.
                             properties:
                               kind:
                                 description: Kind of the backend resource.
@@ -16086,14 +16085,6 @@ components:
                             required:
                               - kind
                             type: object
-                          endpoint:
-                            default: ''
-                            description: |-
-                              Address of OpenTelemetry collector.
-
-                              Deprecated: use BackendRef instead.
-                            example: otel-collector:4317
-                            type: string
                         type: object
                       type:
                         enum:

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -94,7 +94,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -111,14 +111,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
@@ -2,16 +2,8 @@ package v1alpha1
 
 import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 func (t *MeshTraceResource) Deprecations() []string {
-	var deprecations []string
-	for _, backend := range pointer.Deref(t.Spec.Default.Backends) {
-		if backend.OpenTelemetry != nil && backend.OpenTelemetry.Endpoint != "" && backend.OpenTelemetry.BackendRef == nil {
-			deprecations = append(deprecations, "openTelemetry.endpoint is deprecated, use openTelemetry.backendRef with a MeshOpenTelemetryBackend resource instead")
-			break
-		}
-	}
-	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
+	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
@@ -59,15 +59,8 @@ type Backend struct {
 
 // OpenTelemetry tracing backend configuration.
 type OpenTelemetryBackend struct {
-	// Address of OpenTelemetry collector.
-	//
-	// Deprecated: use BackendRef instead.
-	// +kubebuilder:example="otel-collector:4317"
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=""
-	Endpoint string `json:"endpoint"`
 	// BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-	// defines the collector endpoint. Mutually exclusive with Endpoint.
+	// defines the collector endpoint.
 	BackendRef *common_api.BackendResourceRef `json:"backendRef,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -193,7 +193,7 @@ components:
                           backendRef:
                             description: |-
                               BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                              defines the collector endpoint. Mutually exclusive with Endpoint.
+                              defines the collector endpoint.
                             properties:
                               kind:
                                 description: Kind of the backend resource.
@@ -210,14 +210,6 @@ components:
                             required:
                               - kind
                             type: object
-                          endpoint:
-                            default: ""
-                            description: |-
-                              Address of OpenTelemetry collector.
-
-                              Deprecated: use BackendRef instead.
-                            example: otel-collector:4317
-                            type: string
                         type: object
                       type:
                         enum:

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/validator.go
@@ -159,15 +159,14 @@ func validateBackend(conf Conf, backendsPath validators.PathBuilder) validators.
 	case OpenTelemetryBackendType:
 		otelPath := firstBackendPath.Field("openTelemetry")
 		otelBackend := backend.OpenTelemetry
-		if otelBackend == nil {
+		switch {
+		case otelBackend == nil:
 			verr.AddViolationAt(otelPath, validators.MustBeDefined)
-			break
+		case otelBackend.BackendRef == nil:
+			verr.AddViolationAt(otelPath.Field("backendRef"), validators.MustBeDefined)
+		default:
+			verr.AddErrorAt(otelPath.Field("backendRef"), validators.ValidateBackendResourceRef(otelBackend.BackendRef))
 		}
-
-		verr.AddErrorAt(otelPath, validators.ValidateOtelBackendRefOrEndpoint(
-			otelBackend.Endpoint,
-			otelBackend.BackendRef,
-		))
 	default:
 		panic(fmt.Sprintf("unknown backend type %v", backend.Type))
 	}

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/validator_test.go
@@ -49,15 +49,6 @@ default:
     random: "60.1"
     client: 40
 `),
-			Entry("with opentelemetry backend gRPC", `
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: otel-collector:4317
-`),
 			Entry("with empty backends", `
 targetRef:
   kind: Mesh
@@ -373,69 +364,19 @@ violations:
   - field: spec.default.backends[0].openTelemetry
     message: must be defined`,
 			}),
-			Entry("openTelemetry neither endpoint nor backendRef", testCase{
+			Entry("openTelemetry backendRef missing", testCase{
 				inputYaml: `
 targetRef:
   kind: Mesh
 default:
   backends:
     - type: OpenTelemetry
-      openTelemetry:
-        endpoint: ""
+      openTelemetry: {}
 `,
 				expected: `
 violations:
-  - field: spec.default.backends[0].openTelemetry
-    message: "openTelemetry must have exactly one defined: endpoint, backendRef"`,
-			}),
-			Entry("openTelemetry endpoint must not be a URL", testCase{
-				inputYaml: `
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: "http://otel-collector:4318/v1/traces"
-`,
-				expected: `
-violations:
-  - field: spec.default.backends[0].openTelemetry.endpoint
-    message: must be in host:port format, not a URL`,
-			}),
-			Entry("openTelemetry endpoint must not contain a path", testCase{
-				inputYaml: `
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: "otel-collector:4318/v1/traces"
-`,
-				expected: `
-violations:
-  - field: spec.default.backends[0].openTelemetry.endpoint
-    message: must be in host:port format, not a URL`,
-			}),
-			Entry("openTelemetry both endpoint and backendRef", testCase{
-				inputYaml: `
-targetRef:
-  kind: Mesh
-default:
-  backends:
-    - type: OpenTelemetry
-      openTelemetry:
-        endpoint: otel-collector:4317
-        backendRef:
-          kind: MeshOpenTelemetryBackend
-          labels:
-            kuma.io/display-name: my-otel
-`,
-				expected: `
-violations:
-  - field: spec.default.backends[0].openTelemetry
-    message: "openTelemetry must have only one type defined: endpoint, backendRef"`,
+  - field: spec.default.backends[0].openTelemetry.backendRef
+    message: must be defined`,
 			}),
 			Entry("openTelemetry backendRef no labels", testCase{
 				inputYaml: `

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -94,7 +94,7 @@ spec:
                             backendRef:
                               description: |-
                                 BackendRef is a reference to a MeshOpenTelemetryBackend resource that
-                                defines the collector endpoint. Mutually exclusive with Endpoint.
+                                defines the collector endpoint.
                               properties:
                                 kind:
                                   description: Kind of the backend resource.
@@ -111,14 +111,6 @@ spec:
                               required:
                               - kind
                               type: object
-                            endpoint:
-                              default: ""
-                              description: |-
-                                Address of OpenTelemetry collector.
-
-                                Deprecated: use BackendRef instead.
-                              example: otel-collector:4317
-                              type: string
                           type: object
                         type:
                           enum:

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -354,8 +354,8 @@ func applyToClusters(ctx xds_context.Context, rules core_rules.SingleItemRules, 
 		resolved := policies_xds.ResolveOtelBackend(
 			backend.OpenTelemetry.BackendRef,
 			"",
-			policies_xds.ParseOtelEndpoint,
-			func(ep string) string { return ep },
+			nil,
+			nil,
 			ctx.Mesh.Resources,
 		)
 		if resolved == nil {
@@ -424,8 +424,8 @@ func resolveOtelBackendInfo(conf api.Conf, resources xds_context.Resources) *pol
 	return policies_xds.ResolveOtelBackend(
 		backend.OpenTelemetry.BackendRef,
 		"",
-		policies_xds.ParseOtelEndpoint,
-		func(ep string) string { return ep },
+		nil,
+		nil,
 		resources,
 	)
 }

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -266,9 +266,9 @@ func configureListener(ctx xds_context.Context, rules core_rules.SingleItemRules
 	}
 	if resolved != nil {
 		configurer.ResolvedOtelName = resolved.Name
-		// When kuma-dp acts as intermediary for a backendRef backend, Envoy
+		// When kuma-dp acts as intermediary for the resolved backend, Envoy
 		// always speaks gRPC to the pipe cluster. Only fall back to HTTP config
-		// when using direct-to-collector mode (inline endpoint or no feature).
+		// when using direct-to-collector mode (FeatureOtelViaKumaDp not enabled).
 		usePipe := hasOtelBackendRef(conf) && proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp)
 		if !usePipe && resolved.Protocol == motb_api.ProtocolHTTP {
 			configurer.ResolvedOtelUseHTTP = true
@@ -345,7 +345,7 @@ func applyToClusters(ctx xds_context.Context, rules core_rules.SingleItemRules, 
 	case backend.OpenTelemetry != nil:
 		resolved := policies_xds.ResolveOtelBackend(
 			backend.OpenTelemetry.BackendRef,
-			backend.OpenTelemetry.Endpoint,
+			"",
 			policies_xds.ParseOtelEndpoint,
 			func(ep string) string { return ep },
 			ctx.Mesh.Resources,
@@ -415,7 +415,7 @@ func resolveOtelBackendInfo(conf api.Conf, resources xds_context.Resources) *pol
 	}
 	return policies_xds.ResolveOtelBackend(
 		backend.OpenTelemetry.BackendRef,
-		backend.OpenTelemetry.Endpoint,
+		"",
 		policies_xds.ParseOtelEndpoint,
 		func(ep string) string { return ep },
 		resources,

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -262,7 +262,7 @@ func configureListener(ctx xds_context.Context, rules core_rules.SingleItemRules
 		Mesh:                  proxy.Dataplane.GetMeta().GetMesh(),
 		Zone:                  proxy.Zone,
 		WorkloadKRI:           workloadKRI,
-		SkipOpenTelemetry:     shouldSkipUnresolvedOpenTelemetryBackendRef(conf, resolved),
+		SkipOpenTelemetry:     shouldSkipUnresolvedOpenTelemetryBackend(conf, resolved),
 	}
 	if resolved != nil {
 		configurer.ResolvedOtelName = resolved.Name
@@ -291,22 +291,30 @@ func configureListener(ctx xds_context.Context, rules core_rules.SingleItemRules
 }
 
 func hasOtelBackendRef(conf api.Conf) bool {
-	backends := pointer.Deref(conf.Backends)
-	if len(backends) == 0 {
-		return false
-	}
-	otel := backends[0].OpenTelemetry
+	otel := openTelemetryBackend(conf)
 	return otel != nil && otel.BackendRef != nil
 }
 
-func shouldSkipUnresolvedOpenTelemetryBackendRef(
+func hasOpenTelemetryBackend(conf api.Conf) bool {
+	return openTelemetryBackend(conf) != nil
+}
+
+func openTelemetryBackend(conf api.Conf) *api.OpenTelemetryBackend {
+	backends := pointer.Deref(conf.Backends)
+	if len(backends) == 0 {
+		return nil
+	}
+	return backends[0].OpenTelemetry
+}
+
+func shouldSkipUnresolvedOpenTelemetryBackend(
 	conf api.Conf,
 	resolved *policies_xds.ResolvedOtelBackend,
 ) bool {
 	if resolved != nil {
 		return false
 	}
-	return hasOtelBackendRef(conf)
+	return hasOpenTelemetryBackend(conf)
 }
 
 func applyToClusters(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -547,6 +547,65 @@ var _ = Describe("MeshTrace", func() {
 		}),
 	)
 
+	It("should skip opentelemetry provider for legacy inline endpoint config without backendRef", func() {
+		resources := core_xds.NewResourceSet()
+		for _, resource := range inboundAndOutbound() {
+			r := resource
+			resources.Add(&r)
+		}
+
+		meshResources := xds_context.NewResources()
+		meshResources.MeshLocalResources[v1alpha1.MeshServiceType] = &v1alpha1.MeshServiceResourceList{
+			Items: []*v1alpha1.MeshServiceResource{samples.MeshServiceBackendBuilder().
+				WithZone("zone-1").
+				WithNamespace("backend-ns").
+				Build()},
+		}
+
+		context := *xds_samples.SampleContextWith(meshResources).Build()
+		proxy := xds_builders.Proxy().
+			WithDataplane(
+				builders.Dataplane().
+					WithName("backend").
+					AddInbound(builders.Inbound().
+						WithService("backend").
+						WithAddress("127.0.0.1").
+						WithPort(17777)),
+			).
+			WithOutbounds(xds_types.Outbounds{
+				{
+					LegacyOutbound: builders.Outbound().
+						WithService("other-service").
+						WithAddress("127.0.0.1").
+						WithPort(27777).Build(),
+				},
+			}).
+			WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, core_rules.SingleItemRules{
+				Rules: []*core_rules.Rule{
+					{
+						Subset: []subsetutils.Tag{},
+						Conf: api.Conf{
+							Backends: &[]api.Backend{{
+								OpenTelemetry: &api.OpenTelemetryBackend{},
+							}},
+						},
+					},
+				},
+			})).
+			Build()
+
+		meshTracePlugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
+		Expect(meshTracePlugin.Apply(resources, context, proxy)).To(Succeed())
+
+		listenerResources, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ListenerType)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(listenerResources).ToNot(ContainSubstring("envoy.tracers.opentelemetry"))
+
+		clusterResources, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ClusterType)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.TrimSpace(string(clusterResources))).To(Equal("{}"))
+	})
+
 	It("should skip opentelemetry provider for dangling backendRef", func() {
 		resources := core_xds.NewResourceSet()
 		for _, resource := range inboundAndOutbound() {

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -50,10 +50,10 @@ func otelBackendResource(name, address string) *motb_api.MeshOpenTelemetryBacken
 		Labels: map[string]string{mesh_proto.DisplayName: name},
 	})
 	motb.Spec.Endpoint = &motb_api.Endpoint{
-		Address: new(address),
-		Port:    new(int32(4317)),
+		Address: pointer.To(address),
+		Port:    pointer.To(int32(4317)),
 	}
-	motb.Spec.Protocol = new(motb_api.ProtocolGRPC)
+	motb.Spec.Protocol = pointer.To(motb_api.ProtocolGRPC)
 	return motb
 }
 
@@ -691,10 +691,10 @@ var _ = Describe("MeshTrace", func() {
 			Labels: map[string]string{mesh_proto.DisplayName: backendName},
 		})
 		motb.Spec.Endpoint = &motb_api.Endpoint{
-			Address: new("collector.mesh"),
-			Port:    new(int32(4317)),
+			Address: pointer.To("collector.mesh"),
+			Port:    pointer.To(int32(4317)),
 		}
-		motb.Spec.Protocol = new(motb_api.ProtocolGRPC)
+		motb.Spec.Protocol = pointer.To(motb_api.ProtocolGRPC)
 
 		meshResources := xds_context.NewResources()
 		meshResources.MeshLocalResources[motb_api.MeshOpenTelemetryBackendType] = &motb_api.MeshOpenTelemetryBackendResourceList{

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -42,6 +42,28 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/metadata"
 )
 
+func otelBackendResource(name, address string) *motb_api.MeshOpenTelemetryBackendResource {
+	motb := motb_api.NewMeshOpenTelemetryBackendResource()
+	motb.SetMeta(&test_model.ResourceMeta{
+		Mesh:   "default",
+		Name:   name,
+		Labels: map[string]string{mesh_proto.DisplayName: name},
+	})
+	motb.Spec.Endpoint = &motb_api.Endpoint{
+		Address: new(address),
+		Port:    new(int32(4317)),
+	}
+	motb.Spec.Protocol = new(motb_api.ProtocolGRPC)
+	return motb
+}
+
+func otelBackendRef(name string) *common_api.BackendResourceRef {
+	return &common_api.BackendResourceRef{
+		Kind:   common_api.BackendResourceMeshOpenTelemetryBackend,
+		Labels: map[string]string{mesh_proto.DisplayName: name},
+	}
+}
+
 var _ = Describe("MeshTrace", func() {
 	type testCase struct {
 		resources       []core_xds.Resource
@@ -51,6 +73,7 @@ var _ = Describe("MeshTrace", func() {
 		features        xds_types.Features
 		proxyLabels     map[string]string
 		zone            string
+		otelBackends    []*motb_api.MeshOpenTelemetryBackendResource
 	}
 	backendMeshServiceIdentifier := kri.Identifier{
 		ResourceType: "MeshService",
@@ -138,6 +161,11 @@ var _ = Describe("MeshTrace", func() {
 					WithZone("zone-1").
 					WithNamespace("backend-ns").
 					Build()},
+			}
+			if len(given.otelBackends) > 0 {
+				meshResources.MeshLocalResources[motb_api.MeshOpenTelemetryBackendType] = &motb_api.MeshOpenTelemetryBackendResourceList{
+					Items: given.otelBackends,
+				}
 			}
 			context := *xds_samples.SampleContextWith(meshResources).WithMeshBuilder(samples.MeshDefaultBuilder()).Build()
 			dpBuilder := builders.Dataplane().
@@ -323,12 +351,15 @@ var _ = Describe("MeshTrace", func() {
 							},
 							Backends: &[]api.Backend{{
 								OpenTelemetry: &api.OpenTelemetryBackend{
-									Endpoint: "jaeger-collector.mesh-observability:4317",
+									BackendRef: otelBackendRef("otel-collector"),
 								},
 							}},
 						},
 					},
 				},
+			},
+			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
+				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
 			},
 			goldenFile: "inbound-outbound-otel",
 		}),
@@ -349,12 +380,15 @@ var _ = Describe("MeshTrace", func() {
 						Conf: api.Conf{
 							Backends: &[]api.Backend{{
 								OpenTelemetry: &api.OpenTelemetryBackend{
-									Endpoint: "[2001:db8::1]:4317",
+									BackendRef: otelBackendRef("otel-collector-ipv6"),
 								},
 							}},
 						},
 					},
 				},
+			},
+			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
+				otelBackendResource("otel-collector-ipv6", "2001:db8::1"),
 			},
 			goldenFile: "inbound-outbound-otel-ipv6",
 		}),
@@ -798,6 +832,7 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 		singleItemRules     core_rules.SingleItemRules
 		inboundTagsDisabled bool
 		goldenFile          string
+		otelBackends        []*motb_api.MeshOpenTelemetryBackendResource
 	}
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
@@ -807,7 +842,13 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 				rs.Add(&r)
 			}
 
-			ctxBuilder := xds_samples.SampleContextWith(xds_context.NewResources()).
+			meshResources := xds_context.NewResources()
+			if len(given.otelBackends) > 0 {
+				meshResources.MeshLocalResources[motb_api.MeshOpenTelemetryBackendType] = &motb_api.MeshOpenTelemetryBackendResourceList{
+					Items: given.otelBackends,
+				}
+			}
+			ctxBuilder := xds_samples.SampleContextWith(meshResources).
 				WithMeshBuilder(samples.MeshDefaultBuilder())
 			if given.inboundTagsDisabled {
 				ctxBuilder = ctxBuilder.With(func(c *xds_context.Context) {
@@ -881,11 +922,14 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 					Conf: api.Conf{
 						Backends: &[]api.Backend{{
 							OpenTelemetry: &api.OpenTelemetryBackend{
-								Endpoint: "jaeger-collector.mesh-observability:4317",
+								BackendRef: otelBackendRef("otel-collector"),
 							},
 						}},
 					},
 				}},
+			},
+			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
+				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
 			},
 			goldenFile: "zone-egress-only-otel",
 		}),
@@ -935,11 +979,14 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 					Conf: api.Conf{
 						Backends: &[]api.Backend{{
 							OpenTelemetry: &api.OpenTelemetryBackend{
-								Endpoint: "jaeger-collector.mesh-observability:4317",
+								BackendRef: otelBackendRef("otel-collector"),
 							},
 						}},
 					},
 				}},
+			},
+			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
+				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
 			},
 			goldenFile: "zone-ingress-only-otel",
 		}),
@@ -989,11 +1036,14 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 					Conf: api.Conf{
 						Backends: &[]api.Backend{{
 							OpenTelemetry: &api.OpenTelemetryBackend{
-								Endpoint: "jaeger-collector.mesh-observability:4317",
+								BackendRef: otelBackendRef("otel-collector"),
 							},
 						}},
 					},
 				}},
+			},
+			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
+				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
 			},
 			goldenFile: "mixed-inbound-and-zone-egress-otel",
 		}),

--- a/pkg/plugins/policies/meshtrace/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshtrace/plugin/xds/configurer.go
@@ -38,8 +38,7 @@ type Configurer struct {
 	Mesh                  string
 	Zone                  string
 	WorkloadKRI           string
-	// ResolvedOtelName is the resolved backend name for OTel (from backendRef or inline endpoint).
-	// When empty, falls back to backend.OpenTelemetry.Endpoint for naming.
+	// ResolvedOtelName is the resolved MeshOpenTelemetryBackend name for OTel, used for naming.
 	ResolvedOtelName string
 	// ResolvedOtelUseHTTP is true when the resolved backend uses HTTP protocol.
 	ResolvedOtelUseHTTP bool
@@ -144,12 +143,8 @@ func (c *Configurer) Configure(filterChain *envoy_listener.FilterChain) error {
 		}
 
 		if backend.OpenTelemetry != nil && !c.SkipOpenTelemetry {
-			otelName := c.ResolvedOtelName
-			if otelName == "" {
-				otelName = backend.OpenTelemetry.Endpoint
-			}
 			name := getNameOrDefault(
-				core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_otel", core_system_names.CleanName(otelName))),
+				core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_otel", core_system_names.CleanName(c.ResolvedOtelName))),
 				GetTracingClusterName(OpenTelemetryProviderName),
 			)
 			var tracing *envoy_trace.Tracing_Http


### PR DESCRIPTION
## Motivation

Remove the inline OpenTelemetry `Endpoint` field from MeshTrace in favor of `BackendRef`. This consolidates external backend configuration through a single API path, eliminating a deprecated inline endpoint option and simplifying the policy surface.

## Implementation information

- Removed `Endpoint string` field from the OpenTelemetry backend specification
- Updated validator to reject inline `endpoint` configurations and require `BackendRef`
- Refactored the MeshTrace plugin to exclusively use the BackendRef resolver path, removing dead `ParseOtelEndpoint` call sites
- Updated `kuma.io_meshtraces.yaml` CRD definition
- Updated golden test files to reflect the new schema

Closes https://github.com/kumahq/kuma/issues/17268

_Generated by Sybra harness_