### PR TITLE
test(kic): set mesh via pod label

### DIFF
--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -67,10 +67,6 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		"--namespace", t.ingressNamespace,
 		"--set", "controller.ingressController.watchNamespaces={"+watchNamespacesVal+"}",
 		"--set", "controller.ingressController.ingressClass="+t.name,
-		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
-		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,
-		// Mesh association is resolved from the kuma.io/mesh label (MeshOfByLabel),
-		// so the annotation alone leaves KIC pods in the default mesh.
 		"--set", "controller.podLabels.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podLabels.kuma\\.io/mesh="+t.mesh,
 		chartPath,

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -69,6 +69,10 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podAnnotations.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podAnnotations.kuma\\.io/mesh="+t.mesh,
+		// Mesh association is resolved from the kuma.io/mesh label (MeshOfByLabel),
+		// so the annotation alone leaves KIC pods in the default mesh.
+		"--set", "controller.podLabels.kuma\\.io/mesh="+t.mesh,
+		"--set", "gateway.podLabels.kuma\\.io/mesh="+t.mesh,
 		chartPath,
 	)
 	if err != nil {


### PR DESCRIPTION
> Changelog: skip

## Motivation

The delegated gateway e2e suite fails at the baseline connectivity check (HTTP 502 where 200 is expected). Kong's proxy logs show `upstream prematurely closed connection while reading response header from upstream` for every request to the backend.

Root cause: `MeshOfByLabel` (used by the pod controller to build a Dataplane) resolves a pod's mesh from the `kuma.io/mesh` **label** on the pod/namespace, falling back to the default mesh. The KIC deployment helper only set `kuma.io/mesh` as a pod **annotation**, so the Kong controller and gateway pods landed in the `default` mesh instead of the test mesh. The backend (deployed via the testserver helper, which correctly sets the label) stayed in the test mesh with strict mTLS, so Kong — now cross-mesh — sent plaintext to an mTLS-only inbound and the connection was reset.

## Implementation information

Set `kuma.io/mesh` as a pod label (via `controller.podLabels` / `gateway.podLabels`) so KIC pods are associated with the intended mesh. The `testserver` helper already sets the mesh this way.

## Supporting documentation

N/A