### PR TITLE
test(e2e): make dp cache readable by runner

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -88,6 +88,7 @@ runs:
     - name: "Run E2E tests"
       shell: bash
       env:
+        GINKGO_E2E_TEST_FLAGS: "--focus=Compatibility"
         KUMA_DEBUG: ${{ runner.debug == '1' }}
         KUMA_E2E_PRELOAD_MANIFEST: ${{ runner.temp }}/e2e-preloaded-images.txt
         E2E_K8S_VERSION: ${{ inputs.k8s_version }}

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -90,9 +90,11 @@ jobs:
           # You can modify the include to run one of test suites on PRs (though you'd need to then remove it)
           OVERRIDE_JQ_CMD: |-
             .test_e2e = false
+            | .test_e2e_env.target = ["universal"]
+            | .test_e2e_env.k8sVersion = ["kind"]
             | .test_e2e_env.include = []
-            | .test_e2e_env.parallelism = [4]
-            | .test_e2e_env.exclude += [{"arch": "arm64"}, {"k8sVersion": "kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION}}"}]
+            | .test_e2e_env.exclude = []
+            | .test_e2e_env.parallelism = [1]
           FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
           SKIP_E2E_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG }}
         run: |-

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -382,8 +382,10 @@ func (s *UniversalApp) CreateDP(
 		// Try to extract straight from the cached tarball; extraction doubles as the
 		// integrity check. On a miss or a corrupt entry, download, extract that, and
 		// atomically (re)populate the cache via a unique mktemp temp + mv so a fresh
-		// good copy overwrites any bad one. Cache writes are best-effort (|| true) so
-		// a read-only mount never fails the install.
+		// good copy overwrites any bad one. The container writes as root, so chmod
+		// the entry world-readable: actions/cache runs as the (non-root) runner user
+		// and can only save the dir when it can read the files. Cache writes are
+		// best-effort (|| true) so a read-only mount never fails the install.
 		cacheFile := fmt.Sprintf("%s/kuma-%s-linux-%s.tar.gz", dpBinaryCacheMountPath, dpVersion, Config.Arch)
 
 		// Run the install synchronously so a failed download fails the test fast
@@ -396,6 +398,7 @@ if ! { [ -f '%[1]s' ] && tar xzf '%[1]s' --directory /tmp/kuma/ 2>/dev/null; }; 
   tmp=$(mktemp '%[1]s.XXXXXX') && cp /tmp/kuma/kuma.tar.gz "$tmp" && mv "$tmp" '%[1]s' || true
   tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
 fi
+chmod 0644 '%[1]s' 2>/dev/null || true
 cp %[3]s/kuma-dp /usr/bin/kuma-dp
 cp %[3]s/envoy /usr/bin/envoy
 `, cacheFile, url, newPathOut)


### PR DESCRIPTION
## Motivation

The kuma-dp binary cache (added in #17605) never actually persisted on CI: `actions/cache` misses on every run and its save step fails with `Permission denied` / `tar exit code 2`.
The cache file is written by the container as root at mode `0600` (the hardening switched the temp file to `mktemp`, which is `0600`), and `actions/cache` runs as the non-root runner user, so it cannot read the file to archive it.
Net effect: the GitHub cache is never saved, every run misses, and the DP compatibility test re-downloads from `packages.konghq.com` - so egress did not drop.

## Implementation information

`chmod 0644` the cache entry after populate, and on cache hits too, so any pre-existing `0600` entry left on a self-hosted runner self-heals and `actions/cache` can read it.

Verified locally that a populated entry ends up `0644` and a pre-seeded `0600` entry is healed to `0644` on a hit.

## Supporting documentation

Follow-up to #17605.

> [!NOTE]
> The top commit (`TEMP run only universal compat`) narrows CI to just the compat test to verify the fix quickly; it will be dropped before merge.

> Changelog: skip