### PR TITLE
refactor(xds): remove stale legacy naming

### DIFF
--- a/pkg/hds/tracker/callbacks.go
+++ b/pkg/hds/tracker/callbacks.go
@@ -180,7 +180,8 @@ func (t *tracker) OnEndpointHealthResponse(streamID xds.StreamID, resp *envoy_se
 		status := clusterHealth.LocalityEndpointsHealth[0].EndpointsHealth[0].HealthStatus
 		health := status == envoy_core.HealthStatus_HEALTHY || status == envoy_core.HealthStatus_UNKNOWN
 
-		// TODO(unified-resource-naming): adjust when legacy naming is removed
+		// Accept both cluster name formats: pre-unified naming for older dataplanes
+		// and during rolling updates, unified naming for current dataplanes.
 		if clusterHealth.ClusterName == names.GetEnvoyAdminClusterName() || clusterHealth.ClusterName == system_names.SystemResourceNameEnvoyAdmin {
 			envoyHealth = health
 		} else {

--- a/pkg/hds/tracker/healthcheck_generator.go
+++ b/pkg/hds/tracker/healthcheck_generator.go
@@ -68,11 +68,12 @@ func (g *SnapshotGenerator) GenerateSnapshot(ctx context.Context, node *envoy_co
 		}
 		// Mesh deletion doesn't cascade to Dataplanes (mesh_manager only deletes
 		// the Mesh itself), so an orphaned Dataplane can still reach HDS. Fall
-		// back to the legacy admin cluster name instead of failing the snapshot.
+		// back to the pre-unified admin cluster name instead of failing the snapshot.
 		meshFound = false
 	}
 
-	// TODO(unified-resource-naming): adjust when legacy naming is removed
+	// Both cluster name formats must be accepted during rolling updates and for
+	// orphaned dataplanes whose mesh has been deleted.
 	md := xds.DataplaneMetadataFromXdsMetadata(node.Metadata)
 	unifiedNamingEnabled := meshFound && unified_naming.Enabled(md, meshResource)
 	clusterName := names.GetEnvoyAdminClusterName()

--- a/pkg/hds/tracker/healthcheck_generator_test.go
+++ b/pkg/hds/tracker/healthcheck_generator_test.go
@@ -195,10 +195,10 @@ networking:
 				},
 			},
 		}),
-		Entry("should keep legacy admin cluster name for an orphaned dataplane whose mesh was deleted", testCase{
+		Entry("should use pre-unified admin cluster name for an orphaned dataplane whose mesh was deleted", testCase{
 			// Mesh deletion doesn't cascade to Dataplanes, so HDS can still see an
-			// orphaned dataplane after its mesh is gone. It must fall back to the
-			// legacy admin cluster name instead of failing the snapshot.
+			// orphaned dataplane after its mesh is gone. It must use the pre-unified
+			// admin cluster name instead of failing the snapshot.
 			goldenFile: "hds.1.golden.yaml",
 			deleteMesh: true,
 			dataplane: `

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -330,7 +330,7 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 			sidecarContainersEnabled = true
 		} else {
 			log.Info(
-				"Kubernetes server does not support native sidecar containers; falling back to legacy injection",
+				"Kubernetes server does not support native sidecar containers; using init-container injection instead",
 				"version", k8sVersion.GitVersion,
 			)
 		}

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -66,12 +66,12 @@ func addGatewayAPIReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime) er
 	}
 
 	if gatewayAPICRDPresent(mgr, "GatewayClass") {
-		if err := cleanupLegacyGatewayClassFinalizers(
+		if err := removeGatewayClassFinalizers(
 			context.Background(),
 			mgr.GetAPIReader(),
 			mgr.GetClient(),
 		); err != nil {
-			return errors.Wrap(err, "could not clean up legacy GatewayClass finalizers")
+			return errors.Wrap(err, "could not clean up GatewayClass finalizers")
 		}
 	}
 
@@ -96,15 +96,15 @@ func addGatewayAPIReconcilers(mgr kube_ctrl.Manager, rt core_runtime.Runtime) er
 	return nil
 }
 
-// cleanupLegacyGatewayClassFinalizers runs before mgr.Start(), so the manager's
+// removeGatewayClassFinalizers runs before mgr.Start(), so the manager's
 // cached client cannot serve reads yet; list via the direct API reader and
 // only use the cached client for the (uncached) write path.
-func cleanupLegacyGatewayClassFinalizers(ctx context.Context, reader kube_client.Reader, client kube_client.Client) error {
+func removeGatewayClassFinalizers(ctx context.Context, reader kube_client.Reader, client kube_client.Client) error {
 	classes := &gatewayapi.GatewayClassList{}
 	if err := reader.List(ctx, classes); err != nil {
 		if kube_apierrs.IsForbidden(err) {
 			log.Info(
-				"[WARNING] unable to clean up legacy GatewayClass finalizers because RBAC is missing; remove gateway.networking.k8s.io/gatewayclasses finalizers manually if GatewayClass objects are stuck deleting",
+				"[WARNING] unable to remove GatewayClass finalizers because RBAC is missing; remove gateway.networking.k8s.io/gatewayclasses finalizers manually if GatewayClass objects are stuck deleting",
 				"err", err,
 			)
 			return nil
@@ -126,7 +126,7 @@ func cleanupLegacyGatewayClassFinalizers(ctx context.Context, reader kube_client
 		if err := client.Patch(ctx, updated, kube_client.MergeFrom(class)); err != nil {
 			if kube_apierrs.IsForbidden(err) {
 				log.Info(
-					"[WARNING] unable to remove legacy GatewayClass finalizer because RBAC is missing; remove gateway.networking.k8s.io/gatewayclasses finalizers manually if GatewayClass objects are stuck deleting",
+					"[WARNING] unable to remove GatewayClass finalizer because RBAC is missing; remove gateway.networking.k8s.io/gatewayclasses finalizers manually if GatewayClass objects are stuck deleting",
 					"gatewayClass", class.Name,
 					"err", err,
 				)
@@ -135,7 +135,7 @@ func cleanupLegacyGatewayClassFinalizers(ctx context.Context, reader kube_client
 			return err
 		}
 		log.Info(
-			"removed legacy GatewayClass finalizer for removed built-in Gateway API support",
+			"removed GatewayClass finalizer for removed built-in Gateway API support",
 			"gatewayClass", class.Name,
 			"finalizer", gatewayapi_v1.GatewayClassFinalizerGatewaysExist,
 		)

--- a/pkg/plugins/runtime/k8s/plugin_gateway_test.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
 )
 
-func TestCleanupLegacyGatewayClassFinalizers(t *testing.T) {
+func TestRemoveGatewayClassFinalizers(t *testing.T) {
 	scheme, err := bootstrap_k8s.NewScheme()
 	require.NoError(t, err)
 
@@ -42,7 +42,7 @@ func TestCleanupLegacyGatewayClassFinalizers(t *testing.T) {
 		WithObjects(kumaClass, otherClass).
 		Build()
 
-	require.NoError(t, cleanupLegacyGatewayClassFinalizers(context.Background(), client, client))
+	require.NoError(t, removeGatewayClassFinalizers(context.Background(), client, client))
 
 	var updatedKumaClass gatewayapi.GatewayClass
 	require.NoError(t, client.Get(context.Background(), kube_client.ObjectKeyFromObject(kumaClass), &updatedKumaClass))

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -843,7 +843,7 @@ spec:
 		}),
 	)
 
-	It("falls back to legacy sidecar injection when native sidecars are unavailable", func() {
+	It("falls back to init-container sidecar injection when native sidecars are unavailable", func() {
 		var cfg conf.Injector
 		Expect(config.Load(filepath.Join("testdata", "inject.config.yaml"), &cfg)).To(Succeed())
 		cfg.CaCertFile = caCertPath

--- a/pkg/xds/generator/egress/external_services_generator.go
+++ b/pkg/xds/generator/egress/external_services_generator.go
@@ -54,7 +54,7 @@ func getExternalServicesClusters(
 	sniUsed := map[string]struct{}{}
 
 	for _, ref := range destinations.BackendRefs {
-		endpoints := resources.EndpointMap[ref.LegacyServiceName]
+		endpoints := resources.EndpointMap[ref.EndpointMapKey]
 		if _, ok := sniUsed[ref.SNI]; ok || len(endpoints) == 0 || !endpoints[0].IsExternalService() {
 			continue
 		}
@@ -65,7 +65,7 @@ func getExternalServicesClusters(
 
 		cluster := xds.NewClusterBuilder().
 			WithName(clusterName).
-			WithService(ref.LegacyServiceName).
+			WithService(ref.EndpointMapKey).
 			WithSNI(ref.SNI).
 			WithExternalService(true).
 			Build()

--- a/pkg/xds/generator/zone_proxy_listener_generator_test.go
+++ b/pkg/xds/generator/zone_proxy_listener_generator_test.go
@@ -94,8 +94,8 @@ var _ = Describe("ZoneProxyListenerGenerator", func() {
 			ms := samples.MeshServiceBackendBuilder().
 				WithLabels(map[string]string{mesh_proto.ZoneTag: cpZone}).
 				Build()
-			// LegacyServiceName for default/backend/zone=east/port=80: default_backend__east_msvc_80
-			const legacySvcName = "default_backend__east_msvc_80"
+			// endpoint map key for default/backend/zone=east/port=80: default_backend__east_msvc_80
+			const endpointMapKey = "default_backend__east_msvc_80"
 
 			dp := samples.DataplaneBackendBuilder().
 				With(func(r *core_mesh.DataplaneResource) {
@@ -125,7 +125,7 @@ var _ = Describe("ZoneProxyListenerGenerator", func() {
 				meshContext: xds_context.MeshContext{
 					Resource: builders.Mesh().WithName("default").Build(),
 					DataplaneZoneIngressEndpointMap: core_xds.EndpointMap{
-						legacySvcName: []core_xds.Endpoint{
+						endpointMapKey: []core_xds.Endpoint{
 							{
 								Target: "192.168.0.1",
 								Port:   2521,
@@ -149,8 +149,8 @@ var _ = Describe("ZoneProxyListenerGenerator", func() {
 			ms := samples.MeshServiceBackendBuilder().
 				WithLabels(map[string]string{mesh_proto.ZoneTag: cpZone}).
 				Build()
-			// LegacyServiceName for default/backend/zone=east/port=80: default_backend__east_msvc_80
-			const legacySvcName = "default_backend__east_msvc_80"
+			// endpoint map key for default/backend/zone=east/port=80: default_backend__east_msvc_80
+			const endpointMapKey = "default_backend__east_msvc_80"
 
 			dp := samples.DataplaneBackendBuilder().
 				With(func(r *core_mesh.DataplaneResource) {
@@ -180,7 +180,7 @@ var _ = Describe("ZoneProxyListenerGenerator", func() {
 				meshContext: xds_context.MeshContext{
 					Resource: builders.Mesh().WithName("default").Build(),
 					DataplaneZoneIngressEndpointMap: core_xds.EndpointMap{
-						legacySvcName: []core_xds.Endpoint{
+						endpointMapKey: []core_xds.Endpoint{
 							{
 								Target: "192.168.0.1",
 								Port:   2521,
@@ -272,10 +272,10 @@ var _ = Describe("ZoneProxyListenerGenerator", func() {
 				AddIntPort(80, core_meta.ProtocolHTTP).
 				Build()
 
-			// LegacyServiceName used as endpoint map key: default_global-svc___mzsvc_80
+			// endpoint map key: default_global-svc___mzsvc_80
 			// Cluster name (unified naming): kri_mzsvc_default___global-svc_80
 			// Filter chain SNI: sni.mzsvc.default.global-svc.80
-			const legacyMZSSvcName = "default_global-svc___mzsvc_80"
+			const mzsEndpointMapKey = "default_global-svc___mzsvc_80"
 
 			dp := samples.DataplaneBackendBuilder().
 				With(func(r *core_mesh.DataplaneResource) {
@@ -305,7 +305,7 @@ var _ = Describe("ZoneProxyListenerGenerator", func() {
 				meshContext: xds_context.MeshContext{
 					Resource: builders.Mesh().WithName("default").Build(),
 					DataplaneZoneIngressEndpointMap: core_xds.EndpointMap{
-						legacyMZSSvcName: []core_xds.Endpoint{
+						mzsEndpointMapKey: []core_xds.Endpoint{
 							{
 								Target: "192.168.0.1",
 								Port:   8080,

--- a/pkg/xds/generator/zoneproxy/destinations.go
+++ b/pkg/xds/generator/zoneproxy/destinations.go
@@ -29,9 +29,9 @@ type MeshDestinations struct {
 type BackendRefDestination struct {
 	resolve.ResolvedBackendRef
 
-	Mesh            string
-	SNI             string
-	EndpointMapKey  string
+	Mesh           string
+	SNI            string
+	EndpointMapKey string
 }
 
 // BuildMeshDestinations builds destinations for zone proxies using the hash-based SNI format.
@@ -64,8 +64,8 @@ func BuildRealResourceDestinations(destinations []core_resources.Destination, sy
 		for _, port := range dest.GetPorts() {
 			id := kri.WithSectionName(origin, port.GetName())
 			result = append(result, BackendRefDestination{
-				Mesh:              mesh,
-				SNI:               sniFor(id, port),
+				Mesh:           mesh,
+				SNI:            sniFor(id, port),
 				EndpointMapKey: destinationname.ResolveLegacyFromDestination(dest, port),
 				ResolvedBackendRef: resolve.ResolvedBackendRef{
 					Ref: &resolve.RealResourceBackendRef{

--- a/pkg/xds/generator/zoneproxy/destinations.go
+++ b/pkg/xds/generator/zoneproxy/destinations.go
@@ -29,12 +29,12 @@ type MeshDestinations struct {
 type BackendRefDestination struct {
 	resolve.ResolvedBackendRef
 
-	Mesh              string
-	SNI               string
-	LegacyServiceName string
+	Mesh            string
+	SNI             string
+	EndpointMapKey  string
 }
 
-// BuildMeshDestinations builds destinations for legacy zone proxies using the hash-based SNI format.
+// BuildMeshDestinations builds destinations for zone proxies using the hash-based SNI format.
 func BuildMeshDestinations(
 	availableServices []*mesh_proto.ZoneIngress_AvailableService, // available services for a single mesh
 	systemNamespace string,
@@ -66,7 +66,7 @@ func BuildRealResourceDestinations(destinations []core_resources.Destination, sy
 			result = append(result, BackendRefDestination{
 				Mesh:              mesh,
 				SNI:               sniFor(id, port),
-				LegacyServiceName: destinationname.ResolveLegacyFromDestination(dest, port),
+				EndpointMapKey: destinationname.ResolveLegacyFromDestination(dest, port),
 				ResolvedBackendRef: resolve.ResolvedBackendRef{
 					Ref: &resolve.RealResourceBackendRef{
 						Resource: id,

--- a/pkg/xds/generator/zoneproxy/generator.go
+++ b/pkg/xds/generator/zoneproxy/generator.go
@@ -188,7 +188,7 @@ func GetServices(
 
 		cluster := plugins_xds.NewClusterBuilder().
 			WithName(clusterName).
-			WithService(br.LegacyServiceName).
+			WithService(br.EndpointMapKey).
 			WithSNI(br.SNI).
 			WithMesh(br.Mesh).
 			Build()


### PR DESCRIPTION
## Motivation

Part of #17241. Removes stale "legacy" terminology from gateway/zone-proxy destination naming, HDS admin-cluster fallback comments, and k8s GatewayClass finalizer cleanup, without changing public API (REST endpoints, protobuf/wire-format, Envoy resource names). The Go module packages involved (`pkg/xds/generator/zoneproxy`) are internal implementation details of the control plane — they carry no stable Go API contract.

## Implementation information

- Rename `BackendRefDestination.LegacyServiceName` to `EndpointMapKey` (internal Go field, not a public API)
- Replace `TODO(unified-resource-naming)` in HDS with stable comments; dual-name handling preserved for rolling updates/orphaned dataplanes
- Rename `cleanupLegacyGatewayClassFinalizers` to `removeGatewayClassFinalizers`; cleanup behavior and Forbidden handling unchanged
- Reword "falling back to legacy injection" log in plugin.go
- Update test locals and comments to use endpoint-map key terminology

## Supporting documentation

Relates to #17291

Closes https://github.com/kumahq/kuma/issues/17291

_Generated by Sybra harness_