### PR TITLE
test(kds): replace sleep with eventually

### DIFF
--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -32,9 +32,8 @@ var _ = Describe("Full sync tests", func() {
 		zones := make(map[string]store.ResourceStore)
 		wg := sync.WaitGroup{}
 		done := make(chan struct{})
-		closeOnce := sync.Once{}
 		DeferCleanup(func() {
-			closeOnce.Do(func() { close(done) })
+			close(done)
 			wg.Wait()
 		})
 

--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -32,6 +32,11 @@ var _ = Describe("Full sync tests", func() {
 		zones := make(map[string]store.ResourceStore)
 		wg := sync.WaitGroup{}
 		done := make(chan struct{})
+		closeOnce := sync.Once{}
+		DeferCleanup(func() {
+			closeOnce.Do(func() { close(done) })
+			wg.Wait()
+		})
 
 		for _, file := range files {
 			if strings.HasSuffix(file.Name(), ".input.yaml") {
@@ -85,16 +90,17 @@ var _ = Describe("Full sync tests", func() {
 			}()
 		}
 
-		// Wait for some time to ensure sync was complete
-		time.Sleep(time.Second * 5)
-		close(done)
-		wg.Wait()
-
-		// Compare golden files
+		// A fixed sleep here flaked on slow CI runners before sync finished; poll instead.
+		if os.Getenv("UPDATE_GOLDEN_FILES") != "" {
+			time.Sleep(5 * time.Second)
+		}
 		for zoneName, zoneStore := range zones {
-			out, err := test_store.ExtractResources(ctx, zoneStore)
-			Expect(err).To(Succeed())
-			Expect(out).To(matchers.MatchGoldenEqual(folder, zoneName+".golden.yaml"), "zone %s", zoneName)
+			goldenFile := zoneName + ".golden.yaml"
+			Eventually(func(g Gomega) {
+				out, err := test_store.ExtractResources(ctx, zoneStore)
+				g.Expect(err).To(Succeed())
+				g.Expect(out).To(matchers.MatchGoldenEqual(folder, goldenFile), "zone %s", zoneName)
+			}, "30s", "250ms").Should(Succeed())
 		}
 	}, test.EntriesAsFolder("full_sync"))
 })


### PR DESCRIPTION
## Motivation

CI on release-2.13 has been flaking in `pkg/kds/context` `TestContext` /
`Full sync tests`: a fixed `time.Sleep(5s)` was used to let zone-to-global
KDS sync settle before comparing golden files. On slower CI runners 5s
wasn't always enough, so `Zone`/`ZoneInsight` resources that hadn't
synced yet were missing from the comparison, failing the golden-file
match non-deterministically.

## Implementation information

- Replace the fixed sleep with `Eventually` polling (30s timeout, 250ms
  interval) around the golden-file comparison, so fast runs still take
  ~1s and slow runs get the headroom they need.
- Keep the `UPDATE_GOLDEN_FILES=true` path sleeping first, since
  `Eventually` would otherwise write partial state on its first match.
- Use `DeferCleanup` to stop the started components instead of doing it
  inline, since the comparison can now retry multiple times before the
  spec ends.
- This mirrors the equivalent fix already present on `master`, adapted
  to this branch's test code (no other behavior change).

> Changelog: skip

## Supporting documentation

N/A