### PR TITLE
fix(e2e): match inbound listener by name not port

### DIFF
--- a/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
+++ b/test/e2e_env/kubernetes/meshtimeout/meshtimeout.go
@@ -290,7 +290,11 @@ func inboundHasRequestTimeout(cfg *config_dump.EnvoyConfig, port uint32, timeout
 		if err := util_proto.UnmarshalAnyTo(dl.ActiveState.Listener, &listener); err != nil {
 			return false, err
 		}
-		if !strings.HasPrefix(listener.GetName(), "inbound:") ||
+		// A dataplane can also carry a "kri_msvc_..." listener bound to the
+		// MeshService's ClusterIP on the same port (real MeshService
+		// routing), which MeshTimeout never configures. Match only the
+		// dataplane's own inbound listener, under either naming scheme.
+		if !isInboundListenerName(listener.GetName()) ||
 			listener.GetAddress().GetSocketAddress().GetPortValue() != port {
 			continue
 		}
@@ -319,4 +323,11 @@ func inboundHasRequestTimeout(cfg *config_dump.EnvoyConfig, port uint32, timeout
 	}
 
 	return false, fmt.Errorf("no listener on port %d found in config dump", port)
+}
+
+// isInboundListenerName reports whether name is a dataplane's own inbound
+// listener, under legacy ("inbound:<ip>:<port>") or unified naming
+// ("self_inbound_<shortname>_<sectionName>").
+func isInboundListenerName(name string) bool {
+	return strings.HasPrefix(name, "inbound:") || strings.HasPrefix(name, "self_inbound_")
 }


### PR DESCRIPTION
## Motivation

> Changelog: skip

Backport of #17575 to `release-2.14`.

The `MeshTimeout` kubernetes e2e test `should configure timeout for
single inbound` fails when `unifiedResourceNaming` is enabled: the
test helper matched listeners by port only and by the legacy
`"inbound:"` name prefix, which doesn't match unified-naming's
`self_inbound_<shortname>_<sectionName>` scheme. A second, unrelated
listener also exists on the same port for MeshService "real
resource" ClusterIP routing (`kri_msvc_...`), which `MeshTimeout`
never configures, so the port-only match was ambiguous. Verified
against a live k3d cluster that the production `MeshTimeout` plugin
itself applies the timeout correctly; this is a test-only fix.

## Implementation information

Clean cherry-pick of the master fix (#17575) onto `release-2.14`.

## Supporting documentation

See #17575 for the full investigation.