### PR TITLE
fix(meshservice): identities fallback tagless

### DIFF
--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/v2/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/v2/pkg/metrics"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v2/pkg/util/maps"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 	util_time "github.com/kumahq/kuma/v2/pkg/util/time"
@@ -300,7 +301,18 @@ func (s *StatusUpdater) buildIdentities(dpps []*core_mesh.DataplaneResource, mes
 	serviceTagIdentities := map[string]struct{}{}
 	spiffeIDs := map[string]struct{}{}
 	for _, dpp := range dpps {
-		for service := range dpp.Spec.TagSet()[mesh_proto.ServiceTag] {
+		tagIdentities := dpp.Spec.TagSet()[mesh_proto.ServiceTag]
+		if len(tagIdentities) == 0 {
+			// TagSet() is empty once Experimental.InboundTagsDisabled strips
+			// inbound tags. Fall back to the same workload label the mTLS
+			// identity path and MeshService generation already use, so this
+			// dataplane still gets a verifiable identity instead of silently
+			// falling out of Spec.Identities.
+			if workload := dpp.GetMeta().GetLabels()[metadata.KumaWorkload]; workload != "" {
+				serviceTagIdentities[workload] = struct{}{}
+			}
+		}
+		for service := range tagIdentities {
 			serviceTagIdentities[service] = struct{}{}
 		}
 		for _, identity := range meshidentity_api.AllMatched(dpp.Meta.GetLabels(), meshIdentities) {

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -303,11 +303,9 @@ func (s *StatusUpdater) buildIdentities(dpps []*core_mesh.DataplaneResource, mes
 	for _, dpp := range dpps {
 		tagIdentities := dpp.Spec.TagSet()[mesh_proto.ServiceTag]
 		if len(tagIdentities) == 0 {
-			// TagSet() is empty once Experimental.InboundTagsDisabled strips
-			// inbound tags. Fall back to the same workload label the mTLS
-			// identity path and MeshService generation already use, so this
-			// dataplane still gets a verifiable identity instead of silently
-			// falling out of Spec.Identities.
+			// No kuma.io/service tag once Experimental.InboundTagsDisabled
+			// strips inbound tags. Fall back to the workload label, same as
+			// the mTLS identity path and MeshService generation.
 			if workload := dpp.GetMeta().GetLabels()[metadata.KumaWorkload]; workload != "" {
 				serviceTagIdentities[workload] = struct{}{}
 			}

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -152,6 +152,35 @@ var _ = Describe("Updater", func() {
 		}, "10s", "100ms").Should(Succeed())
 	})
 
+	It("should fall back to the workload label for identity when inbound tags are disabled", func() {
+		// when
+		Expect(builders.MeshService().
+			WithName("backend").
+			WithDataplaneLabelsSelector(map[string]string{
+				metadata.KumaWorkload: "backend",
+			}).
+			AddIntPort(int32(builders.FirstInboundPort), int32(builders.FirstInboundPort), "http").
+			Create(resManager)).To(Succeed())
+		taglessDpp := samples.DataplaneBackendBuilder().Build()
+		taglessDpp.Spec.Networking.Inbound[0].Tags = map[string]string{}
+		Expect(resManager.Create(context.TODO(), taglessDpp, store.CreateByKey("dp-1", model.DefaultMesh), store.CreateWithLabels(map[string]string{
+			metadata.KumaWorkload: "backend",
+		}))).To(Succeed())
+
+		// then
+		Eventually(func(g Gomega) {
+			ms := meshservice_api.NewMeshServiceResource()
+			err := resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(ms.Spec.Identities).To(Equal(&[]meshservice_api.MeshServiceIdentity{
+				{
+					Type:  meshservice_api.MeshServiceIdentityServiceTagType,
+					Value: "backend",
+				},
+			}))
+		}, "10s", "100ms").Should(Succeed())
+	})
+
 	It("should not override identity to status of service from another zone", func() {
 		// when
 		Expect(samples.MeshServiceBackendBuilder().


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshservice): identities fallback tagless

Backport of #17657 to release-2.14.

`buildIdentities()` in `pkg/core/resources/apis/meshservice/status/updater.go` computes `MeshService.Spec.Identities` purely from `Dataplane.TagSet()`. Once `InboundTagsDisabled` strips inbound tags, `TagSet()` is empty, so this silently produces zero `ServiceTag` identities for any mesh not using `MeshIdentity`. Downstream, an empty `Spec.Identities` list widens `ClientSideMultiIdentitiesMTLS`'s SAN validation to a mesh-wide `spiffe://<mesh>/` prefix match instead of the intended per-service check.

## Implementation information

Ported directly (`v2` module path, otherwise identical to master's `buildIdentities` — no other drift in the touched files).

- `buildIdentities()` now falls back to the `kuma.io/workload` label when a dataplane's `TagSet()` has no `kuma.io/service` values.
- Added the same unit test covering the tagless-dataplane fallback.

## Supporting documentation

Source PR: kumahq/kuma#17657