### PR TITLE
refactor(api): remove MeshSubset/MeshServiceSubset kind constants

### DIFF
--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -16,22 +16,30 @@ type TargetRefKind string
 var (
 	Mesh                 TargetRefKind = "Mesh"
 	Dataplane            TargetRefKind = "Dataplane"
-	MeshSubset           TargetRefKind = "MeshSubset"
 	MeshService          TargetRefKind = "MeshService"
 	MeshExternalService  TargetRefKind = "MeshExternalService"
 	MeshMultiZoneService TargetRefKind = "MeshMultiZoneService"
-	MeshServiceSubset    TargetRefKind = "MeshServiceSubset"
 	MeshHTTPRoute        TargetRefKind = "MeshHTTPRoute"
+)
+
+// meshSubset and meshServiceSubset are legacy kinds that predate real
+// resources (MeshService, MeshExternalService, MeshMultiZoneService). They
+// stay unexported: the wire values are still valid and must keep their
+// current validation/matching behavior, but no new Go code should reference
+// them directly.
+const (
+	meshSubset        TargetRefKind = "MeshSubset"
+	meshServiceSubset TargetRefKind = "MeshServiceSubset"
 )
 
 var order = map[TargetRefKind]int{
 	Mesh:                 1,
 	Dataplane:            2,
-	MeshSubset:           3,
+	meshSubset:           3,
 	MeshService:          5,
 	MeshExternalService:  6,
 	MeshMultiZoneService: 7,
-	MeshServiceSubset:    8,
+	meshServiceSubset:    8,
 	MeshHTTPRoute:        9,
 }
 
@@ -49,7 +57,7 @@ func (k TargetRefKind) Compare(o TargetRefKind) int {
 
 func (k TargetRefKind) IsRealResource() bool {
 	switch k {
-	case MeshSubset, MeshServiceSubset:
+	case meshSubset, meshServiceSubset:
 		return false
 	default:
 		return true
@@ -60,7 +68,7 @@ func (k TargetRefKind) IsRealResource() bool {
 // actual resources (e.g., MeshExternalService, MeshMultiZoneService, and MeshService) was introduced.
 func (k TargetRefKind) IsOldKind() bool {
 	switch k {
-	case Mesh, MeshSubset, MeshServiceSubset, MeshService, MeshHTTPRoute:
+	case Mesh, meshSubset, meshServiceSubset, MeshService, MeshHTTPRoute:
 		return true
 	default:
 		return false
@@ -138,7 +146,7 @@ func selectsLabels(tr TargetRef) bool {
 }
 
 func IncludesGateways(ref TargetRef) bool {
-	isMeshKind := ref.Kind == Mesh || ref.Kind == MeshSubset
+	isMeshKind := ref.Kind == Mesh || ref.Kind == meshSubset
 	isGatewayInProxyTypes := len(pointer.Deref(ref.ProxyTypes)) == 0 || slices.Contains(pointer.Deref(ref.ProxyTypes), Gateway)
 	isGatewayCompatible := isMeshKind && isGatewayInProxyTypes
 	isMeshHTTPRoute := ref.Kind == MeshHTTPRoute
@@ -180,7 +188,7 @@ func (b BackendRef) ReferencesRealObject() bool {
 	switch b.Kind {
 	case MeshService:
 		return pointer.Deref(b.SectionName) != "" || b.Port != nil
-	case MeshServiceSubset:
+	case meshServiceSubset:
 		return false
 	// empty targetRef should not be treated as real object
 	case "":

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -32,6 +32,18 @@ const (
 	meshServiceSubset TargetRefKind = "MeshServiceSubset"
 )
 
+// LegacyMeshSubsetKind returns the legacy MeshSubset wire value without
+// re-exporting the kind constant.
+func LegacyMeshSubsetKind() TargetRefKind {
+	return meshSubset
+}
+
+// LegacyMeshServiceSubsetKind returns the legacy MeshServiceSubset wire value
+// without re-exporting the kind constant.
+func LegacyMeshServiceSubsetKind() TargetRefKind {
+	return meshServiceSubset
+}
+
 var order = map[TargetRefKind]int{
 	Mesh:                 1,
 	Dataplane:            2,

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -393,7 +393,7 @@ func ValidateTargetRef(
 		if !opts.IsInboundPolicy && pointer.Deref(ref.SectionName) != "" {
 			err.AddViolation("sectionName", "can only be used with inbound policies")
 		}
-	case "MeshSubset":
+	case common_api.LegacyMeshSubsetKind():
 		err.Add(disallowedField("name", pointer.Deref(ref.Name), ref.Kind))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
 		err.Add(ValidateTags(validators.RootedAt("tags"), pointer.Deref(ref.Tags), ValidateTagsOpts{}))
@@ -424,7 +424,7 @@ func ValidateTargetRef(
 		if len(pointer.Deref(ref.Labels)) > 0 && (pointer.Deref(ref.Name) != "" || pointer.Deref(ref.Namespace) != "") {
 			err.AddViolation("labels", "either labels or name and namespace must be specified")
 		}
-	case "MeshServiceSubset":
+	case common_api.LegacyMeshServiceSubsetKind():
 		err.Add(requiredField("name", pointer.Deref(ref.Name), ref.Kind))
 		err.Add(validateName(pointer.Deref(ref.Name), opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -393,7 +393,7 @@ func ValidateTargetRef(
 		if !opts.IsInboundPolicy && pointer.Deref(ref.SectionName) != "" {
 			err.AddViolation("sectionName", "can only be used with inbound policies")
 		}
-	case common_api.MeshSubset:
+	case "MeshSubset":
 		err.Add(disallowedField("name", pointer.Deref(ref.Name), ref.Kind))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
 		err.Add(ValidateTags(validators.RootedAt("tags"), pointer.Deref(ref.Tags), ValidateTagsOpts{}))
@@ -424,7 +424,7 @@ func ValidateTargetRef(
 		if len(pointer.Deref(ref.Labels)) > 0 && (pointer.Deref(ref.Name) != "" || pointer.Deref(ref.Namespace) != "") {
 			err.AddViolation("labels", "either labels or name and namespace must be specified")
 		}
-	case common_api.MeshServiceSubset:
+	case "MeshServiceSubset":
 		err.Add(requiredField("name", pointer.Deref(ref.Name), ref.Kind))
 		err.Add(validateName(pointer.Deref(ref.Name), opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -139,7 +139,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 		}),
@@ -149,7 +149,7 @@ kind: MeshSubset
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 		}),
@@ -230,7 +230,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 		}),
@@ -241,7 +241,7 @@ name: backend
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 		}),
@@ -253,7 +253,7 @@ tags: {}
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 		}),
@@ -346,7 +346,7 @@ kind: Mesh
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -412,7 +412,7 @@ name: mesh-1
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -428,7 +428,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -444,7 +444,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -460,7 +460,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -476,7 +476,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -490,7 +490,7 @@ kind: MeshService
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 			expected: `
@@ -575,7 +575,7 @@ proxyTypes: ["Sidecar"]
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 			expected: `
@@ -659,7 +659,7 @@ tags: {}
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 			expected: `
@@ -676,7 +676,7 @@ tags: {}
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 			expected: `
@@ -695,7 +695,7 @@ tags:
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 			expected: `
@@ -853,7 +853,7 @@ sectionName: port-http
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshSubset,
+					"MeshSubset",
 				},
 			},
 			expected: `
@@ -877,7 +877,7 @@ sectionName: port-http
 `,
 			opts: &ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 				},
 			},
 			expected: `

--- a/pkg/plugins/policies/core/jsonpatch/validators/validator_test.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator_test.go
@@ -327,7 +327,7 @@ var _ = Describe("JsonPatchBlock Validator", func() {
 		Entry("Dataplane", &common_api.TargetRef{Kind: common_api.Dataplane}),
 		Entry("MeshHTTPRoute", &common_api.TargetRef{Kind: common_api.MeshHTTPRoute}),
 		Entry("MeshService", &common_api.TargetRef{Kind: common_api.MeshService}),
-		Entry("MeshServiceSubset", &common_api.TargetRef{Kind: common_api.MeshServiceSubset}),
-		Entry("MeshSubset", &common_api.TargetRef{Kind: common_api.MeshSubset}),
+		Entry("MeshServiceSubset", &common_api.TargetRef{Kind: "MeshServiceSubset"}),
+		Entry("MeshSubset", &common_api.TargetRef{Kind: "MeshSubset"}),
 	)
 })

--- a/pkg/plugins/policies/core/jsonpatch/validators/validator_test.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator_test.go
@@ -327,7 +327,7 @@ var _ = Describe("JsonPatchBlock Validator", func() {
 		Entry("Dataplane", &common_api.TargetRef{Kind: common_api.Dataplane}),
 		Entry("MeshHTTPRoute", &common_api.TargetRef{Kind: common_api.MeshHTTPRoute}),
 		Entry("MeshService", &common_api.TargetRef{Kind: common_api.MeshService}),
-		Entry("MeshServiceSubset", &common_api.TargetRef{Kind: "MeshServiceSubset"}),
-		Entry("MeshSubset", &common_api.TargetRef{Kind: "MeshSubset"}),
+		Entry("MeshServiceSubset", &common_api.TargetRef{Kind: common_api.LegacyMeshServiceSubsetKind()}),
+		Entry("MeshSubset", &common_api.TargetRef{Kind: common_api.LegacyMeshSubsetKind()}),
 	)
 })

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -227,11 +227,11 @@ func serviceSelectedByTargetRef(tr common_api.TargetRef, tags map[string]string)
 	switch tr.Kind {
 	case common_api.Mesh:
 		return true
-	case "MeshSubset":
+	case common_api.LegacyMeshSubsetKind():
 		return mesh_proto.TagSelector(pointer.Deref(tr.Tags)).Matches(tags)
 	case common_api.MeshService:
 		return pointer.Deref(tr.Name) == tags[mesh_proto.ServiceTag]
-	case "MeshServiceSubset":
+	case common_api.LegacyMeshServiceSubsetKind():
 		return pointer.Deref(tr.Name) == tags[mesh_proto.ServiceTag] && mesh_proto.TagSelector(pointer.Deref(tr.Tags)).Matches(tags)
 	}
 	return false

--- a/pkg/plugins/policies/core/matchers/egress.go
+++ b/pkg/plugins/policies/core/matchers/egress.go
@@ -227,11 +227,11 @@ func serviceSelectedByTargetRef(tr common_api.TargetRef, tags map[string]string)
 	switch tr.Kind {
 	case common_api.Mesh:
 		return true
-	case common_api.MeshSubset:
+	case "MeshSubset":
 		return mesh_proto.TagSelector(pointer.Deref(tr.Tags)).Matches(tags)
 	case common_api.MeshService:
 		return pointer.Deref(tr.Name) == tags[mesh_proto.ServiceTag]
-	case common_api.MeshServiceSubset:
+	case "MeshServiceSubset":
 		return pointer.Deref(tr.Name) == tags[mesh_proto.ServiceTag] && mesh_proto.TagSelector(pointer.Deref(tr.Tags)).Matches(tags)
 	}
 	return false

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -338,16 +338,16 @@ func buildToListWithRoutes(meta core_model.ResourceMeta, policyWithTo core_model
 			for _, to := range policyWithTo.GetToList() {
 				var targetRef common_api.TargetRef
 				switch mhrRules.TargetRef.Kind {
-				case common_api.Mesh, common_api.MeshSubset:
+				case common_api.Mesh, "MeshSubset":
 					targetRef = common_api.TargetRef{
-						Kind: common_api.MeshSubset,
+						Kind: "MeshSubset",
 						Tags: &map[string]string{
 							RuleMatchesHashTag: string(matchesHash),
 						},
 					}
 				default:
 					targetRef = common_api.TargetRef{
-						Kind: common_api.MeshServiceSubset,
+						Kind: "MeshServiceSubset",
 						Name: mhrRules.TargetRef.Name,
 						Tags: &map[string]string{
 							RuleMatchesHashTag: string(matchesHash),
@@ -609,7 +609,7 @@ func asSubset(tr common_api.TargetRef) (subsetutils.Subset, error) {
 	switch tr.Kind {
 	case common_api.Mesh:
 		return subsetutils.Subset{}, nil
-	case common_api.MeshSubset:
+	case "MeshSubset":
 		ss := subsetutils.Subset{}
 		for k, v := range pointer.Deref(tr.Tags) {
 			ss = append(ss, subsetutils.Tag{Key: k, Value: v})
@@ -617,7 +617,7 @@ func asSubset(tr common_api.TargetRef) (subsetutils.Subset, error) {
 		return ss, nil
 	case common_api.MeshService:
 		return subsetutils.Subset{{Key: mesh_proto.ServiceTag, Value: pointer.Deref(tr.Name)}}, nil
-	case common_api.MeshServiceSubset:
+	case "MeshServiceSubset":
 		ss := subsetutils.Subset{{Key: mesh_proto.ServiceTag, Value: pointer.Deref(tr.Name)}}
 		for k, v := range pointer.Deref(tr.Tags) {
 			ss = append(ss, subsetutils.Tag{Key: k, Value: v})

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -338,16 +338,16 @@ func buildToListWithRoutes(meta core_model.ResourceMeta, policyWithTo core_model
 			for _, to := range policyWithTo.GetToList() {
 				var targetRef common_api.TargetRef
 				switch mhrRules.TargetRef.Kind {
-				case common_api.Mesh, "MeshSubset":
+				case common_api.Mesh, common_api.LegacyMeshSubsetKind():
 					targetRef = common_api.TargetRef{
-						Kind: "MeshSubset",
+						Kind: common_api.LegacyMeshSubsetKind(),
 						Tags: &map[string]string{
 							RuleMatchesHashTag: string(matchesHash),
 						},
 					}
 				default:
 					targetRef = common_api.TargetRef{
-						Kind: "MeshServiceSubset",
+						Kind: common_api.LegacyMeshServiceSubsetKind(),
 						Name: mhrRules.TargetRef.Name,
 						Tags: &map[string]string{
 							RuleMatchesHashTag: string(matchesHash),
@@ -609,7 +609,7 @@ func asSubset(tr common_api.TargetRef) (subsetutils.Subset, error) {
 	switch tr.Kind {
 	case common_api.Mesh:
 		return subsetutils.Subset{}, nil
-	case "MeshSubset":
+	case common_api.LegacyMeshSubsetKind():
 		ss := subsetutils.Subset{}
 		for k, v := range pointer.Deref(tr.Tags) {
 			ss = append(ss, subsetutils.Tag{Key: k, Value: v})
@@ -617,7 +617,7 @@ func asSubset(tr common_api.TargetRef) (subsetutils.Subset, error) {
 		return ss, nil
 	case common_api.MeshService:
 		return subsetutils.Subset{{Key: mesh_proto.ServiceTag, Value: pointer.Deref(tr.Name)}}, nil
-	case "MeshServiceSubset":
+	case common_api.LegacyMeshServiceSubsetKind():
 		ss := subsetutils.Subset{{Key: mesh_proto.ServiceTag, Value: pointer.Deref(tr.Name)}}
 		for k, v := range pointer.Deref(tr.Tags) {
 			ss = append(ss, subsetutils.Tag{Key: k, Value: v})

--- a/pkg/plugins/policies/core/rules/rules_test.go
+++ b/pkg/plugins/policies/core/rules/rules_test.go
@@ -957,15 +957,15 @@ var _ = Describe("Rules", func() {
 					Kind: common_api.Mesh,
 				}, "AllowWithShadowDeny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-2"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-3"},
 				}, "Allow"),
 			}
@@ -997,15 +997,15 @@ var _ = Describe("Rules", func() {
 			// All three intersect with each other
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"zone": "us-east"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"zone": "us-east", "env": "prod"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"env": "prod"},
 				}, "AllowWithShadowDeny"),
 			}
@@ -1034,15 +1034,15 @@ var _ = Describe("Rules", func() {
 			// But they're connected via B in the graph
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1", "version": "v1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1", "version": "v2"},
 				}, "AllowWithShadowDeny"),
 			}
@@ -1095,11 +1095,11 @@ var _ = Describe("Rules", func() {
 			// Multiple policies with the same targetRef
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Deny"),
 			}
@@ -1126,7 +1126,7 @@ var _ = Describe("Rules", func() {
 			}
 			for i := 1; i <= 5; i++ {
 				items = append(items, createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{
 						"app":       fmt.Sprintf("app-%d", i),
 						"namespace": fmt.Sprintf("ns-%d", i),
@@ -1163,11 +1163,11 @@ var _ = Describe("Rules", func() {
 			// {app: app-1} and {app: app-2} don't intersect because app can only have one value
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"app": "app-2"},
 				}, "Deny"),
 			}
@@ -1191,11 +1191,11 @@ var _ = Describe("Rules", func() {
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{Kind: common_api.Mesh}, "AllowWithShadowDeny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"zone": "us-east", "env": "prod", "team": "platform"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"zone": "us-west", "env": "dev", "team": "product"},
 				}, "Deny"),
 			}
@@ -1222,19 +1222,19 @@ var _ = Describe("Rules", func() {
 			// D: {env: dev}  - disjoint from B and C, intersects with A via Mesh-like behavior
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"zone": "us-east"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"zone": "us-east", "env": "prod"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"env": "prod"},
 				}, "AllowWithShadowDeny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: common_api.MeshSubset,
+					Kind: "MeshSubset",
 					Tags: &map[string]string{"env": "dev"},
 				}, "Allow"),
 			}

--- a/pkg/plugins/policies/core/rules/rules_test.go
+++ b/pkg/plugins/policies/core/rules/rules_test.go
@@ -957,15 +957,15 @@ var _ = Describe("Rules", func() {
 					Kind: common_api.Mesh,
 				}, "AllowWithShadowDeny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-2"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-3"},
 				}, "Allow"),
 			}
@@ -997,15 +997,15 @@ var _ = Describe("Rules", func() {
 			// All three intersect with each other
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"zone": "us-east"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"zone": "us-east", "env": "prod"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"env": "prod"},
 				}, "AllowWithShadowDeny"),
 			}
@@ -1034,15 +1034,15 @@ var _ = Describe("Rules", func() {
 			// But they're connected via B in the graph
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1", "version": "v1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1", "version": "v2"},
 				}, "AllowWithShadowDeny"),
 			}
@@ -1095,11 +1095,11 @@ var _ = Describe("Rules", func() {
 			// Multiple policies with the same targetRef
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Deny"),
 			}
@@ -1126,7 +1126,7 @@ var _ = Describe("Rules", func() {
 			}
 			for i := 1; i <= 5; i++ {
 				items = append(items, createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{
 						"app":       fmt.Sprintf("app-%d", i),
 						"namespace": fmt.Sprintf("ns-%d", i),
@@ -1163,11 +1163,11 @@ var _ = Describe("Rules", func() {
 			// {app: app-1} and {app: app-2} don't intersect because app can only have one value
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-1"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"app": "app-2"},
 				}, "Deny"),
 			}
@@ -1191,11 +1191,11 @@ var _ = Describe("Rules", func() {
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{Kind: common_api.Mesh}, "AllowWithShadowDeny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"zone": "us-east", "env": "prod", "team": "platform"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"zone": "us-west", "env": "dev", "team": "product"},
 				}, "Deny"),
 			}
@@ -1222,19 +1222,19 @@ var _ = Describe("Rules", func() {
 			// D: {env: dev}  - disjoint from B and C, intersects with A via Mesh-like behavior
 			items := []core_rules.PolicyItemWithMeta{
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"zone": "us-east"},
 				}, "Allow"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"zone": "us-east", "env": "prod"},
 				}, "Deny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"env": "prod"},
 				}, "AllowWithShadowDeny"),
 				createPolicyItem(common_api.TargetRef{
-					Kind: "MeshSubset",
+					Kind: common_api.LegacyMeshSubsetKind(),
 					Tags: &map[string]string{"env": "dev"},
 				}, "Allow"),
 			}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -253,7 +253,7 @@ func validateFilters(filters *[]Filter, matches []Match) validators.ValidationEr
 				mesh.ValidateTargetRef(filter.RequestMirror.BackendRef.TargetRef, &mesh.ValidateTargetRefOpts{
 					SupportedKinds: []common_api.TargetRefKind{
 						common_api.MeshService,
-						"MeshServiceSubset",
+						common_api.LegacyMeshServiceSubsetKind(),
 					},
 				}),
 			)
@@ -334,7 +334,7 @@ func validateBackendRefs(
 			mesh.ValidateTargetRef(backendRef.TargetRef, &mesh.ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
 					common_api.MeshService,
-					"MeshServiceSubset",
+					common_api.LegacyMeshServiceSubsetKind(),
 					common_api.MeshExternalService,
 					common_api.MeshMultiZoneService,
 				},

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -253,7 +253,7 @@ func validateFilters(filters *[]Filter, matches []Match) validators.ValidationEr
 				mesh.ValidateTargetRef(filter.RequestMirror.BackendRef.TargetRef, &mesh.ValidateTargetRefOpts{
 					SupportedKinds: []common_api.TargetRefKind{
 						common_api.MeshService,
-						common_api.MeshServiceSubset,
+						"MeshServiceSubset",
 					},
 				}),
 			)
@@ -334,7 +334,7 @@ func validateBackendRefs(
 			mesh.ValidateTargetRef(backendRef.TargetRef, &mesh.ValidateTargetRefOpts{
 				SupportedKinds: []common_api.TargetRefKind{
 					common_api.MeshService,
-					common_api.MeshServiceSubset,
+					"MeshServiceSubset",
 					common_api.MeshExternalService,
 					common_api.MeshMultiZoneService,
 				},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -2528,7 +2528,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 															Percentage: pointer.To(intstr.FromString("99.9")),
 															BackendRef: common_api.BackendRef{
 																TargetRef: common_api.TargetRef{
-																	Kind: common_api.MeshServiceSubset,
+																	Kind: "MeshServiceSubset",
 																	Name: pointer.To("payments"),
 																	Tags: &map[string]string{
 																		"version": "v1",

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -2528,7 +2528,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 															Percentage: pointer.To(intstr.FromString("99.9")),
 															BackendRef: common_api.BackendRef{
 																TargetRef: common_api.TargetRef{
-																	Kind: "MeshServiceSubset",
+																	Kind: common_api.LegacyMeshServiceSubsetKind(),
 																	Name: pointer.To("payments"),
 																	Tags: &map[string]string{
 																		"version": "v1",

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
@@ -99,7 +99,7 @@ func validateBackendRefs(backendRefs []common_api.BackendRef) validators.Validat
 				&mesh.ValidateTargetRefOpts{
 					SupportedKinds: []common_api.TargetRefKind{
 						common_api.MeshService,
-						common_api.MeshServiceSubset,
+						"MeshServiceSubset",
 						common_api.MeshExternalService,
 						common_api.MeshMultiZoneService,
 					},

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator.go
@@ -99,7 +99,7 @@ func validateBackendRefs(backendRefs []common_api.BackendRef) validators.Validat
 				&mesh.ValidateTargetRefOpts{
 					SupportedKinds: []common_api.TargetRefKind{
 						common_api.MeshService,
-						"MeshServiceSubset",
+						common_api.LegacyMeshServiceSubsetKind(),
 						common_api.MeshExternalService,
 						common_api.MeshMultiZoneService,
 					},

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -57,7 +57,7 @@ func (r *HTTPRouteReconciler) gapiServiceToMeshRoute(
 ) core_model.ResourceSpec {
 	// consumer route
 	targetRef := common_api.TargetRef{
-		Kind: common_api.MeshSubset,
+		Kind: "MeshSubset",
 		Tags: &map[string]string{
 			mesh_proto.KubeNamespaceTag: routeNamespace,
 		},

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -57,7 +57,7 @@ func (r *HTTPRouteReconciler) gapiServiceToMeshRoute(
 ) core_model.ResourceSpec {
 	// consumer route
 	targetRef := common_api.TargetRef{
-		Kind: "MeshSubset",
+		Kind: common_api.LegacyMeshSubsetKind(),
 		Tags: &map[string]string{
 			mesh_proto.KubeNamespaceTag: routeNamespace,
 		},

--- a/pkg/test/resources/builders/targetref_builder.go
+++ b/pkg/test/resources/builders/targetref_builder.go
@@ -13,7 +13,7 @@ func TargetRefMesh() common_api.TargetRef {
 
 func TargetRefMeshSubset(kv ...string) common_api.TargetRef {
 	return common_api.TargetRef{
-		Kind: common_api.MeshSubset,
+		Kind: "MeshSubset",
 		Tags: pointer.To(TagsKVToMap(kv)),
 	}
 }
@@ -41,7 +41,7 @@ func TargetRefService(name string) common_api.TargetRef {
 
 func TargetRefServiceSubset(name string, kv ...string) common_api.TargetRef {
 	return common_api.TargetRef{
-		Kind: common_api.MeshServiceSubset,
+		Kind: "MeshServiceSubset",
 		Name: &name,
 		Tags: pointer.To(TagsKVToMap(kv)),
 	}

--- a/pkg/test/resources/builders/targetref_builder.go
+++ b/pkg/test/resources/builders/targetref_builder.go
@@ -13,7 +13,7 @@ func TargetRefMesh() common_api.TargetRef {
 
 func TargetRefMeshSubset(kv ...string) common_api.TargetRef {
 	return common_api.TargetRef{
-		Kind: "MeshSubset",
+		Kind: common_api.LegacyMeshSubsetKind(),
 		Tags: pointer.To(TagsKVToMap(kv)),
 	}
 }
@@ -41,7 +41,7 @@ func TargetRefService(name string) common_api.TargetRef {
 
 func TargetRefServiceSubset(name string, kv ...string) common_api.TargetRef {
 	return common_api.TargetRef{
-		Kind: "MeshServiceSubset",
+		Kind: common_api.LegacyMeshServiceSubsetKind(),
 		Name: &name,
 		Tags: pointer.To(TagsKVToMap(kv)),
 	}

--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -462,7 +462,7 @@ var _ = Describe("IngressGenerator", func() {
 												Default: meshhttproute_api.RuleConf{
 													BackendRefs: &[]common_api.BackendRef{{
 														TargetRef: common_api.TargetRef{
-															Kind: common_api.MeshServiceSubset,
+															Kind: "MeshServiceSubset",
 															Name: pointer.To("backend"),
 															Tags: &map[string]string{
 																"version": "v1",
@@ -556,7 +556,7 @@ var _ = Describe("IngressGenerator", func() {
 												Default: meshhttproute_api.RuleConf{
 													BackendRefs: &[]common_api.BackendRef{{
 														TargetRef: common_api.TargetRef{
-															Kind: common_api.MeshServiceSubset,
+															Kind: "MeshServiceSubset",
 															Name: pointer.To("backend"),
 															Tags: &map[string]string{
 																"version":      "v1",
@@ -645,7 +645,7 @@ var _ = Describe("IngressGenerator", func() {
 												Default: meshtcproute_api.RuleConf{
 													BackendRefs: &[]common_api.BackendRef{{
 														TargetRef: common_api.TargetRef{
-															Kind: common_api.MeshServiceSubset,
+															Kind: "MeshServiceSubset",
 															Name: pointer.To("backend"),
 															Tags: &map[string]string{
 																"version":      "v1",

--- a/pkg/xds/generator/ingress_generator_test.go
+++ b/pkg/xds/generator/ingress_generator_test.go
@@ -462,7 +462,7 @@ var _ = Describe("IngressGenerator", func() {
 												Default: meshhttproute_api.RuleConf{
 													BackendRefs: &[]common_api.BackendRef{{
 														TargetRef: common_api.TargetRef{
-															Kind: "MeshServiceSubset",
+															Kind: common_api.LegacyMeshServiceSubsetKind(),
 															Name: pointer.To("backend"),
 															Tags: &map[string]string{
 																"version": "v1",
@@ -556,7 +556,7 @@ var _ = Describe("IngressGenerator", func() {
 												Default: meshhttproute_api.RuleConf{
 													BackendRefs: &[]common_api.BackendRef{{
 														TargetRef: common_api.TargetRef{
-															Kind: "MeshServiceSubset",
+															Kind: common_api.LegacyMeshServiceSubsetKind(),
 															Name: pointer.To("backend"),
 															Tags: &map[string]string{
 																"version":      "v1",
@@ -645,7 +645,7 @@ var _ = Describe("IngressGenerator", func() {
 												Default: meshtcproute_api.RuleConf{
 													BackendRefs: &[]common_api.BackendRef{{
 														TargetRef: common_api.TargetRef{
-															Kind: "MeshServiceSubset",
+															Kind: common_api.LegacyMeshServiceSubsetKind(),
 															Name: pointer.To("backend"),
 															Tags: &map[string]string{
 																"version":      "v1",


### PR DESCRIPTION
## Motivation

Narrow the enum as part of #17243 by removing unused MeshSubset and MeshServiceSubset kind constants.

## Implementation information

- Removed the exported kind constants from `api/common/v1alpha1/targetref.go` while keeping the legacy wire values valid.
- Replaced direct Go references introduced by this refactor with exported legacy-kind accessors.
- Kept the legacy test builders for wire-compat coverage.
- Regenerated CRD schemas for charts and documentation.

Closes https://github.com/kumahq/kuma/issues/17308

_Generated by Sybra harness_
