### PR TITLE
fix(xds): zone fallback for tagless dataplanes

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -357,7 +357,7 @@ func fillDataplaneOutbounds(
 				Tags:     inboundTags,
 				Labels:   dataplane.GetMeta().GetLabels(),
 				Weight:   endpointWeight,
-				Locality: GetLocality(getZone(inboundTags)),
+				Locality: GetLocality(getZone(inboundTags, dataplane.GetMeta().GetLabels())),
 			})
 		}
 	}
@@ -392,7 +392,7 @@ func fillLocalMeshServices(
 						Tags:     inboundTags,
 						Labels:   dpp.GetMeta().GetLabels(),
 						Weight:   1,
-						Locality: GetLocality(getZone(inboundTags)),
+						Locality: GetLocality(getZone(inboundTags, dpp.GetMeta().GetLabels())),
 					})
 				}
 			}
@@ -505,7 +505,7 @@ func fillIngressOutbounds(
 			serviceTags := maps.Clone(service.GetTags())
 			serviceName := serviceTags[mesh_proto.ServiceTag]
 			serviceInstances := service.GetInstances()
-			locality := GetLocality(getZone(serviceTags))
+			locality := GetLocality(getZone(serviceTags, nil))
 
 			if _, ok := meshServiceDestinations[serviceName]; ok {
 				continue
@@ -764,8 +764,15 @@ func GetLocality(otherZone *string) *core_xds.Locality {
 	}
 }
 
-func getZone(tags map[string]string) *string {
+// getZone returns the kuma.io/zone inbound tag, falling back to the
+// dataplane's own zone label -- set unconditionally by the K8s pod
+// converter, unlike inbound tags, which are empty under
+// Experimental.InboundTagsDisabled.
+func getZone(tags map[string]string, labels map[string]string) *string {
 	if zone, ok := tags[mesh_proto.ZoneTag]; ok {
+		return &zone
+	}
+	if zone, ok := labels[mesh_proto.ZoneTag]; ok {
 		return &zone
 	}
 	return nil

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -262,6 +262,47 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}))
 		})
+
+		It("should fall back to the dataplane zone label when the inbound has no zone tag", func() {
+			// given a dataplane with no kuma.io/zone inbound tag (e.g. InboundTagsDisabled),
+			// but the zone label the K8s pod converter always sets
+			redisNoZoneTag := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Mesh:   "demo",
+					Name:   "redis-no-zone-tag",
+					Labels: map[string]string{mesh_proto.ZoneTag: "eu"},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.7",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port: 6379,
+							},
+						},
+					},
+				},
+			}
+			dataplanes := &core_mesh.DataplaneResourceList{
+				Items: []*core_mesh.DataplaneResource{redisNoZoneTag},
+			}
+
+			// when
+			targets := BuildEdsEndpointMap(context.Background(), defaultMeshWithMTLS, "zone-1", nil, nil, nil, dataplanes.Items, nil, nil, nil, dataSourceLoader, defaultMeshWithMTLS.MTLSEnabled(), nil)
+
+			// then
+			Expect(targets).To(HaveKeyWithValue("", []core_xds.Endpoint{
+				{
+					Target: "192.168.0.7",
+					Port:   6379,
+					Labels: map[string]string{mesh_proto.ZoneTag: "eu"},
+					Locality: &core_xds.Locality{
+						Zone: "eu",
+					},
+					Weight: 1,
+				},
+			}))
+		})
 	})
 
 	Describe("BuildEndpointMap()", func() {


### PR DESCRIPTION
## Motivation

> Changelog: fix(xds): zone fallback for tagless dataplanes

Found while investigating multizone e2e failures on kumahq/kuma#17596 (an exploratory PR flipping `Experimental.InboundTagsDisabled`'s default). `MeshMultiZoneService MeshLbStrategy` failed reproducibly on every leg: traffic that should stay local kept flapping between the local instance and a genuinely remote one.

This is the same class of bug as two already-merged fixes on this theme:
- #17606 — mTLS cert issuance had no workload-label fallback.
- #17657 — `MeshService.Spec.Identities` had no workload-label fallback.

`getZone()` in `pkg/xds/topology/outbound.go` derived an endpoint's locality purely from the `kuma.io/zone` inbound tag. K8s dataplanes lose that tag entirely once `InboundTagsDisabled` strips inbound tags (`tagsOrEmpty()` in `pkg/plugins/runtime/k8s/controllers/inbound_converter.go`). With the local endpoint's zone unset, `MeshLoadBalancingStrategy`'s locality-aware routing can't tell it apart from a remote endpoint, so Envoy load-balances between them essentially at random instead of preferring local.

## Implementation information

- `getZone()` now falls back to the dataplane's own `kuma.io/zone` label — set unconditionally by the K8s pod converter, unlike inbound tags — when the tag is absent.
- Threaded the dataplane/MeshService labels through the two call sites that build locality-aware endpoints (`fillDataplaneOutbounds`, `fillLocalMeshServices`). The third call site (`fillIngressOutbounds`, legacy ZoneIngress `AvailableServices` sync) has no dataplane labels available and is unaffected by this specific gap, so it passes `nil` for the fallback.
- Added a unit test covering the tagless-dataplane-with-zone-label case.

## Supporting documentation

Will need backporting to `release-2.14`.