### PR TITLE
ci(build-publish): cache go build on tag

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -57,6 +57,16 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Cache Go build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         if: ${{ github.ref_type == 'tag' }}
         with:


### PR DESCRIPTION
## Motivation

The `assert-tag-version` job in `_build_publish.yaml` builds `kuma-cp`
from scratch with a bare `go build` and no Go module/build cache,
under a tight 10-minute timeout. On a slow/cold runner this isn't
enough time to download modules and compile the full dependency tree
(including `go-control-plane`), so the job gets cancelled by the
timeout and the whole release publish chain (build-binaries,
build-images, publish-helm) is skipped as a result. This happened on
the v2.14.2 tag push: https://github.com/kumahq/kuma/actions/runs/30468174564

## Implementation information

Add the same "Cache Go build" step (and cache key) already used by
the branch `check` job in `build-test-distribute.yaml`, restoring
`~/.cache/go-build` and `~/go/pkg/mod` keyed on `go.sum`. Since the
tag build reuses the exact SHA that already went green on the branch,
the cache populated by that branch's `check` job run should already
be warm, making this build near-instant instead of a cold compile.

## Supporting documentation

Follow-up to #17445 / #17234.

> Changelog: skip