### PR TITLE
test(e2e): fix meshtimeout count for gw defaults

### DIFF
--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -112,7 +112,7 @@ spec:
 
 			Eventually(func(g Gomega) (int, error) {
 				return NumberOfResources(zoneK8s, meshtimeout.MeshTimeoutResourceTypeDescriptor)
-			}, "30s", "1s").Should(Equal(5), "meshtimeouts are not synced to zone")
+			}, "30s", "1s").Should(Equal(3), "meshtimeouts are not synced to zone")
 
 			By("Sync DPPs from Zone to Global")
 			err = NewClusterSetup().
@@ -200,7 +200,7 @@ spec:
 				g.Expect(err).ToNot(HaveOccurred())
 				policiesUniversalZone, err := NumberOfResources(zoneUniversal, meshtimeout.MeshTimeoutResourceTypeDescriptor)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(policiesGlobal).To(And(Equal(policiesUniversalZone), Equal(policiesK8sZone), Equal(5)))
+				g.Expect(policiesGlobal).To(And(Equal(policiesUniversalZone), Equal(policiesK8sZone), Equal(3)))
 
 				dppsGlobal, err := NumberOfResources(global, mesh.DataplaneResourceTypeDescriptor)
 				g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Motivation

> Changelog: skip

https://github.com/kumahq/kuma/actions/runs/30369674169/job/90311850334#step:4:4267
https://github.com/kumahq/kuma/actions/runs/30429898833/job/90505407130#step:4:4289

https://github.com/kumahq/kuma/pull/17668 removed the `proxyTypes` targetRef field, which dropped the two gateway-specific default MeshTimeout resources (`mesh-gateways-timeout-all`, `mesh-gateways-timeout-to-all`).
The mesh now ships 2 default MeshTimeouts (`mesh-timeout-all`, `mesh-timeout-to-all`) instead of 4.

The helm upgrade multizone test still expected 5 synced policies (4 defaults + 1 it creates).
It should expect 3 (2 defaults + 1 created).
https://github.com/kumahq/kuma/pull/17668 updated its unit tests but missed this e2e test, so master fails deterministically since that merge.

## Implementation information

- `test/e2e/helm/kuma_helm_upgrade_multizone.go`: expected MeshTimeout count 5 -> 3 in both assertions.

## Supporting documentation

N/A