### PR TITLE
Revert "test(e2e): cache kuma-dp release binaries"

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -72,19 +72,6 @@ runs:
           docker load -i "$tar"
           echo "KUMA_E2E_TRUST_CACHED_IMAGE_TAGS=true" >> "$GITHUB_ENV"
         fi
-    # Cache released kuma-dp tarballs pulled from packages.konghq.com by the DP
-    # compatibility tests (universal target only). Without this every run re-pulls
-    # ~130MB per supported version, which dominates Cloudsmith egress. The test
-    # framework reads/writes this dir (see dpBinaryCacheHostDir). restore-keys lets
-    # a version bump reuse the previous cache and only download the new version.
-    - name: "Cache kuma-dp release binaries"
-      if: ${{ inputs.target == 'universal' }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: /tmp/kuma-dp-binaries-cache
-        key: kuma-dp-binaries-${{ inputs.arch }}-${{ hashFiles('versions.yml') }}
-        restore-keys: |
-          kuma-dp-binaries-${{ inputs.arch }}-
     - name: "Run E2E tests"
       shell: bash
       env:

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -37,16 +37,6 @@ const (
 	AppModeDemoClient      = "demo-client"
 
 	sshPort = "22"
-
-	// dpBinaryCacheHostDir is a stable host directory caching released kuma-dp
-	// tarballs across universal e2e runs, so the DP compatibility install reuses
-	// them instead of re-downloading from packages.konghq.com every run. CI
-	// persists it via actions/cache; on self-hosted runners it survives between
-	// runs on its own. It is bind-mounted at dpBinaryCacheMountPath into app
-	// containers on the local docker backend (a host bind-mount is meaningless
-	// for the remote backend).
-	dpBinaryCacheHostDir   = "/tmp/kuma-dp-binaries-cache"
-	dpBinaryCacheMountPath = "/kuma-dp-binaries-cache"
 )
 
 type UniversalApp struct {
@@ -73,7 +63,6 @@ type UniversalApp struct {
 type UniversalAppRunOptions struct {
 	DockerBackend        DockerBackend
 	DPConcurrency        int
-	DPVersion            string
 	EnvironmentVariables []string
 	ContainerName        string
 	Volumes              []string
@@ -122,24 +111,11 @@ func NewUniversalApp(t testing.TestingT, clusterName, appName, mesh string, mode
 		app.logger = logger.Default
 	}
 
-	// Mount the host cache dir so the DP compatibility install can reuse
-	// already-downloaded kuma-dp tarballs instead of pulling them again. Only for
-	// apps that install a specific kuma-dp version (the ones that download) and
-	// only on the local docker backend (a host bind-mount is meaningless for the
-	// remote backend).
-	volumes := runOptions.Volumes
-	_, localBackend := runOptions.DockerBackend.(*LocalDockerBackend)
-	if localBackend && runOptions.DPVersion != "" {
-		if err := os.MkdirAll(dpBinaryCacheHostDir, 0o755); err != nil {
-			return nil, errors.Wrapf(err, "failed to create DP binary cache dir %q", dpBinaryCacheHostDir)
-		}
-		volumes = append(slices.Clone(runOptions.Volumes), fmt.Sprintf("%s:%s", dpBinaryCacheHostDir, dpBinaryCacheMountPath))
-	}
 	container, err := app.dockerBackend.RunAndGetIDE(t, Config.GetUniversalImage(), &docker.RunOptions{
 		Detach:               true,
 		Remove:               true,
 		Name:                 app.containerName,
-		Volumes:              volumes,
+		Volumes:              runOptions.Volumes,
 		Logger:               app.logger,
 		EnvironmentVariables: runOptions.EnvironmentVariables,
 		OtherOptions:         dockerExtraOptions,
@@ -379,26 +355,16 @@ func (s *UniversalApp) CreateDP(
 		url := fmt.Sprintf("https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-%[2]s/versions/%[1]s/kuma-%[1]s-linux-%[2]s.tar.gz", dpVersion, Config.Arch)
 		newPathOut := fmt.Sprintf("/tmp/kuma/kuma-%s/bin", dpVersion)
 
-		// Try to extract straight from the cached tarball; extraction doubles as the
-		// integrity check. On a miss or a corrupt entry, download, extract that, and
-		// atomically (re)populate the cache via a unique mktemp temp + mv so a fresh
-		// good copy overwrites any bad one. Cache writes are best-effort (|| true) so
-		// a read-only mount never fails the install.
-		cacheFile := fmt.Sprintf("%s/kuma-%s-linux-%s.tar.gz", dpBinaryCacheMountPath, dpVersion, Config.Arch)
-
 		// Run the install synchronously so a failed download fails the test fast
 		// instead of silently falling through to the image's bundled binaries.
 		installScript := fmt.Sprintf(`set -e
 rm -f /usr/bin/kuma-dp /usr/bin/envoy
 mkdir -p /tmp/kuma/
-if ! { [ -f '%[1]s' ] && tar xzf '%[1]s' --directory /tmp/kuma/ 2>/dev/null; }; then
-  curl --no-progress-bar --fail '%[2]s' -o /tmp/kuma/kuma.tar.gz
-  tmp=$(mktemp '%[1]s.XXXXXX') && cp /tmp/kuma/kuma.tar.gz "$tmp" && mv "$tmp" '%[1]s' || true
-  tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
-fi
-cp %[3]s/kuma-dp /usr/bin/kuma-dp
-cp %[3]s/envoy /usr/bin/envoy
-`, cacheFile, url, newPathOut)
+curl --no-progress-bar --fail '%s' -o /tmp/kuma/kuma.tar.gz
+tar xzf /tmp/kuma/kuma.tar.gz --directory /tmp/kuma/
+cp %s/kuma-dp /usr/bin/kuma-dp
+cp %s/envoy /usr/bin/envoy
+`, url, newPathOut, newPathOut)
 		if stdout, stderr, err := s.universalNetworking.RunCommand(installScript); err != nil {
 			return errors.Wrapf(err, "failed to install kuma-dp %s: stdout=%q stderr=%q", dpVersion, stdout, stderr)
 		}

--- a/test/framework/universal_cluster.go
+++ b/test/framework/universal_cluster.go
@@ -416,7 +416,6 @@ func (c *UniversalCluster) DeployApp(opt ...AppDeploymentOption) error {
 		UniversalAppRunOptions{
 			DockerBackend: c.dockerBackend,
 			DPConcurrency: 0,
-			DPVersion:     opts.dpVersion,
 			EnableIPv6:    opts.isipv6,
 			Verbose:       *opts.verbose,
 			Capabilities:  caps,


### PR DESCRIPTION
Reverts kumahq/kuma#17605 - we don't pay for OSS usage so this is no longer needed

closes https://github.com/Kong/kong-mesh/issues/10261