### PR TITLE
fix(kds): don't sync MeshTrust status from zone to global

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -22,6 +22,7 @@ import (
 	config_manager "github.com/kumahq/kuma/v3/pkg/core/config/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	hostnamegenerator_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	resource_labels "github.com/kumahq/kuma/v3/pkg/core/resources/labels"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -108,6 +109,11 @@ func DefaultContext(
 		kds_reconcile.If(
 			kds_reconcile.IsKubernetes(cfg.Store.Type),
 			RemoveK8sSystemNamespaceSuffixMapper(cfg.Store.Kubernetes.SystemNamespace)),
+		kds_reconcile.If(
+			// MeshTrust status only carries CP-local bookkeeping (e.g. whether it was
+			// generated from a local MeshIdentity), so it shouldn't be synced to Global.
+			kds_reconcile.TypeIs(meshtrust_api.MeshTrustType),
+			RemoveStatus()),
 		HashSuffixMapper(false, mesh_proto.ZoneTag, mesh_proto.KubeNamespaceTag),
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, VersionHeader, version.Build.Version)

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -22,6 +22,7 @@ import (
 	config_manager "github.com/kumahq/kuma/v3/pkg/core/config/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	hostnamegenerator_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	resource_labels "github.com/kumahq/kuma/v3/pkg/core/resources/labels"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -108,6 +109,11 @@ func DefaultContext(
 		reconcile_v2.If(
 			reconcile_v2.IsKubernetes(cfg.Store.Type),
 			RemoveK8sSystemNamespaceSuffixMapper(cfg.Store.Kubernetes.SystemNamespace)),
+		reconcile_v2.If(
+			// MeshTrust status only carries CP-local bookkeeping (e.g. whether it was
+			// generated from a local MeshIdentity), so it shouldn't be synced to Global.
+			reconcile_v2.TypeIs(meshtrust_api.MeshTrustType),
+			RemoveStatus()),
 		HashSuffixMapper(false, mesh_proto.ZoneTag, mesh_proto.KubeNamespaceTag),
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, VersionHeader, version.Build.Version)

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -15,6 +15,8 @@ import (
 	config_manager "github.com/kumahq/kuma/v3/pkg/core/config/manager"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	meshzoneaddress_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1"
 	core_system "github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -143,6 +145,50 @@ var _ = Describe("Context", func() {
 				},
 			}),
 		)
+
+		It("should remove status from MeshTrust when syncing from zone to global", func() {
+			// given
+			resource := &meshtrust_api.MeshTrustResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mt-1",
+				},
+				Spec: &meshtrust_api.MeshTrust{
+					TrustDomain: "example.com",
+				},
+				Status: &meshtrust_api.MeshTrustStatus{
+					Origin: &meshtrust_api.Origin{
+						KRI: pointer.To("kri_dot_kri_dot_default_dot__dot__dot__dot__dot_mesh-identity-1"),
+					},
+				},
+			}
+
+			// when
+			out, err := mapper(kds.Features{}, resource)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.GetStatus()).To(Equal(&meshtrust_api.MeshTrustStatus{}))
+		})
+
+		It("should keep status of other status-bearing resources when syncing from zone to global", func() {
+			// given
+			resource := &meshservice_api.MeshServiceResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "ms-1",
+				},
+				Spec: &meshservice_api.MeshService{},
+				Status: &meshservice_api.MeshServiceStatus{
+					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
+				},
+			}
+
+			// when
+			out, err := mapper(kds.Features{}, resource)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.GetStatus()).To(Equal(resource.Status))
+		})
 	})
 	Describe("GlobalProvidedFilter", func() {
 		var rm manager.ResourceManager

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -15,6 +15,8 @@ import (
 	config_manager "github.com/kumahq/kuma/v3/pkg/core/config/manager"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	core_system "github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
@@ -31,6 +33,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/test/matchers"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
 
@@ -219,6 +222,50 @@ var _ = Describe("Context", func() {
 				},
 			}),
 		)
+
+		It("should remove status from MeshTrust when syncing from zone to global", func() {
+			// given
+			resource := &meshtrust_api.MeshTrustResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mt-1",
+				},
+				Spec: &meshtrust_api.MeshTrust{
+					TrustDomain: "example.com",
+				},
+				Status: &meshtrust_api.MeshTrustStatus{
+					Origin: &meshtrust_api.Origin{
+						KRI: pointer.To("kri_dot_kri_dot_default_dot__dot__dot__dot__dot_mesh-identity-1"),
+					},
+				},
+			}
+
+			// when
+			out, err := mapper(kds.Features{}, resource)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.GetStatus()).To(Equal(&meshtrust_api.MeshTrustStatus{}))
+		})
+
+		It("should keep status of other status-bearing resources when syncing from zone to global", func() {
+			// given
+			resource := &meshservice_api.MeshServiceResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "ms-1",
+				},
+				Spec: &meshservice_api.MeshService{},
+				Status: &meshservice_api.MeshServiceStatus{
+					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
+				},
+			}
+
+			// when
+			out, err := mapper(kds.Features{}, resource)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.GetStatus()).To(Equal(resource.Status))
+		})
 	})
 	Describe("GlobalProvidedFilter", func() {
 		var rm manager.ResourceManager


### PR DESCRIPTION
## Motivation

MeshTrust's status field only carries CP-local bookkeeping: it records
whether the resource was auto-generated from a local MeshIdentity. It
is populated by a per-zone background updater
(pkg/core/resources/apis/meshidentity/status/updater.go) whose Setup()
explicitly no-ops in Global mode, so Global never computes this status
on its own.

KDS already strips status when syncing Global -> Zone for every
resource type that has one, with the existing rationale "we don't
want status field from global to be synced to the zone" (each zone
recomputes its own status locally). The Zone -> Global direction was
missing the equivalent handling for MeshTrust, so a zone-computed
status (with a zone-scoped KRI reference in status.origin) was synced
up and stored as-is on the Global control plane, even though nothing
reads or needs it there.

This is not a crash or data-loss bug: MeshTrust's Spec (TrustDomain,
CA bundles) is unaffected, and no Global-side code path consumes
status.Origin (pkg/api-server already force-clears it as read-only on
API writes). The effect is limited to stale, zone-scoped metadata
being visible on Global's copy of a zone-originated MeshTrust.

## Approach

Add a MeshTrust-scoped RemoveStatus() mapper to the Zone -> Global
resource mapper chain in pkg/kds/context/context.go, mirroring the
existing Global -> Zone stripping but scoped only to MeshTrust (via
TypeIs) so other status-bearing resources that legitimately need
their zone-computed status synced up to Global (e.g. MeshService's
VIPs/addresses, which Global relays to other zones) are unaffected.

## Validation

go test ./pkg/kds/context/... - all tests pass (46 specs), including
two new cases: MeshTrust status is stripped by ZoneResourceMapper,
while MeshService status (a different has_status resource type) is
left untouched by the same mapper.

go build ./pkg/kds/... and go vet ./pkg/kds/... are clean.

Fixes #16407

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>