### PR TITLE
ci(actions): add release smoke-test trigger

### DIFF
--- a/.github/workflows/trigger-smoke-tests.yaml
+++ b/.github/workflows/trigger-smoke-tests.yaml
@@ -1,9 +1,9 @@
 name: "trigger-smoke-tests"
 
-# Auto-triggers Kong/kong-mesh-smoke for a single version when that version's
-# release-tag build (build-test-distribute) completes. Per-branch/event-driven,
-# not a batch fan-out over all versions. workflow_dispatch re-runs one version
-# by hand.
+# Auto-triggers the downstream enterprise smoke-test workflow for a single
+# version when that version's release-tag build (build-test-distribute)
+# completes. Per-branch/event-driven, not a batch fan-out over all versions.
+# workflow_dispatch re-runs one version by hand.
 on:
   workflow_run:
     workflows: ["build-test-distribute"]
@@ -60,13 +60,13 @@ jobs:
             PRODUCT_VERSION="${BASH_REMATCH[1]}"
           else
             echo "'${RAW}' is not a recognized release version/tag; skipping smoke dispatch."
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [[ -n "${MANUAL_VERSION}" ]]; then
             # deliberate operator override; may target an archived version
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=true" >> "$GITHUB_OUTPUT"
             echo "product_version=${PRODUCT_VERSION}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -76,7 +76,7 @@ jobs:
           TAG="${RAW}"
           if ! TAG_REF_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/dev/null)"; then
             echo "'${TAG}' is not an existing tag ref; skipping smoke dispatch."
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           OBJ_TYPE="$(jq -r '.object.type' <<< "${TAG_REF_JSON}")"
@@ -87,37 +87,35 @@ jobs:
           fi
           if [[ "${OBJ_SHA}" != "${HEAD_SHA}" ]]; then
             echo "'${TAG}' does not currently point at built commit ${HEAD_SHA}; skipping smoke dispatch."
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "is_release=true" >> "$GITHUB_OUTPUT"
+          echo "should_dispatch=true" >> "$GITHUB_OUTPUT"
           echo "product_version=${PRODUCT_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: "Trigger Kong/kong-mesh-smoke"
-        if: steps.version.outputs.is_release == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: "Trigger downstream smoke test"
+        if: steps.version.outputs.should_dispatch == 'true'
         env:
+          # smoke.yaml only triggers on pull_request/push/schedule/workflow_dispatch
+          # (no repository_dispatch), so this must be a workflow_dispatch run, not
+          # a repository_dispatch event. Needs a Kong org admin to provision a
+          # cross-org (kumahq -> Kong) token with `actions:write` on the target
+          # repo; no existing kumahq secret has that scope.
+          GH_TOKEN: ${{ secrets.KONG_MESH_SMOKE_DISPATCH_TOKEN }}
+          SMOKE_OWNER: ${{ secrets.NOTIFY_OWNER }}
+          SMOKE_REPO: ${{ secrets.KONG_MESH_SMOKE_REPO }}
           PRODUCT_VERSION: ${{ steps.version.outputs.product_version }}
-        with:
-          # Same cross-org (kumahq -> Kong) PAT already used by pr-merged.yaml
-          # (KUMA_UPGRADE, to Kong/kong-mesh) and sync_kuma_oas_to_kuma-gui.yaml
-          # (SYNC_KUMA_OAS, to Kong/kuma-gui). Needs a Kong org admin to add
-          # Kong/kong-mesh-smoke to its repo access list; no new secret required.
-          github-token: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: "Kong",
-              repo: "kong-mesh-smoke",
-              event_type: "KUMA_SMOKE_TEST",
-              client_payload: {
-                product_name: "kuma",
-                product_version: process.env.PRODUCT_VERSION,
-                k8s_provider_k3d: true,
-                k8s_provider_gke: true,
-                k8s_provider_eks: true,
-                uni_provider_gcp: true,
-                uni_provider_aws: true,
-                run_tf_provider_tests: false,
-              },
-            });
+        run: |
+          set -euo pipefail
+          gh workflow run smoke.yaml \
+            --repo "${SMOKE_OWNER}/${SMOKE_REPO}" \
+            --ref main \
+            --field product_name=kuma \
+            --field product_version="${PRODUCT_VERSION}" \
+            --field k8s_provider_k3d=true \
+            --field k8s_provider_gke=true \
+            --field k8s_provider_eks=true \
+            --field uni_provider_gcp=true \
+            --field uni_provider_aws=true \
+            --field run_tf_provider_tests=false

--- a/.github/workflows/trigger-smoke-tests.yaml
+++ b/.github/workflows/trigger-smoke-tests.yaml
@@ -74,8 +74,13 @@ jobs:
           # confirm head_branch is this tag, not a same-named branch, and it
           # still points at the built commit, not one it moved to since
           TAG="${RAW}"
-          OBJ_TYPE="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.type')"
-          OBJ_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha')"
+          if ! TAG_REF_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/dev/null)"; then
+            echo "'${TAG}' is not an existing tag ref; skipping smoke dispatch."
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          OBJ_TYPE="$(jq -r '.object.type' <<< "${TAG_REF_JSON}")"
+          OBJ_SHA="$(jq -r '.object.sha' <<< "${TAG_REF_JSON}")"
           # annotated tags point at a tag object, not the commit directly
           if [[ "${OBJ_TYPE}" == "tag" ]]; then
             OBJ_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJ_SHA}" --jq '.object.sha')"

--- a/.github/workflows/trigger-smoke-tests.yaml
+++ b/.github/workflows/trigger-smoke-tests.yaml
@@ -96,22 +96,28 @@ jobs:
 
       - name: "Trigger Kong/kong-mesh-smoke"
         if: steps.version.outputs.is_release == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          # Cross-org (kumahq -> Kong) token with `actions:write` on
-          # Kong/kong-mesh-smoke. Must be provisioned by a Kong org admin;
-          # no existing kumahq GitHub App/secret has that scope.
-          GH_TOKEN: ${{ secrets.KONG_MESH_SMOKE_DISPATCH_TOKEN }}
           PRODUCT_VERSION: ${{ steps.version.outputs.product_version }}
-        run: |
-          set -euo pipefail
-          gh workflow run smoke.yaml \
-            --repo Kong/kong-mesh-smoke \
-            --ref main \
-            --field product_name=kuma \
-            --field product_version="${PRODUCT_VERSION}" \
-            --field k8s_provider_k3d=true \
-            --field k8s_provider_gke=true \
-            --field k8s_provider_eks=true \
-            --field uni_provider_gcp=true \
-            --field uni_provider_aws=true \
-            --field run_tf_provider_tests=false
+        with:
+          # Same cross-org (kumahq -> Kong) PAT already used by pr-merged.yaml
+          # (KUMA_UPGRADE, to Kong/kong-mesh) and sync_kuma_oas_to_kuma-gui.yaml
+          # (SYNC_KUMA_OAS, to Kong/kuma-gui). Needs a Kong org admin to add
+          # Kong/kong-mesh-smoke to its repo access list; no new secret required.
+          github-token: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: "Kong",
+              repo: "kong-mesh-smoke",
+              event_type: "KUMA_SMOKE_TEST",
+              client_payload: {
+                product_name: "kuma",
+                product_version: process.env.PRODUCT_VERSION,
+                k8s_provider_k3d: true,
+                k8s_provider_gke: true,
+                k8s_provider_eks: true,
+                uni_provider_gcp: true,
+                uni_provider_aws: true,
+                run_tf_provider_tests: false,
+              },
+            });

--- a/.github/workflows/trigger-smoke-tests.yaml
+++ b/.github/workflows/trigger-smoke-tests.yaml
@@ -1,0 +1,112 @@
+name: "trigger-smoke-tests"
+
+# Auto-triggers Kong/kong-mesh-smoke for a single version when that version's
+# release-tag build (build-test-distribute) completes. Per-branch/event-driven,
+# not a batch fan-out over all versions. workflow_dispatch re-runs one version
+# by hand.
+on:
+  workflow_run:
+    workflows: ["build-test-distribute"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Product version to smoke-test, e.g. 2.14.1 or v2.14.1"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || inputs.version }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch-smoke:
+    # workflow_run has no reliable tag-level filter at the trigger layer (GitHub
+    # only supports `branches`/`branches-ignore`, and those are documented as
+    # branch-only - unreliable/silently-broken for tag-triggered runs). So this
+    # `if` is the earliest point we can filter, and it excludes the two branch
+    # names that account for the overwhelming majority of build-test-distribute
+    # completions (master, release-*) before a runner is even allocated. Actual
+    # tag-shape validation (vX.Y.Z / 2.9's bare X.Y.Z) still happens in-job below.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch != 'master' &&
+        !startsWith(github.event.workflow_run.head_branch, 'release-')
+      )
+    timeout-minutes: 5
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    permissions:
+      contents: read # to confirm the ref is really a tag, via the git refs API
+    steps:
+      - name: "Resolve version"
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANUAL_VERSION: ${{ inputs.version }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # v-prefix optional: release-2.9 never got the v-prefix backport and
+          # tags bare; manual re-runs also conventionally use the bare form.
+          RAW="${MANUAL_VERSION:-${HEAD_BRANCH}}"
+          if [[ "${RAW}" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            PRODUCT_VERSION="${BASH_REMATCH[1]}"
+          else
+            echo "'${RAW}' is not a recognized release version/tag; skipping smoke dispatch."
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -n "${MANUAL_VERSION}" ]]; then
+            # deliberate operator override; may target an archived version
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "product_version=${PRODUCT_VERSION}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # confirm head_branch is this tag, not a same-named branch, and it
+          # still points at the built commit, not one it moved to since
+          TAG="${RAW}"
+          OBJ_TYPE="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.type')"
+          OBJ_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object.sha')"
+          # annotated tags point at a tag object, not the commit directly
+          if [[ "${OBJ_TYPE}" == "tag" ]]; then
+            OBJ_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJ_SHA}" --jq '.object.sha')"
+          fi
+          if [[ "${OBJ_SHA}" != "${HEAD_SHA}" ]]; then
+            echo "'${TAG}' does not currently point at built commit ${HEAD_SHA}; skipping smoke dispatch."
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "is_release=true" >> "$GITHUB_OUTPUT"
+          echo "product_version=${PRODUCT_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: "Trigger Kong/kong-mesh-smoke"
+        if: steps.version.outputs.is_release == 'true'
+        env:
+          # Cross-org (kumahq -> Kong) token with `actions:write` on
+          # Kong/kong-mesh-smoke. Must be provisioned by a Kong org admin;
+          # no existing kumahq GitHub App/secret has that scope.
+          GH_TOKEN: ${{ secrets.KONG_MESH_SMOKE_DISPATCH_TOKEN }}
+          PRODUCT_VERSION: ${{ steps.version.outputs.product_version }}
+        run: |
+          set -euo pipefail
+          gh workflow run smoke.yaml \
+            --repo Kong/kong-mesh-smoke \
+            --ref main \
+            --field product_name=kuma \
+            --field product_version="${PRODUCT_VERSION}" \
+            --field k8s_provider_k3d=true \
+            --field k8s_provider_gke=true \
+            --field k8s_provider_eks=true \
+            --field uni_provider_gcp=true \
+            --field uni_provider_aws=true \
+            --field run_tf_provider_tests=false

--- a/.github/workflows/trigger-smoke-tests.yaml
+++ b/.github/workflows/trigger-smoke-tests.yaml
@@ -74,8 +74,12 @@ jobs:
           # confirm head_branch is this tag, not a same-named branch, and it
           # still points at the built commit, not one it moved to since
           TAG="${RAW}"
-          if ! TAG_REF_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/dev/null)"; then
-            echo "'${TAG}' is not an existing tag ref; skipping smoke dispatch."
+          # keep stderr in the run log: a missing tag (404) is the intended
+          # clean skip, but a rate-limit/network/auth failure must not vanish
+          # silently behind the same should_dispatch=false line.
+          if ! TAG_REF_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" 2>/tmp/gh_tag_ref_err)"; then
+            echo "'${TAG}' is not an existing tag ref (or the lookup failed); skipping smoke dispatch." >&2
+            cat /tmp/gh_tag_ref_err >&2 || true
             echo "should_dispatch=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -105,12 +109,15 @@ jobs:
           GH_TOKEN: ${{ secrets.KONG_MESH_SMOKE_DISPATCH_TOKEN }}
           SMOKE_OWNER: ${{ secrets.NOTIFY_OWNER }}
           SMOKE_REPO: ${{ secrets.KONG_MESH_SMOKE_REPO }}
+          # branch smoke.yaml lives on downstream; overridable via repo var if
+          # the default branch is renamed or moved to a maintenance branch.
+          SMOKE_REF: ${{ vars.KONG_MESH_SMOKE_REF || 'main' }}
           PRODUCT_VERSION: ${{ steps.version.outputs.product_version }}
         run: |
           set -euo pipefail
           gh workflow run smoke.yaml \
             --repo "${SMOKE_OWNER}/${SMOKE_REPO}" \
-            --ref main \
+            --ref "${SMOKE_REF}" \
             --field product_name=kuma \
             --field product_version="${PRODUCT_VERSION}" \
             --field k8s_provider_k3d=true \


### PR DESCRIPTION
## Motivation

Smoke tests for a released version are triggered by hand today: a release
manager runs `gh workflow run smoke.yaml --repo Kong/kong-mesh-smoke ...`
after eyeballing that the tag build finished. This is the last manual step
in an otherwise automatable release chain (see Kong/team-mesh#719, #722).

> Changelog: skip

## Implementation information

Adds `.github/workflows/trigger-smoke-tests.yaml`, listening on
`workflow_run: [build-test-distribute]` (`types: [completed]`), plus a
`workflow_dispatch` input to re-run smoke for one version by hand.

`workflow_run` has no reliable tag-level filter at the trigger layer (GitHub
only supports `branches`/`branches-ignore`, documented as branch-only and
reported unreliable for tag-triggered runs), so filtering happens in-job
instead:

- Job-level `if` skips allocating a runner at all for the two branch names
  that account for the overwhelming majority of `build-test-distribute`
  completions (`master`, `release-*`), and requires `conclusion == 'success'`
  and the triggering event to have been a `push` (excludes PR-triggered runs).
- A "Resolve version" step normalizes `vX.Y.Z` / bare `X.Y.Z` (release-2.9
  never got the v-prefix backport) to the bare `product_version` that
  `kong-mesh-smoke`'s `smoke.yaml` expects, for both the auto and manual path.
- For the auto path, it then confirms via the GitHub API that the ref is
  genuinely this tag (not e.g. a same-named branch) and that the tag still
  points at the exact commit that was built - dereferencing annotated tags
  to their commit, since `git/ref/tags/{tag}` returns the tag *object's* sha
  for those, not the commit sha `head_sha` is (kuma release tags are a mix of
  annotated and lightweight).
- Only then does it dispatch `smoke.yaml` on `Kong/kong-mesh-smoke` via
  `gh workflow run` (a `workflow_dispatch` run, not `repository_dispatch` -
  `smoke.yaml` only listens on `pull_request`/`push`/`schedule`/`workflow_dispatch`
  and reads its inputs from `inputs.*`) with the same fields the manual
  release checklist has always used. Owner/repo are read from secrets
  (`NOTIFY_OWNER`/`KONG_MESH_SMOKE_REPO`) rather than hardcoded, matching the
  pattern in `pr-merged.yaml`, since this is a public repo.

Known gap: dispatching cross-org (kumahq -> Kong) needs a token with
`actions:write` on `Kong/kong-mesh-smoke`. No existing kumahq credential has
that scope (checked the `kumahq` GitHub App's permissions and installations -
no `actions:write`, not installed in the `Kong` org). The workflow references
a new secret, `KONG_MESH_SMOKE_DISPATCH_TOKEN`, that a Kong org admin needs to
provision (fine-grained PAT or GitHub App) before this can dispatch anything;
it also needs `KONG_MESH_SMOKE_REPO` provisioned (the downstream repo name)
alongside the already-existing `NOTIFY_OWNER`. Until then it will resolve the
version correctly but fail at the dispatch step.

## Supporting documentation

- Kong/team-mesh#722 (smoke-test fan-out)
- Kong/team-mesh#719 (umbrella: automate the patch/minor release process)
- Kong/team-mesh#694 (manual release checklist this replaces the smoke step of)

_Generated by Sybra harness_