### PR TITLE
refactor(targetref): remove proxyTypes field

### DIFF
--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -149,14 +149,14 @@ func selectsLabels(tr TargetRef) bool {
 // IncludesGateways reports whether a policy attached with this targetRef could
 // apply to a Gateway-type dataplane. Kind: Mesh (and the legacy MeshSubset) has
 // no way to exclude gateways, so it always includes them; Kind: Dataplane only
-// includes gateways when it explicitly selects them via the computed
-// kuma.io/proxy-type label; MeshHTTPRoute is always gateway-routing.
+// excludes gateways when it explicitly constrains kuma.io/proxy-type to
+// sidecar; MeshHTTPRoute is always gateway-routing.
 func IncludesGateways(ref TargetRef) bool {
 	switch ref.Kind {
 	case Mesh, meshSubset, MeshHTTPRoute:
 		return true
 	case Dataplane:
-		return pointer.Deref(ref.Labels)[mesh_proto.ProxyTypeLabel] == string(mesh_proto.GatewayLabel)
+		return pointer.Deref(ref.Labels)[mesh_proto.ProxyTypeLabel] != string(mesh_proto.SidecarLabel)
 	default:
 		return false
 	}

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -3,10 +3,10 @@ package v1alpha1
 
 import (
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	util_maps "github.com/kumahq/kuma/v3/pkg/util/maps"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
@@ -54,14 +54,6 @@ var order = map[TargetRefKind]int{
 	meshServiceSubset:    8,
 	MeshHTTPRoute:        9,
 }
-
-// +kubebuilder:validation:Enum=Sidecar;Gateway
-type TargetRefProxyType string
-
-var (
-	Sidecar TargetRefProxyType = "Sidecar"
-	Gateway TargetRefProxyType = "Gateway"
-)
 
 func (k TargetRefKind) Compare(o TargetRefKind) int {
 	return order[k] - order[o]
@@ -116,9 +108,6 @@ type TargetRef struct {
 	Tags *map[string]string `json:"tags,omitempty"`
 	// Mesh is reserved for future use to identify cross mesh resources.
 	Mesh *string `json:"mesh,omitempty"`
-	// ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-	// all data plane types are targeted by the policy.
-	ProxyTypes *[]TargetRefProxyType `json:"proxyTypes,omitempty"`
 	// Namespace specifies the namespace of target resource. If empty only resources in policy namespace
 	// will be targeted.
 	Namespace *string `json:"namespace,omitempty"`
@@ -157,13 +146,20 @@ func selectsLabels(tr TargetRef) bool {
 	return tr.Labels != nil
 }
 
+// IncludesGateways reports whether a policy attached with this targetRef could
+// apply to a Gateway-type dataplane. Kind: Mesh (and the legacy MeshSubset) has
+// no way to exclude gateways, so it always includes them; Kind: Dataplane only
+// includes gateways when it explicitly selects them via the computed
+// kuma.io/proxy-type label; MeshHTTPRoute is always gateway-routing.
 func IncludesGateways(ref TargetRef) bool {
-	isMeshKind := ref.Kind == Mesh || ref.Kind == meshSubset
-	isGatewayInProxyTypes := len(pointer.Deref(ref.ProxyTypes)) == 0 || slices.Contains(pointer.Deref(ref.ProxyTypes), Gateway)
-	isGatewayCompatible := isMeshKind && isGatewayInProxyTypes
-	isMeshHTTPRoute := ref.Kind == MeshHTTPRoute
-
-	return isGatewayCompatible || isMeshHTTPRoute
+	switch ref.Kind {
+	case Mesh, meshSubset, MeshHTTPRoute:
+		return true
+	case Dataplane:
+		return pointer.Deref(ref.Labels)[mesh_proto.ProxyTypeLabel] == string(mesh_proto.GatewayLabel)
+	default:
+		return false
+	}
 }
 
 // +kubebuilder:validation:Enum=MeshOpenTelemetryBackend

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -2,6 +2,8 @@ package v1alpha1
 
 import (
 	"testing"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 )
 
 func TestIncludesGateways(t *testing.T) {
@@ -27,6 +29,17 @@ func TestIncludesGateways(t *testing.T) {
 			ref: TargetRef{
 				Kind:   Dataplane,
 				Labels: &map[string]string{"kuma.io/service": "backend"},
+			},
+			expected: false,
+		},
+		"dataplane with a gateway proxy-type label still excludes gateways": {
+			// Kind: Dataplane never distinguished gateways even when
+			// proxyTypes existed (the field was never valid on it), and
+			// this label doesn't resurrect that: a targetRef can no longer
+			// scope a policy's rules[]/to[] to gateways-only at all.
+			ref: TargetRef{
+				Kind:   Dataplane,
+				Labels: &map[string]string{mesh_proto.ProxyTypeLabel: string(mesh_proto.GatewayLabel)},
 			},
 			expected: false,
 		},

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -1,0 +1,64 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+)
+
+func TestIncludesGateways(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		ref      TargetRef
+		expected bool
+	}{
+		"mesh includes gateways": {
+			ref:      TargetRef{Kind: Mesh},
+			expected: true,
+		},
+		"mesh http route includes gateways": {
+			ref:      TargetRef{Kind: MeshHTTPRoute},
+			expected: true,
+		},
+		"dataplane without labels includes gateways": {
+			ref:      TargetRef{Kind: Dataplane},
+			expected: true,
+		},
+		"dataplane with non proxy type labels includes gateways": {
+			ref: TargetRef{
+				Kind:   Dataplane,
+				Labels: &map[string]string{"kuma.io/service": "backend"},
+			},
+			expected: true,
+		},
+		"dataplane with gateway proxy type includes gateways": {
+			ref: TargetRef{
+				Kind:   Dataplane,
+				Labels: &map[string]string{mesh_proto.ProxyTypeLabel: string(mesh_proto.GatewayLabel)},
+			},
+			expected: true,
+		},
+		"dataplane with sidecar proxy type excludes gateways": {
+			ref: TargetRef{
+				Kind:   Dataplane,
+				Labels: &map[string]string{mesh_proto.ProxyTypeLabel: string(mesh_proto.SidecarLabel)},
+			},
+			expected: false,
+		},
+		"mesh service excludes gateways": {
+			ref:      TargetRef{Kind: MeshService},
+			expected: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IncludesGateways(tt.ref); got != tt.expected {
+				t.Fatalf("IncludesGateways() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/api/common/v1alpha1/zz_generated.deepcopy.go
+++ b/api/common/v1alpha1/zz_generated.deepcopy.go
@@ -260,15 +260,6 @@ func (in *TargetRef) DeepCopyInto(out *TargetRef) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.ProxyTypes != nil {
-		in, out := &in.ProxyTypes, &out.ProxyTypes
-		*out = new([]TargetRefProxyType)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]TargetRefProxyType, len(*in))
-			copy(*out, *in)
-		}
-	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
 		*out = new(string)

--- a/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.json
+++ b/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.json
@@ -14,10 +14,7 @@
   "kri": "kri_mt_default_my-zone_kong-mesh-system_timeout-2_",
   "spec": {
     "targetRef": {
-      "kind": "Mesh",
-      "proxyTypes": [
-        "Gateway"
-      ]
+      "kind": "Mesh"
     },
     "to": [
       {

--- a/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.json
+++ b/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.json
@@ -14,7 +14,10 @@
   "kri": "kri_mt_default_my-zone_kong-mesh-system_timeout-2_",
   "spec": {
     "targetRef": {
-      "kind": "Mesh"
+      "kind": "Dataplane",
+      "labels": {
+        "kuma.io/proxy-type": "gateway"
+      }
     },
     "to": [
       {

--- a/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.yaml
@@ -12,8 +12,6 @@ name: meshtimeout-1
 spec:
   targetRef:
     kind: Mesh
-    proxyTypes:
-    - Gateway
   to:
   - default:
       http:

--- a/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/get/get-meshtimeout.golden.yaml
@@ -11,7 +11,9 @@ modificationTime: "0001-01-01T00:00:00Z"
 name: meshtimeout-1
 spec:
   targetRef:
-    kind: Mesh
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: gateway
   to:
   - default:
       http:

--- a/app/kumactl/cmd/get/testdata/list/get-meshtimeouts.golden.json
+++ b/app/kumactl/cmd/get/testdata/list/get-meshtimeouts.golden.json
@@ -49,10 +49,10 @@
       "kri": "kri_mt_default_my-zone_kong-mesh-system_timeout-2_",
       "spec": {
         "targetRef": {
-          "kind": "Mesh",
-          "proxyTypes": [
-            "Gateway"
-          ]
+          "kind": "Dataplane",
+          "labels": {
+            "kuma.io/proxy-type": "gateway"
+          }
         },
         "to": [
           {

--- a/app/kumactl/cmd/get/testdata/list/get-meshtimeouts.golden.yaml
+++ b/app/kumactl/cmd/get/testdata/list/get-meshtimeouts.golden.yaml
@@ -33,9 +33,9 @@ items:
   name: timeout-2-dz449dwd8fw4486x
   spec:
     targetRef:
-      kind: Mesh
-      proxyTypes:
-      - Gateway
+      kind: Dataplane
+      labels:
+        kuma.io/proxy-type: gateway
     to:
     - default:
         http:

--- a/app/kumactl/cmd/get/testdata/list/get-meshtimeouts.input.yaml
+++ b/app/kumactl/cmd/get/testdata/list/get-meshtimeouts.input.yaml
@@ -31,9 +31,9 @@ modificationTime: "2024-02-08T14:48:32.698089Z"
 name: timeout-2-dz449dwd8fw4486x
 spec:
   targetRef:
-    kind: Mesh
-    proxyTypes:
-    - Gateway
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: gateway
   to:
   - default:
       http:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -291,16 +291,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -381,16 +371,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -510,16 +490,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -839,16 +809,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -1305,16 +1265,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -1667,16 +1617,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -1981,16 +1921,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -2618,16 +2548,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3166,16 +3086,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3462,16 +3372,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3650,16 +3550,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -3850,16 +3740,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4237,16 +4117,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -4601,16 +4471,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4686,16 +4546,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -4760,16 +4610,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -4994,16 +4834,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5114,16 +4944,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -5299,16 +5119,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5603,16 +5413,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5922,16 +5722,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -6983,16 +6773,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7226,16 +7006,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -7654,16 +7424,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7971,16 +7731,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -8633,16 +8383,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -8781,16 +8521,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -8909,16 +8639,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -9176,16 +8896,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -291,16 +291,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -381,16 +371,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -510,16 +490,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -839,16 +809,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -1305,16 +1265,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -1667,16 +1617,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -1981,16 +1921,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -2618,16 +2548,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3166,16 +3086,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3462,16 +3372,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3650,16 +3550,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -3850,16 +3740,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4237,16 +4117,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -4601,16 +4471,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4686,16 +4546,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -4760,16 +4610,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -4994,16 +4834,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5114,16 +4944,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -5299,16 +5119,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5603,16 +5413,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5922,16 +5722,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -6983,16 +6773,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7226,16 +7006,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -7654,16 +7424,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7971,16 +7731,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -8633,16 +8383,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -8781,16 +8521,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -8909,16 +8639,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -9176,16 +8896,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -311,16 +311,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -401,16 +391,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -530,16 +510,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -859,16 +829,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -1325,16 +1285,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -1687,16 +1637,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -2001,16 +1941,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -2638,16 +2568,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3186,16 +3106,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3482,16 +3392,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3670,16 +3570,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -3870,16 +3760,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4257,16 +4137,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -4621,16 +4491,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4706,16 +4566,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -4780,16 +4630,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -5014,16 +4854,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5134,16 +4964,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -5319,16 +5139,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5623,16 +5433,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5942,16 +5742,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7003,16 +6793,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7246,16 +7026,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -7674,16 +7444,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7991,16 +7751,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -8653,16 +8403,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -8801,16 +8541,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -8929,16 +8659,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -9196,16 +8916,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -651,16 +651,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -894,16 +884,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -1322,16 +1302,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -1639,16 +1609,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -2301,16 +2261,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -2449,16 +2399,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -2577,16 +2517,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -2844,16 +2774,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -2974,16 +2894,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -3064,16 +2974,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -3193,16 +3093,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -3522,16 +3412,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -3988,16 +3868,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -4350,16 +4220,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -4664,16 +4524,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5301,16 +5151,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -5849,16 +5689,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -6145,16 +5975,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -6333,16 +6153,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -6461,16 +6271,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -6848,16 +6648,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -7212,16 +7002,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7297,16 +7077,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -7371,16 +7141,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -7605,16 +7365,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -7725,16 +7475,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -7910,16 +7650,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -8214,16 +7944,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -8533,16 +8253,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshaccesslogs.yaml
@@ -321,16 +321,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -564,16 +554,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshcircuitbreakers.yaml
@@ -348,16 +348,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -665,16 +655,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshfaultinjections.yaml
@@ -224,16 +224,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -372,16 +362,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -92,16 +92,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -359,16 +349,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -184,16 +174,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -313,16 +293,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -642,16 +612,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -456,16 +446,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshmetrics.yaml
@@ -278,16 +278,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshpassthroughs.yaml
@@ -145,16 +145,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -516,16 +516,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshratelimits.yaml
@@ -262,16 +262,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -450,16 +440,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshretries.yaml
@@ -92,16 +92,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -479,16 +469,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -179,16 +169,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -253,16 +233,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtimeouts.yaml
@@ -196,16 +196,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -316,16 +306,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtlses.yaml
@@ -149,16 +149,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -272,16 +272,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtrafficpermissions.yaml
@@ -244,16 +244,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -6448,18 +6448,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -6728,18 +6716,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -7401,18 +7377,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -7953,18 +7917,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -8252,18 +8204,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -8437,18 +8377,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -8589,18 +8517,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -8698,20 +8614,6 @@ components:
                                       refers to a real MeshService object
                                     format: int32
                                     type: integer
-                                  proxyTypes:
-                                    description: >-
-                                      ProxyTypes specifies the data plane types
-                                      that are subject to the policy. When not
-                                      specified,
-
-                                      all data plane types are targeted by the
-                                      policy.
-                                    items:
-                                      enum:
-                                        - Sidecar
-                                        - Gateway
-                                      type: string
-                                    type: array
                                   sectionName:
                                     description: >-
                                       SectionName is used to target specific
@@ -8851,20 +8753,6 @@ components:
                                               refers to a real MeshService object
                                             format: int32
                                             type: integer
-                                          proxyTypes:
-                                            description: >-
-                                              ProxyTypes specifies the data plane
-                                              types that are subject to the policy.
-                                              When not specified,
-
-                                              all data plane types are targeted by the
-                                              policy.
-                                            items:
-                                              enum:
-                                                - Sidecar
-                                                - Gateway
-                                              type: string
-                                            type: array
                                           sectionName:
                                             description: >-
                                               SectionName is used to target specific
@@ -9246,18 +9134,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -9389,18 +9265,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -9749,18 +9613,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -9894,18 +9746,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -10397,18 +10237,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -10756,18 +10584,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -11006,18 +10822,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -11713,18 +11517,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -12044,18 +11836,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -12266,18 +12046,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -12408,18 +12176,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -12924,18 +12680,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -13075,18 +12819,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -13181,20 +12913,6 @@ components:
                                       refers to a real MeshService object
                                     format: int32
                                     type: integer
-                                  proxyTypes:
-                                    description: >-
-                                      ProxyTypes specifies the data plane types
-                                      that are subject to the policy. When not
-                                      specified,
-
-                                      all data plane types are targeted by the
-                                      policy.
-                                    items:
-                                      enum:
-                                        - Sidecar
-                                        - Gateway
-                                      type: string
-                                    type: array
                                   sectionName:
                                     description: >-
                                       SectionName is used to target specific
@@ -13274,18 +12992,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -13483,18 +13189,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -13763,18 +13457,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -13931,18 +13613,6 @@ components:
 
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: >-
-                          ProxyTypes specifies the data plane types that are
-                          subject to the policy. When not specified,
-
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: >-
                           SectionName is used to target specific section of
@@ -14311,18 +13981,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.
@@ -14677,18 +14335,6 @@ components:
 
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: >-
-                    ProxyTypes specifies the data plane types that are subject
-                    to the policy. When not specified,
-
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: >-
                     SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshaccesslogs.yaml
@@ -321,16 +321,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -564,16 +554,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshcircuitbreakers.yaml
@@ -348,16 +348,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -665,16 +655,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshfaultinjections.yaml
@@ -224,16 +224,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -372,16 +362,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -92,16 +92,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -359,16 +349,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -184,16 +174,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -313,16 +293,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -642,16 +612,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -456,16 +446,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshmetrics.yaml
@@ -278,16 +278,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshpassthroughs.yaml
@@ -145,16 +145,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
@@ -516,16 +516,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshratelimits.yaml
@@ -262,16 +262,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -450,16 +440,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshretries.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshretries.yaml
@@ -92,16 +92,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -479,16 +469,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -179,16 +169,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -253,16 +233,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtimeouts.yaml
@@ -196,16 +196,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -316,16 +306,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshtlses.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtlses.yaml
@@ -149,16 +149,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -272,16 +272,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtrafficpermissions.yaml
@@ -244,16 +244,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/pkg/core/resources/apis/mesh/validators.go
+++ b/pkg/core/resources/apis/mesh/validators.go
@@ -382,11 +382,9 @@ func ValidateTargetRef(
 		err.Add(disallowedField("labels", pointer.Deref(ref.Labels), ref.Kind))
 		err.Add(disallowedField("namespace", pointer.Deref(ref.Namespace), ref.Kind))
 		err.Add(disallowedField("sectionName", pointer.Deref(ref.SectionName), ref.Kind))
-		err.Add(validateProxyTypes("proxyTypes", ref.ProxyTypes))
 	case common_api.Dataplane:
 		err.Add(disallowedField("tags", pointer.Deref(ref.Tags), ref.Kind))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
-		err.Add(disallowedField("proxyTypes", pointer.Deref(ref.ProxyTypes), ref.Kind))
 		if len(pointer.Deref(ref.Labels)) > 0 && (pointer.Deref(ref.Name) != "" || pointer.Deref(ref.Namespace) != "") {
 			err.AddViolation("labels", "either labels or name and namespace must be specified")
 		}
@@ -400,12 +398,10 @@ func ValidateTargetRef(
 		err.Add(disallowedField("labels", pointer.Deref(ref.Labels), ref.Kind))
 		err.Add(disallowedField("namespace", pointer.Deref(ref.Namespace), ref.Kind))
 		err.Add(disallowedField("sectionName", pointer.Deref(ref.SectionName), ref.Kind))
-		err.Add(validateProxyTypes("proxyTypes", ref.ProxyTypes))
 	case common_api.MeshService:
 		err.Add(validateName(pointer.Deref(ref.Name), opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
 		err.Add(disallowedField("tags", pointer.Deref(ref.Tags), ref.Kind))
-		err.Add(disallowedField("proxyTypes", pointer.Deref(ref.ProxyTypes), ref.Kind))
 		if len(pointer.Deref(ref.Labels)) == 0 && pointer.Deref(ref.Name) == "" {
 			err.AddViolation("", fmt.Sprintf("name or labels must be set when kind is %v", ref.Kind))
 		}
@@ -416,7 +412,6 @@ func ValidateTargetRef(
 		err.Add(validateName(pointer.Deref(ref.Name), opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
 		err.Add(disallowedField("tags", pointer.Deref(ref.Tags), ref.Kind))
-		err.Add(disallowedField("proxyTypes", pointer.Deref(ref.ProxyTypes), ref.Kind))
 		err.Add(disallowedField("sectionName", pointer.Deref(ref.SectionName), ref.Kind))
 		if len(pointer.Deref(ref.Labels)) == 0 && pointer.Deref(ref.Name) == "" {
 			err.AddViolation("", fmt.Sprintf("name or labels must be set when kind is %v", ref.Kind))
@@ -428,7 +423,6 @@ func ValidateTargetRef(
 		err.Add(requiredField("name", pointer.Deref(ref.Name), ref.Kind))
 		err.Add(validateName(pointer.Deref(ref.Name), opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
-		err.Add(disallowedField("proxyTypes", pointer.Deref(ref.ProxyTypes), ref.Kind))
 		err.Add(ValidateSelector(validators.RootedAt("tags"), pointer.Deref(ref.Tags), ValidateTagsOpts{}))
 		err.Add(disallowedField("labels", pointer.Deref(ref.Labels), ref.Kind))
 		err.Add(disallowedField("namespace", pointer.Deref(ref.Namespace), ref.Kind))
@@ -437,7 +431,6 @@ func ValidateTargetRef(
 		err.Add(validateName(pointer.Deref(ref.Name), opts.AllowedInvalidNames))
 		err.Add(disallowedField("mesh", pointer.Deref(ref.Mesh), ref.Kind))
 		err.Add(disallowedField("tags", pointer.Deref(ref.Tags), ref.Kind))
-		err.Add(disallowedField("proxyTypes", pointer.Deref(ref.ProxyTypes), ref.Kind))
 		if len(pointer.Deref(ref.Labels)) == 0 && pointer.Deref(ref.Name) == "" {
 			err.AddViolation("", fmt.Sprintf("name or labels must be set when kind is %v", ref.Kind))
 		}
@@ -477,16 +470,6 @@ func ValidateMatch(match common_api.Match) validators.ValidationError {
 	return verr
 }
 
-func validateProxyTypes(field string, proxyTypes *[]common_api.TargetRefProxyType) validators.ValidationError {
-	var err validators.ValidationError
-
-	if proxyTypes != nil && len(pointer.Deref(proxyTypes)) == 0 {
-		err.AddViolation(field, "must be undefined or have at least one element")
-	}
-
-	return err
-}
-
 func validateName(value string, allowedInvalidNames []string) validators.ValidationError {
 	var err validators.ValidationError
 
@@ -500,7 +483,7 @@ func validateName(value string, allowedInvalidNames []string) validators.Validat
 	return err
 }
 
-func disallowedField[T ~string | ~map[string]string | ~[]common_api.TargetRefProxyType](
+func disallowedField[T ~string | ~map[string]string](
 	name string,
 	value T,
 	kind common_api.TargetRefKind,
@@ -528,13 +511,11 @@ func requiredField[T ~string | ~map[string]string](
 	return err
 }
 
-func isSet[T ~string | ~map[string]string | ~[]common_api.TargetRefProxyType](value T) bool {
+func isSet[T ~string | ~map[string]string](value T) bool {
 	switch v := any(value).(type) {
 	case string:
 		return v != ""
 	case map[string]string:
-		return len(v) > 0
-	case []common_api.TargetRefProxyType:
 		return len(v) > 0
 	default:
 		return false

--- a/pkg/core/resources/apis/mesh/validators_test.go
+++ b/pkg/core/resources/apis/mesh/validators_test.go
@@ -550,79 +550,6 @@ violations:
     message: "invalid characters: must consist of lower case alphanumeric characters, '-', '.' and '_'."
 `,
 		}),
-		Entry("MeshService with proxyTypes", testCase{
-			inputYaml: `
-kind: MeshService
-name: "test"
-proxyTypes: ["Sidecar"]
-`,
-			opts: &ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					common_api.MeshService,
-				},
-			},
-			expected: `
-violations:
-  - field: targetRef.proxyTypes
-    message: must not be set with kind MeshService
-`,
-		}),
-		Entry("MeshServiceSubset with proxyTypes", testCase{
-			inputYaml: `
-kind: MeshServiceSubset
-name: "test"
-proxyTypes: ["Sidecar"]
-`,
-			opts: &ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					"MeshServiceSubset",
-				},
-			},
-			expected: `
-violations:
-  - field: targetRef.proxyTypes
-    message: must not be set with kind MeshServiceSubset
-`,
-		}),
-		Entry("Mesh with empty proxyTypes", testCase{
-			inputYaml: `
-kind: Mesh
-proxyTypes: []
-`,
-			opts: &ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					common_api.Mesh,
-				},
-			},
-			expected: `
-violations:
-  - field: targetRef.proxyTypes
-    message: must be undefined or have at least one element
-`,
-		}),
-		Entry("Mesh with one proxyTypes", testCase{
-			inputYaml: `
-kind: Mesh
-proxyTypes: ["Sidecar"]
-`,
-			opts: &ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					common_api.Mesh,
-				},
-			},
-			expected: "violations: null",
-		}),
-		Entry("Mesh with no proxyTypes", testCase{
-			inputYaml: `
-kind: Mesh
-`,
-			opts: &ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					common_api.Mesh,
-				},
-			},
-			expected: "violations: null",
-		}),
 		Entry("MeshGateway when it's not supported", testCase{
 			inputYaml: `
 kind: MeshGateway
@@ -931,25 +858,7 @@ violations:
   message: must not be set with kind Dataplane
 `,
 		}),
-		Entry("Dataplane with proxyTypes", testCase{
-			inputYaml: `
-kind: Dataplane
-name: test
-namespace: test-ns
-proxyTypes: ["Sidecar"]
-`,
-			opts: &ValidateTargetRefOpts{
-				SupportedKinds: []common_api.TargetRefKind{
-					common_api.Dataplane,
-				},
-			},
-			expected: `
-violations:
-- field: targetRef.proxyTypes
-  message: must not be set with kind Dataplane
-`,
-		}),
-		Entry("Dataplane with proxyTypes", testCase{
+		Entry("Dataplane with sectionName on a non-inbound policy", testCase{
 			inputYaml: `
 kind: Dataplane
 name: test

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -10,8 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
@@ -67,8 +65,8 @@ func EnsureDefaultMeshResources(
 	if err := migrateCombinedMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
 		return errors.Wrap(err, "could not migrate legacy combined default MeshTimeout resources")
 	}
-	if err := migrateMeshTimeoutTargetRefProxyTypes(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
-		return errors.Wrap(err, "could not migrate default MeshTimeout targetRef from proxyTypes to dataplane labels")
+	if err := migrateGatewayMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
+		return errors.Wrap(err, "could not migrate legacy gateway-specific default MeshTimeout resources")
 	}
 	if slices.Contains(skippedPolicies, "*") {
 		logger.Info("skipping all default policy creation")
@@ -76,12 +74,10 @@ func EnsureDefaultMeshResources(
 	}
 
 	defaultResourceBuilders := map[string]func() model.Resource{
-		"mesh-gateways-timeout-all":    defaulMeshGatewaysTimeoutResource,
-		"mesh-gateways-timeout-to-all": defaulMeshGatewaysTimeoutToResource,
-		"mesh-timeout-all":             defaultMeshTimeoutResource,
-		"mesh-timeout-to-all":          defaultMeshTimeoutToResource,
-		"mesh-circuit-breaker-all":     defaultMeshCircuitBreakerResource,
-		"mesh-retry-all":               defaultMeshRetryResource,
+		"mesh-timeout-all":         defaultMeshTimeoutResource,
+		"mesh-timeout-to-all":      defaultMeshTimeoutToResource,
+		"mesh-circuit-breaker-all": defaultMeshCircuitBreakerResource,
+		"mesh-retry-all":           defaultMeshRetryResource,
 	}
 	for prefix, resourceBuilder := range defaultResourceBuilders {
 		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)
@@ -133,7 +129,7 @@ func migrateCombinedMeshTimeoutDefaults(
 	systemNamespace string,
 	logger logr.Logger,
 ) error {
-	for _, prefix := range []string{"mesh-timeout-all", "mesh-gateways-timeout-all"} {
+	for _, prefix := range []string{"mesh-timeout-all"} {
 		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)
 		if k8sStore {
 			resourceName = fmt.Sprintf("%s.%s", resourceName, systemNamespace)
@@ -159,16 +155,14 @@ func migrateCombinedMeshTimeoutDefaults(
 	return nil
 }
 
-// migrateMeshTimeoutTargetRefProxyTypes rewrites default MeshTimeout resources
-// persisted by CP versions that selected sidecars/gateways via
-// TargetRef{Kind: Mesh, ProxyTypes: [...]} to the current
-// TargetRef{Kind: Dataplane, Labels: {kuma.io/proxy-type: ...}} shape.
-// Without this, ensureDefaultResource's label-healing Get() unmarshals the
-// legacy stored spec onto the new default's pre-populated struct (JSON
-// unmarshal reuses existing pointers instead of replacing them), so a field
-// absent from the legacy JSON (labels) would survive alongside a field
-// restored from it (kind: Mesh), producing an invalid combination.
-func migrateMeshTimeoutTargetRefProxyTypes(
+// migrateGatewayMeshTimeoutDefaults removes the gateway-specific default
+// MeshTimeout resources persisted by CP versions that split sidecar/gateway
+// defaults into separate resources. A single mesh-wide default now applies to
+// every proxy type, so the gateway-specific resources are deleted rather than
+// migrated, and any leftover proxyTypes restriction on the surviving
+// mesh-timeout-all/mesh-timeout-to-all resources is cleared so they go back
+// to applying mesh-wide.
+func migrateGatewayMeshTimeoutDefaults(
 	ctx context.Context,
 	resManager manager.ResourceManager,
 	meshName string,
@@ -176,20 +170,27 @@ func migrateMeshTimeoutTargetRefProxyTypes(
 	systemNamespace string,
 	logger logr.Logger,
 ) error {
-	proxyTypeByPrefix := map[string]mesh_proto.ProxyTypeLabelValues{
-		"mesh-timeout-all":             mesh_proto.SidecarLabel,
-		"mesh-timeout-to-all":          mesh_proto.SidecarLabel,
-		"mesh-gateways-timeout-all":    mesh_proto.GatewayLabel,
-		"mesh-gateways-timeout-to-all": mesh_proto.GatewayLabel,
-	}
-
-	for prefix, proxyType := range proxyTypeByPrefix {
+	resourceKey := func(prefix string) model.ResourceKey {
 		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)
 		if k8sStore {
 			resourceName = fmt.Sprintf("%s.%s", resourceName, systemNamespace)
 		}
-		key := model.ResourceKey{Mesh: meshName, Name: resourceName}
+		return model.ResourceKey{Mesh: meshName, Name: resourceName}
+	}
 
+	for _, prefix := range []string{"mesh-gateways-timeout-all", "mesh-gateways-timeout-to-all"} {
+		key := resourceKey(prefix)
+		if err := resManager.Delete(ctx, v1alpha1.NewMeshTimeoutResource(), store.DeleteBy(key)); err != nil {
+			if store.IsNotFound(err) {
+				continue
+			}
+			return errors.Wrapf(err, "could not delete legacy default MeshTimeout %q", key.Name)
+		}
+		logger.Info("deleted legacy gateway-specific default MeshTimeout, a single default now applies to every proxy type", "name", key.Name)
+	}
+
+	for _, prefix := range []string{"mesh-timeout-all", "mesh-timeout-to-all"} {
+		key := resourceKey(prefix)
 		existing := v1alpha1.NewMeshTimeoutResource()
 		if err := resManager.Get(ctx, existing, store.GetBy(key), store.GetConsistent()); err != nil {
 			if store.IsNotFound(err) {
@@ -197,19 +198,14 @@ func migrateMeshTimeoutTargetRefProxyTypes(
 			}
 			return errors.Wrapf(err, "could not retrieve default MeshTimeout %q", key.Name)
 		}
-		if existing.Spec.TargetRef == nil || existing.Spec.TargetRef.Kind != common_api.Mesh {
+		if existing.Spec.TargetRef == nil || len(pointer.Deref(existing.Spec.TargetRef.ProxyTypes)) == 0 {
 			continue // already migrated, or an operator-modified resource
 		}
-		existing.Spec.TargetRef = &common_api.TargetRef{
-			Kind: common_api.Dataplane,
-			Labels: &map[string]string{
-				mesh_proto.ProxyTypeLabel: string(proxyType),
-			},
-		}
+		existing.Spec.TargetRef.ProxyTypes = nil
 		if err := resManager.Update(ctx, existing); err != nil {
 			return errors.Wrapf(err, "could not migrate default MeshTimeout %q", key.Name)
 		}
-		logger.Info("migrated legacy default MeshTimeout targetRef from proxyTypes to dataplane labels", "name", key.Name)
+		logger.Info("cleared legacy proxyTypes restriction on default MeshTimeout, it now applies mesh-wide", "name", key.Name)
 	}
 	return nil
 }

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -159,9 +159,10 @@ func migrateCombinedMeshTimeoutDefaults(
 // MeshTimeout resources persisted by CP versions that split sidecar/gateway
 // defaults into separate resources. A single mesh-wide default now applies to
 // every proxy type, so the gateway-specific resources are deleted rather than
-// migrated, and any leftover proxyTypes restriction on the surviving
-// mesh-timeout-all/mesh-timeout-to-all resources is cleared so they go back
-// to applying mesh-wide.
+// migrated. Any legacy proxyTypes restriction on the surviving
+// mesh-timeout-all/mesh-timeout-to-all resources needs no migration: the
+// field no longer exists on TargetRef, so it's silently dropped on the next
+// unmarshal, and the resource already applies mesh-wide.
 func migrateGatewayMeshTimeoutDefaults(
 	ctx context.Context,
 	resManager manager.ResourceManager,
@@ -170,16 +171,12 @@ func migrateGatewayMeshTimeoutDefaults(
 	systemNamespace string,
 	logger logr.Logger,
 ) error {
-	resourceKey := func(prefix string) model.ResourceKey {
+	for _, prefix := range []string{"mesh-gateways-timeout-all", "mesh-gateways-timeout-to-all"} {
 		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)
 		if k8sStore {
 			resourceName = fmt.Sprintf("%s.%s", resourceName, systemNamespace)
 		}
-		return model.ResourceKey{Mesh: meshName, Name: resourceName}
-	}
-
-	for _, prefix := range []string{"mesh-gateways-timeout-all", "mesh-gateways-timeout-to-all"} {
-		key := resourceKey(prefix)
+		key := model.ResourceKey{Mesh: meshName, Name: resourceName}
 		if err := resManager.Delete(ctx, v1alpha1.NewMeshTimeoutResource(), store.DeleteBy(key)); err != nil {
 			if store.IsNotFound(err) {
 				continue
@@ -187,25 +184,6 @@ func migrateGatewayMeshTimeoutDefaults(
 			return errors.Wrapf(err, "could not delete legacy default MeshTimeout %q", key.Name)
 		}
 		logger.Info("deleted legacy gateway-specific default MeshTimeout, a single default now applies to every proxy type", "name", key.Name)
-	}
-
-	for _, prefix := range []string{"mesh-timeout-all", "mesh-timeout-to-all"} {
-		key := resourceKey(prefix)
-		existing := v1alpha1.NewMeshTimeoutResource()
-		if err := resManager.Get(ctx, existing, store.GetBy(key), store.GetConsistent()); err != nil {
-			if store.IsNotFound(err) {
-				continue
-			}
-			return errors.Wrapf(err, "could not retrieve default MeshTimeout %q", key.Name)
-		}
-		if existing.Spec.TargetRef == nil || len(pointer.Deref(existing.Spec.TargetRef.ProxyTypes)) == 0 {
-			continue // already migrated, or an operator-modified resource
-		}
-		existing.Spec.TargetRef.ProxyTypes = nil
-		if err := resManager.Update(ctx, existing); err != nil {
-			return errors.Wrapf(err, "could not migrate default MeshTimeout %q", key.Name)
-		}
-		logger.Info("cleared legacy proxyTypes restriction on default MeshTimeout, it now applies mesh-wide", "name", key.Name)
 	}
 	return nil
 }

--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
@@ -64,6 +66,9 @@ func EnsureDefaultMeshResources(
 	}
 	if err := migrateCombinedMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
 		return errors.Wrap(err, "could not migrate legacy combined default MeshTimeout resources")
+	}
+	if err := migrateMeshTimeoutTargetRefProxyTypes(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
+		return errors.Wrap(err, "could not migrate default MeshTimeout targetRef from proxyTypes to dataplane labels")
 	}
 	if slices.Contains(skippedPolicies, "*") {
 		logger.Info("skipping all default policy creation")
@@ -150,6 +155,61 @@ func migrateCombinedMeshTimeoutDefaults(
 			return errors.Wrapf(err, "could not migrate default MeshTimeout %q", key.Name)
 		}
 		logger.Info("migrated legacy combined default MeshTimeout, outbound defaults now live in a separate resource", "name", key.Name)
+	}
+	return nil
+}
+
+// migrateMeshTimeoutTargetRefProxyTypes rewrites default MeshTimeout resources
+// persisted by CP versions that selected sidecars/gateways via
+// TargetRef{Kind: Mesh, ProxyTypes: [...]} to the current
+// TargetRef{Kind: Dataplane, Labels: {kuma.io/proxy-type: ...}} shape.
+// Without this, ensureDefaultResource's label-healing Get() unmarshals the
+// legacy stored spec onto the new default's pre-populated struct (JSON
+// unmarshal reuses existing pointers instead of replacing them), so a field
+// absent from the legacy JSON (labels) would survive alongside a field
+// restored from it (kind: Mesh), producing an invalid combination.
+func migrateMeshTimeoutTargetRefProxyTypes(
+	ctx context.Context,
+	resManager manager.ResourceManager,
+	meshName string,
+	k8sStore bool,
+	systemNamespace string,
+	logger logr.Logger,
+) error {
+	proxyTypeByPrefix := map[string]mesh_proto.ProxyTypeLabelValues{
+		"mesh-timeout-all":             mesh_proto.SidecarLabel,
+		"mesh-timeout-to-all":          mesh_proto.SidecarLabel,
+		"mesh-gateways-timeout-all":    mesh_proto.GatewayLabel,
+		"mesh-gateways-timeout-to-all": mesh_proto.GatewayLabel,
+	}
+
+	for prefix, proxyType := range proxyTypeByPrefix {
+		resourceName := fmt.Sprintf("%s-%s", prefix, meshName)
+		if k8sStore {
+			resourceName = fmt.Sprintf("%s.%s", resourceName, systemNamespace)
+		}
+		key := model.ResourceKey{Mesh: meshName, Name: resourceName}
+
+		existing := v1alpha1.NewMeshTimeoutResource()
+		if err := resManager.Get(ctx, existing, store.GetBy(key), store.GetConsistent()); err != nil {
+			if store.IsNotFound(err) {
+				continue
+			}
+			return errors.Wrapf(err, "could not retrieve default MeshTimeout %q", key.Name)
+		}
+		if existing.Spec.TargetRef == nil || existing.Spec.TargetRef.Kind != common_api.Mesh {
+			continue // already migrated, or an operator-modified resource
+		}
+		existing.Spec.TargetRef = &common_api.TargetRef{
+			Kind: common_api.Dataplane,
+			Labels: &map[string]string{
+				mesh_proto.ProxyTypeLabel: string(proxyType),
+			},
+		}
+		if err := resManager.Update(ctx, existing); err != nil {
+			return errors.Wrapf(err, "could not migrate default MeshTimeout %q", key.Name)
+		}
+		logger.Info("migrated legacy default MeshTimeout targetRef from proxyTypes to dataplane labels", "name", key.Name)
 	}
 	return nil
 }

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -169,9 +169,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			legacy.Spec = &meshtimeout.MeshTimeout{
 				TargetRef: &common_api.TargetRef{
 					Kind: common_api.Mesh,
-					ProxyTypes: &[]common_api.TargetRefProxyType{
-						common_api.Sidecar,
-					},
 				},
 				Rules: &[]meshtimeout.Rule{
 					{Default: meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}}},
@@ -199,7 +196,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(migrated.Spec.TargetRef).ToNot(BeNil())
 			Expect(migrated.Spec.TargetRef.Kind).To(Equal(common_api.Mesh))
-			Expect(migrated.Spec.TargetRef.ProxyTypes).To(BeNil())
 			Expect(migrated.Spec.To).To(BeNil())
 			Expect(migrated.Spec.Rules).ToNot(BeNil())
 

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -210,7 +210,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(migrated.Spec.TargetRef).ToNot(BeNil())
 			Expect(migrated.Spec.TargetRef.Kind).To(Equal(common_api.Dataplane))
-			Expect(migrated.Spec.TargetRef.ProxyTypes).To(BeNil())
 			Expect(migrated.Spec.TargetRef.Labels).ToNot(BeNil())
 			Expect(*migrated.Spec.TargetRef.Labels).To(HaveKeyWithValue(mesh_proto.ProxyTypeLabel, string(mesh_proto.SidecarLabel)))
 			Expect(migrated.Spec.To).To(BeNil())

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -183,9 +183,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			legacy.Spec = &meshtimeout.MeshTimeout{
 				TargetRef: &common_api.TargetRef{
 					Kind: common_api.Mesh,
-					ProxyTypes: &[]common_api.TargetRefProxyType{
-						common_api.Sidecar,
-					},
 				},
 				Rules: &[]meshtimeout.Rule{
 					{Default: meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}}},

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -211,6 +211,11 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			migrated := meshtimeout.NewMeshTimeoutResource()
 			err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
+			Expect(migrated.Spec.TargetRef).ToNot(BeNil())
+			Expect(migrated.Spec.TargetRef.Kind).To(Equal(common_api.Dataplane))
+			Expect(migrated.Spec.TargetRef.ProxyTypes).To(BeNil())
+			Expect(migrated.Spec.TargetRef.Labels).ToNot(BeNil())
+			Expect(*migrated.Spec.TargetRef.Labels).To(HaveKeyWithValue(mesh_proto.ProxyTypeLabel, string(mesh_proto.SidecarLabel)))
 			Expect(migrated.Spec.To).To(BeNil())
 			Expect(migrated.Spec.Rules).ToNot(BeNil())
 

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -55,10 +55,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
 
-			// and default Gateway's MeshTimeout for the mesh exists
-			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default", model.DefaultMesh))
-			Expect(err).ToNot(HaveOccurred())
-
 			// and default MeshCircuitBreaker for the mesh exists
 			err = resManager.Get(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
@@ -78,8 +74,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
-			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default", model.DefaultMesh))
-			Expect(err).ToNot(HaveOccurred())
 			err = resManager.Get(context.Background(), meshcircuitbreaker.NewMeshCircuitBreakerResource(), core_store.GetByKey("mesh-circuit-breaker-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
 			err = resManager.Get(context.Background(), system.NewSecretResource(), core_store.GetBy(tokens.SigningKeyResourceKey(system.DataplaneTokenSigningKey(model.DefaultMesh), tokens.DefaultKeyID, model.DefaultMesh)))
@@ -97,10 +91,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 			// and default MeshTimeout for the mesh doesn't exists
 			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
-			Expect(core_store.IsNotFound(err)).To(BeTrue())
-
-			// and default Gateway's MeshTimeout for the mesh doesn't exists
-			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default", model.DefaultMesh))
 			Expect(core_store.IsNotFound(err)).To(BeTrue())
 
 			// and default MeshCircuitBreaker for the mesh doesn't exists
@@ -123,10 +113,6 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 
 			// and default MeshTimeout for the mesh doesn't exists
 			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
-			Expect(core_store.IsNotFound(err)).To(BeTrue())
-
-			// and default Gateway's MeshTimeout for the mesh doesn't exists
-			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default", model.DefaultMesh))
 			Expect(core_store.IsNotFound(err)).To(BeTrue())
 
 			// and default MeshCircuitBreaker for the mesh does exists
@@ -212,10 +198,8 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(migrated.Spec.TargetRef).ToNot(BeNil())
-			Expect(migrated.Spec.TargetRef.Kind).To(Equal(common_api.Dataplane))
+			Expect(migrated.Spec.TargetRef.Kind).To(Equal(common_api.Mesh))
 			Expect(migrated.Spec.TargetRef.ProxyTypes).To(BeNil())
-			Expect(migrated.Spec.TargetRef.Labels).ToNot(BeNil())
-			Expect(*migrated.Spec.TargetRef.Labels).To(HaveKeyWithValue(mesh_proto.ProxyTypeLabel, string(mesh_proto.SidecarLabel)))
 			Expect(migrated.Spec.To).To(BeNil())
 			Expect(migrated.Spec.Rules).ToNot(BeNil())
 
@@ -225,6 +209,47 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(toResource.Spec.To).ToNot(BeNil())
 			Expect(toResource.Spec.Rules).To(BeNil())
+		})
+
+		It("should delete legacy gateway-specific default MeshTimeout resources", func() {
+			// given gateway-specific default MeshTimeout resources, as an older
+			// CP version stored them before sidecar/gateway defaults were merged
+			gatewayRules := meshtimeout.NewMeshTimeoutResource()
+			gatewayRules.Spec = &meshtimeout.MeshTimeout{
+				TargetRef: &common_api.TargetRef{Kind: common_api.Mesh},
+				Rules: &[]meshtimeout.Rule{
+					{Default: meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}}},
+				},
+			}
+			err := rawStore.Create(context.Background(), gatewayRules, core_store.CreateByKey("mesh-gateways-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+
+			gatewayTo := meshtimeout.NewMeshTimeoutResource()
+			gatewayTo.Spec = &meshtimeout.MeshTimeout{
+				TargetRef: &common_api.TargetRef{Kind: common_api.Mesh},
+				To: &[]meshtimeout.To{
+					{
+						TargetRef: common_api.TargetRef{Kind: common_api.Mesh},
+						Default:   meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}},
+					},
+				},
+			}
+			err = rawStore.Create(context.Background(), gatewayTo, core_store.CreateByKey("mesh-gateways-timeout-to-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+
+			// when EnsureDefaultMeshResources runs
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then the legacy gateway-specific defaults are gone
+			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default", model.DefaultMesh))
+			Expect(core_store.IsNotFound(err)).To(BeTrue())
+			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-to-all-default", model.DefaultMesh))
+			Expect(core_store.IsNotFound(err)).To(BeTrue())
+
+			// and the single mesh-wide default still exists
+			err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should not recreate a default policy deleted by an operator", func() {

--- a/pkg/defaults/mesh/meshtimeout.go
+++ b/pkg/defaults/mesh/meshtimeout.go
@@ -20,10 +20,7 @@ var defaultMeshTimeoutResource = func() model.Resource {
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Dataplane,
-				Labels: &map[string]string{
-					mesh_proto.ProxyTypeLabel: string(mesh_proto.SidecarLabel),
-				},
+				Kind: common_api.Mesh,
 			},
 
 			// bigger than outbound side timeouts or disabled.
@@ -58,10 +55,7 @@ var defaultMeshTimeoutToResource = func() model.Resource {
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Dataplane,
-				Labels: &map[string]string{
-					mesh_proto.ProxyTypeLabel: string(mesh_proto.SidecarLabel),
-				},
+				Kind: common_api.Mesh,
 			},
 			To: &[]v1alpha1.To{
 				{
@@ -81,66 +75,6 @@ var defaultMeshTimeoutToResource = func() model.Resource {
 							},
 							StreamIdleTimeout: &kube_meta.Duration{
 								Duration: policies_defaults.DefaultStreamIdleTimeout,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-var defaulMeshGatewaysTimeoutResource = func() model.Resource {
-	return &v1alpha1.MeshTimeoutResource{
-		Spec: &v1alpha1.MeshTimeout{
-			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Dataplane,
-				Labels: &map[string]string{
-					mesh_proto.ProxyTypeLabel: string(mesh_proto.GatewayLabel),
-				},
-			},
-			Rules: &[]v1alpha1.Rule{
-				{
-					Default: v1alpha1.Conf{
-						IdleTimeout: &kube_meta.Duration{
-							Duration: policies_defaults.DefaultGatewayIdleTimeout,
-						},
-						Http: &v1alpha1.Http{
-							StreamIdleTimeout: &kube_meta.Duration{
-								Duration: policies_defaults.DefaultGatewayStreamIdleTimeout,
-							},
-							RequestHeadersTimeout: &kube_meta.Duration{
-								Duration: policies_defaults.DefaultGatewayRequestHeadersTimeout,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-var defaulMeshGatewaysTimeoutToResource = func() model.Resource {
-	return &v1alpha1.MeshTimeoutResource{
-		Spec: &v1alpha1.MeshTimeout{
-			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Dataplane,
-				Labels: &map[string]string{
-					mesh_proto.ProxyTypeLabel: string(mesh_proto.GatewayLabel),
-				},
-			},
-			To: &[]v1alpha1.To{
-				{
-					TargetRef: common_api.TargetRef{
-						Kind: common_api.Mesh,
-					},
-					Default: v1alpha1.Conf{
-						IdleTimeout: &kube_meta.Duration{
-							Duration: policies_defaults.DefaultIdleTimeout,
-						},
-						Http: &v1alpha1.Http{
-							StreamIdleTimeout: &kube_meta.Duration{
-								Duration: policies_defaults.DefaultGatewayStreamIdleTimeout,
 							},
 						},
 					},

--- a/pkg/defaults/mesh/meshtimeout.go
+++ b/pkg/defaults/mesh/meshtimeout.go
@@ -20,9 +20,9 @@ var defaultMeshTimeoutResource = func() model.Resource {
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Mesh,
-				ProxyTypes: &[]common_api.TargetRefProxyType{
-					common_api.Sidecar,
+				Kind: common_api.Dataplane,
+				Labels: &map[string]string{
+					mesh_proto.ProxyTypeLabel: string(mesh_proto.SidecarLabel),
 				},
 			},
 
@@ -58,9 +58,9 @@ var defaultMeshTimeoutToResource = func() model.Resource {
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Mesh,
-				ProxyTypes: &[]common_api.TargetRefProxyType{
-					common_api.Sidecar,
+				Kind: common_api.Dataplane,
+				Labels: &map[string]string{
+					mesh_proto.ProxyTypeLabel: string(mesh_proto.SidecarLabel),
 				},
 			},
 			To: &[]v1alpha1.To{
@@ -94,9 +94,9 @@ var defaulMeshGatewaysTimeoutResource = func() model.Resource {
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Mesh,
-				ProxyTypes: &[]common_api.TargetRefProxyType{
-					common_api.Gateway,
+				Kind: common_api.Dataplane,
+				Labels: &map[string]string{
+					mesh_proto.ProxyTypeLabel: string(mesh_proto.GatewayLabel),
 				},
 			},
 			Rules: &[]v1alpha1.Rule{
@@ -124,9 +124,9 @@ var defaulMeshGatewaysTimeoutToResource = func() model.Resource {
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TargetRef{
-				Kind: common_api.Mesh,
-				ProxyTypes: &[]common_api.TargetRefProxyType{
-					common_api.Gateway,
+				Kind: common_api.Dataplane,
+				Labels: &map[string]string{
+					mesh_proto.ProxyTypeLabel: string(mesh_proto.GatewayLabel),
 				},
 			},
 			To: &[]v1alpha1.To{

--- a/pkg/plugins/policies/core/defaults/consts.go
+++ b/pkg/plugins/policies/core/defaults/consts.go
@@ -13,8 +13,4 @@ const (
 	DefaultRequestHeadersTimeout = 0
 	DefaultMaxStreamDuration     = 0
 	DefaultMaxConnectionDuration = 0
-	// Gateway
-	DefaultGatewayIdleTimeout           = 5 * time.Minute
-	DefaultGatewayStreamIdleTimeout     = 5 * time.Second
-	DefaultGatewayRequestHeadersTimeout = 500 * time.Millisecond
 )

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -155,12 +155,9 @@ func DppSelectedByPolicy(
 	}
 	switch ref.Kind {
 	case common_api.Mesh:
-		if isSupportedProxyType(pointer.Deref(ref.ProxyTypes), resolveDataplaneProxyType(dpp)) {
-			inbounds := allInboundListeners(dpp)
-			inbounds = append(inbounds, embeddedListenersAsInboundListeners(dpp)...)
-			return inbounds, dpp.Spec.IsDelegatedGateway(), nil
-		}
-		return []core_rules.InboundListener{}, false, nil
+		inbounds := allInboundListeners(dpp)
+		inbounds = append(inbounds, embeddedListenersAsInboundListeners(dpp)...)
+		return inbounds, dpp.Spec.IsDelegatedGateway(), nil
 	case common_api.Dataplane:
 		if allDataplanesSelected(ref) || isSelectedByResourceIdentifier(dpp, ref, meta) || isSelectedByLabels(dpp, ref) {
 			inboundInterfaces := dpp.Spec.GetNetworking().InboundsSelectedBySectionName(pointer.Deref(ref.SectionName))
@@ -261,17 +258,6 @@ func resolveMeshHTTPRouteRef(refMeta core_model.ResourceMeta, refName string, mh
 		}
 	}
 	return nil
-}
-
-func resolveDataplaneProxyType(dpp *core_mesh.DataplaneResource) common_api.TargetRefProxyType {
-	if dpp.Spec.GetNetworking().GetGateway() != nil {
-		return common_api.Gateway
-	}
-	return common_api.Sidecar
-}
-
-func isSupportedProxyType(supportedTypes []common_api.TargetRefProxyType, dppType common_api.TargetRefProxyType) bool {
-	return len(supportedTypes) == 0 || slices.Contains(supportedTypes, dppType)
 }
 
 // allInboundListeners returns every inbound of the dataplane as an InboundListener

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshexternalservice/01.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/meshexternalservice/01.policies.yaml
@@ -16,8 +16,9 @@ mesh: mesh-1
 name: mr-2
 spec:
   targetRef:
-    kind: Mesh
-    proxyTypes: ["Gateway"]
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: gateway
   to:
     - targetRef:
         kind: Mesh

--- a/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/05.policies.yaml
+++ b/pkg/plugins/policies/core/matchers/testdata/matchedpolicies/torules/05.policies.yaml
@@ -16,8 +16,9 @@ mesh: mesh-1
 name: mtp-2
 spec:
   targetRef:
-    kind: Mesh
-    proxyTypes: ["Gateway"]
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: gateway
   to:
     - targetRef:
         kind: Mesh

--- a/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
+++ b/pkg/plugins/policies/donothingpolicy/k8s/crd/kuma.io_donothingpolicies.yaml
@@ -104,16 +104,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.
@@ -172,16 +162,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -251,16 +231,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -410,16 +410,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -648,16 +638,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
+++ b/pkg/plugins/policies/meshaccesslog/k8s/crd/kuma.io_meshaccesslogs.yaml
@@ -321,16 +321,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -564,16 +554,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -444,16 +444,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -758,16 +748,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/k8s/crd/kuma.io_meshcircuitbreakers.yaml
@@ -348,16 +348,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -665,16 +655,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -310,16 +310,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -451,16 +441,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
@@ -53,13 +53,14 @@ rules:
   - default:
       http: []
 `),
-		Entry("Kind Mesh with to and only gateway", `
+		Entry("Kind Dataplane gateway label with to", `
 type: MeshFaultInjection
 mesh: mesh-1
 name: fi1
 targetRef:
-  kind: Mesh
-  proxyTypes: ["Gateway"]
+  kind: Dataplane
+  labels:
+    kuma.io/proxy-type: gateway
 to:
   - targetRef:
       kind: Mesh

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/validator_test.go
@@ -224,6 +224,8 @@ mesh: mesh-1
 name: fi1
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
   sectionName: test
 to:
   - targetRef:

--- a/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/k8s/crd/kuma.io_meshfaultinjections.yaml
@@ -224,16 +224,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -372,16 +362,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -192,16 +192,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -453,16 +443,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -92,16 +92,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -359,16 +349,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -192,16 +192,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -277,16 +267,6 @@ components:
                                     description: Port is only supported when this ref refers to a real MeshService object
                                     format: int32
                                     type: integer
-                                  proxyTypes:
-                                    description: |-
-                                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                      all data plane types are targeted by the policy.
-                                    items:
-                                      enum:
-                                        - Sidecar
-                                        - Gateway
-                                      type: string
-                                    type: array
                                   sectionName:
                                     description: |-
                                       SectionName is used to target specific section of resource.
@@ -401,16 +381,6 @@ components:
                                             description: Port is only supported when this ref refers to a real MeshService object
                                             format: int32
                                             type: integer
-                                          proxyTypes:
-                                            description: |-
-                                              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                              all data plane types are targeted by the policy.
-                                            items:
-                                              enum:
-                                                - Sidecar
-                                                - Gateway
-                                              type: string
-                                            type: array
                                           sectionName:
                                             description: |-
                                               SectionName is used to target specific section of resource.
@@ -723,16 +693,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -184,16 +174,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -313,16 +293,6 @@ spec:
                                                 object
                                               format: int32
                                               type: integer
-                                            proxyTypes:
-                                              description: |-
-                                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                                all data plane types are targeted by the policy.
-                                              items:
-                                                enum:
-                                                - Sidecar
-                                                - Gateway
-                                                type: string
-                                              type: array
                                             sectionName:
                                               description: |-
                                                 SectionName is used to target specific section of resource.
@@ -642,16 +612,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -192,16 +192,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -540,16 +530,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -456,16 +446,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -363,16 +363,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
+++ b/pkg/plugins/policies/meshmetric/k8s/crd/kuma.io_meshmetrics.yaml
@@ -278,16 +278,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -240,16 +240,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
+++ b/pkg/plugins/policies/meshpassthrough/k8s/crd/kuma.io_meshpassthroughs.yaml
@@ -145,16 +145,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -584,16 +584,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -516,16 +516,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -345,16 +345,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -523,16 +513,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/validator_test.go
@@ -27,6 +27,8 @@ var _ = Describe("MeshRateLimit", func() {
 			Entry("full example", `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - default:
       local:
@@ -49,6 +51,8 @@ rules:
 			Entry("full example, only http", `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - default:
       local:
@@ -65,6 +69,8 @@ rules:
 			Entry("full example, only tcp", `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - default:
       local:
@@ -76,6 +82,8 @@ rules:
 			Entry("minimal example", `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - default:
       local:
@@ -90,6 +98,8 @@ rules:
 			Entry("disable rate limit", `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - default:
       local:
@@ -100,6 +110,8 @@ rules:
 			Entry("rules example with sni match", `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - matches:
       - sni:
@@ -137,6 +149,8 @@ rules:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
 - default:
     local:
@@ -172,6 +186,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
 - default: {}`,
 				expected: `
@@ -183,6 +199,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
   sectionName: test
 to:
 - targetRef:
@@ -199,6 +217,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
 - default:
     local: {}`,
@@ -211,6 +231,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
 - default:
     local:
@@ -224,6 +246,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
 - default:
     local:
@@ -287,6 +311,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - matches:
       - spiffeID:
@@ -307,6 +333,8 @@ violations:
 				inputYaml: `
 targetRef:
   kind: Dataplane
+  labels:
+    kuma.io/proxy-type: sidecar
 rules:
   - matches:
       - spiffeID:

--- a/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
+++ b/pkg/plugins/policies/meshratelimit/k8s/crd/kuma.io_meshratelimits.yaml
@@ -262,16 +262,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -450,16 +440,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -192,16 +192,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -569,16 +559,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
+++ b/pkg/plugins/policies/meshretry/k8s/crd/kuma.io_meshretries.yaml
@@ -92,16 +92,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -479,16 +469,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -192,16 +192,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -274,16 +264,6 @@ components:
                                     description: Port is only supported when this ref refers to a real MeshService object
                                     format: int32
                                     type: integer
-                                  proxyTypes:
-                                    description: |-
-                                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                      all data plane types are targeted by the policy.
-                                    items:
-                                      enum:
-                                        - Sidecar
-                                        - Gateway
-                                      type: string
-                                    type: array
                                   sectionName:
                                     description: |-
                                       SectionName is used to target specific section of resource.
@@ -347,16 +327,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -94,16 +94,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -179,16 +169,6 @@ spec:
                                         ref refers to a real MeshService object
                                       format: int32
                                       type: integer
-                                    proxyTypes:
-                                      description: |-
-                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                                        all data plane types are targeted by the policy.
-                                      items:
-                                        enum:
-                                        - Sidecar
-                                        - Gateway
-                                        type: string
-                                      type: array
                                     sectionName:
                                       description: |-
                                         SectionName is used to target specific section of resource.
@@ -253,16 +233,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -286,16 +286,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.
@@ -403,16 +393,6 @@ components:
                           Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                           will be targeted.
                         type: string
-                      proxyTypes:
-                        description: |-
-                          ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                          all data plane types are targeted by the policy.
-                        items:
-                          enum:
-                            - Sidecar
-                            - Gateway
-                          type: string
-                        type: array
                       sectionName:
                         description: |-
                           SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
+++ b/pkg/plugins/policies/meshtimeout/k8s/crd/kuma.io_meshtimeouts.yaml
@@ -196,16 +196,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.
@@ -316,16 +306,6 @@ spec:
                             Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                             will be targeted.
                           type: string
-                        proxyTypes:
-                          description: |-
-                            ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                            all data plane types are targeted by the policy.
-                          items:
-                            enum:
-                            - Sidecar
-                            - Gateway
-                            type: string
-                          type: array
                         sectionName:
                           description: |-
                             SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -246,16 +246,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
+++ b/pkg/plugins/policies/meshtls/k8s/crd/kuma.io_meshtlses.yaml
@@ -149,16 +149,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -370,16 +370,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -272,16 +272,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -316,16 +316,6 @@ components:
                     Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                     will be targeted.
                   type: string
-                proxyTypes:
-                  description: |-
-                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                    all data plane types are targeted by the policy.
-                  items:
-                    enum:
-                      - Sidecar
-                      - Gateway
-                    type: string
-                  type: array
                 sectionName:
                   description: |-
                     SectionName is used to target specific section of resource.

--- a/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/k8s/crd/kuma.io_meshtrafficpermissions.yaml
@@ -244,16 +244,6 @@ spec:
                       Namespace specifies the namespace of target resource. If empty only resources in policy namespace
                       will be targeted.
                     type: string
-                  proxyTypes:
-                    description: |-
-                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
-                      all data plane types are targeted by the policy.
-                    items:
-                      enum:
-                      - Sidecar
-                      - Gateway
-                      type: string
-                    type: array
                   sectionName:
                     description: |-
                       SectionName is used to target specific section of resource.

--- a/test/e2e_env/kubernetes/inspect/inspect.go
+++ b/test/e2e_env/kubernetes/inspect/inspect.go
@@ -48,16 +48,10 @@ spec:
           maxStreamDuration: 0s`, Config.KumaNamespace, meshName))).
 			Setup(kubernetes.Cluster)
 		Expect(err).ToNot(HaveOccurred())
-		// remove default meshtimeout policies
 		Expect(DeleteMeshPolicyOrError(
 			kubernetes.Cluster,
 			v1alpha1.MeshTimeoutResourceTypeDescriptor,
 			fmt.Sprintf("mesh-timeout-all-%s", meshName),
-		)).To(Succeed())
-		Expect(DeleteMeshPolicyOrError(
-			kubernetes.Cluster,
-			v1alpha1.MeshTimeoutResourceTypeDescriptor,
-			fmt.Sprintf("mesh-gateways-timeout-all-%s", meshName),
 		)).To(Succeed())
 	})
 

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.input.yaml
@@ -5,7 +5,9 @@ labels:
   kuma.io/effect: shadow
 spec:
   targetRef:
-    kind: Mesh
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: sidecar
   rules:
     - default:
         local:

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.input.yaml
@@ -5,8 +5,9 @@ labels:
   kuma.io/effect: shadow
 spec:
   targetRef:
-    kind: Mesh
-    proxyTypes: [Sidecar]
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: sidecar
   rules:
     - default:
         local:

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.input.yaml
@@ -6,7 +6,6 @@ labels:
 spec:
   targetRef:
     kind: Mesh
-    proxyTypes: [Sidecar]
   rules:
     - default:
         local:

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.input.yaml
@@ -5,7 +5,9 @@ labels:
   kuma.io/effect: shadow
 spec:
   targetRef:
-    kind: Mesh
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: sidecar
   rules:
     - default:
         local:

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.input.yaml
@@ -5,8 +5,9 @@ labels:
   kuma.io/effect: shadow
 spec:
   targetRef:
-    kind: Mesh
-    proxyTypes: [Sidecar]
+    kind: Dataplane
+    labels:
+      kuma.io/proxy-type: sidecar
   rules:
     - default:
         local:

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.input.yaml
@@ -6,7 +6,6 @@ labels:
 spec:
   targetRef:
     kind: Mesh
-    proxyTypes: [Sidecar]
   rules:
     - default:
         local:


### PR DESCRIPTION
## Motivation

> Changelog: skip

`proxyTypes` let a `Kind: Mesh` targetRef restrict a policy to
sidecars or gateways. Outside the default `MeshTimeout` resources,
nothing in the codebase actually set it.

## Implementation information

- Default `MeshTimeout` resources (`pkg/defaults/mesh/meshtimeout.go`)
  now use a single `Kind: Mesh` default for every proxy type, instead
  of separate sidecar/gateway resources selected via `ProxyTypes`.
  A delegated gateway is an ordinary Dataplane from the CP's
  perspective, so it now gets the same timeout values as sidecars.
  Migration (`pkg/defaults/mesh/mesh.go`) deletes the legacy
  gateway-specific default resources on mesh reconciliation.

  (Earlier iterations of this tried `Kind: Dataplane` + labels for the
  sidecar/gateway split instead of collapsing to one default — that
  broke cross-policy merge precedence, since `SortByTargetRef` ranks
  `Dataplane` above `Mesh` and that ranking also drives which policy's
  config wins when merging overlapping `to[]`/`rules[]` config. A
  single default avoids the split entirely.)

- Removed `ProxyTypes`/`TargetRefProxyType` from the `TargetRef` API,
  its validators, and the matcher's proxy-type filtering — `Kind: Mesh`
  now always matches every proxy type, same as an unset `proxyTypes`
  did before.
- `IncludesGateways` (used by `MeshRateLimit`/`MeshFaultInjection` to
  gate `rules[]` vs `to[]`) no longer distinguishes gateways via
  `Kind: Dataplane` at all — that kind never included gateways before
  `proxyTypes` existed either (the field was never valid on it), so
  this keeps that exact behavior. There is no longer any way to scope
  a `MeshRateLimit`/`MeshFaultInjection` policy's `rules[]`/`to[]` to
  gateways-only; only `Kind: Mesh` (which always includes every proxy
  type) remains.
- Regenerated CRDs/OpenAPI/rest.yaml for every policy (`make generate`,
  `make docs`) and updated test fixtures that relied on the old shape.

This removes a field from every targetRef-based policy's CRD/OpenAPI
schema; any existing policy setting `proxyTypes` today loses that
restriction (its policy becomes mesh-wide instead of gateway/sidecar
scoped), with no equivalent replacement.

## Supporting documentation