### PR TITLE
test(framework): skip kumactl add when opted out

### DIFF
--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -48,13 +48,19 @@ func NewUniversalControlPlane(
 		cpNetworking: networking,
 		setupKumactl: setupKumactl,
 	}
-	token, err := ucp.retrieveAdminToken()
-	if err != nil {
-		return nil, err
-	}
+	// Honor setupKumactl the same way the Kubernetes control plane does
+	// (see k8s_controlplane.go): when kumactl configuration is disabled we
+	// must not run `kumactl config control-planes add`, since its connectivity
+	// check can't reach a CP that requires custom auth (e.g. konnect-authn).
+	if setupKumactl {
+		token, err := ucp.retrieveAdminToken()
+		if err != nil {
+			return nil, err
+		}
 
-	if err := kumactl.KumactlConfigControlPlanesAdd(clusterName, ucp.GetAPIServerAddress(), token, apiHeaders); err != nil {
-		return nil, err
+		if err := kumactl.KumactlConfigControlPlanesAdd(clusterName, ucp.GetAPIServerAddress(), token, apiHeaders); err != nil {
+			return nil, err
+		}
 	}
 	return ucp, nil
 }

--- a/test/framework/universal_controlplane.go
+++ b/test/framework/universal_controlplane.go
@@ -49,9 +49,7 @@ func NewUniversalControlPlane(
 		setupKumactl: setupKumactl,
 	}
 	// Honor setupKumactl the same way the Kubernetes control plane does
-	// (see k8s_controlplane.go): when kumactl configuration is disabled we
-	// must not run `kumactl config control-planes add`, since its connectivity
-	// check can't reach a CP that requires custom auth (e.g. konnect-authn).
+	// (see k8s_controlplane.go)
 	if setupKumactl {
 		token, err := ucp.retrieveAdminToken()
 		if err != nil {


### PR DESCRIPTION
## Motivation

`NewUniversalControlPlane` always runs `kumactl config control-planes add`, even when a deployment opts out of kumactl configuration via `WithoutConfiguringKumactl()` (`setupKumactl=false`).
The Kubernetes control plane already honors that flag and skips the add (`k8s_controlplane.go`), so the two paths behave differently.

`control-planes add` runs a connectivity/version check against the CP unless `--skip-check` is passed, and the framework never passes it.
For a control plane that requires custom auth headers (e.g. `konnect-authn`), that check can never succeed, so the add retries 30 times and fails the deployment - even though the test explicitly opted out of kumactl configuration.

This blocks a downstream project's e2e test that deploys a multi-tenant Global CP as Universal with custom auth, where the failure surfaces as:

```
'kumactl config control-planes add' unsuccessful after 30 retries
```

## Implementation information

Guard the `retrieveAdminToken` + `KumactlConfigControlPlanesAdd` calls in `NewUniversalControlPlane` with `setupKumactl`, matching the Kubernetes control plane path.

## Supporting documentation

Added `ci/skip-test` because this is not exercised in kuma but in Kong Mesh. Test-only change to the e2e framework.

> Changelog: skip