### PR TITLE
fix(mesh): gateway tag not required tagless

### DIFF
--- a/pkg/core/resources/apis/mesh/dataplane_validator.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator.go
@@ -376,7 +376,9 @@ func validateGateway(gateway *mesh_proto.Dataplane_Networking_Gateway) validator
 		return result
 	}
 	result.Add(ValidateTags(validators.RootedAt("tags"), gateway.Tags, ValidateTagsOpts{
-		RequireService:      true,
+		// Require service tag only if gateway has any tags (old setup).
+		// With InboundTagsDisabled gateways have no tags (new setup).
+		RequireService:      len(gateway.Tags) > 0,
 		ExtraTagsValidators: []TagsValidatorFunc{validateProtocol},
 	}),
 	)

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1720,5 +1720,22 @@ var _ = Describe("Dataplane", func() {
                 - field: networking.inbound[0].tags["kuma.io/service"]
                   message: tag has to exist`))
 		})
+
+		It("should allow dataplane with empty gateway tags (InboundTagsDisabled)", func() {
+			dataplane := core_mesh.NewDataplaneResource()
+
+			// when
+			err := util_proto.FromYAML([]byte(`
+                networking:
+                  address: 192.168.0.1
+                  gateway:
+                    type: DELEGATED
+`), dataplane.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then - empty tags = new setup, no service tag required
+			err = dataplane.Validate()
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -1730,6 +1730,7 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   gateway:
                     type: DELEGATED
+                    tags: {}
 `), dataplane.Spec)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(mesh): gateway tag not required tagless

Backport of #17610 to release-2.14.

`validateGateway()` in `pkg/core/resources/apis/mesh/dataplane_validator.go` unconditionally required `kuma.io/service` on `spec.networking.gateway.tags`. The regular inbound path already has an equivalent exemption once inbound tags are empty (`InboundTagsDisabled`), but the gateway path never got the same fix. Every delegated-gateway/KIC Dataplane gets an empty `gateway.tags` map in that mode, so the admission webhook rejected them outright, keeping the gateway sidecar from ever registering.

## Implementation information

Ported directly (`v2` module path, otherwise identical to master's `validateGateway` at the time of the fix — no other drift in the touched files).

- `validateGateway()` now requires the service tag only if `gateway.Tags` is non-empty, mirroring the exact pattern and comment already used for `networking.inbound`.
- Added unit tests: gateway with empty tags is now valid; the existing "gateway has other tags but no service tag" case (still required) is unchanged and still passes.

## Supporting documentation

Source PR: kumahq/kuma#17610