### PR TITLE
refactor(kds): remove subset handling from outbound tag matching

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
@@ -34,7 +33,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/kds/service"
 	"github.com/kumahq/kuma/v3/pkg/kds/util"
 	reconcile_v2 "github.com/kumahq/kuma/v3/pkg/kds/v2/reconcile"
-	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	"github.com/kumahq/kuma/v3/pkg/util/rsa"
 	"github.com/kumahq/kuma/v3/pkg/version"
 )
@@ -316,12 +314,6 @@ func GlobalProvidedFilter(rm manager.ResourceManager) reconcile_v2.ResourceFilte
 				// if the actual role is not 'producer' then no syncing
 				if role != mesh_proto.ProducerPolicyRole {
 					return false
-				}
-				if policy.GetTargetRef().Kind == common_api.MeshSubset {
-					// if top-level targetRef has 'kuma.io/zone' then we can sync it only to required zone
-					if targetZone, ok := pointer.Deref(policy.GetTargetRef().Tags)[mesh_proto.ZoneTag]; ok && targetZone != zoneName {
-						return false
-					}
 				}
 			}
 

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/kds/util"
 	reconcile_v2 "github.com/kumahq/kuma/v3/pkg/kds/v2/reconcile"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
+	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/v3/pkg/test/matchers"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
@@ -415,6 +417,38 @@ var _ = Describe("Context", func() {
 				},
 				entries,
 			)
+		})
+
+		It("should not filter out a producer policy solely due to a top-level MeshSubset zone tag mismatch", func() {
+			ctx := stdcontext.Background()
+			// given
+			targetRef := builders.TargetRefMeshSubset(mesh_proto.ZoneTag, "different-zone")
+			resource := &meshtimeout_api.MeshTimeoutResource{
+				Meta: &test_model.ResourceMeta{
+					Mesh: "default",
+					Name: "mt-1",
+					Labels: map[string]string{
+						mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+						mesh_proto.ZoneTag:             "origin-zone",
+						mesh_proto.PolicyRoleLabel:     string(mesh_proto.ProducerPolicyRole),
+						mesh_proto.KubeNamespaceTag:    "kuma-demo",
+					},
+				},
+				Spec: &meshtimeout_api.MeshTimeout{
+					TargetRef: &targetRef,
+					To: &[]meshtimeout_api.To{
+						{
+							TargetRef: builders.TargetRefMeshService("backend", "kuma-demo", ""),
+						},
+					},
+				},
+			}
+
+			// when
+			ok := predicate(ctx, clusterID, kds.Features{kds.FeatureProducerPolicyFlow: true}, resource)
+
+			// then
+			Expect(ok).To(BeTrue())
 		})
 	})
 	Describe("GlobalResourceMapper", func() {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -407,20 +407,9 @@ func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 			return common_api.TargetRef{}, nil, err
 		}
 
-		// During conversion of GatewayAPI's `backendRefs` to our own `backendRefs`, we need
-		// to consider the scope of the referenced resource.
-		//   - Kubernetes Services: These have cluster-wide scope. When referencing a Kubernetes
-		//     Service, our `backendRef` should be restricted to the mesh service within the same
-		//     zone.
-		//   - Future Support: In the future, we might support Multi-Cluster Services (MCS)
-		//     (https://gateway-api.sigs.k8s.io/geps/gep-1748/). This will allow targeting
-		//     services across multiple zones.
 		return common_api.TargetRef{
-			Kind: common_api.MeshServiceSubset,
+			Kind: common_api.MeshService,
 			Name: pointer.To(k8s_util.ServiceTag(kube_client.ObjectKeyFromObject(svc), &port)),
-			Tags: &map[string]string{
-				mesh_proto.ZoneTag: r.Zone,
-			},
 		}, nil, nil
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -1,0 +1,56 @@
+package gatewayapi
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kube_core "k8s.io/api/core/v1"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+)
+
+var _ = Describe("uncheckedGapiToKumaRef", func() {
+	It("should convert a Service backendRef to a MeshService targetRef without tags", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{
+				Name:      "backend",
+				Namespace: "kuma-demo",
+			},
+		}
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build(),
+			Zone:   "zone-1",
+		}
+
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		namespace := gatewayapi.Namespace("kuma-demo")
+		port := gatewayapi.PortNumber(80)
+		ref := gatewayapi.BackendObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      "backend",
+			Namespace: &namespace,
+			Port:      &port,
+		}
+
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "kuma-demo", ref)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(condition).To(BeNil())
+		Expect(targetRef).To(Equal(common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Name: pointer.To("backend_kuma-demo_svc_80"),
+		}))
+	})
+})

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -113,24 +113,17 @@ func (t Tags) String() string {
 
 func FromLegacyTargetRef(targetRef common_api.TargetRef) (Tags, bool) {
 	var service string
-	tags := Tags{}
 
 	switch targetRef.Kind {
-	case common_api.MeshService:
+	case common_api.MeshService, common_api.MeshServiceSubset:
 		service = pointer.Deref(targetRef.Name)
-	case common_api.MeshServiceSubset:
-		service = pointer.Deref(targetRef.Name)
-		tags = pointer.Deref(targetRef.Tags)
-	case common_api.Mesh:
+	case common_api.Mesh, common_api.MeshSubset:
 		service = mesh_proto.MatchAllTag
-	case common_api.MeshSubset:
-		service = mesh_proto.MatchAllTag
-		tags = pointer.Deref(targetRef.Tags)
 	default:
 		return nil, false
 	}
 
-	return tags.WithTags(mesh_proto.ServiceTag, service), true
+	return Tags{}.WithTags(mesh_proto.ServiceTag, service), true
 }
 
 type (

--- a/pkg/xds/envoy/tags/match.go
+++ b/pkg/xds/envoy/tags/match.go
@@ -115,9 +115,9 @@ func FromLegacyTargetRef(targetRef common_api.TargetRef) (Tags, bool) {
 	var service string
 
 	switch targetRef.Kind {
-	case common_api.MeshService, common_api.MeshServiceSubset:
+	case common_api.MeshService:
 		service = pointer.Deref(targetRef.Name)
-	case common_api.Mesh, common_api.MeshSubset:
+	case common_api.Mesh:
 		service = mesh_proto.MatchAllTag
 	default:
 		return nil, false

--- a/pkg/xds/envoy/tags/match_test.go
+++ b/pkg/xds/envoy/tags/match_test.go
@@ -6,7 +6,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	"github.com/kumahq/kuma/v3/pkg/xds/envoy/tags"
 )
 
@@ -139,6 +141,54 @@ var _ = Describe("MatchingRegex", func() {
 			expected: true,
 		}),
 	)
+})
+
+var _ = Describe("FromLegacyTargetRef", func() {
+	type testCase struct {
+		targetRef common_api.TargetRef
+		expected  tags.Tags
+	}
+
+	DescribeTable("should ignore subset tags and return only service or match-all tags",
+		func(given testCase) {
+			result, ok := tags.FromLegacyTargetRef(given.targetRef)
+			Expect(ok).To(BeTrue())
+			Expect(result).To(Equal(given.expected))
+		},
+		Entry("MeshService", testCase{
+			targetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: pointer.To("backend"),
+			},
+			expected: tags.Tags{mesh_proto.ServiceTag: "backend"},
+		}),
+		Entry("MeshServiceSubset ignores tags", testCase{
+			targetRef: common_api.TargetRef{
+				Kind: common_api.MeshServiceSubset,
+				Name: pointer.To("backend"),
+				Tags: &map[string]string{"version": "v1", mesh_proto.ZoneTag: "east"},
+			},
+			expected: tags.Tags{mesh_proto.ServiceTag: "backend"},
+		}),
+		Entry("Mesh", testCase{
+			targetRef: common_api.TargetRef{
+				Kind: common_api.Mesh,
+			},
+			expected: tags.Tags{mesh_proto.ServiceTag: mesh_proto.MatchAllTag},
+		}),
+		Entry("MeshSubset ignores tags", testCase{
+			targetRef: common_api.TargetRef{
+				Kind: common_api.MeshSubset,
+				Tags: &map[string]string{"version": "v1", mesh_proto.ZoneTag: "east"},
+			},
+			expected: tags.Tags{mesh_proto.ServiceTag: mesh_proto.MatchAllTag},
+		}),
+	)
+
+	It("should return false for unsupported kind", func() {
+		_, ok := tags.FromLegacyTargetRef(common_api.TargetRef{Kind: common_api.Dataplane})
+		Expect(ok).To(BeFalse())
+	})
 })
 
 var _ = Describe("RegexOR", func() {

--- a/pkg/xds/envoy/tags/match_test.go
+++ b/pkg/xds/envoy/tags/match_test.go
@@ -149,7 +149,7 @@ var _ = Describe("FromLegacyTargetRef", func() {
 		expected  tags.Tags
 	}
 
-	DescribeTable("should ignore subset tags and return only service or match-all tags",
+	DescribeTable("should return only service or match-all tags",
 		func(given testCase) {
 			result, ok := tags.FromLegacyTargetRef(given.targetRef)
 			Expect(ok).To(BeTrue())
@@ -162,24 +162,9 @@ var _ = Describe("FromLegacyTargetRef", func() {
 			},
 			expected: tags.Tags{mesh_proto.ServiceTag: "backend"},
 		}),
-		Entry("MeshServiceSubset ignores tags", testCase{
-			targetRef: common_api.TargetRef{
-				Kind: common_api.MeshServiceSubset,
-				Name: pointer.To("backend"),
-				Tags: &map[string]string{"version": "v1", mesh_proto.ZoneTag: "east"},
-			},
-			expected: tags.Tags{mesh_proto.ServiceTag: "backend"},
-		}),
 		Entry("Mesh", testCase{
 			targetRef: common_api.TargetRef{
 				Kind: common_api.Mesh,
-			},
-			expected: tags.Tags{mesh_proto.ServiceTag: mesh_proto.MatchAllTag},
-		}),
-		Entry("MeshSubset ignores tags", testCase{
-			targetRef: common_api.TargetRef{
-				Kind: common_api.MeshSubset,
-				Tags: &map[string]string{"version": "v1", mesh_proto.ZoneTag: "east"},
 			},
 			expected: tags.Tags{mesh_proto.ServiceTag: mesh_proto.MatchAllTag},
 		}),

--- a/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
+++ b/pkg/xds/generator/egress/testdata/subsets-with-meshhttproute.golden.yaml
@@ -11,12 +11,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    lbSubsetConfig:
-      fallbackPolicy: ANY_ENDPOINT
-      subsetSelectors:
-      - fallbackPolicy: NO_FALLBACK
-        keys:
-        - version
     name: mesh-1:service-in-zone-2
     type: EDS
 - name: mesh-1:service-in-zone-2
@@ -48,34 +42,6 @@ resources:
         portValue: 10002
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        serverNames:
-        - service-in-zone-2{mesh=mesh-1,version=v1}
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: mesh-1:service-in-zone-2
-          metadataMatch:
-            filterMetadata:
-              envoy.lb:
-                version: v1
-          statPrefix: mesh-1_service-in-zone-2
-    - filterChainMatch:
-        serverNames:
-        - service-in-zone-2{mesh=mesh-1,version=v2}
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: mesh-1:service-in-zone-2
-          metadataMatch:
-            filterMetadata:
-              envoy.lb:
-                version: v2
-          statPrefix: mesh-1_service-in-zone-2
     - filterChainMatch:
         serverNames:
         - service-in-zone-2{mesh=mesh-1}

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute-subset.envoy.golden.yaml
@@ -8,13 +8,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    lbSubsetConfig:
-      fallbackPolicy: ANY_ENDPOINT
-      subsetSelectors:
-      - fallbackPolicy: NO_FALLBACK
-        keys:
-        - region
-        - version
     name: mesh1:backend
     type: EDS
 - name: mesh1:backend
@@ -68,21 +61,6 @@ resources:
         portValue: 10001
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        serverNames:
-        - backend{kuma.io/zone=zone,mesh=mesh1,region=eu,version=v1}
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: mesh1:backend
-          metadataMatch:
-            filterMetadata:
-              envoy.lb:
-                region: eu
-                version: v1
-          statPrefix: mesh1_backend
     - filterChainMatch:
         serverNames:
         - backend{mesh=mesh1}

--- a/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshhttproute.envoy.golden.yaml
@@ -8,13 +8,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    lbSubsetConfig:
-      fallbackPolicy: ANY_ENDPOINT
-      subsetSelectors:
-      - fallbackPolicy: NO_FALLBACK
-        keys:
-        - region
-        - version
     name: mesh1:backend
     type: EDS
 - name: mesh1:backend
@@ -64,21 +57,6 @@ resources:
         portValue: 10001
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        serverNames:
-        - backend{mesh=mesh1,region=eu,version=v1}
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: mesh1:backend
-          metadataMatch:
-            filterMetadata:
-              envoy.lb:
-                region: eu
-                version: v1
-          statPrefix: mesh1_backend
     - filterChainMatch:
         serverNames:
         - backend{mesh=mesh1}

--- a/pkg/xds/generator/testdata/ingress/with-meshtcproute-subset.envoy.golden.yaml
+++ b/pkg/xds/generator/testdata/ingress/with-meshtcproute-subset.envoy.golden.yaml
@@ -8,13 +8,6 @@ resources:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    lbSubsetConfig:
-      fallbackPolicy: ANY_ENDPOINT
-      subsetSelectors:
-      - fallbackPolicy: NO_FALLBACK
-        keys:
-        - region
-        - version
     name: mesh1:backend
     type: EDS
 - name: mesh1:backend
@@ -68,21 +61,6 @@ resources:
         portValue: 10001
     enableReusePort: false
     filterChains:
-    - filterChainMatch:
-        serverNames:
-        - backend{kuma.io/zone=zone,mesh=mesh1,region=eu,version=v1}
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.tcp_proxy
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: mesh1:backend
-          metadataMatch:
-            filterMetadata:
-              envoy.lb:
-                region: eu
-                version: v1
-          statPrefix: mesh1_backend
     - filterChainMatch:
         serverNames:
         - backend{mesh=mesh1}


### PR DESCRIPTION
## Motivation

Part of #17243. Removes legacy subset target kind handling from outbound tag matching, eliminating `MeshServiceSubset` and `MeshSubset` support from the xDS generation pipeline.

## Implementation information

- Refactors `FromLegacyTargetRef` in `pkg/xds/envoy/tags/match.go` to drop `MeshServiceSubset` and `MeshSubset` kind handling
- Updates xDS generator golden files to remove subset-based load balancing configuration (`lbSubsetConfig`) and subset-tagged SNI entries from outbound clusters
- Removes subset-specific behavior from Gateway API route conversion logic in `http_route_conversion.go`

Closes https://github.com/kumahq/kuma/issues/17307

_Generated by Sybra harness_