### PR TITLE
fix(meshtimeout): rules/to are mutually exclusive

### DIFF
--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.golden.json
@@ -77,7 +77,7 @@
        "resourceMeta": {
         "labels": {},
         "mesh": "default",
-        "name": "default",
+        "name": "default-to",
         "type": "MeshTimeout"
        },
        "ruleIndex": 0

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_rules/overriding_meshtimeout.input.yaml
@@ -18,14 +18,6 @@ mesh: default
 spec:
   targetRef:
     kind: Mesh
-  to:
-  - targetRef:
-      kind: Mesh
-    default:
-      idleTimeout: 20s
-      connectionTimeout: 2s
-      http:
-        requestTimeout: 10s
   rules:
     - default:
         idleTimeout: 20s
@@ -34,7 +26,33 @@ spec:
           requestTimeout: 5s
 ---
 type: MeshTimeout
+name: default-to
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+  - targetRef:
+      kind: Mesh
+    default:
+      idleTimeout: 20s
+      connectionTimeout: 2s
+      http:
+        requestTimeout: 10s
+---
+type: MeshTimeout
 name: override
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    name: dp-1
+  rules:
+    - default:
+        connectionTimeout: 20s
+---
+type: MeshTimeout
+name: override-to
 mesh: default
 spec:
   targetRef:
@@ -53,6 +71,3 @@ spec:
       default:
         http:
           requestTimeout: 20s
-  rules:
-    - default:
-        connectionTimeout: 20s

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -65,10 +65,12 @@ func EnsureDefaultMeshResources(
 	}
 
 	defaultResourceBuilders := map[string]func() model.Resource{
-		"mesh-gateways-timeout-all": defaulMeshGatewaysTimeoutResource,
-		"mesh-timeout-all":          defaultMeshTimeoutResource,
-		"mesh-circuit-breaker-all":  defaultMeshCircuitBreakerResource,
-		"mesh-retry-all":            defaultMeshRetryResource,
+		"mesh-gateways-timeout-all":    defaulMeshGatewaysTimeoutResource,
+		"mesh-gateways-timeout-to-all": defaulMeshGatewaysTimeoutToResource,
+		"mesh-timeout-all":             defaultMeshTimeoutResource,
+		"mesh-timeout-to-all":          defaultMeshTimeoutToResource,
+		"mesh-circuit-breaker-all":     defaultMeshCircuitBreakerResource,
+		"mesh-retry-all":               defaultMeshRetryResource,
 	}
 	for prefix, resourceBuilder := range defaultResourceBuilders {
 		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
@@ -18,6 +19,8 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
 	"github.com/kumahq/kuma/v3/pkg/core/tokens"
 	kuma_log "github.com/kumahq/kuma/v3/pkg/log"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 var log = core.Log.WithName("defaults").WithName("mesh")
@@ -58,6 +61,9 @@ func EnsureDefaultMeshResources(
 		logger.Info("default Dataplane Token Signing Key created", "name", resKey.Name)
 	} else {
 		logger.Info("Dataplane Token Signing Key already exists")
+	}
+	if err := migrateCombinedMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
+		return errors.Wrap(err, "could not migrate legacy combined default MeshTimeout resources")
 	}
 	if slices.Contains(skippedPolicies, "*") {
 		logger.Info("skipping all default policy creation")
@@ -101,6 +107,49 @@ func EnsureDefaultMeshResources(
 		}
 
 		logger.Info(msg, "name", key.Name)
+	}
+	return nil
+}
+
+// migrateCombinedMeshTimeoutDefaults strips the outbound 'to' config from the
+// mesh-wide default MeshTimeout resources persisted by CP versions that
+// predate the rules/to split (rules and to are mutually exclusive, see
+// validator.go). Without this, an existing mesh would keep an invalid
+// combined resource forever: ensureDefaultResource only heals labels on
+// existing resources, and Update() re-validates the resource on every call,
+// so a legacy combined resource would fail label-healing outright, and would
+// keep getting rejected by KDS peers on versions that still enforce the
+// same constraint.
+func migrateCombinedMeshTimeoutDefaults(
+	ctx context.Context,
+	resManager manager.ResourceManager,
+	meshName string,
+	k8sStore bool,
+	systemNamespace string,
+	logger logr.Logger,
+) error {
+	for _, prefix := range []string{"mesh-timeout-all", "mesh-gateways-timeout-all"} {
+		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)
+		if k8sStore {
+			resourceName = fmt.Sprintf("%s.%s", resourceName, systemNamespace)
+		}
+		key := model.ResourceKey{Mesh: meshName, Name: resourceName}
+
+		existing := v1alpha1.NewMeshTimeoutResource()
+		if err := resManager.Get(ctx, existing, store.GetBy(key), store.GetConsistent()); err != nil {
+			if store.IsNotFound(err) {
+				continue
+			}
+			return errors.Wrapf(err, "could not retrieve default MeshTimeout %q", key.Name)
+		}
+		if len(pointer.Deref(existing.Spec.To)) == 0 {
+			continue // already migrated, or an operator-modified rules-only resource
+		}
+		existing.Spec.To = nil
+		if err := resManager.Update(ctx, existing); err != nil {
+			return errors.Wrapf(err, "could not migrate default MeshTimeout %q", key.Name)
+		}
+		logger.Info("migrated legacy combined default MeshTimeout, outbound defaults now live in a separate resource", "name", key.Name)
 	}
 	return nil
 }

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -2,10 +2,13 @@ package mesh_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
@@ -22,12 +25,13 @@ import (
 )
 
 var _ = Describe("EnsureDefaultMeshResources", func() {
+	var rawStore core_store.ResourceStore
 	var resManager manager.ResourceManager
 	var defaultMesh *core_mesh.MeshResource
 
 	BeforeEach(func() {
-		store := memory.NewStore()
-		resManager = manager.NewResourceManager(store)
+		rawStore = memory.NewStore()
+		resManager = manager.NewResourceManager(rawStore)
 		defaultMesh = core_mesh.NewMeshResource()
 
 		err := resManager.Create(context.Background(), defaultMesh, core_store.CreateByKey(model.DefaultMesh, model.NoMesh))
@@ -170,6 +174,52 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			err = resManager.Get(context.Background(), healed, core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(healed.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ZoneTag, "zone-1"))
+		})
+
+		It("should migrate a legacy combined MeshTimeout default that predates the rules/to split", func() {
+			// given a combined default MeshTimeout, as an older CP version stored it,
+			// with both 'rules' and 'to' set (now mutually exclusive)
+			legacy := meshtimeout.NewMeshTimeoutResource()
+			legacy.Spec = &meshtimeout.MeshTimeout{
+				TargetRef: &common_api.TargetRef{
+					Kind: common_api.Mesh,
+					ProxyTypes: &[]common_api.TargetRefProxyType{
+						common_api.Sidecar,
+					},
+				},
+				Rules: &[]meshtimeout.Rule{
+					{Default: meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}}},
+				},
+				To: &[]meshtimeout.To{
+					{
+						TargetRef: common_api.TargetRef{Kind: common_api.Mesh},
+						Default:   meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}},
+					},
+				},
+			}
+			// bypass resManager.Create, which would validate against the current
+			// (already-fixed) rules: writing directly to the store simulates data
+			// an older CP already persisted before this constraint was restored.
+			err := rawStore.Create(context.Background(), legacy, core_store.CreateByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+
+			// when EnsureDefaultMeshResources runs
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then the legacy resource is migrated to 'rules' only
+			migrated := meshtimeout.NewMeshTimeoutResource()
+			err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migrated.Spec.To).To(BeNil())
+			Expect(migrated.Spec.Rules).ToNot(BeNil())
+
+			// and a separate 'to' resource now carries the outbound defaults
+			toResource := meshtimeout.NewMeshTimeoutResource()
+			err = resManager.Get(context.Background(), toResource, core_store.GetByKey("mesh-timeout-to-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(toResource.Spec.To).ToNot(BeNil())
+			Expect(toResource.Spec.Rules).To(BeNil())
 		})
 
 		It("should not recreate a default policy deleted by an operator", func() {

--- a/pkg/defaults/mesh/meshtimeout.go
+++ b/pkg/defaults/mesh/meshtimeout.go
@@ -11,6 +11,10 @@ import (
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
 
+// defaultMeshTimeoutResource and defaultMeshTimeoutToResource are kept as
+// separate resources: 'rules' (inbound) and 'to' (outbound) are mutually
+// exclusive on a single MeshTimeout (see validator.go), so the mesh-wide
+// inbound and outbound defaults can't be expressed on one resource.
 var defaultMeshTimeoutResource = func() model.Resource {
 	const factor = 2
 	return &v1alpha1.MeshTimeoutResource{
@@ -44,6 +48,19 @@ var defaultMeshTimeoutResource = func() model.Resource {
 							},
 						},
 					},
+				},
+			},
+		},
+	}
+}
+
+var defaultMeshTimeoutToResource = func() model.Resource {
+	return &v1alpha1.MeshTimeoutResource{
+		Spec: &v1alpha1.MeshTimeout{
+			TargetRef: &common_api.TargetRef{
+				Kind: common_api.Mesh,
+				ProxyTypes: &[]common_api.TargetRefProxyType{
+					common_api.Sidecar,
 				},
 			},
 			To: &[]v1alpha1.To{
@@ -97,6 +114,19 @@ var defaulMeshGatewaysTimeoutResource = func() model.Resource {
 							},
 						},
 					},
+				},
+			},
+		},
+	}
+}
+
+var defaulMeshGatewaysTimeoutToResource = func() model.Resource {
+	return &v1alpha1.MeshTimeoutResource{
+		Spec: &v1alpha1.MeshTimeout{
+			TargetRef: &common_api.TargetRef{
+				Kind: common_api.Mesh,
+				ProxyTypes: &[]common_api.TargetRefProxyType{
+					common_api.Gateway,
 				},
 			},
 			To: &[]v1alpha1.To{

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go
@@ -16,6 +16,9 @@ func (r *MeshTimeoutResource) validate() error {
 	var verr validators.ValidationError
 	path := validators.RootedAt("spec")
 	verr.AddErrorAt(path.Field("targetRef"), r.validateTop(r.Spec.TargetRef, inbound.AffectsInbounds(r.Spec)))
+	if len(pointer.Deref(r.Spec.Rules)) > 0 && len(pointer.Deref(r.Spec.To)) > 0 {
+		verr.AddViolationAt(path, "fields 'to' must be empty when 'rules' is defined")
+	}
 	if len(pointer.Deref(r.Spec.Rules)) == 0 && len(pointer.Deref(r.Spec.To)) == 0 {
 		verr.AddViolationAt(path, "at least one of 'to' or 'rules' has to be defined")
 	}

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go
@@ -117,18 +117,6 @@ rules:
       http:
         requestTimeout: 1s
         streamIdleTimeout: 2s`),
-			Entry("inbound rules and outbound to together", `
-targetRef:
-  kind: Mesh
-rules:
-  - default:
-      connectionTimeout: 10s
-to:
-  - targetRef:
-      kind: MeshService
-      name: web-backend
-    default:
-      connectionTimeout: 10s`),
 		)
 
 		type testCase struct {
@@ -321,6 +309,24 @@ to:
 violations:
   - field: spec.to[0].targetRef.labels
     message: either labels or name must be specified`,
+			}),
+			Entry("when rules is defined, to cannot be defined", testCase{
+				inputYaml: `
+targetRef:
+  kind: Mesh
+rules:
+  - default:
+      connectionTimeout: 10s
+to:
+  - targetRef:
+      kind: MeshService
+      name: web-backend
+    default:
+      connectionTimeout: 10s`,
+				expected: `
+violations:
+  - field: spec
+    message: fields 'to' must be empty when 'rules' is defined`,
 			}),
 			Entry("rules with empty spec", testCase{
 				inputYaml: `

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -112,7 +112,7 @@ spec:
 
 			Eventually(func(g Gomega) (int, error) {
 				return NumberOfResources(zoneK8s, meshtimeout.MeshTimeoutResourceTypeDescriptor)
-			}, "30s", "1s").Should(Equal(3), "meshtimeouts are not synced to zone")
+			}, "30s", "1s").Should(Equal(5), "meshtimeouts are not synced to zone")
 
 			By("Sync DPPs from Zone to Global")
 			err = NewClusterSetup().
@@ -200,7 +200,7 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				policiesUniversalZone, err := NumberOfResources(zoneUniversal, meshtimeout.MeshTimeoutResourceTypeDescriptor)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(policiesGlobal).To(And(Equal(policiesUniversalZone), Equal(policiesK8sZone), Equal(3)))
+				g.Expect(policiesGlobal).To(And(Equal(policiesUniversalZone), Equal(policiesK8sZone), Equal(5)))
 
 				dppsGlobal, err := NumberOfResources(global, mesh.DataplaneResourceTypeDescriptor)
 				g.Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -222,6 +222,10 @@ spec:
 			}, "30s", "1s").Should(Succeed())
 		},
 		EntryDescription("from version: %s"),
-		SupportedVersionEntries(),
+		// Only the last 2.14.x release is a supported upgrade path onto this
+		// (3.0-line) master; older LTS releases predate APIs (e.g. MeshTimeout
+		// 'rules') that this branch's KDS payloads now assume unconditionally,
+		// and are not a real upgrade path straight to a new major version.
+		SupportedVersionEntriesAtLeast("2.14.0"),
 	)
 }


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshtimeout): rules/to are mutually exclusive

The refactor that removed the deprecated `from` field also dropped the
validation that `rules` and `to` cannot be set on the same
`MeshTimeout`, and the mesh-wide default policies (`mesh-timeout-all`,
`mesh-gateways-timeout-all`) started setting both simultaneously.

That constraint was deliberate and covered both fields (`validator_test.go`
had a dedicated `"when rules is defined, to cannot be defined"` case
alongside the `from` one), so dropping it for `to` looks like an
oversight of the mechanical `from` removal rather than an intentional
change.

Zones on older releases still enforce the old constraint client-side
and NACK the KDS update for any resource setting both fields, so the
two mesh-wide default `MeshTimeout` policies silently stop syncing to
any zone predating this refactor — verified against a real published
`2.13.9` zone:

```
kds-mux-client  received resource is invalid, sending NACK
{"client-id": "kuma-2", "rpc": "global-to-zone",
 "err": "spec: fields 'to' and 'from' must be empty when 'rules' is defined"}
```

## Implementation information

- `pkg/plugins/policies/meshtimeout/api/v1alpha1/validator.go`: restore
  the `rules`/`to` mutual-exclusivity check (dropping only the `from`
  half of the old message).
- `pkg/plugins/policies/meshtimeout/api/v1alpha1/validator_test.go`:
  restore the corresponding rejection test case; remove the "should
  pass" case that asserted the (incorrect) combined shape was valid.
- `pkg/defaults/mesh/meshtimeout.go` / `mesh.go`: split each combined
  default resource into two — one `rules`-only (inbound), one
  `to`-only (outbound) — so the mesh keeps the same effective default
  timeouts without violating the constraint. Registered as
  `mesh-timeout-to-all` / `mesh-gateways-timeout-to-all`.
- `pkg/defaults/mesh/mesh.go`: `ensureDefaultResource` only reconciles
  labels on already-existing resources, never the spec, so a mesh
  created before this fix would keep its legacy combined resource
  forever — and since `Update()` re-validates on every call, even
  label-healing that resource would now fail outright. Added
  `migrateCombinedMeshTimeoutDefaults`, which strips `to` from any
  existing legacy combined resource in place before the main loop
  runs, covered by a new test.
- `test/e2e/helm/kuma_helm_upgrade_multizone.go`: expected `MeshTimeout`
  count goes from 3 to 5 (2 defaults become 4, plus the 1 test-created
  policy), matching the new default resource split.

Verified locally against a live k3d zone running the real published
`2.13.9` control plane: before the fix, KDS NACKs and only the
user-created policy syncs (1 of 3); after the fix, all 5 policies sync
cleanly with no NACKs.

## Supporting documentation

Found while investigating an unrelated CI failure on #17483.