### PR TITLE
fix(meshservice): identities fallback tagless

### DIFF
--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -303,11 +303,9 @@ func (s *StatusUpdater) buildIdentities(dpps []*core_mesh.DataplaneResource, mes
 	for _, dpp := range dpps {
 		tagIdentities := dpp.Spec.TagSet()[mesh_proto.ServiceTag]
 		if len(tagIdentities) == 0 {
-			// TagSet() is empty once Experimental.InboundTagsDisabled strips
-			// inbound tags. Fall back to the same workload label the mTLS
-			// identity path and MeshService generation already use, so this
-			// dataplane still gets a verifiable identity instead of silently
-			// falling out of Spec.Identities.
+			// No kuma.io/service tag once Experimental.InboundTagsDisabled
+			// strips inbound tags. Fall back to the workload label, same as
+			// the mTLS identity path and MeshService generation.
 			if workload := dpp.GetMeta().GetLabels()[metadata.KumaWorkload]; workload != "" {
 				serviceTagIdentities[workload] = struct{}{}
 			}

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/v3/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
+	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v3/pkg/util/maps"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	util_time "github.com/kumahq/kuma/v3/pkg/util/time"
@@ -300,7 +301,18 @@ func (s *StatusUpdater) buildIdentities(dpps []*core_mesh.DataplaneResource, mes
 	serviceTagIdentities := map[string]struct{}{}
 	spiffeIDs := map[string]struct{}{}
 	for _, dpp := range dpps {
-		for service := range dpp.Spec.TagSet()[mesh_proto.ServiceTag] {
+		tagIdentities := dpp.Spec.TagSet()[mesh_proto.ServiceTag]
+		if len(tagIdentities) == 0 {
+			// TagSet() is empty once Experimental.InboundTagsDisabled strips
+			// inbound tags. Fall back to the same workload label the mTLS
+			// identity path and MeshService generation already use, so this
+			// dataplane still gets a verifiable identity instead of silently
+			// falling out of Spec.Identities.
+			if workload := dpp.GetMeta().GetLabels()[metadata.KumaWorkload]; workload != "" {
+				serviceTagIdentities[workload] = struct{}{}
+			}
+		}
+		for service := range tagIdentities {
 			serviceTagIdentities[service] = struct{}{}
 		}
 		for _, identity := range meshidentity_api.AllMatched(dpp.Meta.GetLabels(), meshIdentities) {

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -152,6 +152,35 @@ var _ = Describe("Updater", func() {
 		}, "10s", "100ms").Should(Succeed())
 	})
 
+	It("should fall back to the workload label for identity when inbound tags are disabled", func() {
+		// when
+		Expect(builders.MeshService().
+			WithName("backend").
+			WithDataplaneLabelsSelector(map[string]string{
+				metadata.KumaWorkload: "backend",
+			}).
+			AddIntPort(int32(builders.FirstInboundPort), int32(builders.FirstInboundPort), "http").
+			Create(resManager)).To(Succeed())
+		taglessDpp := samples.DataplaneBackendBuilder().Build()
+		taglessDpp.Spec.Networking.Inbound[0].Tags = map[string]string{}
+		Expect(resManager.Create(context.TODO(), taglessDpp, store.CreateByKey("dp-1", model.DefaultMesh), store.CreateWithLabels(map[string]string{
+			metadata.KumaWorkload: "backend",
+		}))).To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			ms := meshservice_api.NewMeshServiceResource()
+			err := resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(ms.Spec.Identities).To(Equal(&[]meshservice_api.MeshServiceIdentity{
+				{
+					Type:  meshservice_api.MeshServiceIdentityServiceTagType,
+					Value: "backend",
+				},
+			}))
+		}, "10s", "100ms").Should(Succeed())
+	})
+
 	It("should not override identity to status of service from another zone", func() {
 		// when
 		Expect(samples.MeshServiceBackendBuilder().


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshservice): identities fallback tagless

Found while investigating multizone e2e failures on kumahq/kuma#17596 (an exploratory PR flipping `Experimental.InboundTagsDisabled`'s default). `MeshMultiZoneService` and `MeshIdentity Migration` tests failed with 503s ("no healthy upstream") reproduced identically across kindIpv6/v1.34.9/v1.35.3.

`buildIdentities()` in `pkg/core/resources/apis/meshservice/status/updater.go` computes `MeshService.Spec.Identities` purely from `Dataplane.TagSet()`. Once `InboundTagsDisabled` strips inbound tags, `TagSet()` is empty, so this silently produces zero `ServiceTag` identities for any mesh not using `MeshIdentity`.

This is the same class of bug as two already-merged fixes on this theme:
- #17606 — mTLS cert issuance had no workload-label fallback, producing certs with no CN/SAN.
- #17610 — the K8s gateway validator hard-required `kuma.io/service` even with empty gateway tags.

Downstream, an empty `Spec.Identities` list widens `ClientSideMultiIdentitiesMTLS`'s SAN validation to a mesh-wide `spiffe://<mesh>/` prefix match (`pkg/xds/envoy/tls/v3/tls.go:52-54`) instead of the intended per-service check — a real identity-verification gap, and the most likely contributing cause to the multizone 503s (not yet confirmed as the sole cause via live reproduction, but a genuine regression regardless).

## Implementation information

- `buildIdentities()` now falls back to the `kuma.io/workload` label — the same identity source already used for mTLS cert issuance (`pkg/xds/secrets/identity_tags.go`) and MeshService generation (`pkg/core/resources/apis/meshservice/generate/generator.go`) — when a dataplane's `TagSet()` has no `kuma.io/service` values.
- Added a unit test covering the tagless-dataplane fallback in `pkg/core/resources/apis/meshservice/status/updater_test.go`.

## Supporting documentation

Will need backporting to `release-2.14`.