### PR TITLE
fix(mtp): unified naming for zone egress

### DIFF
--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin.go
@@ -7,12 +7,12 @@ import (
 
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core"
-	"github.com/kumahq/kuma/v2/pkg/core/naming/unified-naming"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/destinationname"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/matchers"
 	core_rules "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/inbound"
@@ -50,7 +50,11 @@ func (p plugin) EgressMatchedPolicies(tags map[string]string, resources xds_cont
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	if proxy.ZoneEgressProxy != nil {
-		return p.configureEgress(rs, proxy, unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource))
+		// ZoneEgress isn't scoped to a single mesh (ctx.Mesh is empty for zone proxies),
+		// so unlike mesh-scoped plugins we can't use unified_naming.Enabled here: it
+		// would always see a nil mesh and report unified naming as disabled.
+		unifiedNaming := proxy.Metadata.HasFeature(xds_types.FeatureUnifiedResourceNaming)
+		return p.configureEgress(rs, proxy, unifiedNaming)
 	}
 
 	if proxy.Dataplane == nil || proxy.Dataplane.Spec.IsBuiltinGateway() {

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -12,8 +12,12 @@ import (
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/plugins"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/core/destinationname"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	meshexternalservice_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/v2/pkg/core/xds"
+	xds_types "github.com/kumahq/kuma/v2/pkg/core/xds/types"
 	core_rules "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/common"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules/inbound"
@@ -700,6 +704,94 @@ var _ = Describe("RBAC", func() {
 			bytes, err := util_proto.ToYAML(resp)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(matchers.MatchGoldenYAML(path.Join("testdata", "apply-egress.golden.yaml")))
+		})
+	})
+
+	Context("for ZoneEgress proxy with unified naming", func() {
+		It("should attach RBAC filter chain when unified naming is enabled", func() {
+			// given a MeshExternalService whose egress filter chain is named using the
+			// unified (KRI) scheme, not the legacy one
+			mes := builders.MeshExternalService().WithMesh("mesh-1").WithName("es-1").Build()
+			filterChainName := destinationname.MustResolve(true, mes, mes.Spec.Match)
+
+			rs := core_xds.NewResourceSet()
+			listener, err := listeners.NewInboundListenerBuilder(envoy.APIV3, "192.168.0.1", 10002, core_xds.SocketAddressProtocolTCP, true).
+				WithOverwriteName("egress-listener").
+				Configure(
+					listeners.FilterChain(listeners.NewFilterChainBuilder(envoy.APIV3, filterChainName).Configure(
+						listeners.MatchTransportProtocol("tls"),
+						listeners.TCPProxy(filterChainName),
+					)),
+				).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			rs.Add(&core_xds.Resource{
+				Name:     listener.GetName(),
+				Origin:   metadata.OriginEgress,
+				Resource: listener,
+			})
+
+			meshRes := builders.Mesh().WithName("mesh-1").WithBuiltinMTLSBackend("builtin-1").WithEnabledMTLSBackend("builtin-1").Build()
+			ctx := xds_builders.Context().WithMeshBuilder(builders.Mesh().WithName("mesh-1").WithBuiltinMTLSBackend("builtin-1").WithEnabledMTLSBackend("builtin-1")).Build()
+
+			proxy := &core_xds.Proxy{
+				APIVersion: envoy.APIV3,
+				Metadata: &core_xds.DataplaneMetadata{
+					Features: xds_types.Features{xds_types.FeatureUnifiedResourceNaming: true},
+				},
+				ZoneEgressProxy: &core_xds.ZoneEgressProxy{
+					ZoneEgressResource: &mesh.ZoneEgressResource{
+						Meta: &test_model.ResourceMeta{Name: "ze1", Mesh: "mesh-1"},
+						Spec: &mesh_proto.ZoneEgress{
+							Networking: &mesh_proto.ZoneEgress_Networking{
+								Address: "192.168.0.1",
+								Port:    10002,
+							},
+						},
+					},
+					MeshResourcesList: []*core_xds.MeshResources{
+						{
+							Mesh: meshRes,
+							Resources: map[core_model.ResourceType]core_model.ResourceList{
+								meshexternalservice_api.MeshExternalServiceType: &meshexternalservice_api.MeshExternalServiceResourceList{
+									Items: []*meshexternalservice_api.MeshExternalServiceResource{mes},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// when
+			p := meshtrafficpermission.NewPlugin().(plugins.PolicyPlugin)
+			Expect(p.Apply(rs, *ctx, proxy)).To(Succeed())
+
+			// then the RBAC filter must have attached to the unified-named filter chain:
+			// ctx.Mesh.Resource is always nil for zone-egress proxies, so a naive
+			// unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource) call would always
+			// report unified naming as disabled and this filter chain (named per the
+			// unified scheme) would never match, silently skipping RBAC entirely.
+			var egressListener *envoy_listener.Listener
+			for _, r := range rs.List() {
+				if r.Name == "egress-listener" {
+					egressListener = r.Resource.(*envoy_listener.Listener)
+				}
+			}
+			Expect(egressListener).ToNot(BeNil())
+			var matched *envoy_listener.FilterChain
+			for _, fc := range egressListener.GetFilterChains() {
+				if fc.GetName() == filterChainName {
+					matched = fc
+				}
+			}
+			Expect(matched).ToNot(BeNil())
+			hasRBAC := false
+			for _, filter := range matched.GetFilters() {
+				if filter.GetName() == "envoy.filters.network.rbac" {
+					hasRBAC = true
+				}
+			}
+			Expect(hasRBAC).To(BeTrue())
 		})
 	})
 })

--- a/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/plugin/v1alpha1/plugin_test.go
@@ -31,6 +31,7 @@ import (
 	xds_builders "github.com/kumahq/kuma/v2/pkg/test/xds/builders"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
+	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
 	"github.com/kumahq/kuma/v2/pkg/xds/envoy"
 	"github.com/kumahq/kuma/v2/pkg/xds/envoy/listeners"
 	"github.com/kumahq/kuma/v2/pkg/xds/generator/metadata"
@@ -732,7 +733,12 @@ var _ = Describe("RBAC", func() {
 			})
 
 			meshRes := builders.Mesh().WithName("mesh-1").WithBuiltinMTLSBackend("builtin-1").WithEnabledMTLSBackend("builtin-1").Build()
-			ctx := xds_builders.Context().WithMeshBuilder(builders.Mesh().WithName("mesh-1").WithBuiltinMTLSBackend("builtin-1").WithEnabledMTLSBackend("builtin-1")).Build()
+			// ctx.Mesh.Resource is deliberately left nil here: zone-egress proxies
+			// aren't scoped to a single mesh, so this is what production actually
+			// passes. A non-nil ctx.Mesh would make unified_naming.Enabled() return
+			// true even on the old buggy code, masking the regression this test
+			// exists to catch.
+			ctx := &xds_context.Context{}
 
 			proxy := &core_xds.Proxy{
 				APIVersion: envoy.APIV3,

--- a/pkg/xds/generator/egress/testdata/01.externalservice-only-unified-naming.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/01.externalservice-only-unified-naming.golden.yaml
@@ -151,15 +151,20 @@ resources:
         - a45e197ed7825551b.meshexternalservice-1.9090.mesh-1.mes
         transportProtocol: tls
       filters:
-      - name: envoy.filters.network.rbac
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
-          rules: {}
-          statPrefix: kri_extsvc_mesh-1___meshexternalservice-1_9090.
       - name: envoy.filters.network.http_connection_manager
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           httpFilters:
+          - name: envoy.filters.http.rbac
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+              rules:
+                policies:
+                  MeshTrafficPermission:
+                    permissions:
+                    - any: true
+                    principals:
+                    - any: true
           - name: envoy.filters.http.router
             typedConfig:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
## Motivation

Backport of the master fix. Zone-egress proxies aren't scoped to a
single mesh, so `ctx.Mesh` is always empty for them.
`unified_naming.Enabled(proxy.Metadata, ctx.Mesh.Resource)` requires a
non-nil mesh, so it unconditionally reports unified naming as disabled
for the egress RBAC plugin path, regardless of whether the dataplane
actually has the `FeatureUnifiedResourceNaming` feature. The same bug
was already fixed for the egress/ingress generators on this branch,
but this MeshTrafficPermission plugin instance of the same pattern was
missed.

Consequence: once unified naming is enabled, the egress generator
builds MeshExternalService filter chain names using the unified (KRI)
scheme, but this plugin still computes the name it matches against
using the legacy scheme. The names never match, so the RBAC filter is
silently never attached to the filter chain — MeshExternalService
traffic permissions (including `defaultForbidMeshExternalServiceAccess`)
have no effect under unified naming for zone egress.

> Changelog: fix(mtp): unified naming for zone egress

## Implementation information

Mirror the existing workaround from `egress/generator.go` /
`ingress_generator.go`: read the feature flag directly off
`proxy.Metadata` instead of going through `unified_naming.Enabled()`.

Added a regression test that builds a ZoneEgress proxy with a unified
(KRI)-named filter chain and confirms the RBAC filter gets attached;
verified it fails against the old code and passes with the fix.

## Supporting documentation

Backport of the master fix for kumahq/kuma.