### PR TITLE
fix(xds): zone fallback for tagless dataplanes

### DIFF
--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -383,7 +383,7 @@ func fillDataplaneOutbounds(
 				Tags:     inboundTags,
 				Labels:   dataplane.GetMeta().GetLabels(),
 				Weight:   endpointWeight,
-				Locality: GetLocality(localZone, getZone(inboundTags), mesh.LocalityAwareLbEnabled()),
+				Locality: GetLocality(localZone, getZone(inboundTags, dataplane.GetMeta().GetLabels()), mesh.LocalityAwareLbEnabled()),
 			})
 		}
 	}
@@ -420,7 +420,7 @@ func fillLocalMeshServices(
 						Tags:     inboundTags,
 						Labels:   dpp.GetMeta().GetLabels(),
 						Weight:   1,
-						Locality: GetLocality(localZone, getZone(inboundTags), mesh.LocalityAwareLbEnabled()),
+						Locality: GetLocality(localZone, getZone(inboundTags, dpp.GetMeta().GetLabels()), mesh.LocalityAwareLbEnabled()),
 					})
 				}
 			}
@@ -526,7 +526,7 @@ func fillLocalCrossMeshOutbounds(
 				Port:     listener.GetPort(),
 				Tags:     mesh_proto.Merge(dpTags, gateway.Spec.GetTags(), listener.GetTags()),
 				Weight:   endpointWeight,
-				Locality: GetLocality(localZone, getZone(dpTags), mesh.LocalityAwareLbEnabled()),
+				Locality: GetLocality(localZone, getZone(dpTags, dataplane.GetMeta().GetLabels()), mesh.LocalityAwareLbEnabled()),
 			})
 		}
 	}
@@ -614,7 +614,7 @@ func fillIngressOutbounds(
 			serviceTags := maps.Clone(service.GetTags())
 			serviceName := serviceTags[mesh_proto.ServiceTag]
 			serviceInstances := service.GetInstances()
-			locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
+			locality := GetLocality(localZone, getZone(serviceTags, nil), mesh.LocalityAwareLbEnabled())
 
 			if _, ok := meshServiceDestinations[serviceName]; ok {
 				continue
@@ -851,7 +851,7 @@ func fillExternalServicesOutboundsThroughEgress(
 			// deep copy map to not modify tags in ExternalService.
 			serviceTags := maps.Clone(externalService.Spec.GetTags())
 			serviceName := serviceTags[mesh_proto.ServiceTag]
-			locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
+			locality := GetLocality(localZone, getZone(serviceTags, nil), mesh.LocalityAwareLbEnabled())
 
 			for _, ze := range egressAddresses {
 				endpoint := core_xds.Endpoint{
@@ -873,7 +873,7 @@ func fillExternalServicesOutboundsThroughEgress(
 		// deep copy map to not modify tags in ExternalService.
 		serviceTags := maps.Clone(mes.Meta.GetLabels())
 		serviceName := destinationname.MustResolve(false, mes, mes.Spec.Match)
-		locality := GetLocality(localZone, getZone(serviceTags), mesh.LocalityAwareLbEnabled())
+		locality := GetLocality(localZone, getZone(serviceTags, nil), mesh.LocalityAwareLbEnabled())
 		tls := mes.Spec.Tls
 		es := &core_xds.ExternalService{
 			Protocol:      mes.Spec.Match.Protocol,
@@ -954,7 +954,7 @@ func NewExternalServiceEndpoint(
 		Tags:            tags,
 		Weight:          1,
 		ExternalService: es,
-		Locality:        GetLocality(zone, getZone(tags), mesh.LocalityAwareLbEnabled()),
+		Locality:        GetLocality(zone, getZone(tags, nil), mesh.LocalityAwareLbEnabled()),
 	}, nil
 }
 
@@ -999,8 +999,15 @@ func GetLocality(localZone string, otherZone *string, localityAwareness bool) *c
 	}
 }
 
-func getZone(tags map[string]string) *string {
+// getZone returns the kuma.io/zone inbound tag, falling back to the
+// dataplane's own zone label -- set unconditionally by the K8s pod
+// converter, unlike inbound tags, which are empty under
+// Experimental.InboundTagsDisabled.
+func getZone(tags map[string]string, labels map[string]string) *string {
 	if zone, ok := tags[mesh_proto.ZoneTag]; ok {
+		return &zone
+	}
+	if zone, ok := labels[mesh_proto.ZoneTag]; ok {
 		return &zone
 	}
 	return nil

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -303,6 +303,7 @@ var _ = Describe("TrafficRoute", func() {
 						Address: "192.168.0.7",
 						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
 							{
+								Tags: map[string]string{mesh_proto.ServiceTag: "redis"},
 								Port: 6379,
 							},
 						},
@@ -318,10 +319,11 @@ var _ = Describe("TrafficRoute", func() {
 			targets := BuildEdsEndpointMap(context.Background(), defaultMeshWithMTLS, "zone-1", nil, nil, nil, dataplanes.Items, nil, nil, nil, externalServices.Items, dataSourceLoader, defaultMeshWithMTLS.MTLSEnabled(), nil)
 
 			// then
-			Expect(targets).To(HaveKeyWithValue("", []core_xds.Endpoint{
+			Expect(targets).To(HaveKeyWithValue("redis", []core_xds.Endpoint{
 				{
 					Target: "192.168.0.7",
 					Port:   6379,
+					Tags:   map[string]string{mesh_proto.ServiceTag: "redis"},
 					Labels: map[string]string{mesh_proto.ZoneTag: "eu"},
 					Locality: &core_xds.Locality{
 						Zone: "eu",

--- a/pkg/xds/topology/outbound_test.go
+++ b/pkg/xds/topology/outbound_test.go
@@ -288,6 +288,48 @@ var _ = Describe("TrafficRoute", func() {
 				},
 			}))
 		})
+
+		It("should fall back to the dataplane zone label when the inbound has no zone tag", func() {
+			// given a dataplane with no kuma.io/zone inbound tag (e.g. InboundTagsDisabled),
+			// but the zone label the K8s pod converter always sets
+			redisNoZoneTag := &core_mesh.DataplaneResource{
+				Meta: &test_model.ResourceMeta{
+					Mesh:   "demo",
+					Name:   "redis-no-zone-tag",
+					Labels: map[string]string{mesh_proto.ZoneTag: "eu"},
+				},
+				Spec: &mesh_proto.Dataplane{
+					Networking: &mesh_proto.Dataplane_Networking{
+						Address: "192.168.0.7",
+						Inbound: []*mesh_proto.Dataplane_Networking_Inbound{
+							{
+								Port: 6379,
+							},
+						},
+					},
+				},
+			}
+			dataplanes := &core_mesh.DataplaneResourceList{
+				Items: []*core_mesh.DataplaneResource{redisNoZoneTag},
+			}
+			externalServices := &core_mesh.ExternalServiceResourceList{}
+
+			// when
+			targets := BuildEdsEndpointMap(context.Background(), defaultMeshWithMTLS, "zone-1", nil, nil, nil, dataplanes.Items, nil, nil, nil, externalServices.Items, dataSourceLoader, defaultMeshWithMTLS.MTLSEnabled(), nil)
+
+			// then
+			Expect(targets).To(HaveKeyWithValue("", []core_xds.Endpoint{
+				{
+					Target: "192.168.0.7",
+					Port:   6379,
+					Labels: map[string]string{mesh_proto.ZoneTag: "eu"},
+					Locality: &core_xds.Locality{
+						Zone: "eu",
+					},
+					Weight: 1,
+				},
+			}))
+		})
 	})
 
 	Describe("BuildEndpointMap()", func() {


### PR DESCRIPTION
## Motivation

> Changelog: fix(xds): zone fallback for tagless dataplanes

Backport of #17673 to release-2.14.

`getZone()` in `pkg/xds/topology/outbound.go` derived an endpoint's locality purely from the `kuma.io/zone` inbound tag. K8s dataplanes lose that tag entirely once `InboundTagsDisabled` strips inbound tags. With the local endpoint's zone unset, `MeshLoadBalancingStrategy`'s locality-aware routing can't tell it apart from a remote endpoint, so Envoy load-balances between them essentially at random instead of preferring local.

## Implementation information

This branch's `outbound.go` predates the master-side locality/priority refactor (`GetLocality` here still takes `localZone`/`localityAwareness` params directly, computing priority inline, rather than deferring to `MeshLoadBalancingStrategy`), so the fix touches more call sites than on master:

- `getZone()` now falls back to the dataplane's own `kuma.io/zone` label when the tag is absent.
- Threaded dataplane/MeshService labels through the 3 call sites that build endpoints from an actual Dataplane resource: `fillDataplaneOutbounds`, `fillLocalMeshServices`, and `fillLocalCrossMeshOutbounds` (builtin-gateway cross-mesh, a code path already removed on master).
- The other 4 call sites derive zone from `ExternalService`/legacy `ZoneIngress.AvailableServices` tags, which have no associated dataplane labels and aren't affected by this gap — they pass `nil` for the fallback.
- Added a unit test covering the tagless-dataplane-with-zone-label case.

## Supporting documentation

Source PR: kumahq/kuma#17673