### PR TITLE
ci(release): backport 17231 pipeline speedups

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -43,7 +43,31 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
+  assert-tag-version:
+    # Tag check lives on the steps, not the job, so this job always reports
+    # success/failure and never "skipped". That lets build-binaries and
+    # build-images depend on it with a plain `needs:` and GitHub's default
+    # job-status semantics, which correctly cascade to digest-images and
+    # publish-helm further down the chain and correctly stop on cancellation.
+    timeout-minutes: 10
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
+          version: 2026.5.7
+      - name: Assert built binary reports tag version
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          make build/assert-tag-version
   build-binaries:
+    needs: [assert-tag-version]
     timeout-minutes: 70
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
@@ -97,6 +121,7 @@ jobs:
         run: |
           make publish/pulp
   build-images:
+    needs: [assert-tag-version]
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -7,6 +7,9 @@ on:
       RUNNERS_BY_ARCH:
         required: true
         type: string
+      IS_RELEASE_TAG:
+        required: true
+        type: boolean
 permissions:
   contents: read
 env:
@@ -18,7 +21,7 @@ env:
 jobs:
   test_unit:
     timeout-minutes: 30
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -79,7 +82,7 @@ jobs:
             | .test_e2e_env.include = []
             | .test_e2e_env.exclude += [{"arch": "arm64"}, {"k8sVersion": "kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION}}"}]
           FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
-          SKIP_E2E_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+          SKIP_E2E_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG }}
         run: |-
           BASE_MATRIX_ALL="$BASE_MATRIX"
           if [[ "$FULL_MATRIX" != "true" ]]; then

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -21,7 +21,93 @@ concurrency:
   group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, github.event_name == 'push' && github.sha || github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
 jobs:
+  release_sha_gate:
+    timeout-minutes: 5
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: "Verify tagged SHA has a trusted green push run"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${REF_TYPE}" != "tag" ]]; then
+            echo "Not a tag push; skipping release SHA gate."
+            exit 0
+          fi
+
+          WORKFLOW="build-test-distribute.yaml"
+
+          runs_ndjson="$(mktemp)"
+          if ! gh api --method GET "/repos/${REPO}/actions/workflows/${WORKFLOW}/runs" \
+              -f head_sha="${SHA}" -f status=completed -f event=push -f per_page=100 --paginate \
+              --jq '.workflow_runs[] | {id, conclusion, created_at, html_url}' \
+              > "${runs_ndjson}" 2>gate_runs_err.log; then
+            echo "::error title=release_sha_gate::gate could not query GitHub Actions for prior runs of ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_err.log)"
+            exit 1
+          fi
+
+          if ! selected_run="$(jq -s -r '
+              map(select(.conclusion == "success"))
+              | sort_by(.created_at)
+              | last
+              // empty
+            ' "${runs_ndjson}" 2>gate_runs_jq_err.log)"; then
+            echo "::error title=release_sha_gate::gate could not parse GitHub Actions run data for ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_jq_err.log)"
+            exit 1
+          fi
+
+          if [[ -z "${selected_run}" ]]; then
+            echo "::error title=release_sha_gate::No successful completed push run of ${WORKFLOW} found for tagged SHA ${SHA}. Every tag push requires a prior green branch push CI run for the tagged commit. Recovery: re-run the branch push CI on this SHA (re-tests and re-publishes the preview), then re-tag."
+            exit 1
+          fi
+
+          run_id="$(jq -r '.id' <<<"${selected_run}")"
+          run_url="$(jq -r '.html_url' <<<"${selected_run}")"
+
+          jobs_ndjson="$(mktemp)"
+          if ! gh api --method GET "/repos/${REPO}/actions/runs/${run_id}/jobs" -f per_page=100 --paginate \
+              --jq '.jobs[] | {name, conclusion}' \
+              > "${jobs_ndjson}" 2>gate_jobs_err.log; then
+            echo "::error title=release_sha_gate::gate could not query GitHub Actions for jobs of run ${run_url}: $(cat gate_jobs_err.log)"
+            exit 1
+          fi
+
+          if ! missing="$(jq -s -r '
+              def has_success($jobs; $pattern):
+                ($jobs | any(.[]; (.name | test($pattern)) and .conclusion == "success"));
+
+              . as $jobs
+              | [
+                  {label: "test / test_unit", pattern: "^test / test_unit$"},
+                  {label: "test / e2e ...", pattern: "^test / e2e"},
+                  {label: "build_publish / digest-images", pattern: "^build_publish / digest-images$"},
+                  {label: "build_publish / build-binaries", pattern: "^build_publish / build-binaries$"},
+                  {label: "build_publish / build-images ...", pattern: "^build_publish / build-images"},
+                  {label: "build_publish / publish-helm", pattern: "^build_publish / publish-helm$"}
+                ]
+              | map(select(has_success($jobs; .pattern) | not))
+              | map(.label)
+              | join(", ")
+            ' "${jobs_ndjson}" 2>gate_jobs_jq_err.log)"; then
+            echo "::error title=release_sha_gate::gate could not parse GitHub Actions job data for run ${run_url}: $(cat gate_jobs_jq_err.log)"
+            exit 1
+          fi
+
+          if [[ -n "${missing}" ]]; then
+            echo "::error title=release_sha_gate::Selected run ${run_url} is missing required successful job(s): ${missing}. Recovery: re-run the branch push CI on SHA ${SHA}, then re-tag."
+            exit 1
+          fi
+
+          echo "Trusted source run: ${run_url}"
   check:
+    needs: ["release_sha_gate"]
     permissions:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
@@ -197,7 +283,7 @@ jobs:
       NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
       IMAGE_DIGESTS: ${{ needs.build_publish.outputs.IMAGE_DIGESTS }}
   distributions:
-    needs: ["build_publish", "check", "test", "provenance"]
+    needs: ["release_sha_gate", "build_publish", "check", "test", "provenance"]
     permissions:
       id-token: write
     timeout-minutes: 10

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -191,7 +191,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        if: steps.changes.outputs.code == 'true'
+        if: ${{ steps.changes.outputs.code == 'true' && github.ref_type != 'tag' }}
         env:
           GOGC: "80" # run GC more aggressively
         with:
@@ -199,9 +199,15 @@ jobs:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           only-new-issues: false
 
-      - run: |
+      # Lint and "make check" are redundant on a tag: release_sha_gate already
+      # requires a green branch push run for this exact tree/SHA. We
+      # intentionally keep metadata and SBOM/SCA on tag refs so release tags
+      # continue publishing security assets.
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make clean
-      - run: |
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make check
       - name: "Set metadata for downstream jobs"
         id: metadata

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -153,6 +153,7 @@ jobs:
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
+      IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
       # Per-arch lookup (each side independent):
       #   1. fork PR                    -> free GitHub-hosted runners (security)
       #   2. vars.RUNS_ON_MASTER_<ARCH> -> per-branch + per-arch override

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -76,6 +76,15 @@ build/info/short:
 build/info/version:
 	@echo $(BUILD_INFO_VERSION)
 
+.PHONY: build/assert-tag-version
+build/assert-tag-version: build/kuma-cp ## Dev: Assert the built kuma-cp binary reports the tag version
+	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$NF}'); \
+	if [ -z "$$actual" ] || [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
+		echo "kuma-cp binary reports version '$$actual', expected tag version '$(BUILD_INFO_VERSION)'"; \
+		exit 1; \
+	fi; \
+	echo "kuma-cp binary correctly reports tag version '$(BUILD_INFO_VERSION)'"
+
 .PHONY: build
 build: build/release build/test ## Dev: Build all binaries
 


### PR DESCRIPTION
## Motivation

Speed up patch releasing on release-2.14 the same way it was sped up on
master (issue #17231): a `vX.Y.Z` tag is byte-identical to the green
`release-2.14` HEAD it's cut from, yet the tag re-runs the full unit +
e2e matrix and redundant lint/check steps before shipping. This bundles
all four merged master PRs from #17231 into one backport for
release-2.14; each will be backported individually to the remaining
active branches afterward.

## Implementation information

Cherry-picked from master, adapted to release-2.14's workflow structure
(no `meta`/`build_check` job split here, so the green-SHA gate hooks
into the existing `check` job instead):

- #17414 skip unit + e2e suites on release tags
- #17417 fail-hard green-SHA gate job before release
- #17445 assert built binary reports tag version
- #17452 skip check's redundant lint/`make check` on tag, keep metadata/SBOM

## Supporting documentation

Fix #17231

> Changelog: skip
