### PR TITLE
feat(xds): unified-name for empty listener tags

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -53,9 +53,10 @@ const (
 
 	MeshTag = "kuma.io/mesh"
 
-	// KRITag is the io.kuma.tags listener key holding a synthesized KRI, written
-	// when identity has moved off tags so listenerTags keeps matching.
-	KRITag = "kuma.io/kri"
+	// UnifiedNameTag is the io.kuma.tags listener key filled when tags are empty
+	// so listenerTags keeps matching: the destination KRI on an outbound, the
+	// contextual self-reference on an inbound.
+	UnifiedNameTag = "kuma.io/unified-name"
 
 	// Optional tag that has a reserved meaning in Kuma.
 	// If absent, Kuma will treat application's protocol as opaque TCP.

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -53,6 +53,10 @@ const (
 
 	MeshTag = "kuma.io/mesh"
 
+	// KRITag is the io.kuma.tags listener key holding a synthesized KRI, written
+	// when identity has moved off tags so listenerTags keeps matching.
+	KRITag = "kuma.io/kri"
+
 	// Optional tag that has a reserved meaning in Kuma.
 	// If absent, Kuma will treat application's protocol as opaque TCP.
 	ProtocolTag = "kuma.io/protocol"

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -84,6 +84,16 @@ func (ds *DestinationService) ConditionallyResolveKRIWithFallback(condition bool
 	return fallback
 }
 
+// OutboundListenerTags returns the outbound listener's io.kuma.tags: real
+// outbound tags without kuma.io/mesh for a legacy outbound, or a synthesized
+// kuma.io/kri tag from the destination KRI for a resource-based one.
+func (ds *DestinationService) OutboundListenerTags() envoy_tags.Tags {
+	if id, ok := ds.Outbound.AssociatedServiceResource(); ok {
+		return envoy_tags.Tags{mesh_proto.KRITag: id.String()}
+	}
+	return envoy_tags.Tags(ds.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)
+}
+
 func (ds *DestinationService) DefaultBackendRef() *resolve.ResolvedBackendRef {
 	if r, ok := ds.Outbound.AssociatedServiceResource(); ok {
 		return resolve.NewResolvedBackendRef(&resolve.RealResourceBackendRef{

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -87,11 +87,11 @@ func (ds *DestinationService) ConditionallyResolveKRIWithFallback(condition bool
 // OutboundListenerTags returns the outbound listener's io.kuma.tags: real
 // outbound tags without kuma.io/mesh for a legacy outbound, or a synthesized
 // kuma.io/kri tag from the destination KRI for a resource-based one.
-func (ds *DestinationService) OutboundListenerTags() envoy_tags.Tags {
+func (ds *DestinationService) OutboundListenerTags() map[string]string {
 	if id, ok := ds.Outbound.AssociatedServiceResource(); ok {
-		return envoy_tags.Tags{mesh_proto.KRITag: id.String()}
+		return map[string]string{mesh_proto.KRITag: id.String()}
 	}
-	return envoy_tags.Tags(ds.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)
+	return map[string]string(envoy_tags.Tags(ds.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag))
 }
 
 func (ds *DestinationService) DefaultBackendRef() *resolve.ResolvedBackendRef {

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -84,15 +84,15 @@ func (ds *DestinationService) ConditionallyResolveKRIWithFallback(condition bool
 	return fallback
 }
 
-// OutboundListenerTags returns the outbound listener's io.kuma.tags: real
-// outbound tags without kuma.io/mesh for a legacy outbound, or a synthesized
-// kuma.io/kri tag from the destination KRI for a resource-based one.
+// OutboundListenerTags returns the outbound listener's io.kuma.tags: real tags
+// without kuma.io/mesh for a legacy outbound, or the destination KRI under
+// kuma.io/unified-name for a resource-based one.
 func (ds *DestinationService) OutboundListenerTags() map[string]string {
 	if ds.Outbound == nil {
 		return nil
 	}
 	if id, ok := ds.Outbound.AssociatedServiceResource(); ok {
-		return map[string]string{mesh_proto.KRITag: id.String()}
+		return map[string]string{mesh_proto.UnifiedNameTag: id.String()}
 	}
 	return map[string]string(envoy_tags.Tags(ds.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag))
 }

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -88,6 +88,9 @@ func (ds *DestinationService) ConditionallyResolveKRIWithFallback(condition bool
 // outbound tags without kuma.io/mesh for a legacy outbound, or a synthesized
 // kuma.io/kri tag from the destination KRI for a resource-based one.
 func (ds *DestinationService) OutboundListenerTags() map[string]string {
+	if ds.Outbound == nil {
+		return nil
+	}
 	if id, ok := ds.Outbound.AssociatedServiceResource(); ok {
 		return map[string]string{mesh_proto.KRITag: id.String()}
 	}

--- a/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("OutboundListenerTags", func() {
-	It("returns a synthesized kuma.io/kri tag for a real-resource outbound", func() {
+	It("returns a synthesized kuma.io/unified-name tag for a real-resource outbound", func() {
 		// given
 		ms := builders.MeshService().
 			WithName("backend").
@@ -27,7 +27,7 @@ var _ = Describe("OutboundListenerTags", func() {
 		tags := ds.OutboundListenerTags()
 
 		// then
-		Expect(tags).To(BeEquivalentTo(map[string]string{mesh_proto.KRITag: id.String()}))
+		Expect(tags).To(BeEquivalentTo(map[string]string{mesh_proto.UnifiedNameTag: id.String()}))
 	})
 
 	It("returns the real outbound tags without kuma.io/mesh for a legacy outbound", func() {

--- a/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
@@ -52,4 +52,45 @@ var _ = Describe("OutboundListenerTags", func() {
 		}))
 		Expect(tags).NotTo(HaveKey(mesh_proto.MeshTag))
 	})
+
+	It("returns an empty map for a legacy outbound with nil tags", func() {
+		// given
+		ds := meshroute.DestinationService{Outbound: &xds_types.Outbound{
+			LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+				Tags: nil,
+			},
+		}}
+
+		// when
+		tags := ds.OutboundListenerTags()
+
+		// then
+		Expect(tags).To(BeEmpty())
+	})
+
+	It("returns an empty map for a legacy outbound with empty tags", func() {
+		// given
+		ds := meshroute.DestinationService{Outbound: &xds_types.Outbound{
+			LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+				Tags: map[string]string{},
+			},
+		}}
+
+		// when
+		tags := ds.OutboundListenerTags()
+
+		// then
+		Expect(tags).To(BeEmpty())
+	})
+
+	It("returns nil when Outbound is nil", func() {
+		// given
+		ds := meshroute.DestinationService{Outbound: nil}
+
+		// when
+		tags := ds.OutboundListenerTags()
+
+		// then
+		Expect(tags).To(BeNil())
+	})
 })

--- a/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
@@ -1,0 +1,55 @@
+package meshroute_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
+	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
+	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds/meshroute"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+)
+
+var _ = Describe("OutboundListenerTags", func() {
+	It("returns a synthesized kuma.io/kri tag for a real-resource outbound", func() {
+		// given
+		ms := builders.MeshService().
+			WithName("backend").
+			WithMesh("default").
+			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
+			Build()
+		id := kri.WithSectionName(kri.From(ms), "http")
+		ds := meshroute.DestinationService{Outbound: &xds_types.Outbound{Resource: id}}
+
+		// when
+		tags := ds.OutboundListenerTags()
+
+		// then
+		Expect(tags).To(BeEquivalentTo(map[string]string{mesh_proto.KRITag: id.String()}))
+	})
+
+	It("returns the real outbound tags without kuma.io/mesh for a legacy outbound", func() {
+		// given
+		ds := meshroute.DestinationService{Outbound: &xds_types.Outbound{
+			LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+				Tags: map[string]string{
+					mesh_proto.ServiceTag: "backend",
+					mesh_proto.MeshTag:    "default",
+					"version":             "v1",
+				},
+			},
+		}}
+
+		// when
+		tags := ds.OutboundListenerTags()
+
+		// then
+		Expect(tags).To(BeEquivalentTo(map[string]string{
+			mesh_proto.ServiceTag: "backend",
+			"version":             "v1",
+		}))
+		Expect(tags).NotTo(HaveKey(mesh_proto.MeshTag))
+	})
+})

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
@@ -149,6 +149,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+      kuma.io/unified-name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute.listener.golden.yaml
@@ -148,6 +148,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute_unified_naming.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute_unified_naming.listener.golden.yaml
@@ -110,6 +110,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute_unified_naming.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_meshhttproute_unified_naming.listener.golden.yaml
@@ -111,6 +111,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+      kuma.io/unified-name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshexternalservice-http___extsvc_47777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_extsvc_default___other-meshexternalservice-http_
 name: outbound:127.0.0.1:47777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshexternalservice.listener.golden.yaml
@@ -54,6 +54,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_extsvc_default___other-meshexternalservice-http_
+      kuma.io/unified-name: kri_extsvc_default___other-meshexternalservice-http_
 name: outbound:127.0.0.1:47777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
@@ -54,6 +54,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+      kuma.io/unified-name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/basic_outbound_real_meshservice.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
@@ -93,6 +93,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/disable_mal_for_meshhttproute.listener.golden.yaml
@@ -94,6 +94,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+      kuma.io/unified-name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_workload_identity.listener.golden.yaml
@@ -54,6 +54,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+      kuma.io/unified-name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_file_workload_identity.listener.golden.yaml
@@ -53,6 +53,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
@@ -83,6 +83,6 @@ filterChains:
 metadata:
   filterMetadata:
     io.kuma.tags:
-      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
+      kuma.io/unified-name: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
@@ -82,6 +82,7 @@ filterChains:
       statPrefix: default_other-meshservice-http_other-ns_zone-1_msvc_27777
 metadata:
   filterMetadata:
-    io.kuma.tags: {}
+    io.kuma.tags:
+      kuma.io/kri: kri_msvc_default_zone-1_other-ns_other-meshservice-http_
 name: outbound:127.0.0.1:27777
 trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -27,7 +27,6 @@ import (
 	envoy_listeners "github.com/kumahq/kuma/v3/pkg/xds/envoy/listeners"
 	envoy_listeners_v3 "github.com/kumahq/kuma/v3/pkg/xds/envoy/listeners/v3"
 	envoy_names "github.com/kumahq/kuma/v3/pkg/xds/envoy/names"
-	envoy_tags "github.com/kumahq/kuma/v3/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/metadata"
 )
 
@@ -75,7 +74,7 @@ func GenerateOutboundListener(
 		Configure(envoy_listeners.StatPrefix(listenerStatPrefix)).
 		Configure(envoy_listeners.OutboundListener(address, port, core_xds.SocketAddressProtocolTCP)).
 		Configure(envoy_listeners.TransparentProxying(transparentProxyEnabled)).
-		Configure(envoy_listeners.TagsMetadata(envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag))).
+		Configure(envoy_listeners.TagsMetadata(svc.OutboundListenerTags())).
 		Configure(envoy_listeners.FilterChain(filterChain))
 
 	resource, err := listener.Build()

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
@@ -61,7 +61,8 @@ resources:
           statPrefix: kri_msvc_default___backend_test-port
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: kri_msvc_default___backend_test-port
     statPrefix: kri_msvc_default___backend_test-port
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels-unified-naming.listeners.golden.yaml
@@ -62,7 +62,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_test-port
+          kuma.io/unified-name: kri_msvc_default___backend_test-port
     name: kri_msvc_default___backend_test-port
     statPrefix: kri_msvc_default___backend_test-port
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
@@ -62,6 +62,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_test-port
+          kuma.io/unified-name: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -62,6 +62,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_test-port
+          kuma.io/unified-name: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -61,6 +61,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -86,6 +86,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_test-port
+          kuma.io/unified-name: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -85,6 +85,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default_remote-zone__ext-backend_9000
     name: kri_extsvc_default_remote-zone__ext-backend_9000
     statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice-mesh-scoped-zone.listeners.golden.yaml
@@ -39,7 +39,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default_remote-zone__ext-backend_9000
+          kuma.io/unified-name: kri_extsvc_default_remote-zone__ext-backend_9000
     name: kri_extsvc_default_remote-zone__ext-backend_9000
     statPrefix: kri_extsvc_default_remote-zone__ext-backend_9000
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -39,6 +39,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
@@ -38,6 +38,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_mzsvc_default___multi-backend_80
+          kuma.io/unified-name: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
@@ -38,6 +38,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_mzsvc_default___multi-backend_80
+          kuma.io/unified-name: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
@@ -38,6 +38,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_mzsvc_default___multi-backend_80
+          kuma.io/unified-name: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_multi-backend___mzsvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -38,6 +38,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_mzsvc_default___multi-backend_80
+          kuma.io/unified-name: kri_mzsvc_default___multi-backend_80
     name: outbound:10.0.0.2:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend__remote-zone_msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default_remote-zone__backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
@@ -38,6 +38,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default_remote-zone__backend_80
+          kuma.io/unified-name: kri_msvc_default_remote-zone__backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
@@ -38,7 +38,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_80
+          kuma.io/unified-name: kri_msvc_default___backend_80
     name: kri_msvc_default___backend_80
     statPrefix: kri_msvc_default___backend_80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-unified-naming.listeners.golden.yaml
@@ -37,7 +37,8 @@ resources:
           statPrefix: kri_msvc_default___backend_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: kri_msvc_default___backend_80
     statPrefix: kri_msvc_default___backend_80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -37,6 +37,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -38,6 +38,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_80
+          kuma.io/unified-name: kri_msvc_default___backend_80
     name: outbound:10.0.0.1:80
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -53,6 +53,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -52,6 +52,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
@@ -39,7 +39,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: kri_extsvc_default___example_
     statPrefix: kri_extsvc_default___example_
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings-unified-naming.listeners.golden.yaml
@@ -38,7 +38,8 @@ resources:
           statPrefix: kri_extsvc_default___example_
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: kri_extsvc_default___example_
     statPrefix: kri_extsvc_default___example_
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -39,6 +39,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -39,6 +39,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -39,6 +39,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -38,6 +38,7 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
@@ -89,6 +89,7 @@ resources:
           statPrefix: default_ms-1_ns-1_zone-1_msvc_27777
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default_zone-1_ns-1_ms-1_
     name: outbound:127.0.0.1:27777
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/plugin/v1alpha1/testdata/route.listeners.golden.yaml
@@ -90,6 +90,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default_zone-1_ns-1_ms-1_
+          kuma.io/unified-name: kri_msvc_default_zone-1_ns-1_ms-1_
     name: outbound:127.0.0.1:27777
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/core/naming/unified-naming"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
@@ -14,7 +13,6 @@ import (
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
 	envoy_listeners "github.com/kumahq/kuma/v3/pkg/xds/envoy/listeners"
 	envoy_names "github.com/kumahq/kuma/v3/pkg/xds/envoy/names"
-	envoy_tags "github.com/kumahq/kuma/v3/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/metadata"
 )
 
@@ -39,7 +37,7 @@ func GenerateOutboundListener(
 		tcpProxyStatPrefix = listenerName
 	}
 
-	tags := envoy_tags.Tags(svc.Outbound.TagsOrNil()).WithoutTags(mesh_proto.MeshTag)
+	tags := svc.OutboundListenerTags()
 
 	filterChain := envoy_listeners.NewFilterChainBuilder(proxy.APIVersion, envoy_common.AnonymousResource).
 		Configure(envoy_listeners.TCPProxy(tcpProxyStatPrefix, splits...)).

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -16,6 +16,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_msvc_default___backend_test-port
+          kuma.io/unified-name: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -15,6 +15,7 @@ resources:
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_msvc_default___backend_test-port
     name: outbound:127.0.0.1:10001
     trafficDirection: OUTBOUND

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -16,7 +16,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -16,7 +16,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example_
+          kuma.io/unified-name: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:10.20.20.2:9090
@@ -36,7 +36,7 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_extsvc_default___example2_
+          kuma.io/unified-name: kri_extsvc_default___example2_
     name: outbound:10.20.20.2:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -15,7 +15,8 @@ resources:
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example_
     name: outbound:10.20.20.1:9090
     trafficDirection: OUTBOUND
 - name: outbound:10.20.20.2:9090
@@ -34,7 +35,8 @@ resources:
           statPrefix: default_example2___extsvc_9090
     metadata:
       filterMetadata:
-        io.kuma.tags: {}
+        io.kuma.tags:
+          kuma.io/kri: kri_extsvc_default___example2_
     name: outbound:10.20.20.2:9090
     trafficDirection: OUTBOUND
 - name: outbound:127.0.0.1:10001

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -373,7 +373,7 @@ func configureListener(
 		Configure(envoy_listeners.InboundListener(iface.DataplaneIP, iface.DataplanePort, core_xds.SocketAddressProtocolTCP, proxy.Metadata.HasFeature(xds_types.FeatureReusePort))).
 		Configure(envoy_listeners.StatPrefix(statPrefix)).
 		Configure(envoy_listeners.TransparentProxying(proxy)).
-		Configure(envoy_listeners.TagsMetadata(generator.InboundListenerTags(proxy.Dataplane, inbound.GetTags(), inbound.Name)))
+		Configure(envoy_listeners.TagsMetadata(generator.InboundListenerTags(inbound.GetTags(), inboundContextualID)))
 
 	downstreamCtx, err := downstreamTLSContext(xdsCtx, proxy, conf)
 	if err != nil {

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -373,7 +373,7 @@ func configureListener(
 		Configure(envoy_listeners.InboundListener(iface.DataplaneIP, iface.DataplanePort, core_xds.SocketAddressProtocolTCP, proxy.Metadata.HasFeature(xds_types.FeatureReusePort))).
 		Configure(envoy_listeners.StatPrefix(statPrefix)).
 		Configure(envoy_listeners.TransparentProxying(proxy)).
-		Configure(envoy_listeners.TagsMetadata(inbound.GetTags()))
+		Configure(envoy_listeners.TagsMetadata(generator.InboundListenerTags(proxy.Dataplane, inbound.GetTags(), inbound.Name)))
 
 	downstreamCtx, err := downstreamTLSContext(xdsCtx, proxy, conf)
 	if err != nil {

--- a/pkg/xds/generator/inbound_listener_tags_test.go
+++ b/pkg/xds/generator/inbound_listener_tags_test.go
@@ -5,57 +5,38 @@ import (
 	. "github.com/onsi/gomega"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
-	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
-	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/xds/generator"
 )
 
 var _ = Describe("InboundListenerTags", func() {
-	dpWithLabels := func() *core_mesh.DataplaneResource {
-		return &core_mesh.DataplaneResource{
-			Meta: &test_model.ResourceMeta{
-				Name: "backend-7f9c",
-				Mesh: "default",
-				Labels: map[string]string{
-					mesh_proto.ZoneTag:          "east",
-					mesh_proto.KubeNamespaceTag: "kuma-demo",
-					mesh_proto.DisplayName:      "backend-7f9c",
-				},
-			},
-			Spec: &mesh_proto.Dataplane{},
-		}
-	}
-
 	It("keeps existing inbound tags untouched", func() {
 		// given
 		tags := map[string]string{mesh_proto.ServiceTag: "backend", "version": "v1"}
 
 		// when
-		out := generator.InboundListenerTags(dpWithLabels(), tags, "http")
+		out := generator.InboundListenerTags(tags, "self_inbound_dp_http")
 
 		// then
 		Expect(out).To(Equal(tags))
 	})
 
-	It("synthesizes a kuma.io/kri tag with the port as section name when tags are empty", func() {
+	It("writes the contextual name under kuma.io/unified-name when tags are empty", func() {
 		// when
-		out := generator.InboundListenerTags(dpWithLabels(), map[string]string{}, "http")
+		out := generator.InboundListenerTags(map[string]string{}, "self_inbound_dp_http")
 
 		// then
 		Expect(out).To(Equal(map[string]string{
-			mesh_proto.KRITag: "kri_dp_default_east_kuma-demo_backend-7f9c_http",
+			mesh_proto.UnifiedNameTag: "self_inbound_dp_http",
 		}))
 	})
 
-	It("returns the empty tags unchanged when the Dataplane KRI cannot be built", func() {
-		// given a Dataplane with no meta, so no KRI can be synthesized
-		dp := &core_mesh.DataplaneResource{Spec: &mesh_proto.Dataplane{}}
-		tags := map[string]string{}
-
+	It("writes the contextual name when tags are nil", func() {
 		// when
-		out := generator.InboundListenerTags(dp, tags, "http")
+		out := generator.InboundListenerTags(nil, "self_inbound_dp_8080")
 
 		// then
-		Expect(out).To(BeEmpty())
+		Expect(out).To(Equal(map[string]string{
+			mesh_proto.UnifiedNameTag: "self_inbound_dp_8080",
+		}))
 	})
 })

--- a/pkg/xds/generator/inbound_listener_tags_test.go
+++ b/pkg/xds/generator/inbound_listener_tags_test.go
@@ -1,0 +1,61 @@
+package generator_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/xds/generator"
+)
+
+var _ = Describe("InboundListenerTags", func() {
+	dpWithLabels := func() *core_mesh.DataplaneResource {
+		return &core_mesh.DataplaneResource{
+			Meta: &test_model.ResourceMeta{
+				Name: "backend-7f9c",
+				Mesh: "default",
+				Labels: map[string]string{
+					mesh_proto.ZoneTag:          "east",
+					mesh_proto.KubeNamespaceTag: "kuma-demo",
+					mesh_proto.DisplayName:      "backend-7f9c",
+				},
+			},
+			Spec: &mesh_proto.Dataplane{},
+		}
+	}
+
+	It("keeps existing inbound tags untouched", func() {
+		// given
+		tags := map[string]string{mesh_proto.ServiceTag: "backend", "version": "v1"}
+
+		// when
+		out := generator.InboundListenerTags(dpWithLabels(), tags, "http")
+
+		// then
+		Expect(out).To(Equal(tags))
+	})
+
+	It("synthesizes a kuma.io/kri tag with the port as section name when tags are empty", func() {
+		// when
+		out := generator.InboundListenerTags(dpWithLabels(), map[string]string{}, "http")
+
+		// then
+		Expect(out).To(Equal(map[string]string{
+			mesh_proto.KRITag: "kri_dp_default_east_kuma-demo_backend-7f9c_http",
+		}))
+	})
+
+	It("returns the empty tags unchanged when the Dataplane KRI cannot be built", func() {
+		// given a Dataplane with no meta, so no KRI can be synthesized
+		dp := &core_mesh.DataplaneResource{Spec: &mesh_proto.Dataplane{}}
+		tags := map[string]string{}
+
+		// when
+		out := generator.InboundListenerTags(dp, tags, "http")
+
+		// then
+		Expect(out).To(BeEmpty())
+	})
+})

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/kumahq/kuma/v3/api/common/v1alpha1/tls"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
-	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/core/naming"
-	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
@@ -83,7 +81,7 @@ func (g InboundProxyGenerator) Generate(_ context.Context, _ *core_xds.ResourceS
 			Configure(envoy_listeners.InboundListener(endpoint.DataplaneIP, endpoint.DataplanePort, core_xds.SocketAddressProtocolTCP, proxy.Metadata.HasFeature(xds_types.FeatureReusePort))).
 			Configure(envoy_listeners.StatPrefix(statPrefix)).
 			Configure(envoy_listeners.TransparentProxying(proxy)).
-			Configure(envoy_listeners.TagsMetadata(InboundListenerTags(proxy.Dataplane, iface.GetTags(), iface.Name)))
+			Configure(envoy_listeners.TagsMetadata(InboundListenerTags(iface.GetTags(), unifiedName)))
 
 		switch xdsCtx.Mesh.Resource.GetEnabledCertificateAuthorityBackend().GetMode() {
 		case mesh_proto.CertificateAuthorityBackend_STRICT:
@@ -169,18 +167,15 @@ func FilterChainBuilder(
 		Configure(envoy_listeners.Timeout(defaults_mesh.DefaultInboundTimeout(), protocol))
 }
 
-// InboundListenerTags returns the inbound listener's io.kuma.tags. When the
-// inbound has no tags, it synthesizes a kuma.io/kri tag from the Dataplane KRI
-// (port as section name) so the listener stays selectable.
-func InboundListenerTags(dataplane *core_mesh.DataplaneResource, tags map[string]string, portName string) map[string]string {
+// InboundListenerTags keeps the inbound's own tags, or when they are empty
+// falls back to the contextual name (self_inbound_dp_<sectionName>) under
+// kuma.io/unified-name so the listener stays selectable. The name carries no
+// Dataplane identity, so it survives Pod churn that a Dataplane KRI would not.
+func InboundListenerTags(tags map[string]string, contextualName string) map[string]string {
 	if len(tags) > 0 {
 		return tags
 	}
-	id := kri.WithSectionName(kri.FromResourceMeta(dataplane.GetMeta(), core_mesh.DataplaneType), portName)
-	if id.IsEmpty() {
-		return tags
-	}
-	return map[string]string{mesh_proto.KRITag: id.String()}
+	return map[string]string{mesh_proto.UnifiedNameTag: contextualName}
 }
 
 func GenerateRoutes(proxy *core_xds.Proxy, endpoint mesh_proto.InboundInterface, cluster envoy_common.Cluster) envoy_common.Routes {

--- a/pkg/xds/generator/inbound_proxy_generator.go
+++ b/pkg/xds/generator/inbound_proxy_generator.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/kumahq/kuma/v3/api/common/v1alpha1/tls"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/core/naming"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
@@ -81,7 +83,7 @@ func (g InboundProxyGenerator) Generate(_ context.Context, _ *core_xds.ResourceS
 			Configure(envoy_listeners.InboundListener(endpoint.DataplaneIP, endpoint.DataplanePort, core_xds.SocketAddressProtocolTCP, proxy.Metadata.HasFeature(xds_types.FeatureReusePort))).
 			Configure(envoy_listeners.StatPrefix(statPrefix)).
 			Configure(envoy_listeners.TransparentProxying(proxy)).
-			Configure(envoy_listeners.TagsMetadata(iface.GetTags()))
+			Configure(envoy_listeners.TagsMetadata(InboundListenerTags(proxy.Dataplane, iface.GetTags(), iface.Name)))
 
 		switch xdsCtx.Mesh.Resource.GetEnabledCertificateAuthorityBackend().GetMode() {
 		case mesh_proto.CertificateAuthorityBackend_STRICT:
@@ -165,6 +167,20 @@ func FilterChainBuilder(
 	}
 	return filterChainBuilder.
 		Configure(envoy_listeners.Timeout(defaults_mesh.DefaultInboundTimeout(), protocol))
+}
+
+// InboundListenerTags returns the inbound listener's io.kuma.tags. When the
+// inbound has no tags, it synthesizes a kuma.io/kri tag from the Dataplane KRI
+// (port as section name) so the listener stays selectable.
+func InboundListenerTags(dataplane *core_mesh.DataplaneResource, tags map[string]string, portName string) map[string]string {
+	if len(tags) > 0 {
+		return tags
+	}
+	id := kri.WithSectionName(kri.FromResourceMeta(dataplane.GetMeta(), core_mesh.DataplaneType), portName)
+	if id.IsEmpty() {
+		return tags
+	}
+	return map[string]string{mesh_proto.KRITag: id.String()}
 }
 
 func GenerateRoutes(proxy *core_xds.Proxy, endpoint mesh_proto.InboundInterface, cluster envoy_common.Cluster) envoy_common.Routes {

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -22,11 +22,12 @@ import (
 
 var _ = Describe("InboundProxyGenerator", func() {
 	type testCase struct {
-		dataplaneFile    string
-		dataplaneMeta    *model.DataplaneMetadata
-		expected         string
-		mode             mesh_proto.CertificateAuthorityBackend_Mode
-		casByTrustDomain map[string][]xds_context.PEMBytes
+		dataplaneFile         string
+		dataplaneMeta         *model.DataplaneMetadata
+		dataplaneResourceMeta *test_model.ResourceMeta
+		expected              string
+		mode                  mesh_proto.CertificateAuthorityBackend_Mode
+		casByTrustDomain      map[string][]xds_context.PEMBytes
 	}
 
 	DescribeTable("Generate Envoy xDS resources",
@@ -65,12 +66,14 @@ var _ = Describe("InboundProxyGenerator", func() {
 			dpBytes, err := os.ReadFile(filepath.Join("testdata", "inbound-proxy", given.dataplaneFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
+			dpMeta := given.dataplaneResourceMeta
+			if dpMeta == nil {
+				dpMeta = &test_model.ResourceMeta{Version: "1"}
+			}
 			proxy := &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
 				Dataplane: &core_mesh.DataplaneResource{
-					Meta: &test_model.ResourceMeta{
-						Version: "1",
-					},
+					Meta: dpMeta,
 					Spec: &dataplane,
 				},
 				SecretsTracker: envoy_common.NewSecretsTracker(xdsCtx.Mesh.Resource.Meta.GetName(), []string{xdsCtx.Mesh.Resource.Meta.GetName()}),
@@ -142,6 +145,20 @@ var _ = Describe("InboundProxyGenerator", func() {
 		Entry("10. transparent_proxying=false, no kuma.io/service tag, http protocol", testCase{
 			dataplaneFile: "10-dataplane.input.yaml",
 			expected:      "10-envoy-config.golden.yaml",
+		}),
+		Entry("11. inbound with no tags, listener tags filled from Dataplane KRI", testCase{
+			dataplaneFile: "11-dataplane.input.yaml",
+			dataplaneResourceMeta: &test_model.ResourceMeta{
+				Version: "1",
+				Name:    "backend-7f9c",
+				Mesh:    "default",
+				Labels: map[string]string{
+					mesh_proto.ZoneTag:          "east",
+					mesh_proto.KubeNamespaceTag: "kuma-demo",
+					mesh_proto.DisplayName:      "backend-7f9c",
+				},
+			},
+			expected: "11-envoy-config.golden.yaml",
 		}),
 	)
 })

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -22,12 +22,11 @@ import (
 
 var _ = Describe("InboundProxyGenerator", func() {
 	type testCase struct {
-		dataplaneFile         string
-		dataplaneMeta         *model.DataplaneMetadata
-		dataplaneResourceMeta *test_model.ResourceMeta
-		expected              string
-		mode                  mesh_proto.CertificateAuthorityBackend_Mode
-		casByTrustDomain      map[string][]xds_context.PEMBytes
+		dataplaneFile    string
+		dataplaneMeta    *model.DataplaneMetadata
+		expected         string
+		mode             mesh_proto.CertificateAuthorityBackend_Mode
+		casByTrustDomain map[string][]xds_context.PEMBytes
 	}
 
 	DescribeTable("Generate Envoy xDS resources",
@@ -66,14 +65,12 @@ var _ = Describe("InboundProxyGenerator", func() {
 			dpBytes, err := os.ReadFile(filepath.Join("testdata", "inbound-proxy", given.dataplaneFile))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(util_proto.FromYAML(dpBytes, &dataplane)).To(Succeed())
-			dpMeta := given.dataplaneResourceMeta
-			if dpMeta == nil {
-				dpMeta = &test_model.ResourceMeta{Version: "1"}
-			}
 			proxy := &model.Proxy{
 				Id: *model.BuildProxyId("", "side-car"),
 				Dataplane: &core_mesh.DataplaneResource{
-					Meta: dpMeta,
+					Meta: &test_model.ResourceMeta{
+						Version: "1",
+					},
 					Spec: &dataplane,
 				},
 				SecretsTracker: envoy_common.NewSecretsTracker(xdsCtx.Mesh.Resource.Meta.GetName(), []string{xdsCtx.Mesh.Resource.Meta.GetName()}),
@@ -146,19 +143,9 @@ var _ = Describe("InboundProxyGenerator", func() {
 			dataplaneFile: "10-dataplane.input.yaml",
 			expected:      "10-envoy-config.golden.yaml",
 		}),
-		Entry("11. inbound with no tags, listener tags filled from Dataplane KRI", testCase{
+		Entry("11. inbound with no tags, listener tags filled with self-reference", testCase{
 			dataplaneFile: "11-dataplane.input.yaml",
-			dataplaneResourceMeta: &test_model.ResourceMeta{
-				Version: "1",
-				Name:    "backend-7f9c",
-				Mesh:    "default",
-				Labels: map[string]string{
-					mesh_proto.ZoneTag:          "east",
-					mesh_proto.KubeNamespaceTag: "kuma-demo",
-					mesh_proto.DisplayName:      "backend-7f9c",
-				},
-			},
-			expected: "11-envoy-config.golden.yaml",
+			expected:      "11-envoy-config.golden.yaml",
 		}),
 	)
 })

--- a/pkg/xds/generator/testdata/inbound-proxy/11-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/11-dataplane.input.yaml
@@ -1,0 +1,6 @@
+networking:
+  address: 192.168.0.1
+  inbound:
+    - name: http-port
+      port: 9000
+      servicePort: 9001

--- a/pkg/xds/generator/testdata/inbound-proxy/11-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/11-envoy-config.golden.yaml
@@ -1,0 +1,66 @@
+resources:
+- name: localhost:9001
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    altStatName: localhost_9001
+    connectTimeout: 10s
+    loadAssignment:
+      clusterName: localhost:9001
+      endpoints:
+      - lbEndpoints:
+        - endpoint:
+            address:
+              socketAddress:
+                address: 192.168.0.1
+                portValue: 9001
+    name: localhost:9001
+    type: STATIC
+- name: inbound:192.168.0.1:9000
+  resource:
+    '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 192.168.0.1
+        portValue: 9000
+    enableReusePort: false
+    filterChains:
+    - filters:
+      - name: envoy.filters.network.rbac
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+          rules: {}
+          statPrefix: inbound_192_168_0_1_9000.
+      - name: envoy.filters.network.tcp_proxy
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          cluster: localhost:9001
+          idleTimeout: 7200s
+          statPrefix: localhost_9001
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            combinedValidationContext:
+              defaultValidationContext:
+                matchTypedSubjectAltNames:
+                - matcher:
+                    prefix: spiffe://default/
+                  sanType: URI
+              validationContextSdsSecretConfig:
+                name: mesh_ca:secret:default
+                sdsConfig:
+                  ads: {}
+                  resourceApiVersion: V3
+            tlsCertificateSdsSecretConfigs:
+            - name: identity_cert:secret:default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          requireClientCertificate: true
+    metadata:
+      filterMetadata:
+        io.kuma.tags:
+          kuma.io/kri: kri_dp_default_east_kuma-demo_backend-7f9c_http-port
+    name: inbound:192.168.0.1:9000
+    trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/inbound-proxy/11-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/11-envoy-config.golden.yaml
@@ -1,11 +1,10 @@
 resources:
-- name: localhost:9001
+- name: self_inbound_dp_http-port
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    altStatName: localhost_9001
     connectTimeout: 10s
     loadAssignment:
-      clusterName: localhost:9001
+      clusterName: self_inbound_dp_http-port
       endpoints:
       - lbEndpoints:
         - endpoint:
@@ -13,9 +12,9 @@ resources:
               socketAddress:
                 address: 192.168.0.1
                 portValue: 9001
-    name: localhost:9001
+    name: self_inbound_dp_http-port
     type: STATIC
-- name: inbound:192.168.0.1:9000
+- name: self_inbound_dp_http-port
   resource:
     '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     address:
@@ -25,17 +24,12 @@ resources:
     enableReusePort: false
     filterChains:
     - filters:
-      - name: envoy.filters.network.rbac
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
-          rules: {}
-          statPrefix: inbound_192_168_0_1_9000.
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: localhost:9001
+          cluster: self_inbound_dp_http-port
           idleTimeout: 7200s
-          statPrefix: localhost_9001
+          statPrefix: self_inbound_dp_http-port
       transportSocket:
         name: envoy.transport_sockets.tls
         typedConfig:
@@ -48,12 +42,12 @@ resources:
                     prefix: spiffe://default/
                   sanType: URI
               validationContextSdsSecretConfig:
-                name: mesh_ca:secret:default
+                name: system_mtls_ca_default
                 sdsConfig:
                   ads: {}
                   resourceApiVersion: V3
             tlsCertificateSdsSecretConfigs:
-            - name: identity_cert:secret:default
+            - name: system_mtls_identity_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
@@ -62,5 +56,6 @@ resources:
       filterMetadata:
         io.kuma.tags:
           kuma.io/unified-name: self_inbound_dp_http-port
-    name: inbound:192.168.0.1:9000
+    name: self_inbound_dp_http-port
+    statPrefix: self_inbound_dp_http-port
     trafficDirection: INBOUND

--- a/pkg/xds/generator/testdata/inbound-proxy/11-envoy-config.golden.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/11-envoy-config.golden.yaml
@@ -61,6 +61,6 @@ resources:
     metadata:
       filterMetadata:
         io.kuma.tags:
-          kuma.io/kri: kri_dp_default_east_kuma-demo_backend-7f9c_http-port
+          kuma.io/unified-name: self_inbound_dp_http-port
     name: inbound:192.168.0.1:9000
     trafficDirection: INBOUND

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -469,7 +469,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -559,7 +559,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -468,7 +468,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -556,7 +558,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -456,7 +456,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -546,7 +546,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -455,7 +455,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -543,7 +545,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -469,7 +469,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -559,7 +559,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -468,7 +468,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -556,7 +558,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
@@ -642,7 +642,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -851,7 +853,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
@@ -643,7 +643,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -854,7 +854,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
@@ -656,7 +656,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -867,7 +867,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
@@ -655,7 +655,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -864,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
@@ -552,7 +552,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -740,7 +740,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
@@ -551,7 +551,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -737,7 +739,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
@@ -565,7 +565,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -753,7 +753,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
@@ -564,7 +564,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -750,7 +752,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -477,7 +477,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -602,7 +602,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -476,7 +476,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -599,7 +601,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -490,7 +490,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -615,7 +615,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -489,7 +489,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -612,7 +614,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -481,7 +481,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -571,7 +571,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -480,7 +480,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -568,7 +570,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -467,7 +467,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -555,7 +557,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -468,7 +468,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -558,7 +558,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -481,7 +481,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -571,7 +571,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -480,7 +480,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -568,7 +570,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -467,7 +467,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -555,7 +557,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -468,7 +468,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -558,7 +558,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -481,7 +481,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -571,7 +571,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -480,7 +480,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -568,7 +570,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
@@ -495,7 +495,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -583,7 +585,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.demo-client.golden.json
@@ -496,7 +496,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -586,7 +586,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
@@ -508,7 +508,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -596,7 +598,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound-overwrite-meshhealthcheck-healthypanicthreshold.test-server.golden.json
@@ -509,7 +509,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -599,7 +599,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -499,7 +499,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -587,7 +589,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -500,7 +500,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -590,7 +590,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -512,7 +512,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -600,7 +602,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -513,7 +513,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -603,7 +603,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -532,7 +534,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -535,7 +535,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
@@ -610,7 +610,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -671,7 +673,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -706,7 +708,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
@@ -611,7 +611,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -709,7 +709,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
@@ -450,7 +450,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -540,7 +540,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
@@ -449,7 +449,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -537,7 +539,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
@@ -467,7 +467,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -555,7 +557,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
@@ -468,7 +468,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -558,7 +558,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
@@ -481,7 +481,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -571,7 +571,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
@@ -480,7 +480,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -568,7 +570,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
@@ -464,7 +464,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -559,7 +561,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
@@ -465,7 +465,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -562,7 +562,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
@@ -477,7 +477,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -572,7 +574,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
@@ -478,7 +478,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -575,7 +575,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
@@ -464,7 +464,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -559,7 +561,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
@@ -465,7 +465,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -562,7 +562,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
@@ -477,7 +477,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -572,7 +574,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
@@ -478,7 +478,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -575,7 +575,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
@@ -532,7 +532,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -735,7 +737,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
@@ -533,7 +533,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -738,7 +738,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
@@ -545,7 +545,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -748,7 +750,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
@@ -546,7 +546,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -751,7 +751,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
@@ -532,7 +532,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -735,7 +737,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
@@ -533,7 +533,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -738,7 +738,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
@@ -545,7 +545,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -748,7 +750,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
@@ -546,7 +546,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -751,7 +751,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -527,7 +527,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -615,7 +617,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -528,7 +528,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -618,7 +618,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -540,7 +540,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -628,7 +630,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -541,7 +541,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -631,7 +631,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -599,7 +599,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -687,7 +689,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -600,7 +600,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -690,7 +690,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -612,7 +612,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -700,7 +702,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -613,7 +613,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -703,7 +703,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -500,7 +500,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -588,7 +590,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -501,7 +501,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -591,7 +591,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -500,7 +500,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -588,7 +590,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -501,7 +501,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -591,7 +591,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -500,7 +500,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -588,7 +590,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -501,7 +501,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -591,7 +591,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
@@ -450,7 +450,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -540,7 +540,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
@@ -449,7 +449,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -537,7 +539,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -524,7 +524,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -664,7 +664,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -523,7 +523,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -661,7 +663,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -536,7 +536,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -674,7 +676,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -537,7 +537,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -677,7 +677,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
@@ -536,7 +536,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -688,7 +688,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
@@ -535,7 +535,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -685,7 +687,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
@@ -549,7 +549,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -701,7 +701,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
@@ -548,7 +548,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -698,7 +700,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
@@ -449,7 +449,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -545,7 +547,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
@@ -450,7 +450,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -548,7 +548,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
@@ -462,7 +462,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -558,7 +560,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
@@ -463,7 +463,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -561,7 +561,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -511,7 +511,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -601,7 +601,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -510,7 +510,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -598,7 +600,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -458,7 +458,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -548,7 +548,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -457,7 +457,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -545,7 +547,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -511,7 +511,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -601,7 +601,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -510,7 +510,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -598,7 +600,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -458,7 +458,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -548,7 +548,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -457,7 +457,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -545,7 +547,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -511,7 +511,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -601,7 +601,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -510,7 +510,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -598,7 +600,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -450,7 +450,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -540,7 +540,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -449,7 +449,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -537,7 +539,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -528,7 +528,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -656,7 +656,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -527,7 +527,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -653,7 +655,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -540,7 +540,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -666,7 +668,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -541,7 +541,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -669,7 +669,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
@@ -528,7 +528,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -656,7 +656,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
@@ -527,7 +527,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -653,7 +655,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
@@ -540,7 +540,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -666,7 +668,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
@@ -541,7 +541,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -669,7 +669,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -498,7 +498,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -588,7 +588,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -497,7 +497,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -585,7 +587,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -511,7 +511,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -601,7 +601,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -510,7 +510,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -598,7 +600,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -641,7 +641,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -729,7 +731,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -642,7 +642,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -732,7 +732,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -777,7 +777,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -867,7 +867,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -776,7 +776,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -864,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -641,7 +641,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -729,7 +731,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -642,7 +642,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -732,7 +732,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -777,7 +777,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -867,7 +867,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -776,7 +776,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -864,7 +866,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -485,7 +485,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -575,7 +575,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -484,7 +484,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -572,7 +574,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -498,7 +498,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -588,7 +588,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -497,7 +497,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -585,7 +587,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -485,7 +485,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -575,7 +575,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -484,7 +484,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -572,7 +574,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -498,7 +498,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -588,7 +588,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -497,7 +497,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -585,7 +587,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
@@ -501,7 +501,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -589,7 +591,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
@@ -502,7 +502,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -592,7 +592,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
@@ -540,7 +540,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -630,7 +630,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
@@ -539,7 +539,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -627,7 +629,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
@@ -502,7 +502,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -590,7 +592,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
@@ -503,7 +503,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -593,7 +593,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
@@ -603,7 +603,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -691,7 +693,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
@@ -604,7 +604,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -694,7 +694,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
@@ -576,7 +576,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -664,7 +666,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
@@ -577,7 +577,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -667,7 +667,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
@@ -589,7 +589,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -677,7 +679,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
@@ -590,7 +590,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -680,7 +680,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
@@ -641,7 +641,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -729,7 +731,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
@@ -642,7 +642,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -732,7 +732,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
@@ -654,7 +654,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -742,7 +744,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
@@ -655,7 +655,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -745,7 +745,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
@@ -437,7 +437,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -527,7 +527,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
@@ -436,7 +436,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -524,7 +526,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
@@ -450,7 +450,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
             }
           }
         },
@@ -540,7 +540,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
@@ -449,7 +449,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
@@ -537,7 +539,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
@@ -746,7 +746,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -780,7 +780,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -870,7 +870,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -960,7 +960,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
@@ -745,7 +745,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -777,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -865,7 +869,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -953,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
@@ -754,7 +754,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -788,7 +788,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -886,7 +886,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -984,7 +984,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
@@ -717,7 +717,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/service=zone-proxy-demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/service=zone-proxy-demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],
@@ -753,7 +753,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -785,7 +787,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -846,7 +850,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/service=zone-proxy-demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/service=zone-proxy-demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],
@@ -881,7 +885,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -942,7 +948,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/service=zone-proxy-demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/service=zone-proxy-demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],
@@ -977,7 +983,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -767,7 +767,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -801,7 +801,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -899,7 +899,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -997,7 +997,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -730,7 +730,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=zone-proxy-test-server-no-reusable-ports&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -766,7 +766,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -798,7 +800,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -859,7 +863,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=zone-proxy-test-server-no-reusable-ports&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -894,7 +898,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -955,7 +961,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=zone-proxy-test-server-no-reusable-ports&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -990,7 +996,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
@@ -730,7 +730,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=zone-proxy-test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=zone-proxy-test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -766,7 +766,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -798,7 +800,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -859,7 +863,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=zone-proxy-test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=zone-proxy-test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -894,7 +898,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -955,7 +961,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/protocol=http\u0026\u0026kuma.io/service=zone-proxy-test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/protocol=http&&kuma.io/service=zone-proxy-test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -990,7 +996,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
@@ -767,7 +767,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -801,7 +801,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -899,7 +899,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -997,7 +997,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
@@ -746,7 +746,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -780,7 +780,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -870,7 +870,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -960,7 +960,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
@@ -745,7 +745,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -777,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -865,7 +869,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -953,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
@@ -908,7 +908,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -940,7 +942,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1028,7 +1032,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1116,7 +1122,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
@@ -909,7 +909,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -943,7 +943,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1033,7 +1033,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1123,7 +1123,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -921,7 +921,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -953,7 +955,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1041,7 +1045,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1129,7 +1135,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -922,7 +922,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -956,7 +956,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1046,7 +1046,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1136,7 +1136,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
@@ -921,7 +921,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -953,7 +955,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1041,7 +1045,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1129,7 +1135,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
@@ -922,7 +922,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -956,7 +956,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1046,7 +1046,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1136,7 +1136,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
@@ -761,7 +761,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -795,7 +795,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -885,7 +885,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -975,7 +975,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
@@ -760,7 +760,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -792,7 +794,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -880,7 +884,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -968,7 +974,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -774,7 +774,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -808,7 +808,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -898,7 +898,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -988,7 +988,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -773,7 +773,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -805,7 +807,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -893,7 +897,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -981,7 +987,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
@@ -774,7 +774,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -808,7 +808,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -898,7 +898,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -988,7 +988,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
@@ -773,7 +773,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -805,7 +807,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -893,7 +897,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -981,7 +987,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
@@ -746,7 +746,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -780,7 +780,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -870,7 +870,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -960,7 +960,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
@@ -745,7 +745,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -777,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -865,7 +869,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -953,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
@@ -746,7 +746,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -780,7 +780,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -870,7 +870,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -960,7 +960,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
@@ -745,7 +745,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -777,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -865,7 +869,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -953,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-demo-client.golden.json
@@ -1039,7 +1039,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1127,7 +1129,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-demo-client.golden.json
@@ -1040,7 +1040,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1130,7 +1130,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1117,7 +1117,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1207,7 +1207,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1116,7 +1116,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1204,7 +1206,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server.golden.json
@@ -1117,7 +1117,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1207,7 +1207,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server.golden.json
@@ -1116,7 +1116,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1204,7 +1206,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
@@ -746,7 +746,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -780,7 +780,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -870,7 +870,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -960,7 +960,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
@@ -745,7 +745,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -777,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -865,7 +869,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -953,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-demo-client.golden.json
@@ -1251,7 +1251,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1341,7 +1341,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-demo-client.golden.json
@@ -1250,7 +1250,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1338,7 +1340,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1408,7 +1408,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1498,7 +1498,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -1407,7 +1407,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1495,7 +1497,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server.golden.json
@@ -1408,7 +1408,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1498,7 +1498,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server.golden.json
@@ -1407,7 +1407,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:3000",
@@ -1495,7 +1497,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "outbound:IP_REDACTED:80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
@@ -889,7 +889,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -923,7 +923,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1047,7 +1047,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1171,7 +1171,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
@@ -888,7 +888,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -920,7 +922,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1042,7 +1046,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1164,7 +1170,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -939,7 +939,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -971,7 +973,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1093,7 +1097,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1215,7 +1221,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -940,7 +940,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -974,7 +974,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1098,7 +1098,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1222,7 +1222,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
@@ -939,7 +939,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -971,7 +973,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1093,7 +1097,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1215,7 +1221,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
@@ -940,7 +940,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -974,7 +974,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1098,7 +1098,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1222,7 +1222,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
@@ -895,7 +895,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -929,7 +929,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1056,7 +1056,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1183,7 +1183,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
@@ -894,7 +894,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -926,7 +928,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1051,7 +1055,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1176,7 +1182,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -948,7 +948,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -980,7 +982,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1105,7 +1109,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1230,7 +1236,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -949,7 +949,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -983,7 +983,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1110,7 +1110,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1237,7 +1237,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
@@ -948,7 +948,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -980,7 +982,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -1105,7 +1109,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -1230,7 +1236,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
@@ -949,7 +949,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -983,7 +983,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -1110,7 +1110,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -1237,7 +1237,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
@@ -746,7 +746,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -780,7 +780,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -870,7 +870,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -960,7 +960,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
@@ -745,7 +745,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -777,7 +779,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -865,7 +869,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -953,7 +959,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
@@ -759,7 +759,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+              "kuma.io/unified-name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
             }
           }
         },
@@ -793,7 +793,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
             }
           }
         },
@@ -883,7 +883,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
             }
           }
         },
@@ -973,7 +973,7 @@
         "metadata": {
           "filterMetadata": {
             "io.kuma.tags": {
-              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+              "kuma.io/unified-name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
             }
           }
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
@@ -758,7 +758,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80"
+            }
           }
         },
         "name": "kri_extsvc_envoyconfig-zoneproxies_kuma-3__mes-zone-proxy_80",
@@ -790,7 +792,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-demo-client_3000",
@@ -878,7 +882,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server-no-reusable-ports_80",
@@ -966,7 +972,9 @@
         ],
         "metadata": {
           "filterMetadata": {
-            "io.kuma.tags": {}
+            "io.kuma.tags": {
+              "kuma.io/kri": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80"
+            }
           }
         },
         "name": "kri_msvc_envoyconfig-zoneproxies_kuma-3__zone-proxy-test-server_80",


### PR DESCRIPTION
## Motivation

`MeshProxyPatch` selects generated Envoy listeners with `listenerTags`, matching key/value pairs Kuma writes into listener metadata under `io.kuma.tags`. As identity moved out of tags and into resource labels (`MeshService`, `InboundTagsDisabled`), those listeners started writing an empty `io.kuma.tags: {}`. The policy still validates and is accepted, but matches nothing — a silent regression on a user-facing API.

## Implementation information

Fills `io.kuma.tags` wherever it would otherwise be empty with a synthesized `kuma.io/unified-name` tag (MADR 105, sub-option B). The value is direction-specific:

- Outbound listeners get the destination `Mesh*Service` KRI, with the port as section name, via a new `DestinationService.OutboundListenerTags()` used by both the `meshtcproute` and `meshhttproute` generators. Legacy outbounds keep their real tags with `kuma.io/mesh` stripped, as before.
- Inbound listeners whose tags are empty get a stable self-reference, `self_inbound_dp_<sectionName>` — the same contextual name already used as the inbound's unified listener name (`naming.ContextualInboundName`) — via a new `generator.InboundListenerTags()` wired into both `inbound_proxy_generator` and the `meshtls` plugin. Inbounds that carry tags keep them unchanged.

The inbound value is deliberately not the `Dataplane` KRI: on Kubernetes the `Dataplane` name is the Pod name, so a KRI there carries the Pod hash and rotates on every rollout, which cannot be written ahead of time and would reintroduce the silent match-nothing failure. A `MeshProxyPatch` already selects the proxy through `spec.targetRef`, so the inbound match only has to disambiguate the port, which the section name does.

The rule keys on the tags being empty, not on any flag, so a hand-written Universal `Dataplane` with tagless inbounds is covered too. There is no `MeshProxyPatch` API change and the fill is unconditional. Because it can only add matches, nothing that matches today can stop matching.

Policies that matched `kuma.io/service: <name>` have to be rewritten against `kuma.io/unified-name`: the destination KRI on an outbound, `self_inbound_dp_<port>` on an inbound.

Tests: unit tests for both new helpers, an end-to-end golden for the emptied inbound path, plus the mechanical golden updates where outbound listeners now carry the synthesized KRI.

## Supporting documentation

- MADR 105: Source Envoy listener tags from resource labels
- Closes part of https://github.com/kumahq/kuma/issues/17381
