### PR TITLE
fix(api-server): return after HandleError in inspect handlers

### DIFF
--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -1098,9 +1098,11 @@ func (r *resourceEndpoints) getPoliciesConf(plugins []core_plugins.RegisteredPol
 			res, err := policyPlugin.Plugin.MatchedPolicies(dataplane, baseMeshContext.Resources())
 			if err != nil {
 				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
+				return
 			}
 			if res.Type == "" {
 				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("matched policy didn't set type for policy plugin %s", policyPlugin.Name))
+				return
 			}
 
 			matchedPolicies = append(matchedPolicies, res)
@@ -1353,6 +1355,7 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 		baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 		if err != nil {
 			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build Mesh context")
+			return
 		}
 
 		resources := xds_context.Resources{
@@ -1383,9 +1386,11 @@ func (r *resourceEndpoints) rulesForResource() restful.RouteFunction {
 			}
 			if err != nil {
 				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
+				return
 			}
 			if res.Type == "" {
 				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("matched policy didn't set type for policy plugin %s", policyPlugin.Name))
+				return
 			}
 
 			//nolint:staticcheck // SA1019 REST API backward compatibility: return old Rules format for existing clients


### PR DESCRIPTION
## Motivation

An unreachable DB caused a nil-pointer panic in the api-server. `BuildBaseMeshContextIfChanged` returns `(nil, err)` on failure, but `rulesForResource` did not `return` after `HandleError`, so it dereferenced the nil mesh context and crashed the request handler. 

## Implementation information

Add the missing `return` after `HandleError` in `rulesForResource`, and fix the same pattern in the two policy-plugin loops (`rulesForResource` and `getPoliciesConf`), where a missing return continued with partial data and double-wrote the error response.

This is already fixed on `master` incidentally via the inspect-handler refactor (#16996), which was not backported to release branches. This is the surgical equivalent for `release-2.14`.

The remaining `HandleError` calls in this file are each the last statement of their handler (the function returns naturally), so no change is needed there.

## Supporting documentation

N/A
