### PR TITLE
fix(mesh): gateway tag not required tagless

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -358,7 +358,9 @@ func validateGateway(gateway *mesh_proto.Dataplane_Networking_Gateway) validator
 		return result
 	}
 	result.Add(ValidateTags(validators.RootedAt("tags"), gateway.Tags, ValidateTagsOpts{
-		RequireService:      true,
+		// Require service tag only if gateway has any tags (old setup).
+		// With InboundTagsDisabled gateways have no tags (new setup).
+		RequireService:      len(gateway.Tags) > 0,
 		ExtraTagsValidators: []TagsValidatorFunc{validateProtocol},
 	}),
 	)

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1649,6 +1649,7 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   gateway:
                     type: DELEGATED
+                    tags: {}
 `), dataplane.Spec)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1639,5 +1639,22 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.inbound[0].tags["kuma.io/service"]
                   message: tag has to exist`))
 		})
+
+		It("should allow dataplane with empty gateway tags (InboundTagsDisabled)", func() {
+			dataplane := core_mesh.NewDataplaneResource()
+
+			// when
+			err := util_proto.FromYAML([]byte(`
+                networking:
+                  address: 192.168.0.1
+                  gateway:
+                    type: DELEGATED
+`), dataplane.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then - empty tags = new setup, no service tag required
+			err = dataplane.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
## Motivation

> Changelog: fix(mesh): gateway tag not required tagless

Found while investigating remaining Kubernetes e2e failures on kumahq/kuma#17596 (an exploratory PR flipping `Experimental.InboundTagsDisabled`'s default), after the mTLS identity fix (#17606) resolved the bulk of the failures.

`validateGateway()` in `pkg/core/resources/apis/mesh/dataplane_validator.go` unconditionally requires `kuma.io/service` on `spec.networking.gateway.tags`. The regular inbound path already has an equivalent exemption once inbound tags are empty (`InboundTagsDisabled`), but the gateway path never got the same fix.

`GatewayByServiceFor`/`GatewayByDeploymentFor` (`pkg/plugins/runtime/k8s/controllers/pod_converter.go`) populate `gateway.Tags = {}` for every delegated-gateway/KIC pod once inbound tags are disabled. The admission webhook then rejects every such Dataplane outright:

```
Failed to generate Kuma Dataplane: admission webhook "validator.kuma-admission.kuma.io" denied the request:
spec.networking.gateway.tags: mandatory tag "kuma.io/service" is missing
```

Confirmed live in CI events on `kic-controller-*`, `kic-gateway-*`, `delegated-gateway-ms-controller-*`, and `delegated-gateway-ms-gateway-*` pods — the Dataplane never registers, so the gateway sidecar never becomes ready, and any test/deployment using Kong Ingress Controller or a delegated gateway under `InboundTagsDisabled` breaks outright.

## Implementation information

- `validateGateway()` now requires the service tag only if `gateway.Tags` is non-empty, mirroring the exact pattern and comment already used for `networking.inbound`.
- Added unit tests: gateway with empty tags is now valid; the existing "gateway has other tags but no service tag" case (still required) is unchanged and still passes.

## Supporting documentation

N/A