### PR TITLE
refactor(policy): remove legacy naming from mesh route clusters/listeners

### DIFF
--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -10,7 +10,6 @@ import (
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
-	unified_naming "github.com/kumahq/kuma/v3/pkg/core/naming/unified-naming"
 	core_resources "github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core/destinationname"
 	meshmultizoneservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
@@ -41,8 +40,6 @@ func GenerateClusters(
 	systemNamespace string,
 ) (*core_xds.ResourceSet, error) {
 	resources := core_xds.NewResourceSet()
-
-	unifiedNaming := unified_naming.Enabled(proxy.Metadata, meshCtx.Resource)
 
 	for _, serviceName := range services.Sorted() {
 		service := services[serviceName]
@@ -89,7 +86,7 @@ func GenerateClusters(
 						Configure(envoy_clusters.EdsCluster()).
 						Configure(envoy_clusters.ClientSideMTLSCustomSNI(
 							proxy.SecretsTracker,
-							unifiedNaming,
+							true,
 							meshCtx.Resource,
 							mesh_proto.ZoneEgressServiceName,
 							true,
@@ -115,7 +112,7 @@ func GenerateClusters(
 						if otherMesh.GetMeta().GetName() == upstreamMeshName {
 							edsClusterBuilder.Configure(
 								envoy_clusters.CrossMeshClientSideMTLS(
-									proxy.SecretsTracker, unifiedNaming, meshCtx.Resource, otherMesh, serviceName, tlsReady, clusterTags,
+									proxy.SecretsTracker, true, meshCtx.Resource, otherMesh, serviceName, tlsReady, clusterTags,
 								),
 							)
 							break
@@ -192,7 +189,7 @@ func GenerateClusters(
 						} else {
 							edsClusterBuilder.Configure(envoy_clusters.ClientSideMultiIdentitiesMTLS(
 								proxy.SecretsTracker,
-								unifiedNaming,
+								true,
 								meshCtx.Resource,
 								tlsReady,
 								sni,
@@ -201,7 +198,7 @@ func GenerateClusters(
 							))
 						}
 					} else {
-						edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, unifiedNaming, meshCtx.Resource, serviceName, tlsReady, clusterTags, len(meshCtx.CAsByTrustDomain) > 0))
+						edsClusterBuilder.Configure(envoy_clusters.ClientSideMTLS(proxy.SecretsTracker, true, meshCtx.Resource, serviceName, tlsReady, clusterTags, len(meshCtx.CAsByTrustDomain) > 0))
 					}
 				}
 			}

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -25,7 +25,6 @@ func MakeTCPSplit(
 	servicesAcc envoy_common.ServicesAccumulator,
 	refs []resolve.ResolvedBackendRef,
 	meshCtx xds_context.MeshContext,
-	unifiedNaming bool,
 ) []envoy_common.Split {
 	return makeSplits(
 		map[core_meta.Protocol]struct{}{
@@ -40,7 +39,6 @@ func MakeTCPSplit(
 		servicesAcc,
 		refs,
 		meshCtx,
-		unifiedNaming,
 	)
 }
 
@@ -49,7 +47,6 @@ func MakeHTTPSplit(
 	servicesAcc envoy_common.ServicesAccumulator,
 	refs []resolve.ResolvedBackendRef,
 	meshCtx xds_context.MeshContext,
-	unifiedNaming bool,
 ) []envoy_common.Split {
 	return makeSplits(
 		map[core_meta.Protocol]struct{}{
@@ -61,7 +58,6 @@ func MakeHTTPSplit(
 		servicesAcc,
 		refs,
 		meshCtx,
-		unifiedNaming,
 	)
 }
 
@@ -197,13 +193,12 @@ func makeSplits(
 	servicesAcc envoy_common.ServicesAccumulator,
 	refs []resolve.ResolvedBackendRef,
 	meshCtx xds_context.MeshContext,
-	unifiedNaming bool,
 ) []envoy_common.Split {
 	var result []envoy_common.Split
 
 	splitFromRef := func(ref resolve.ResolvedBackendRef) envoy_common.Split {
 		if ref.ReferencesRealResource() {
-			return handleRealResources(protocols, clusterCache, servicesAcc, ref.RealResourceBackendRef(), meshCtx, unifiedNaming)
+			return handleRealResources(protocols, clusterCache, servicesAcc, ref.RealResourceBackendRef(), meshCtx)
 		}
 
 		return handleLegacyBackendRef(protocols, clusterCache, servicesAcc, ref.LegacyBackendRef(), meshCtx)
@@ -228,7 +223,6 @@ func handleRealResources(
 	servicesAcc envoy_common.ServicesAccumulator,
 	ref *resolve.RealResourceBackendRef,
 	meshCtx xds_context.MeshContext,
-	unifiedNaming bool,
 ) envoy_common.Split {
 	if ref.Weight == 0 {
 		return nil
@@ -245,10 +239,7 @@ func handleRealResources(
 
 	service := destinationname.MustResolve(false, dest, port)
 
-	clusterName := service
-	if unifiedNaming {
-		clusterName = ref.Resource.String()
-	}
+	clusterName := ref.Resource.String()
 
 	isExternalService := ref.Resource.ResourceType == meshexternalservice_api.MeshExternalServiceType
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -105,7 +105,7 @@ func generateFromService(
 	unifiedNaming := unified_naming.Enabled(proxy.Metadata, meshCtx.Resource)
 
 	for _, route := range prepareRoutes(rules, svc, meshCtx, unifiedNaming) {
-		split := meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx, unifiedNaming)
+		split := meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx)
 		if len(split) == 0 {
 			continue
 		}
@@ -116,7 +116,6 @@ func generateFromService(
 					clusterCache, servicesAcc,
 					[]resolve.ResolvedBackendRef{*resolve.NewResolvedBackendRef(pointer.To(resolve.LegacyBackendRef(filter.RequestMirror.BackendRef)))},
 					meshCtx,
-					unifiedNaming,
 				)
 			}
 		}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend___msvc_80
+    name: kri_msvc_default___backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -37,14 +37,14 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_backend___mzsvc_80
+- name: kri_msvc_default___backend_test-port
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend___mzsvc_80
+    name: kri_msvc_default___backend_test-port
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -59,12 +59,50 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: a601e0c00295a9fbe.backend.80.default.ms
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+- name: kri_mzsvc_default___backend_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: kri_mzsvc_default___backend_80
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: system_mtls_ca_default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.endpoints.golden.yaml
@@ -1,9 +1,13 @@
 resources:
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend___msvc_80
-- name: default_backend___mzsvc_80
+    clusterName: kri_msvc_default___backend_80
+- name: kri_msvc_default___backend_test-port
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend___mzsvc_80
+    clusterName: kri_msvc_default___backend_test-port
+- name: kri_mzsvc_default___backend_80
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: kri_mzsvc_default___backend_80

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.listeners.golden.yaml
@@ -32,31 +32,31 @@ resources:
                   path: /mzms
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___mzsvc_80
+                  cluster: kri_mzsvc_default___backend_80
                   timeout: 0s
               - match:
                   prefix: /mzms/
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___mzsvc_80
+                  cluster: kri_mzsvc_default___backend_80
                   timeout: 0s
               - match:
                   path: /ms
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_80
                   timeout: 0s
               - match:
                   prefix: /ms/
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_80
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
           statPrefix: default_backend___msvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_backend-second___msvc_80
+- name: kri_msvc_default___backend-second_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend-second___msvc_80
+    name: kri_msvc_default___backend-second_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend-second
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -37,14 +37,14 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend___msvc_80
+    name: kri_msvc_default___backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -59,12 +59,50 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: a601e0c00295a9fbe.backend.80.default.ms
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicitHttpConfig:
+          http2ProtocolOptions: {}
+- name: kri_msvc_default___backend_test-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: kri_msvc_default___backend_test-port
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: system_mtls_ca_default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.endpoints.golden.yaml
@@ -1,9 +1,13 @@
 resources:
-- name: default_backend-second___msvc_80
+- name: kri_msvc_default___backend-second_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend-second___msvc_80
-- name: default_backend___msvc_80
+    clusterName: kri_msvc_default___backend-second_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend___msvc_80
+    clusterName: kri_msvc_default___backend_80
+- name: kri_msvc_default___backend_test-port
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: kri_msvc_default___backend_test-port

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.listeners.golden.yaml
@@ -32,31 +32,31 @@ resources:
                   path: /version1
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_80
                   timeout: 0s
               - match:
                   prefix: /version1/
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_80
                   timeout: 0s
               - match:
                   path: /version2
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend-second___msvc_80
+                  cluster: kri_msvc_default___backend-second_80
                   timeout: 0s
               - match:
                   prefix: /version2/
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend-second___msvc_80
+                  cluster: kri_msvc_default___backend-second_80
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
           statPrefix: default_backend___msvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -27,14 +27,14 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_test-port
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend___msvc_80
+    name: kri_msvc_default___backend_test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -53,10 +53,10 @@ resources:
             envoy.transport_socket_match:
               kuma.io/protocol: http
               region: us
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_test-port
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend___msvc_80
+    clusterName: kri_msvc_default___backend_test-port
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -68,19 +68,19 @@ resources:
                   path: /v4
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
               - match:
                   prefix: /v4/
                 name: kri_mhttpr_default___test-origin_
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
           statPrefix: default_backend___msvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example___extsvc_9090
+    name: kri_extsvc_default___example_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___extsvc_9090
+    clusterName: kri_extsvc_default___example_
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -33,7 +33,7 @@ resources:
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
           statPrefix: default_example___extsvc_9090
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_multi-backend___mzsvc_80
+    name: kri_mzsvc_default___multi-backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_multi-backend___mzsvc_80
+    clusterName: kri_mzsvc_default___multi-backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-legacy-zone.listeners.golden.yaml
@@ -32,7 +32,7 @@ resources:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_multi-backend___mzsvc_80
+                  cluster: kri_mzsvc_default___multi-backend_80
                   timeout: 0s
           statPrefix: default_multi-backend___mzsvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_multi-backend___mzsvc_80
+    name: kri_mzsvc_default___multi-backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_multi-backend___mzsvc_80
+    clusterName: kri_mzsvc_default___multi-backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.listeners.golden.yaml
@@ -32,7 +32,7 @@ resources:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_multi-backend___mzsvc_80
+                  cluster: kri_mzsvc_default___multi-backend_80
                   timeout: 0s
           statPrefix: default_multi-backend___mzsvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_multi-backend___mzsvc_80
+    name: kri_mzsvc_default___multi-backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_multi-backend___mzsvc_80
+    clusterName: kri_mzsvc_default___multi-backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mixed-zones.listeners.golden.yaml
@@ -32,7 +32,7 @@ resources:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_multi-backend___mzsvc_80
+                  cluster: kri_mzsvc_default___multi-backend_80
                   timeout: 0s
           statPrefix: default_multi-backend___mzsvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_multi-backend___mzsvc_80
+    name: kri_mzsvc_default___multi-backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_multi-backend___mzsvc_80
+- name: kri_mzsvc_default___multi-backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_multi-backend___mzsvc_80
+    clusterName: kri_mzsvc_default___multi-backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.listeners.golden.yaml
@@ -32,7 +32,7 @@ resources:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_multi-backend___mzsvc_80
+                  cluster: kri_mzsvc_default___multi-backend_80
                   timeout: 0s
           statPrefix: default_multi-backend___mzsvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_backend__remote-zone_msvc_80
+- name: kri_msvc_default_remote-zone__backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend__remote-zone_msvc_80
+    name: kri_msvc_default_remote-zone__backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_backend__remote-zone_msvc_80
+- name: kri_msvc_default_remote-zone__backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend__remote-zone_msvc_80
+    clusterName: kri_msvc_default_remote-zone__backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.listeners.golden.yaml
@@ -32,7 +32,7 @@ resources:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_backend__remote-zone_msvc_80
+                  cluster: kri_msvc_default_remote-zone__backend_80
                   timeout: 0s
           statPrefix: default_backend__remote-zone_msvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend___msvc_80
+    name: kri_msvc_default___backend_80
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend___msvc_80
+    clusterName: kri_msvc_default___backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.listeners.golden.yaml
@@ -32,7 +32,7 @@ resources:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
-                  cluster: default_backend___msvc_80
+                  cluster: kri_msvc_default___backend_80
                   timeout: 0s
           statPrefix: default_backend___msvc_80
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-outbound-with-tags-with-mtls.clusters.golden.yaml
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example___extsvc_9090
+    name: kri_extsvc_default___example_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___extsvc_9090
+    clusterName: kri_extsvc_default___example_
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshexternalservice.listeners.golden.yaml
@@ -33,21 +33,21 @@ resources:
                 name: kri_mhttpr_default___test-origin_
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
               - match:
                   prefix: /v1/
                 name: kri_mhttpr_default___test-origin_
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
           statPrefix: default_example___extsvc_9090
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example___extsvc_9090
+    name: kri_extsvc_default___example_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___extsvc_9090
+    clusterName: kri_extsvc_default___example_
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-custom-settings.listeners.golden.yaml
@@ -33,7 +33,7 @@ resources:
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
           statPrefix: default_example___extsvc_9090
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example___extsvc_9090
+    name: kri_extsvc_default___example_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___extsvc_9090
+    clusterName: kri_extsvc_default___example_
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls-and-skipall.listeners.golden.yaml
@@ -33,7 +33,7 @@ resources:
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
           statPrefix: default_example___extsvc_9090
     metadata:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example___extsvc_9090
+    name: kri_extsvc_default___example_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___extsvc_9090
+    clusterName: kri_extsvc_default___example_
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/meshexternalservice-with-tls.listeners.golden.yaml
@@ -33,7 +33,7 @@ resources:
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=
                 route:
                   autoHostRewrite: true
-                  cluster: default_example___extsvc_9090
+                  cluster: kri_extsvc_default___example_
                   timeout: 0s
           statPrefix: default_example___extsvc_9090
     metadata:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/listeners.go
@@ -82,7 +82,7 @@ func generateFromService(
 		return nil, nil
 	}
 
-	splits := meshroute_xds.MakeTCPSplit(clusterCache, servicesAccumulator, backendRefs, meshCtx, unifiedNaming)
+	splits := meshroute_xds.MakeTCPSplit(clusterCache, servicesAccumulator, backendRefs, meshCtx)
 
 	listener, err := GenerateOutboundListener(proxy, svc, splits, unifiedNaming)
 	if err != nil {

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -1,12 +1,12 @@
 resources:
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_backend___msvc_80
+    name: kri_msvc_default___backend_80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -1,8 +1,8 @@
 resources:
-- name: default_backend___msvc_80
+- name: kri_msvc_default___backend_80
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_backend___msvc_80
+    clusterName: kri_msvc_default___backend_80
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -11,7 +11,7 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_backend___msvc_80
+          cluster: kri_msvc_default___backend_80
           statPrefix: default_backend___msvc_80
     metadata:
       filterMetadata:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -37,14 +37,14 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example___extsvc_9090
+    name: kri_extsvc_default___example_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -59,12 +59,12 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.endpoints.golden.yaml
@@ -3,10 +3,10 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend
-- name: default_example___extsvc_9090
+- name: kri_extsvc_default___example_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example___extsvc_9090
+    clusterName: kri_extsvc_default___example_
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.listeners.golden.yaml
@@ -11,7 +11,7 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_example___extsvc_9090
+          cluster: kri_extsvc_default___example_
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
@@ -21,12 +21,12 @@ resources:
                   exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
@@ -37,14 +37,14 @@ resources:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicitHttpConfig:
           http2ProtocolOptions: {}
-- name: default_example2___extsvc_9090
+- name: kri_extsvc_default___example2_
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       edsConfig:
         ads: {}
         resourceApiVersion: V3
-    name: default_example2___extsvc_9090
+    name: kri_extsvc_default___example2_
     transportSocket:
       name: envoy.transport_sockets.tls
       typedConfig:
@@ -59,12 +59,45 @@ resources:
                   exact: spiffe://default/zone-egress
                 sanType: URI
             validationContextSdsSecretConfig:
-              name: mesh_ca:secret:default
+              name: system_mtls_ca_default
               sdsConfig:
                 ads: {}
                 resourceApiVersion: V3
           tlsCertificateSdsSecretConfigs:
-          - name: identity_cert:secret:default
+          - name: system_mtls_identity_default
+            sdsConfig:
+              ads: {}
+              resourceApiVersion: V3
+        sni: a0ac70962fd61fdc0.example2.9090.default.mes
+    type: EDS
+- name: kri_extsvc_default___example2_9090
+  resource:
+    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      edsConfig:
+        ads: {}
+        resourceApiVersion: V3
+    name: kri_extsvc_default___example2_9090
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - kuma
+          combinedValidationContext:
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/zone-egress
+                sanType: URI
+            validationContextSdsSecretConfig:
+              name: system_mtls_ca_default
+              sdsConfig:
+                ads: {}
+                resourceApiVersion: V3
+          tlsCertificateSdsSecretConfigs:
+          - name: system_mtls_identity_default
             sdsConfig:
               ads: {}
               resourceApiVersion: V3

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.endpoints.golden.yaml
@@ -3,10 +3,22 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     clusterName: backend
-- name: default_example2___extsvc_9090
+- name: kri_extsvc_default___example2_
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: default_example2___extsvc_9090
+    clusterName: kri_extsvc_default___example2_
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 127.0.0.1
+              portValue: 10002
+        loadBalancingWeight: 1
+- name: kri_extsvc_default___example2_9090
+  resource:
+    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    clusterName: kri_extsvc_default___example2_9090
     endpoints:
     - lbEndpoints:
       - endpoint:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.listeners.golden.yaml
@@ -11,7 +11,7 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_example2___extsvc_9090
+          cluster: kri_extsvc_default___example2_9090
           statPrefix: default_example___extsvc_9090
     metadata:
       filterMetadata:
@@ -30,7 +30,7 @@ resources:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default_example2___extsvc_9090
+          cluster: kri_extsvc_default___example2_
           statPrefix: default_example2___extsvc_9090
     metadata:
       filterMetadata:


### PR DESCRIPTION
## Motivation

Modernize mesh route naming conventions as part of the broader policies core refactoring effort (#17241).

## Implementation information

Removed legacy naming from mesh route cluster and listener definitions:
- Refactored helpers and generators in `pkg/plugins/policies/core/xds/meshroute/`
- Updated naming conventions in `core/generator/generator.go`
- Regenerated ~521 testdata files to reflect the naming updates

Closes https://github.com/kumahq/kuma/issues/17287

_Generated by Sybra harness_