### PR TITLE
fix(mtls): derive identity without tags

### DIFF
--- a/pkg/xds/secrets/identity_tags.go
+++ b/pkg/xds/secrets/identity_tags.go
@@ -1,0 +1,35 @@
+package secrets
+
+import (
+	"github.com/pkg/errors"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	k8s_metadata "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
+)
+
+// identityTags returns the tag set used to derive a dataplane's mTLS
+// identity (SPIFFE/kuma SAN URIs). Dataplane.TagSet() is empty when
+// Experimental.InboundTagsDisabled strips inbound tags, which would
+// otherwise produce a certificate with no SAN and no Subject, rejected
+// outright by Envoy. In that case, fall back to the kuma.io/workload
+// label, the same identity signal MeshService generation and the
+// MeshIdentity Universal default already rely on when tags are disabled.
+func identityTags(dataplane *core_mesh.DataplaneResource) (mesh_proto.MultiValueTagSet, error) {
+	tags := dataplane.Spec.TagSet()
+	if len(tags.Values(mesh_proto.ServiceTag)) > 0 {
+		return tags, nil
+	}
+
+	workload := dataplane.GetMeta().GetLabels()[k8s_metadata.KumaWorkload]
+	if workload == "" {
+		return nil, errors.Errorf(
+			"dataplane %q has no %s tag and no %s label, cannot derive mTLS identity",
+			dataplane.GetMeta().GetName(), mesh_proto.ServiceTag, k8s_metadata.KumaWorkload,
+		)
+	}
+
+	return mesh_proto.MultiValueTagSetFrom(map[string][]string{
+		mesh_proto.ServiceTag: {workload},
+	}), nil
+}

--- a/pkg/xds/secrets/secrets.go
+++ b/pkg/xds/secrets/secrets.go
@@ -156,7 +156,11 @@ func (s *secrets) GetForDataPlane(
 	mesh *core_mesh.MeshResource,
 	otherMeshes []*core_mesh.MeshResource,
 ) (*core_xds.IdentitySecret, map[string]*core_xds.CaSecret, error) {
-	identity, cas, _, err := s.get(ctx, mesh_proto.DataplaneProxyType, dataplane, dataplane.Spec.TagSet(), mesh, otherMeshes)
+	tags, err := identityTags(dataplane)
+	if err != nil {
+		return nil, nil, err
+	}
+	identity, cas, _, err := s.get(ctx, mesh_proto.DataplaneProxyType, dataplane, tags, mesh, otherMeshes)
 	return identity, cas, err
 }
 
@@ -166,7 +170,11 @@ func (s *secrets) GetAllInOne(
 	dataplane *core_mesh.DataplaneResource,
 	otherMeshes []*core_mesh.MeshResource,
 ) (*core_xds.IdentitySecret, *core_xds.CaSecret, error) {
-	identity, _, allInOne, err := s.get(ctx, mesh_proto.DataplaneProxyType, dataplane, dataplane.Spec.TagSet(), mesh, otherMeshes)
+	tags, err := identityTags(dataplane)
+	if err != nil {
+		return nil, nil, err
+	}
+	identity, _, allInOne, err := s.get(ctx, mesh_proto.DataplaneProxyType, dataplane, tags, mesh, otherMeshes)
 	return identity, allInOne.CaSecret, err
 }
 

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -338,6 +338,30 @@ var _ = Describe("Secrets", Ordered, func() {
 				// then
 				Expect(err).To(HaveOccurred())
 			})
+
+			It("GetAllInOne should fall back to the kuma.io/workload label for identity", func() {
+				// given a dataplane with no inbound tags but a workload label
+				dataplane := newTaglessDataplane(map[string]string{"kuma.io/workload": "web"})
+
+				// when
+				identity, ca, err := secrets.GetAllInOne(context.Background(), newMesh("default"), dataplane, nil)
+
+				// then a cert is still generated, keyed off the workload label
+				Expect(err).ToNot(HaveOccurred())
+				Expect(identity.PemCerts).ToNot(BeEmpty())
+				Expect(ca.PemCerts).ToNot(BeEmpty())
+			})
+
+			It("GetAllInOne should error rather than issue a cert with no SAN when the workload label is also missing", func() {
+				// given a dataplane with neither inbound tags nor a workload label
+				dataplane := newTaglessDataplane(nil)
+
+				// when
+				_, _, err := secrets.GetAllInOne(context.Background(), newMesh("default"), dataplane, nil)
+
+				// then
+				Expect(err).To(HaveOccurred())
+			})
 		})
 	})
 

--- a/pkg/xds/secrets/secrets_test.go
+++ b/pkg/xds/secrets/secrets_test.go
@@ -299,6 +299,46 @@ var _ = Describe("Secrets", Ordered, func() {
 			// then
 			Expect(secrets.Info(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(newDataplane().Meta))).To(BeNil())
 		})
+
+		Context("when inbound tags are disabled", func() {
+			newTaglessDataplane := func(labels map[string]string) *core_mesh.DataplaneResource {
+				dp := newDataplane()
+				dp.Spec.Networking.Inbound[0].Tags = map[string]string{}
+				dp.Meta.(*model.ResourceMeta).Labels = labels
+				return dp
+			}
+
+			It("should fall back to the kuma.io/workload label for identity", func() {
+				// given a dataplane with no inbound tags but a workload label
+				dataplane := newTaglessDataplane(map[string]string{"kuma.io/workload": "web"})
+
+				// when
+				identity, ca, err := secrets.GetForDataPlane(context.Background(), dataplane, newMesh("default"), nil)
+
+				// then a cert is still generated, keyed off the workload label
+				Expect(err).ToNot(HaveOccurred())
+				Expect(identity.PemCerts).ToNot(BeEmpty())
+				Expect(ca).To(HaveLen(1))
+
+				info := secrets.Info(mesh_proto.DataplaneProxyType, core_model.MetaToResourceKey(dataplane.Meta))
+				Expect(info.Tags).To(Equal(mesh_proto.MultiValueTagSet{
+					"kuma.io/service": map[string]bool{
+						"web": true,
+					},
+				}))
+			})
+
+			It("should error rather than issue a cert with no SAN when the workload label is also missing", func() {
+				// given a dataplane with neither inbound tags nor a workload label
+				dataplane := newTaglessDataplane(nil)
+
+				// when
+				_, _, err := secrets.GetForDataPlane(context.Background(), dataplane, newMesh("default"), nil)
+
+				// then
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 
 	Context("zone egress", func() {


### PR DESCRIPTION
## Motivation

> Changelog: fix(mtls): derive identity without tags

When `Experimental.InboundTagsDisabled` strips inbound tags, `Dataplane.TagSet()` returns empty, and the built-in/provided CA issues mTLS certs with neither a Subject CN nor any SAN. Envoy rejects these outright, NACKing every inbound listener on the affected proxy — a full connectivity outage, reproduced live on a Kubernetes e2e run:

```
Error adding/updating listener(s) self_inbound_dp_main: Invalid TLS context has neither subject CN nor SAN names
self_inbound_dp_secondary: Invalid TLS context has neither subject CN nor SAN names
```

Root-caused while investigating kumahq/kuma#17596 (an exploratory PR flipping `InboundTagsDisabled`'s default). This flag is already shippable today (opt-in), so any user enabling it manually on a Kubernetes cluster with the built-in/provided CA hits this now.

## Implementation information

- `pkg/xds/secrets/identity_tags.go`: new `identityTags` helper. When `Dataplane.TagSet()` has no `kuma.io/service` values, falls back to the `kuma.io/workload` label — the same identity signal MeshService generation and the Universal-default MeshIdentity SPIFFE template already use once tags are disabled. If the label is also missing, returns an error instead of silently issuing an unusable cert.
- `pkg/xds/secrets/secrets.go`: `GetForDataPlane`/`GetAllInOne` now compute tags via `identityTags` instead of calling `dataplane.Spec.TagSet()` directly.
- Fallback is keyed on the tag set being empty, not on the `InboundTagsDisabled` flag itself, so it also covers a hand-authored tagless Universal `Dataplane`.
- The newer MeshIdentity/WorkloadIdentity path is unaffected by this bug (it already derives identity from `Dataplane.Meta` labels, never `TagSet()`) and is unaffected by this fix.

Unit tests added in `pkg/xds/secrets/secrets_test.go` covering: fallback to workload label producing a valid cert, and an explicit error when both the tag and the label are missing.

## Supporting documentation

Will need backporting to `release-2.14` once merged (the `InboundTagsDisabled` flag exists there per the tag-free rollout MADR).