### PR TITLE
fix(kds): retry sync updates on write conflicts

### DIFF
--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sethvargo/go-retry"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
@@ -28,15 +29,16 @@ import (
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
 	resources_k8s "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
 	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
-	util_time "github.com/kumahq/kuma/v3/pkg/util/time"
 )
 
 var globalSyncLog = core.Log.WithName("kds-global-sync")
 
 const (
-	updateConflictAttempts = 3
-	// Upper bound of the jittered pause before a retry, so a cached store
-	// (Kubernetes informer) can observe the write that won.
+	// Retries of an update that lost a write conflict. The first one runs
+	// immediately, which is all a store reading its own writes needs; the later
+	// ones wait so a cached store (Kubernetes informer) can observe the write
+	// that won.
+	updateConflictRetries = 2
 	updateConflictBackoff = 100 * time.Millisecond
 )
 
@@ -271,6 +273,7 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 		}
 	}
 	var nackError error
+	var conflicted []OnUpdate
 	err = store.InTx(ctx, s.transactions, func(ctx context.Context) error {
 		for _, r := range onCreate {
 			rk := core_model.MetaToResourceKey(r.GetMeta())
@@ -307,45 +310,74 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 
 		for _, upd := range onUpdate {
 			log.V(1).Info("updating a resource", "name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh())
-			if err := s.updateWithConflictRetry(ctx, upd, opts, log); err != nil {
-				return err
+			// some stores manage ModificationTime time on they own (Kubernetes), in order to be consistent
+			// we set ModificationTime when we add to downstream store. This time is almost the same with ModificationTime
+			// from upstream store, because we update downstream only when resource have changed in upstream
+			if err := s.resourceStore.Update(ctx, upd.r, append(upd.opts, store.ModifiedAt(time.Now()))...); err != nil {
+				if !store.IsConflict(err) {
+					return err
+				}
+				// Retry outside the transaction, so the backoff doesn't hold its
+				// connection and row locks. Continuing is safe: a conflict is a
+				// zero-row update, not a database error, so the transaction lives on.
+				conflicted = append(conflicted, upd)
 			}
 		}
 		return nil
 	})
-	return err, nackError
+	if err != nil {
+		return err, nackError
+	}
+	return s.retryConflictedUpdates(ctx, conflicted, opts, log), nackError
 }
 
-// updateWithConflictRetry writes an upstream change downstream, reapplying it on
-// top of a freshly read copy when the write loses an optimistic concurrency race.
-// Zone-local writers (VIP allocator, hostname generators) touch the same
-// resources, and stores version the whole resource, so any of their writes
-// invalidates the version read at List time.
-//
-// When retries run out the error goes back to the caller, which tears the stream
-// down and forces a resync. Skipping the resource would be worse: delta xDS marks
-// it delivered on send, so the upstream would consider the zone current while it
-// silently drifts.
-func (s *syncResourceStore) updateWithConflictRetry(ctx context.Context, upd OnUpdate, opts *SyncOption, log logr.Logger) error {
-	var err error
-	for attempt := 1; attempt <= updateConflictAttempts; attempt++ {
-		// some stores manage ModificationTime time on they own (Kubernetes), in order to be consistent
-		// we set ModificationTime when we add to downstream store. This time is almost the same with ModificationTime
-		// from upstream store, because we update downstream only when resource have changed in upstream
-		err = s.resourceStore.Update(ctx, upd.r, append(upd.opts, store.ModifiedAt(time.Now()))...)
-		if err == nil || !store.IsConflict(err) {
+// retryConflictedUpdates reapplies updates that lost a write conflict, rebased on a
+// fresh copy: zone-local writers (VIP allocator, hostname generators) invalidate the
+// version read at List time. It runs after the transaction commits, so the waits
+// hold no connection or row locks, and the batch shares one wait per attempt. Sync
+// is no longer all-or-nothing, which is fine for a convergent reconciliation of a
+// single type, and the Kubernetes store has no transactions anyway. Exhausting the
+// retries returns the error and forces a resync; skipping would drift silently,
+// since delta xDS marks the resource delivered on send.
+func (s *syncResourceStore) retryConflictedUpdates(ctx context.Context, pending []OnUpdate, opts *SyncOption, log logr.Logger) error {
+	if len(pending) == 0 {
+		return nil
+	}
+	backoff := retry.WithMaxRetries(updateConflictRetries, retry.WithFullJitter(retry.NewConstant(updateConflictBackoff)))
+	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
+		for _, upd := range pending {
+			s.conflictRetries.Inc()
+			log.Info("resource was modified in another place while syncing, retrying with a fresh copy",
+				"name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh())
+			if err := s.refreshForUpdate(ctx, upd, opts); err != nil {
+				return err
+			}
+		}
+		var conflicted []OnUpdate
+		var lastConflict error
+		if err := store.InTx(ctx, s.transactions, func(ctx context.Context) error {
+			for _, upd := range pending {
+				if err := s.resourceStore.Update(ctx, upd.r, append(upd.opts, store.ModifiedAt(time.Now()))...); err != nil {
+					if !store.IsConflict(err) {
+						return err
+					}
+					lastConflict = err
+					conflicted = append(conflicted, upd)
+				}
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
-		s.conflictRetries.Inc()
-		log.Info("resource was modified in another place while syncing, retrying with a fresh copy",
-			"name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh(), "attempt", attempt)
-		if attempt == updateConflictAttempts {
-			break
+		pending = conflicted
+		if len(pending) > 0 {
+			return retry.RetryableError(lastConflict)
 		}
-		util_time.SleepUpTo(updateConflictBackoff)
-		if refreshErr := s.refreshForUpdate(ctx, upd, opts); refreshErr != nil {
-			return refreshErr
-		}
+		return nil
+	})
+	if store.IsConflict(err) {
+		log.Info("gave up syncing a resource that keeps being modified in another place, forcing a resync",
+			"name", pending[0].r.GetMeta().GetName(), "mesh", pending[0].r.GetMeta().GetMesh())
 	}
 	return err
 }

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -104,12 +104,11 @@ func PrefilterBy(predicate func(r core_model.Resource) bool) SyncOptionFunc {
 }
 
 type syncResourceStore struct {
-	log             logr.Logger
-	resourceStore   store.ResourceStore
-	transactions    store.Transactions
-	metric          prometheus.Histogram
-	conflictRetries prometheus.Counter
-	extensions      context.Context
+	log           logr.Logger
+	resourceStore store.ResourceStore
+	transactions  store.Transactions
+	metric        prometheus.Histogram
+	extensions    context.Context
 }
 
 func NewResourceSyncer(
@@ -126,20 +125,12 @@ func NewResourceSyncer(
 	if err := metrics.Register(metric); err != nil {
 		return nil, err
 	}
-	conflictRetries := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "kds_resources_sync_conflict_retries",
-		Help: "Number of times syncing a resource from the upstream was retried after losing a write conflict",
-	})
-	if err := metrics.Register(conflictRetries); err != nil {
-		return nil, err
-	}
 	return &syncResourceStore{
-		log:             log,
-		resourceStore:   resourceStore,
-		transactions:    transactions,
-		metric:          metric,
-		conflictRetries: conflictRetries,
-		extensions:      extensions,
+		log:           log,
+		resourceStore: resourceStore,
+		transactions:  transactions,
+		metric:        metric,
+		extensions:    extensions,
 	}, nil
 }
 
@@ -346,7 +337,6 @@ func (s *syncResourceStore) retryConflictedUpdates(ctx context.Context, pending 
 	backoff := retry.WithMaxRetries(updateConflictRetries, retry.WithFullJitter(retry.NewConstant(updateConflictBackoff)))
 	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
 		for _, upd := range pending {
-			s.conflictRetries.Inc()
 			log.Info("resource was modified in another place while syncing, retrying with a fresh copy",
 				"name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh())
 			if err := s.refreshForUpdate(ctx, upd, opts); err != nil {

--- a/pkg/kds/v2/store/sync.go
+++ b/pkg/kds/v2/store/sync.go
@@ -28,9 +28,17 @@ import (
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
 	resources_k8s "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
 	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
+	util_time "github.com/kumahq/kuma/v3/pkg/util/time"
 )
 
 var globalSyncLog = core.Log.WithName("kds-global-sync")
+
+const (
+	updateConflictAttempts = 3
+	// Upper bound of the jittered pause before a retry, so a cached store
+	// (Kubernetes informer) can observe the write that won.
+	updateConflictBackoff = 100 * time.Millisecond
+)
 
 // ResourceSyncer allows to synchronize resources in Store
 type ResourceSyncer interface {
@@ -94,11 +102,12 @@ func PrefilterBy(predicate func(r core_model.Resource) bool) SyncOptionFunc {
 }
 
 type syncResourceStore struct {
-	log           logr.Logger
-	resourceStore store.ResourceStore
-	transactions  store.Transactions
-	metric        prometheus.Histogram
-	extensions    context.Context
+	log             logr.Logger
+	resourceStore   store.ResourceStore
+	transactions    store.Transactions
+	metric          prometheus.Histogram
+	conflictRetries prometheus.Counter
+	extensions      context.Context
 }
 
 func NewResourceSyncer(
@@ -115,12 +124,20 @@ func NewResourceSyncer(
 	if err := metrics.Register(metric); err != nil {
 		return nil, err
 	}
+	conflictRetries := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kds_resources_sync_conflict_retries",
+		Help: "Number of times syncing a resource from the upstream was retried after losing a write conflict",
+	})
+	if err := metrics.Register(conflictRetries); err != nil {
+		return nil, err
+	}
 	return &syncResourceStore{
-		log:           log,
-		resourceStore: resourceStore,
-		transactions:  transactions,
-		metric:        metric,
-		extensions:    extensions,
+		log:             log,
+		resourceStore:   resourceStore,
+		transactions:    transactions,
+		metric:          metric,
+		conflictRetries: conflictRetries,
+		extensions:      extensions,
 	}, nil
 }
 
@@ -290,17 +307,67 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse clien
 
 		for _, upd := range onUpdate {
 			log.V(1).Info("updating a resource", "name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh())
-			now := time.Now()
-			// some stores manage ModificationTime time on they own (Kubernetes), in order to be consistent
-			// we set ModificationTime when we add to downstream store. This time is almost the same with ModificationTime
-			// from upstream store, because we update downstream only when resource have changed in upstream
-			if err := s.resourceStore.Update(ctx, upd.r, append(upd.opts, store.ModifiedAt(now))...); err != nil {
+			if err := s.updateWithConflictRetry(ctx, upd, opts, log); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
 	return err, nackError
+}
+
+// updateWithConflictRetry writes an upstream change downstream, reapplying it on
+// top of a freshly read copy when the write loses an optimistic concurrency race.
+// Zone-local writers (VIP allocator, hostname generators) touch the same
+// resources, and stores version the whole resource, so any of their writes
+// invalidates the version read at List time.
+//
+// When retries run out the error goes back to the caller, which tears the stream
+// down and forces a resync. Skipping the resource would be worse: delta xDS marks
+// it delivered on send, so the upstream would consider the zone current while it
+// silently drifts.
+func (s *syncResourceStore) updateWithConflictRetry(ctx context.Context, upd OnUpdate, opts *SyncOption, log logr.Logger) error {
+	var err error
+	for attempt := 1; attempt <= updateConflictAttempts; attempt++ {
+		// some stores manage ModificationTime time on they own (Kubernetes), in order to be consistent
+		// we set ModificationTime when we add to downstream store. This time is almost the same with ModificationTime
+		// from upstream store, because we update downstream only when resource have changed in upstream
+		err = s.resourceStore.Update(ctx, upd.r, append(upd.opts, store.ModifiedAt(time.Now()))...)
+		if err == nil || !store.IsConflict(err) {
+			return err
+		}
+		s.conflictRetries.Inc()
+		log.Info("resource was modified in another place while syncing, retrying with a fresh copy",
+			"name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh(), "attempt", attempt)
+		if attempt == updateConflictAttempts {
+			break
+		}
+		util_time.SleepUpTo(updateConflictBackoff)
+		if refreshErr := s.refreshForUpdate(ctx, upd, opts); refreshErr != nil {
+			return refreshErr
+		}
+	}
+	return err
+}
+
+// refreshForUpdate re-reads the downstream copy and rebases the pending upstream
+// change onto it, so the retry carries the current version. Status comes from the
+// fresh copy for the same reason Sync preserves it: on the Zone it belongs to
+// local components, not to the upstream.
+func (s *syncResourceStore) refreshForUpdate(ctx context.Context, upd OnUpdate, opts *SyncOption) error {
+	fresh, err := registry.Global().NewObject(upd.r.Descriptor().Name)
+	if err != nil {
+		return err
+	}
+	rk := core_model.MetaToResourceKey(upd.r.GetMeta())
+	if err := s.resourceStore.Get(ctx, fresh, store.GetByKey(rk.Name, rk.Mesh)); err != nil {
+		return err
+	}
+	upd.r.SetMeta(fresh.GetMeta())
+	if upd.r.Descriptor().HasStatus && opts.IgnoreStatusChange {
+		return upd.r.SetStatus(fresh.GetStatus())
+	}
+	return nil
 }
 
 func filter(rs core_model.ResourceList, predicate func(r core_model.Resource) bool) (core_model.ResourceList, error) {

--- a/pkg/kds/v2/store/sync_test.go
+++ b/pkg/kds/v2/store/sync_test.go
@@ -10,9 +10,12 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core"
+	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
 	"github.com/kumahq/kuma/v3/pkg/kds/util"
 	client_v2 "github.com/kumahq/kuma/v3/pkg/kds/v2/client"
@@ -20,6 +23,7 @@ import (
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
 	. "github.com/kumahq/kuma/v3/pkg/test/matchers"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	model2 "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 	test_store "github.com/kumahq/kuma/v3/pkg/test/store"
 )
@@ -321,18 +325,36 @@ resource already exists: type="GlobalSecret" name="zone-token-signing-public-key
 	})
 })
 
-// conflictingStore fails the first 'conflicts' updates the way a store does when
-// another writer changed the resource in between.
+// conflictingStore simulates another writer winning the race on the first
+// 'conflicts' updates: the update is rejected and the stored record is bumped to
+// a new version, so a retry that doesn't rebase on a fresh copy keeps losing.
 type conflictingStore struct {
 	store.ResourceStore
 	conflicts int
 	updates   int
+	// mutate changes the record the winning writer leaves behind, on top of the
+	// version bump.
+	mutate func(model.Resource)
 }
 
 func (c *conflictingStore) Update(ctx context.Context, r model.Resource, fs ...store.UpdateOptionsFunc) error {
 	c.updates++
 	if c.updates <= c.conflicts {
-		return store.ErrorResourceConflict(r.Descriptor().Name, r.GetMeta().GetName(), r.GetMeta().GetMesh())
+		current, err := registry.Global().NewObject(r.Descriptor().Name)
+		if err != nil {
+			return err
+		}
+		key := model.MetaToResourceKey(r.GetMeta())
+		if err := c.Get(ctx, current, store.GetBy(key)); err != nil {
+			return err
+		}
+		if c.mutate != nil {
+			c.mutate(current)
+		}
+		if err := c.ResourceStore.Update(ctx, current); err != nil {
+			return err
+		}
+		return store.ErrorResourceConflict(r.Descriptor().Name, key.Name, key.Mesh)
 	}
 	return c.ResourceStore.Update(ctx, r, fs...)
 }
@@ -372,7 +394,7 @@ var _ = Describe("SyncResourceStoreDelta write conflicts", func() {
 		Expect(resourceStore.Create(context.Background(), res, store.CreateBy(key))).To(Succeed())
 	})
 
-	It("should retry the update and apply the change after losing a conflict", func() {
+	It("should rebase the update on the winner's version and apply the change", func() {
 		resourceStore.conflicts = 1
 
 		err, nackError := syncChangedMesh()
@@ -383,17 +405,107 @@ var _ = Describe("SyncResourceStoreDelta write conflicts", func() {
 		Expect(resourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
 		Expect(actual.Spec.Mtls.EnabledBackend).To(Equal("ca-changed"))
 		Expect(resourceStore.updates).To(Equal(2))
+		// create, then the concurrent writer, then the retried sync: without a
+		// rebase on the fresh copy the retry would carry version 1 and conflict again
+		Expect(actual.GetMeta().GetVersion()).To(Equal("3"))
 	})
 
-	It("should give up and return the error when conflicts do not stop", func() {
+	It("should give up once the retries are exhausted and return the error", func() {
 		resourceStore.conflicts = 100
 
 		err, nackError := syncChangedMesh()
 		Expect(store.IsConflict(err)).To(BeTrue())
 		Expect(nackError).ToNot(HaveOccurred())
+		// the update in the transaction, then 3 attempts: immediate, then 2 backed off
+		Expect(resourceStore.updates).To(Equal(4))
 
 		actual := mesh.NewMeshResource()
 		Expect(resourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
 		Expect(actual.Spec.Mtls.EnabledBackend).To(Equal("ca-1"))
+	})
+
+	It("should apply the rest of the batch when one resource conflicts", func() {
+		for i := 2; i <= 3; i++ {
+			res := meshBuilder(i)
+			Expect(resourceStore.Create(context.Background(), res, store.CreateBy(model.MetaToResourceKey(res.GetMeta())))).To(Succeed())
+		}
+		// only the first update of the batch loses the race
+		resourceStore.conflicts = 1
+
+		upstream := &mesh.MeshResourceList{}
+		for i := 1; i <= 3; i++ {
+			m := meshBuilder(i)
+			m.Spec.Mtls.EnabledBackend = "ca-changed"
+			m.Spec.Mtls.Backends[0].Name = "ca-changed"
+			Expect(upstream.AddItem(m)).To(Succeed())
+		}
+		err, nackError := syncer.Sync(context.Background(), client_v2.UpstreamResponse{
+			Type:           upstream.GetItemType(),
+			AddedResources: upstream,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := &mesh.MeshResourceList{}
+		Expect(resourceStore.List(context.Background(), actual)).To(Succeed())
+		Expect(actual.Items).To(HaveLen(3))
+		for _, item := range actual.Items {
+			Expect(item.Spec.Mtls.EnabledBackend).To(Equal("ca-changed"))
+		}
+		// 3 updates in the transaction, 1 retried after it
+		Expect(resourceStore.updates).To(Equal(4))
+	})
+})
+
+var _ = Describe("SyncResourceStoreDelta write conflicts on zone-owned status", func() {
+	var resourceStore *conflictingStore
+	var syncer sync_store.ResourceSyncer
+
+	BeforeEach(func() {
+		resourceStore = &conflictingStore{ResourceStore: memory.NewStore()}
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, store.NoTransactions{}, metrics, context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(builders.MeshService().
+			AddIntPort(80, 8080, core_meta.ProtocolHTTP).
+			WithKumaVIP("10.0.0.1").
+			Create(resourceStore)).To(Succeed())
+	})
+
+	// The rebase is only safe because Global owns the spec and the Zone owns the
+	// status. The VIP allocator writes a status while Sync is applying a spec, and
+	// the retry has to carry the allocator's status, not the one read before it ran.
+	It("should keep the status written by the writer that won the race", func() {
+		resourceStore.conflicts = 1
+		resourceStore.mutate = func(r model.Resource) {
+			Expect(r.SetStatus(&meshservice_api.MeshServiceStatus{
+				VIPs: []meshservice_api.VIP{{IP: "10.0.0.2"}},
+			})).To(Succeed())
+		}
+
+		// Global syncs the spec down with the status stripped
+		upstream := &meshservice_api.MeshServiceResourceList{}
+		Expect(upstream.AddItem(builders.MeshService().
+			AddIntPort(90, 9090, core_meta.ProtocolHTTP).
+			WithoutVIP().
+			Build())).To(Succeed())
+
+		err, nackError := syncer.Sync(context.Background(), client_v2.UpstreamResponse{
+			Type:           upstream.GetItemType(),
+			AddedResources: upstream,
+		}, sync_store.IgnoreStatusChange())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := meshservice_api.NewMeshServiceResource()
+		Expect(resourceStore.Get(context.Background(), actual, store.GetBy(builders.MeshService().Key()))).To(Succeed())
+		// upstream owns the spec
+		Expect(actual.Spec.Ports).To(HaveLen(1))
+		Expect(actual.Spec.Ports[0].Port).To(Equal(int32(90)))
+		// the zone owns the status, and the retry must not roll it back to the copy
+		// read before the allocator wrote
+		Expect(actual.Status.VIPs).To(Equal([]meshservice_api.VIP{{IP: "10.0.0.2"}}))
 	})
 })

--- a/pkg/kds/v2/store/sync_test.go
+++ b/pkg/kds/v2/store/sync_test.go
@@ -320,3 +320,80 @@ var _ = Describe("SyncResourceStoreDelta errors", func() {
 resource already exists: type="GlobalSecret" name="zone-token-signing-public-key-1" mesh=""`))
 	})
 })
+
+// conflictingStore fails the first 'conflicts' updates the way a store does when
+// another writer changed the resource in between.
+type conflictingStore struct {
+	store.ResourceStore
+	conflicts int
+	updates   int
+}
+
+func (c *conflictingStore) Update(ctx context.Context, r model.Resource, fs ...store.UpdateOptionsFunc) error {
+	c.updates++
+	if c.updates <= c.conflicts {
+		return store.ErrorResourceConflict(r.Descriptor().Name, r.GetMeta().GetName(), r.GetMeta().GetMesh())
+	}
+	return c.ResourceStore.Update(ctx, r, fs...)
+}
+
+var _ = Describe("SyncResourceStoreDelta write conflicts", func() {
+	var resourceStore *conflictingStore
+	var syncer sync_store.ResourceSyncer
+	var key model.ResourceKey
+
+	// meshBuilder(1) with a different spec, so syncing it against the stored copy
+	// produces an update rather than a create.
+	changedMesh := func() *mesh.MeshResource {
+		m := meshBuilder(1)
+		m.Spec.Mtls.EnabledBackend = "ca-changed"
+		m.Spec.Mtls.Backends[0].Name = "ca-changed"
+		return m
+	}
+
+	syncChangedMesh := func() (error, error) {
+		upstream := &mesh.MeshResourceList{}
+		Expect(upstream.AddItem(changedMesh())).To(Succeed())
+		return syncer.Sync(context.Background(), client_v2.UpstreamResponse{
+			Type:           upstream.GetItemType(),
+			AddedResources: upstream,
+		})
+	}
+
+	BeforeEach(func() {
+		resourceStore = &conflictingStore{ResourceStore: memory.NewStore()}
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		syncer, err = sync_store.NewResourceSyncer(core.Log, resourceStore, store.NoTransactions{}, metrics, context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		res := meshBuilder(1)
+		key = model.MetaToResourceKey(res.GetMeta())
+		Expect(resourceStore.Create(context.Background(), res, store.CreateBy(key))).To(Succeed())
+	})
+
+	It("should retry the update and apply the change after losing a conflict", func() {
+		resourceStore.conflicts = 1
+
+		err, nackError := syncChangedMesh()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := mesh.NewMeshResource()
+		Expect(resourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
+		Expect(actual.Spec.Mtls.EnabledBackend).To(Equal("ca-changed"))
+		Expect(resourceStore.updates).To(Equal(2))
+	})
+
+	It("should give up and return the error when conflicts do not stop", func() {
+		resourceStore.conflicts = 100
+
+		err, nackError := syncChangedMesh()
+		Expect(store.IsConflict(err)).To(BeTrue())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := mesh.NewMeshResource()
+		Expect(resourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
+		Expect(actual.Spec.Mtls.EnabledBackend).To(Equal("ca-1"))
+	})
+})


### PR DESCRIPTION
## Motivation

On a Zone, KDS sync competes with zone-local writers for the same resources: the VIP allocator owns `Status.VIPs` and the hostname generators own `Status.Addresses`. Stores version the whole resource rather than its halves, so any of those writes invalidates the version KDS read at `List` time and the downstream `Update` fails with a conflict. On Kubernetes the store reads through an informer cache, which can hand back an already stale version even without a concurrent writer.

The conflict propagates out of `Sync` and tears the stream down. Because delta xDS marks a resource delivered when the response is sent, the upstream keeps considering the zone current while it silently drifts until the next full resync.

## Implementation information

- Updates that lose a write conflict are collected instead of aborting the transaction, and reapplied by `retryConflictedUpdates` after it commits, so the backoff holds no connection or row locks.
- Each retry re-reads the stored copy and rebases the pending upstream change onto it, taking `Status` from the fresh copy when `IgnoreStatusChange` is set, matching what `Sync` already does when it first decides to update.
- Up to 3 attempts with a jittered pause of at most 100ms in between, shared by the whole batch: the first retry runs immediately, which is all a store reading its own writes needs, and the later ones wait so a cached store (Kubernetes informer) can observe the write that won.
- Exhausted retries return the conflict to the caller, keeping the existing tear-down-and-resync behaviour rather than silently skipping the resource, which would leave the zone drifting.
- Unit tests cover both the recovering case and the give-up case.

## Supporting documentation

N/A
