### PR TITLE
test(e2e): cache kuma-dp release binaries

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -73,6 +73,19 @@ runs:
           docker load -i "$tar"
           echo "KUMA_E2E_TRUST_CACHED_IMAGE_TAGS=true" >> "$GITHUB_ENV"
         fi
+    # Cache released kuma-dp tarballs pulled from packages.konghq.com by the DP
+    # compatibility tests (universal target only). Without this every run re-pulls
+    # ~130MB per supported version, which dominates Cloudsmith egress. The test
+    # framework reads/writes this dir (see dpBinaryCacheHostDir). restore-keys lets
+    # a version bump reuse the previous cache and only download the new version.
+    - name: "Cache kuma-dp release binaries"
+      if: ${{ inputs.target == 'universal' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: /tmp/kuma-dp-binaries-cache
+        key: kuma-dp-binaries-${{ inputs.arch }}-${{ hashFiles('versions.yml') }}
+        restore-keys: |
+          kuma-dp-binaries-${{ inputs.arch }}-
     - name: "Run E2E tests"
       shell: bash
       env:

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -371,9 +371,10 @@ func (s *UniversalApp) CreateDP(
 		url := fmt.Sprintf("https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-%[2]s/versions/%[1]s/kuma-%[1]s-linux-%[2]s.tar.gz", dpVersion, Config.Arch)
 		newPathOut := fmt.Sprintf("/tmp/kuma/kuma-%s/bin", dpVersion)
 
-		// Reuse the cached tarball on a hit; on a miss download it and populate the
-		// cache atomically (cp+mv) for future runs. The cache populate is
-		// best-effort (|| true) so a read-only mount never fails the install.
+		// Extract straight from the cached tarball on a hit; on a miss download it,
+		// populate the cache atomically (cp+mv) for future runs, and extract the
+		// download. The cache populate is best-effort (|| true) so a read-only mount
+		// never fails the install.
 		cacheFile := fmt.Sprintf("%s/kuma-%s-linux-%s.tar.gz", dpBinaryCacheMountPath, dpVersion, Config.Arch)
 
 		// Run the install synchronously so a failed download fails the test fast
@@ -382,12 +383,13 @@ func (s *UniversalApp) CreateDP(
 rm -f /usr/bin/kuma-dp /usr/bin/envoy
 mkdir -p /tmp/kuma/
 if [ -f '%[1]s' ]; then
-  cp '%[1]s' /tmp/kuma/kuma.tar.gz
+  tarball='%[1]s'
 else
   curl --no-progress-bar --fail '%[2]s' -o /tmp/kuma/kuma.tar.gz
   cp /tmp/kuma/kuma.tar.gz '%[1]s.tmp.'"$$" && mv '%[1]s.tmp.'"$$" '%[1]s' || true
+  tarball=/tmp/kuma/kuma.tar.gz
 fi
-tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
+tar xzf "$tarball" --directory /tmp/kuma/
 cp %[3]s/kuma-dp /usr/bin/kuma-dp
 cp %[3]s/envoy /usr/bin/envoy
 `, cacheFile, url, newPathOut)

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -42,8 +42,9 @@ const (
 	// tarballs across universal e2e runs, so the DP compatibility install reuses
 	// them instead of re-downloading from packages.konghq.com every run. CI
 	// persists it via actions/cache; on self-hosted runners it survives between
-	// runs on its own. It is bind-mounted into every app container at
-	// dpBinaryCacheMountPath.
+	// runs on its own. It is bind-mounted at dpBinaryCacheMountPath into app
+	// containers on the local docker backend (a host bind-mount is meaningless
+	// for the remote backend).
 	dpBinaryCacheHostDir   = "/tmp/kuma-dp-binaries-cache"
 	dpBinaryCacheMountPath = "/kuma-dp-binaries-cache"
 )
@@ -373,10 +374,11 @@ func (s *UniversalApp) CreateDP(
 		url := fmt.Sprintf("https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-%[2]s/versions/%[1]s/kuma-%[1]s-linux-%[2]s.tar.gz", dpVersion, Config.Arch)
 		newPathOut := fmt.Sprintf("/tmp/kuma/kuma-%s/bin", dpVersion)
 
-		// Extract straight from the cached tarball on a hit; on a miss download it,
-		// populate the cache atomically (cp+mv) for future runs, and extract the
-		// download. The cache populate is best-effort (|| true) so a read-only mount
-		// never fails the install.
+		// Try to extract straight from the cached tarball; extraction doubles as the
+		// integrity check. On a miss or a corrupt entry, download, extract that, and
+		// atomically (re)populate the cache via a unique mktemp temp + mv so a fresh
+		// good copy overwrites any bad one. Cache writes are best-effort (|| true) so
+		// a read-only mount never fails the install.
 		cacheFile := fmt.Sprintf("%s/kuma-%s-linux-%s.tar.gz", dpBinaryCacheMountPath, dpVersion, Config.Arch)
 
 		// Run the install synchronously so a failed download fails the test fast
@@ -384,14 +386,11 @@ func (s *UniversalApp) CreateDP(
 		installScript := fmt.Sprintf(`set -e
 rm -f /usr/bin/kuma-dp /usr/bin/envoy
 mkdir -p /tmp/kuma/
-if [ -f '%[1]s' ]; then
-  tarball='%[1]s'
-else
+if ! { [ -f '%[1]s' ] && tar xzf '%[1]s' --directory /tmp/kuma/ 2>/dev/null; }; then
   curl --no-progress-bar --fail '%[2]s' -o /tmp/kuma/kuma.tar.gz
-  cp /tmp/kuma/kuma.tar.gz '%[1]s.tmp.'"$$" && mv '%[1]s.tmp.'"$$" '%[1]s' || true
-  tarball=/tmp/kuma/kuma.tar.gz
+  tmp=$(mktemp '%[1]s.XXXXXX') && cp /tmp/kuma/kuma.tar.gz "$tmp" && mv "$tmp" '%[1]s' || true
+  tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
 fi
-tar xzf "$tarball" --directory /tmp/kuma/
 cp %[3]s/kuma-dp /usr/bin/kuma-dp
 cp %[3]s/envoy /usr/bin/envoy
 `, cacheFile, url, newPathOut)

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -73,6 +73,7 @@ type UniversalApp struct {
 type UniversalAppRunOptions struct {
 	DockerBackend        DockerBackend
 	DPConcurrency        int
+	DPVersion            string
 	EnvironmentVariables []string
 	ContainerName        string
 	Volumes              []string
@@ -122,9 +123,13 @@ func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode
 	}
 
 	// Mount the host cache dir so the DP compatibility install can reuse
-	// already-downloaded kuma-dp tarballs instead of pulling them again.
+	// already-downloaded kuma-dp tarballs instead of pulling them again. Only for
+	// apps that install a specific kuma-dp version (the ones that download) and
+	// only on the local docker backend (a host bind-mount is meaningless for the
+	// remote backend).
 	volumes := runOptions.Volumes
-	if _, ok := runOptions.DockerBackend.(*LocalDockerBackend); ok {
+	_, localBackend := runOptions.DockerBackend.(*LocalDockerBackend)
+	if localBackend && runOptions.DPVersion != "" {
 		if err := os.MkdirAll(dpBinaryCacheHostDir, 0o755); err != nil {
 			return nil, errors.Wrapf(err, "failed to create DP binary cache dir %q", dpBinaryCacheHostDir)
 		}

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -37,6 +37,15 @@ const (
 	AppModeDemoClient      = "demo-client"
 
 	sshPort = "22"
+
+	// dpBinaryCacheHostDir is a stable host directory caching released kuma-dp
+	// tarballs across universal e2e runs, so the DP compatibility install reuses
+	// them instead of re-downloading from packages.konghq.com every run. CI
+	// persists it via actions/cache; on self-hosted runners it survives between
+	// runs on its own. It is bind-mounted into every app container at
+	// dpBinaryCacheMountPath.
+	dpBinaryCacheHostDir   = "/tmp/kuma-dp-binaries-cache"
+	dpBinaryCacheMountPath = "/kuma-dp-binaries-cache"
 )
 
 type UniversalApp struct {
@@ -111,11 +120,18 @@ func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode
 		app.logger = logger.Default
 	}
 
+	// Mount the host cache dir so the DP compatibility install can reuse
+	// already-downloaded kuma-dp tarballs instead of pulling them again.
+	if err := os.MkdirAll(dpBinaryCacheHostDir, 0o755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create DP binary cache dir %q", dpBinaryCacheHostDir)
+	}
+	volumes := append(runOptions.Volumes, fmt.Sprintf("%s:%s", dpBinaryCacheHostDir, dpBinaryCacheMountPath))
+
 	container, err := app.dockerBackend.RunAndGetIDE(t, Config.GetUniversalImage(), &docker.RunOptions{
 		Detach:               true,
 		Remove:               true,
 		Name:                 app.containerName,
-		Volumes:              runOptions.Volumes,
+		Volumes:              volumes,
 		Logger:               app.logger,
 		EnvironmentVariables: runOptions.EnvironmentVariables,
 		OtherOptions:         dockerExtraOptions,
@@ -355,16 +371,26 @@ func (s *UniversalApp) CreateDP(
 		url := fmt.Sprintf("https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-%[2]s/versions/%[1]s/kuma-%[1]s-linux-%[2]s.tar.gz", dpVersion, Config.Arch)
 		newPathOut := fmt.Sprintf("/tmp/kuma/kuma-%s/bin", dpVersion)
 
+		// Reuse the cached tarball on a hit; on a miss download it and populate the
+		// cache atomically (cp+mv) for future runs. The cache populate is
+		// best-effort (|| true) so a read-only mount never fails the install.
+		cacheFile := fmt.Sprintf("%s/kuma-%s-linux-%s.tar.gz", dpBinaryCacheMountPath, dpVersion, Config.Arch)
+
 		// Run the install synchronously so a failed download fails the test fast
 		// instead of silently falling through to the image's bundled binaries.
 		installScript := fmt.Sprintf(`set -e
 rm -f /usr/bin/kuma-dp /usr/bin/envoy
 mkdir -p /tmp/kuma/
-curl --no-progress-bar --fail '%s' -o /tmp/kuma/kuma.tar.gz
+if [ -f '%[1]s' ]; then
+  cp '%[1]s' /tmp/kuma/kuma.tar.gz
+else
+  curl --no-progress-bar --fail '%[2]s' -o /tmp/kuma/kuma.tar.gz
+  cp /tmp/kuma/kuma.tar.gz '%[1]s.tmp.'"$$" && mv '%[1]s.tmp.'"$$" '%[1]s' || true
+fi
 tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
-cp %s/kuma-dp /usr/bin/kuma-dp
-cp %s/envoy /usr/bin/envoy
-`, url, newPathOut, newPathOut)
+cp %[3]s/kuma-dp /usr/bin/kuma-dp
+cp %[3]s/envoy /usr/bin/envoy
+`, cacheFile, url, newPathOut)
 		if stdout, stderr, err := s.universalNetworking.RunCommand(installScript); err != nil {
 			return errors.Wrapf(err, "failed to install kuma-dp %s: stdout=%q stderr=%q", dpVersion, stdout, stderr)
 		}

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -122,11 +122,13 @@ func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode
 
 	// Mount the host cache dir so the DP compatibility install can reuse
 	// already-downloaded kuma-dp tarballs instead of pulling them again.
-	if err := os.MkdirAll(dpBinaryCacheHostDir, 0o755); err != nil {
-		return nil, errors.Wrapf(err, "failed to create DP binary cache dir %q", dpBinaryCacheHostDir)
+	volumes := runOptions.Volumes
+	if _, ok := runOptions.DockerBackend.(*LocalDockerBackend); ok {
+		if err := os.MkdirAll(dpBinaryCacheHostDir, 0o755); err != nil {
+			return nil, errors.Wrapf(err, "failed to create DP binary cache dir %q", dpBinaryCacheHostDir)
+		}
+		volumes = append(slices.Clone(runOptions.Volumes), fmt.Sprintf("%s:%s", dpBinaryCacheHostDir, dpBinaryCacheMountPath))
 	}
-	volumes := append(runOptions.Volumes, fmt.Sprintf("%s:%s", dpBinaryCacheHostDir, dpBinaryCacheMountPath))
-
 	container, err := app.dockerBackend.RunAndGetIDE(t, Config.GetUniversalImage(), &docker.RunOptions{
 		Detach:               true,
 		Remove:               true,

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -416,6 +416,7 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 		UniversalAppRunOptions{
 			DockerBackend: c.dockerBackend,
 			DPConcurrency: 0,
+			DPVersion:     opts.dpVersion,
 			EnableIPv6:    opts.isipv6,
 			Verbose:       *opts.verbose,
 			Capabilities:  caps,


### PR DESCRIPTION
## Motivation

The DP compatibility tests download a ~130MB kuma-dp tarball per supported version from `packages.konghq.com` on every run.
That traffic is the bulk of our egress there.

## Implementation information

Bind-mount a host cache dir into every universal app container and reuse an already-downloaded tarball when present; on a miss download it and populate the cache atomically.
CI persists the dir via `actions/cache` keyed by `versions.yml`, so a tarball is fetched once per version+arch instead of every run.

Runs in the existing `e2e (universal, ...)` job on the default PR matrix, so no extra CI labels are needed to exercise it.

## Verification

Verified on CI with a temporary commit that narrowed the matrix to only the focused `Compatibility` spec ([since reverted](https://github.com/kumahq/kuma/compare/5eae1d74a3e60579115a2f02f562f0cf492c4290..5159a7dcef71109e8c45ad2cdcc703186a23874e)), running the same job twice:

- Run 1 (cold cache): [e2e (universal, kind, amd64)](https://github.com/kumahq/kuma/actions/runs/30080844797/job/89442098752) - `Cache not found for input keys: kuma-dp-binaries-amd64-688d06...` then `Cache saved with key: kuma-dp-binaries-amd64-688d06...`.
- Run 2 (warm cache): [e2e (universal, kind, amd64)](https://github.com/kumahq/kuma/actions/runs/30081674160/job/89444821818) - `Cache restored from key: kuma-dp-binaries-amd64-688d06...` (131 MB), `0` requests to `packages.konghq.com`, job still green.

So on a warm cache the compatibility install pulls the tarballs from the cache instead of Cloudsmith.

## Supporting documentation

> Changelog: skip