### PR TITLE
fix(e2e): match inbound listener by name not port

### DIFF
--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -277,7 +277,11 @@ func inboundHasRequestTimeout(cfg *config_dump.EnvoyConfig, port uint32, timeout
 		if err := util_proto.UnmarshalAnyTo(dl.ActiveState.Listener, &listener); err != nil {
 			return false, err
 		}
-		if !strings.HasPrefix(listener.GetName(), "inbound:") ||
+		// A dataplane can also carry a "kri_msvc_..." listener bound to the
+		// MeshService's ClusterIP on the same port (real MeshService
+		// routing), which MeshTimeout never configures. Match only the
+		// dataplane's own inbound listener, under either naming scheme.
+		if !isInboundListenerName(listener.GetName()) ||
 			listener.GetAddress().GetSocketAddress().GetPortValue() != port {
 			continue
 		}
@@ -306,4 +310,11 @@ func inboundHasRequestTimeout(cfg *config_dump.EnvoyConfig, port uint32, timeout
 	}
 
 	return false, fmt.Errorf("no listener on port %d found in config dump", port)
+}
+
+// isInboundListenerName reports whether name is a dataplane's own inbound
+// listener, under legacy ("inbound:<ip>:<port>") or unified naming
+// ("self_inbound_<shortname>_<sectionName>").
+func isInboundListenerName(name string) bool {
+	return strings.HasPrefix(name, "inbound:") || strings.HasPrefix(name, "self_inbound_")
 }


### PR DESCRIPTION
## Motivation

> Changelog: skip

The `MeshTimeout` kubernetes e2e test `should configure timeout for
single inbound` fails when `unifiedResourceNaming` is enabled: it
waits for a route-level `requestTimeout` to appear on the targeted
inbound listener and times out.

This is a test bug, not a production bug. Verified against a live
k3d cluster with `dataPlane.features.unifiedResourceNaming=true`: the
`MeshTimeout` plugin correctly sets the `2s` route timeout on the
dataplane's own inbound listener (`self_inbound_dp_secondary`,
bound to the pod IP). A second, unrelated listener also exists on
the same port — `kri_msvc_<mesh>_<zone>_<ns>_<svc>_secondary`,
bound to the MeshService's ClusterIP for "real" MeshService routing
(exists regardless of the unified-naming setting, since Exclusive
MeshService mode is now unconditional). That listener correctly
keeps the default `15s` timeout, since `MeshTimeout` never touches it.

The test's `inboundHasRequestTimeout` helper matched listeners by
port only, so depending on config-dump ordering it could inspect
either listener. Previously it also filtered by the legacy
`"inbound:"` name prefix, which incidentally disambiguated the two
— but that prefix doesn't match unified-naming's
`self_inbound_<shortname>_<sectionName>` scheme, so under unified
naming every listener was filtered out, and `Eventually` timed out.

## Implementation information

- `test/e2e_env/kubernetes/meshtimeout/meshtimeout.go`: replace the
  legacy-only `"inbound:"` prefix check with `isInboundListenerName`,
  which matches the dataplane's own inbound listener under either
  legacy (`"inbound:"`) or unified (`"self_inbound_"`) naming, still
  excluding the MeshService ClusterIP listener.

## Supporting documentation

Found while investigating CI failures on #17483, which flips the
`unifiedResourceNaming` default to `true`.