### PR TITLE
feat(kds): add zone-version header to KDS client

### DIFF
--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -124,6 +124,7 @@ func (c *client) Start(stop <-chan struct{}) (errs error) {
 	withKDSCtx, cancel := context.WithCancel(metadata.AppendToOutgoingContext(c.ctx,
 		"client-id", c.clientID,
 		KDSVersionHeaderKey, KDSVersionV3,
+		ZoneVersionHeaderKey, ZoneVersionV3,
 		kds.FeaturesMetadataKey, kds.FeatureZonePingHealth,
 		kds.FeaturesMetadataKey, kds.FeatureHashSuffix,
 	))

--- a/pkg/kds/mux/version.go
+++ b/pkg/kds/mux/version.go
@@ -15,6 +15,11 @@ const (
 	KDSVersionHeaderKey = "kds-version"
 	KDSVersionV2        = "v2"
 	KDSVersionV3        = "v3"
+
+	// ZoneVersionHeaderKey marks the zone CP's KDS generation so the global CP
+	// can route it. Set unconditionally by clients built from this code line.
+	ZoneVersionHeaderKey = "zone-version"
+	ZoneVersionV3        = "v3"
 )
 
 func KDSVersion(ctx context.Context) string {


### PR DESCRIPTION
## Motivation

Zone CPs need to announce their KDS generation to the global CP over the KDS connection so we can route them later. Today the zone CP version only lives deep in the xDS `Node.Metadata`, which isn't available for cheap connection-level routing.

## Implementation information

Zone CPs built from this code line now send a fixed `zone-version: v3` gRPC metadata header on the KDS connection, alongside the existing `client-id`/`kds-version`/`features` headers in `pkg/kds/mux/client.go`. Routing on the global side will be built on top of this in a follow-up.

## Supporting documentation

Fix https://github.com/Kong/kong-mesh/issues/9996