### PR TITLE
refactor(targetref): resolve backendRef by labels only

### DIFF
--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -340,6 +340,9 @@ func parseMeshServiceName(name string) (string, string, int32, bool) {
 	default:
 		return "", "", 0, false
 	}
+	if segments[2] != "svc" {
+		return "", "", 0, false
+	}
 
 	return segments[0], segments[1], port, true
 }

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -223,7 +223,7 @@ func (b BackendRef) RealResourceSelector(defaultNamespace string) (map[string]st
 		return nil, "", false
 	}
 
-	if port := pointer.Deref(b.Port); port > 0 {
+	if port := pointer.Deref(b.Port); port > 0 && sectionName == "" {
 		sectionName = fmt.Sprintf("%d", port)
 	}
 

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -3,6 +3,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -347,8 +348,6 @@ func parseMeshServiceName(name string) (string, string, int32, bool) {
 
 func cloneStringMap(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -4,8 +4,10 @@ package v1alpha1
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	util_maps "github.com/kumahq/kuma/v3/pkg/util/maps"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
@@ -193,8 +195,8 @@ type BackendRef struct {
 
 func (b BackendRef) ReferencesRealObject() bool {
 	switch b.Kind {
-	case MeshService:
-		return pointer.Deref(b.SectionName) != "" || b.Port != nil
+	case MeshService, MeshExternalService, MeshMultiZoneService:
+		return true
 	case meshServiceSubset:
 		return false
 	// empty targetRef should not be treated as real object
@@ -211,8 +213,42 @@ type MatchesHash string
 
 type BackendRefHash string
 
+func (b BackendRef) RealResourceSelector(defaultNamespace string) (map[string]string, string, bool) {
+	if !b.ReferencesRealObject() {
+		return nil, "", false
+	}
+
+	labels, sectionName, ok := realResourceSelector(b.TargetRef, defaultNamespace)
+	if !ok {
+		return nil, "", false
+	}
+
+	if port := pointer.Deref(b.Port); port > 0 {
+		sectionName = fmt.Sprintf("%d", port)
+	}
+
+	return labels, sectionName, true
+}
+
 // Hash returns a hash of the BackendRef
 func (in BackendRef) Hash() BackendRefHash {
+	if in.ReferencesRealObject() {
+		labels, sectionName, _ := in.RealResourceSelector("")
+		keys := util_maps.SortedKeys(labels)
+		orderedLabels := make([]string, 0, len(labels))
+		for _, k := range keys {
+			orderedLabels = append(orderedLabels, fmt.Sprintf("%s=%s", k, labels[k]))
+		}
+
+		return BackendRefHash(fmt.Sprintf(
+			"%s/%s/%d/%s",
+			in.Kind,
+			strings.Join(orderedLabels, "/"),
+			pointer.DerefOr(in.Port, 0),
+			sectionName,
+		))
+	}
+
 	keys := util_maps.SortedKeys(pointer.Deref(in.Tags))
 	orderedTags := make([]string, 0, len(keys))
 	for _, k := range keys {
@@ -230,4 +266,83 @@ func (in BackendRef) Hash() BackendRefHash {
 		name = pointer.To(fmt.Sprintf("%s_svc_%d", pointer.Deref(in.Name), *in.Port))
 	}
 	return BackendRefHash(fmt.Sprintf("%s/%s/%s/%s/%s", in.Kind, pointer.Deref(name), strings.Join(orderedTags, "/"), strings.Join(orderedLabels, "/"), pointer.Deref(in.Mesh)))
+}
+
+func realResourceSelector(ref TargetRef, defaultNamespace string) (map[string]string, string, bool) {
+	if len(pointer.Deref(ref.Labels)) > 0 {
+		return cloneStringMap(pointer.Deref(ref.Labels)), pointer.Deref(ref.SectionName), true
+	}
+
+	name := pointer.Deref(ref.Name)
+	if name == "" {
+		return nil, "", false
+	}
+
+	switch ref.Kind {
+	case MeshService:
+		if pointer.Deref(ref.SectionName) == "" {
+			if serviceName, namespace, port, ok := parseMeshServiceName(name); ok {
+				labels := map[string]string{
+					mesh_proto.DisplayName:      serviceName,
+					mesh_proto.KubeNamespaceTag: namespace,
+				}
+				sectionName := ""
+				if port > 0 {
+					sectionName = fmt.Sprintf("%d", port)
+				}
+				return labels, sectionName, true
+			}
+		}
+
+		namespace := pointer.Deref(ref.Namespace)
+		if namespace == "" {
+			namespace = defaultNamespace
+		}
+
+		labels := map[string]string{
+			mesh_proto.DisplayName: name,
+		}
+		if namespace != "" {
+			labels[mesh_proto.KubeNamespaceTag] = namespace
+		}
+		return labels, pointer.Deref(ref.SectionName), true
+	case MeshExternalService, MeshMultiZoneService:
+		labels := map[string]string{
+			mesh_proto.DisplayName: name,
+		}
+		if namespace := pointer.Deref(ref.Namespace); namespace != "" {
+			labels[mesh_proto.KubeNamespaceTag] = namespace
+		}
+		return labels, pointer.Deref(ref.SectionName), true
+	default:
+		return nil, "", false
+	}
+}
+
+func parseMeshServiceName(name string) (string, string, int32, bool) {
+	segments := strings.Split(name, "_")
+
+	var port int32
+	switch len(segments) {
+	case 4:
+		p, err := strconv.ParseInt(segments[3], 10, 32)
+		if err != nil {
+			return "", "", 0, false
+		}
+		port = int32(p)
+	case 3:
+		port = 0
+	default:
+		return "", "", 0, false
+	}
+
+	return segments[0], segments[1], port, true
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -307,10 +307,15 @@ func realResourceSelector(ref TargetRef, defaultNamespace string) (map[string]st
 		}
 		return labels, pointer.Deref(ref.SectionName), true
 	case MeshExternalService, MeshMultiZoneService:
+		namespace := pointer.Deref(ref.Namespace)
+		if namespace == "" {
+			namespace = defaultNamespace
+		}
+
 		labels := map[string]string{
 			mesh_proto.DisplayName: name,
 		}
-		if namespace := pointer.Deref(ref.Namespace); namespace != "" {
+		if namespace != "" {
 			labels[mesh_proto.KubeNamespaceTag] = namespace
 		}
 		return labels, pointer.Deref(ref.SectionName), true

--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -280,7 +280,7 @@ func realResourceSelector(ref TargetRef, defaultNamespace string) (map[string]st
 
 	switch ref.Kind {
 	case MeshService:
-		if pointer.Deref(ref.SectionName) == "" {
+		if ref.Namespace == nil && pointer.Deref(ref.SectionName) == "" {
 			if serviceName, namespace, port, ok := parseMeshServiceName(name); ok {
 				labels := map[string]string{
 					mesh_proto.DisplayName:      serviceName,
@@ -335,8 +335,6 @@ func parseMeshServiceName(name string) (string, string, int32, bool) {
 			return "", "", 0, false
 		}
 		port = int32(p)
-	case 3:
-		port = 0
 	default:
 		return "", "", 0, false
 	}

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -224,6 +224,34 @@ func TestBackendRefRealResourceSelectorKeepsExplicitSectionNameOverPort(t *testi
 	}
 }
 
+func TestBackendRefRealResourceSelectorTreatsPlainUnderscoreMeshServiceNamesAsNames(t *testing.T) {
+	t.Parallel()
+
+	ref := BackendRef{
+		TargetRef: TargetRef{
+			Kind:      MeshService,
+			Name:      pointer.To("web_app_prod"),
+			Namespace: pointer.To("team-a"),
+		},
+	}
+
+	labels, sectionName, ok := ref.RealResourceSelector("default")
+	if !ok {
+		t.Fatal("RealResourceSelector() returned ok=false")
+	}
+	if sectionName != "" {
+		t.Fatalf("RealResourceSelector() sectionName = %q, want empty", sectionName)
+	}
+
+	expectedLabels := map[string]string{
+		mesh_proto.DisplayName:      "web_app_prod",
+		mesh_proto.KubeNamespaceTag: "team-a",
+	}
+	if !reflect.DeepEqual(labels, expectedLabels) {
+		t.Fatalf("RealResourceSelector() labels = %v, want %v", labels, expectedLabels)
+	}
+}
+
 func TestBackendRefHashUsesRealResourceLabels(t *testing.T) {
 	t.Parallel()
 

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -203,6 +203,27 @@ func TestBackendRefRealResourceSelectorDefaultsNamespaceForNameRefs(t *testing.T
 	}
 }
 
+func TestBackendRefRealResourceSelectorKeepsExplicitSectionNameOverPort(t *testing.T) {
+	t.Parallel()
+
+	ref := BackendRef{
+		TargetRef: TargetRef{
+			Kind:        MeshService,
+			Name:        pointer.To("backend"),
+			SectionName: pointer.To("http"),
+		},
+		Port: pointer.To(uint32(80)),
+	}
+
+	_, sectionName, ok := ref.RealResourceSelector("kuma-demo")
+	if !ok {
+		t.Fatal("RealResourceSelector() returned ok=false")
+	}
+	if sectionName != "http" {
+		t.Fatalf("RealResourceSelector() sectionName = %q, want http", sectionName)
+	}
+}
+
 func TestBackendRefHashUsesRealResourceLabels(t *testing.T) {
 	t.Parallel()
 

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"reflect"
 	"testing"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
@@ -116,6 +117,87 @@ func TestBackendRefReferencesRealObject(t *testing.T) {
 
 			if got := tt.ref.ReferencesRealObject(); got != tt.expected {
 				t.Fatalf("ReferencesRealObject() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBackendRefRealResourceSelectorDefaultsNamespaceForNameRefs(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		ref            BackendRef
+		defaultNs      string
+		expectedLabels map[string]string
+	}{
+		"MeshService": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshService,
+					Name: pointer.To("backend"),
+				},
+			},
+			defaultNs: "team-a",
+			expectedLabels: map[string]string{
+				mesh_proto.DisplayName:      "backend",
+				mesh_proto.KubeNamespaceTag: "team-a",
+			},
+		},
+		"MeshExternalService": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshExternalService,
+					Name: pointer.To("payments"),
+				},
+			},
+			defaultNs: "team-a",
+			expectedLabels: map[string]string{
+				mesh_proto.DisplayName:      "payments",
+				mesh_proto.KubeNamespaceTag: "team-a",
+			},
+		},
+		"MeshMultiZoneService": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshMultiZoneService,
+					Name: pointer.To("global-backend"),
+				},
+			},
+			defaultNs: "team-a",
+			expectedLabels: map[string]string{
+				mesh_proto.DisplayName:      "global-backend",
+				mesh_proto.KubeNamespaceTag: "team-a",
+			},
+		},
+		"explicit namespace wins": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind:      MeshExternalService,
+					Name:      pointer.To("payments"),
+					Namespace: pointer.To("team-b"),
+				},
+			},
+			defaultNs: "team-a",
+			expectedLabels: map[string]string{
+				mesh_proto.DisplayName:      "payments",
+				mesh_proto.KubeNamespaceTag: "team-b",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			labels, sectionName, ok := tt.ref.RealResourceSelector(tt.defaultNs)
+			if !ok {
+				t.Fatal("RealResourceSelector() returned ok=false")
+			}
+			if sectionName != "" {
+				t.Fatalf("RealResourceSelector() sectionName = %q, want empty", sectionName)
+			}
+			if !reflect.DeepEqual(labels, tt.expectedLabels) {
+				t.Fatalf("RealResourceSelector() labels = %v, want %v", labels, tt.expectedLabels)
 			}
 		})
 	}

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -183,6 +183,33 @@ func TestBackendRefRealResourceSelectorDefaultsNamespaceForNameRefs(t *testing.T
 				mesh_proto.KubeNamespaceTag: "team-b",
 			},
 		},
+		"MeshService explicit namespace wins over legacy-looking name": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind:      MeshService,
+					Name:      pointer.To("backend_prod_svc"),
+					Namespace: pointer.To("explicit-ns"),
+				},
+			},
+			defaultNs: "team-a",
+			expectedLabels: map[string]string{
+				mesh_proto.DisplayName:      "backend_prod_svc",
+				mesh_proto.KubeNamespaceTag: "explicit-ns",
+			},
+		},
+		"MeshService unported svc-suffixed name is literal": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshService,
+					Name: pointer.To("foo_bar_svc"),
+				},
+			},
+			defaultNs: "team-a",
+			expectedLabels: map[string]string{
+				mesh_proto.DisplayName:      "foo_bar_svc",
+				mesh_proto.KubeNamespaceTag: "team-a",
+			},
+		},
 	}
 
 	for name, tt := range tests {

--- a/api/common/v1alpha1/targetref_test.go
+++ b/api/common/v1alpha1/targetref_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 func TestIncludesGateways(t *testing.T) {
@@ -58,4 +59,116 @@ func TestIncludesGateways(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBackendRefReferencesRealObject(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		ref      BackendRef
+		expected bool
+	}{
+		"mesh service by name is real": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshService,
+					Name: pointer.To("backend"),
+				},
+			},
+			expected: true,
+		},
+		"mesh external service is real": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshExternalService,
+					Name: pointer.To("payments"),
+				},
+			},
+			expected: true,
+		},
+		"mesh multizone service is real": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: MeshMultiZoneService,
+					Name: pointer.To("global-backend"),
+				},
+			},
+			expected: true,
+		},
+		"legacy mesh service subset is not real": {
+			ref: BackendRef{
+				TargetRef: TargetRef{
+					Kind: LegacyMeshServiceSubsetKind(),
+					Name: pointer.To("backend"),
+				},
+			},
+			expected: false,
+		},
+		"empty ref is not real": {
+			ref:      BackendRef{},
+			expected: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.ref.ReferencesRealObject(); got != tt.expected {
+				t.Fatalf("ReferencesRealObject() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBackendRefHashUsesRealResourceLabels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("real backend refs ignore name and mesh when labels match", func(t *testing.T) {
+		t.Parallel()
+
+		a := BackendRef{
+			TargetRef: TargetRef{
+				Kind:   MeshService,
+				Name:   pointer.To("backend-a"),
+				Mesh:   pointer.To("mesh-a"),
+				Labels: &map[string]string{mesh_proto.DisplayName: "backend", mesh_proto.KubeNamespaceTag: "kuma-demo"},
+			},
+			Port: pointer.To(uint32(8080)),
+		}
+		b := BackendRef{
+			TargetRef: TargetRef{
+				Kind:   MeshService,
+				Name:   pointer.To("backend-b"),
+				Mesh:   pointer.To("mesh-b"),
+				Labels: &map[string]string{mesh_proto.KubeNamespaceTag: "kuma-demo", mesh_proto.DisplayName: "backend"},
+			},
+			Port: pointer.To(uint32(8080)),
+		}
+
+		if a.Hash() != b.Hash() {
+			t.Fatalf("Hash() should be based on real-resource labels, got %q and %q", a.Hash(), b.Hash())
+		}
+	})
+
+	t.Run("legacy mesh service name forms keep derived port distinctions", func(t *testing.T) {
+		t.Parallel()
+
+		base := BackendRef{
+			TargetRef: TargetRef{
+				Kind: MeshService,
+				Name: pointer.To("backend_kuma-demo_svc_8080"),
+			},
+		}
+		otherPort := BackendRef{
+			TargetRef: TargetRef{
+				Kind: MeshService,
+				Name: pointer.To("backend_kuma-demo_svc_9090"),
+			},
+		}
+
+		if base.Hash() == otherPort.Hash() {
+			t.Fatalf("Hash() should distinguish derived ports, got %q", base.Hash())
+		}
+	})
 }

--- a/pkg/plugins/policies/core/rules/resolve/backendref.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref.go
@@ -37,11 +37,23 @@ func BackendRef(origin kri.Identifier, br common_api.BackendRef, resolver LabelR
 		Weight:   pointer.DerefOr(br.Weight, 1),
 	}
 	if rr.Resource.IsEmpty() {
+		if shouldFallbackToLegacyMeshService(br) {
+			return ResolvedBackendRef{Ref: pointer.To(LegacyBackendRef(br))}, true
+		}
 		return ResolvedBackendRef{}, false
 	}
 	rr.Resource.SectionName = sectionName
 
 	return ResolvedBackendRef{Ref: rr}, true
+}
+
+func shouldFallbackToLegacyMeshService(br common_api.BackendRef) bool {
+	return br.Kind == common_api.MeshService &&
+		br.Name != nil && *br.Name != "" &&
+		br.Labels == nil &&
+		br.Namespace == nil &&
+		br.SectionName == nil &&
+		br.Port == nil
 }
 
 type IsResolvedBackendRef interface {

--- a/pkg/plugins/policies/core/rules/resolve/backendref.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref.go
@@ -50,7 +50,7 @@ func BackendRef(origin kri.Identifier, br common_api.BackendRef, resolver LabelR
 func shouldFallbackToLegacyMeshService(br common_api.BackendRef) bool {
 	return br.Kind == common_api.MeshService &&
 		br.Name != nil && *br.Name != "" &&
-		br.Labels == nil &&
+		len(pointer.Deref(br.Labels)) == 0 &&
 		br.Namespace == nil &&
 		br.SectionName == nil &&
 		br.Port == nil

--- a/pkg/plugins/policies/core/rules/resolve/backendref.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref.go
@@ -1,8 +1,6 @@
 package resolve
 
 import (
-	"fmt"
-
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
@@ -28,25 +26,20 @@ func BackendRef(origin kri.Identifier, br common_api.BackendRef, resolver LabelR
 		return ResolvedBackendRef{Ref: pointer.To(LegacyBackendRef(br))}, true
 	}
 
-	rr := &RealResourceBackendRef{
-		Resource: TargetRefToKRI(origin, br.TargetRef),
-		Origin:   origin,
-		Weight:   pointer.DerefOr(br.Weight, 1),
-	}
-
-	if labels := pointer.Deref(br.Labels); len(labels) > 0 {
-		rr.Resource = resolver(core_model.ResourceType(br.Kind), labels)
-	}
-
-	if rr.Resource.IsEmpty() {
+	labels, sectionName, ok := br.RealResourceSelector(origin.Namespace)
+	if !ok {
 		return ResolvedBackendRef{}, false
 	}
 
-	if sectionName := pointer.Deref(br.SectionName); sectionName != "" {
-		rr.Resource.SectionName = sectionName
-	} else if port := pointer.Deref(br.Port); port > 0 {
-		rr.Resource.SectionName = fmt.Sprintf("%d", port)
+	rr := &RealResourceBackendRef{
+		Resource: resolver(core_model.ResourceType(br.Kind), labels),
+		Origin:   origin,
+		Weight:   pointer.DerefOr(br.Weight, 1),
 	}
+	if rr.Resource.IsEmpty() {
+		return ResolvedBackendRef{}, false
+	}
+	rr.Resource.SectionName = sectionName
 
 	return ResolvedBackendRef{Ref: rr}, true
 }

--- a/pkg/plugins/policies/core/rules/resolve/backendref_test.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref_test.go
@@ -120,6 +120,55 @@ var _ = Describe("Resolve BackendRef", func() {
 		Expect(resolved.Resource()).To(Equal(expected))
 	})
 
+	It("should keep explicit namespace for legacy-looking MeshService names", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "default"}
+		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "backend_prod_svc"}
+
+		var capturedLabels map[string]string
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind:      common_api.MeshService,
+				Name:      pointer.To("backend_prod_svc"),
+				Namespace: pointer.To("explicit-ns"),
+			},
+		}, func(_ core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+			capturedLabels = gotLabels
+			return expected
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(capturedLabels).To(Equal(map[string]string{
+			mesh_proto.DisplayName:      "backend_prod_svc",
+			mesh_proto.KubeNamespaceTag: "explicit-ns",
+		}))
+		Expect(resolved.ReferencesRealResource()).To(BeTrue())
+		Expect(resolved.Resource()).To(Equal(expected))
+	})
+
+	It("should treat unported svc-suffixed MeshService names as literal real-resource names", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "team-a"}
+		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "foo_bar_svc"}
+
+		var capturedLabels map[string]string
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: pointer.To("foo_bar_svc"),
+			},
+		}, func(_ core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+			capturedLabels = gotLabels
+			return expected
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(capturedLabels).To(Equal(map[string]string{
+			mesh_proto.DisplayName:      "foo_bar_svc",
+			mesh_proto.KubeNamespaceTag: "team-a",
+		}))
+		Expect(resolved.ReferencesRealResource()).To(BeTrue())
+		Expect(resolved.Resource()).To(Equal(expected))
+	})
+
 	It("should fall back to a legacy MeshService backendRef when a plain name does not resolve to a real resource", func() {
 		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
 

--- a/pkg/plugins/policies/core/rules/resolve/backendref_test.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref_test.go
@@ -95,6 +95,31 @@ var _ = Describe("Resolve BackendRef", func() {
 		Expect(resolved.Resource()).To(Equal(expected))
 	})
 
+	It("should treat plain underscore MeshService names as literal real-resource names", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "default"}
+		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "web_app_prod"}
+
+		var capturedLabels map[string]string
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind:      common_api.MeshService,
+				Name:      pointer.To("web_app_prod"),
+				Namespace: pointer.To("team-a"),
+			},
+		}, func(_ core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+			capturedLabels = gotLabels
+			return expected
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(capturedLabels).To(Equal(map[string]string{
+			mesh_proto.DisplayName:      "web_app_prod",
+			mesh_proto.KubeNamespaceTag: "team-a",
+		}))
+		Expect(resolved.ReferencesRealResource()).To(BeTrue())
+		Expect(resolved.Resource()).To(Equal(expected))
+	})
+
 	It("should fall back to a legacy MeshService backendRef when a plain name does not resolve to a real resource", func() {
 		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
 
@@ -119,6 +144,31 @@ var _ = Describe("Resolve BackendRef", func() {
 			TargetRef: common_api.TargetRef{
 				Kind: common_api.MeshService,
 				Name: pointer.To("payments"),
+			},
+		}))
+	})
+
+	It("should fall back to a legacy MeshService backendRef when empty labels do not resolve to a real resource", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
+
+		labels := map[string]string{}
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind:   common_api.MeshService,
+				Name:   pointer.To("payments"),
+				Labels: pointer.To(labels),
+			},
+		}, func(_ core_model.ResourceType, _ map[string]string) kri.Identifier {
+			return kri.Identifier{}
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(resolved.ReferencesRealResource()).To(BeFalse())
+		Expect(resolved.LegacyBackendRef()).To(Equal(&resolve.LegacyBackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind:   common_api.MeshService,
+				Name:   pointer.To("payments"),
+				Labels: pointer.To(labels),
 			},
 		}))
 	})

--- a/pkg/plugins/policies/core/rules/resolve/backendref_test.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref_test.go
@@ -1,0 +1,121 @@
+package resolve_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+)
+
+var _ = Describe("Resolve BackendRef", func() {
+	DescribeTable("should resolve label-selected real backendRefs",
+		func(kind common_api.TargetRefKind, labels map[string]string, expectedType core_model.ResourceType) {
+			origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
+			expected := kri.Identifier{ResourceType: expectedType, Mesh: "mesh-1", Name: "resolved"}
+
+			var capturedType core_model.ResourceType
+			var capturedLabels map[string]string
+			resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+				TargetRef: common_api.TargetRef{
+					Kind:   kind,
+					Labels: pointer.To(labels),
+				},
+			}, func(resType core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+				capturedType = resType
+				capturedLabels = gotLabels
+				return expected
+			})
+
+			Expect(ok).To(BeTrue())
+			Expect(resolved.LegacyBackendRef()).To(BeNil())
+			Expect(resolved.RealResourceBackendRef()).ToNot(BeNil())
+			Expect(resolved.Resource()).To(Equal(expected))
+			Expect(capturedType).To(Equal(expectedType))
+			Expect(capturedLabels).To(Equal(labels))
+		},
+		Entry("MeshService", common_api.MeshService, map[string]string{
+			mesh_proto.DisplayName:      "backend",
+			mesh_proto.KubeNamespaceTag: "kuma-demo",
+		}, core_model.ResourceType(common_api.MeshService)),
+		Entry("MeshExternalService", common_api.MeshExternalService, map[string]string{
+			mesh_proto.DisplayName: "payments",
+		}, core_model.ResourceType(common_api.MeshExternalService)),
+		Entry("MeshMultiZoneService", common_api.MeshMultiZoneService, map[string]string{
+			mesh_proto.DisplayName: "global-backend",
+		}, core_model.ResourceType(common_api.MeshMultiZoneService)),
+	)
+
+	It("should treat MeshService backendRefs without port or sectionName as real resources when labels identify them", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
+		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "backend"}
+
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Labels: pointer.To(map[string]string{
+					mesh_proto.DisplayName:      "backend",
+					mesh_proto.KubeNamespaceTag: "kuma-demo",
+				}),
+			},
+		}, func(_ core_model.ResourceType, _ map[string]string) kri.Identifier {
+			return expected
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(resolved.ReferencesRealResource()).To(BeTrue())
+		Expect(resolved.LegacyBackendRef()).To(BeNil())
+		Expect(resolved.Resource()).To(Equal(expected))
+	})
+
+	It("should derive labels from a MeshService name and policy namespace before resolving", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
+		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "backend"}
+
+		var capturedLabels map[string]string
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: pointer.To("backend"),
+			},
+		}, func(_ core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+			capturedLabels = gotLabels
+			return expected
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(capturedLabels).To(Equal(map[string]string{
+			mesh_proto.DisplayName:      "backend",
+			mesh_proto.KubeNamespaceTag: "kuma-demo",
+		}))
+		Expect(resolved.Resource()).To(Equal(expected))
+	})
+
+	It("should derive compatibility labels and port from legacy MeshService name forms", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "ignored"}
+		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "backend"}
+
+		var capturedLabels map[string]string
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: pointer.To("backend_kuma-demo_svc_8080"),
+			},
+		}, func(_ core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+			capturedLabels = gotLabels
+			return expected
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(capturedLabels).To(Equal(map[string]string{
+			mesh_proto.DisplayName:      "backend",
+			mesh_proto.KubeNamespaceTag: "kuma-demo",
+		}))
+		Expect(resolved.ReferencesRealResource()).To(BeTrue())
+		Expect(resolved.Resource()).To(Equal(kri.WithSectionName(expected, "8080")))
+	})
+})

--- a/pkg/plugins/policies/core/rules/resolve/backendref_test.go
+++ b/pkg/plugins/policies/core/rules/resolve/backendref_test.go
@@ -95,6 +95,53 @@ var _ = Describe("Resolve BackendRef", func() {
 		Expect(resolved.Resource()).To(Equal(expected))
 	})
 
+	It("should fall back to a legacy MeshService backendRef when a plain name does not resolve to a real resource", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
+
+		var capturedLabels map[string]string
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: pointer.To("payments"),
+			},
+		}, func(_ core_model.ResourceType, gotLabels map[string]string) kri.Identifier {
+			capturedLabels = gotLabels
+			return kri.Identifier{}
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(capturedLabels).To(Equal(map[string]string{
+			mesh_proto.DisplayName:      "payments",
+			mesh_proto.KubeNamespaceTag: "kuma-demo",
+		}))
+		Expect(resolved.ReferencesRealResource()).To(BeFalse())
+		Expect(resolved.LegacyBackendRef()).To(Equal(&resolve.LegacyBackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Name: pointer.To("payments"),
+			},
+		}))
+	})
+
+	It("should not fall back to legacy for unresolved label-selected MeshService backendRefs", func() {
+		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "kuma-demo"}
+
+		resolved, ok := resolve.BackendRef(origin, common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind: common_api.MeshService,
+				Labels: pointer.To(map[string]string{
+					mesh_proto.DisplayName:      "payments",
+					mesh_proto.KubeNamespaceTag: "kuma-demo",
+				}),
+			},
+		}, func(_ core_model.ResourceType, _ map[string]string) kri.Identifier {
+			return kri.Identifier{}
+		})
+
+		Expect(ok).To(BeFalse())
+		Expect(resolved.Ref).To(BeNil())
+	})
+
 	It("should derive compatibility labels and port from legacy MeshService name forms", func() {
 		origin := kri.Identifier{Mesh: "mesh-1", Namespace: "ignored"}
 		expected := kri.Identifier{ResourceType: core_model.ResourceType(common_api.MeshService), Mesh: "mesh-1", Name: "backend"}

--- a/pkg/plugins/policies/core/rules/resolve/targetref.go
+++ b/pkg/plugins/policies/core/rules/resolve/targetref.go
@@ -155,6 +155,9 @@ func parseService(host string) (string, string, int32, error) {
 	default:
 		return "", "", 0, errors.Errorf("service tag in unexpected format")
 	}
+	if segments[2] != "svc" {
+		return "", "", 0, errors.Errorf("service tag in unexpected format")
+	}
 
 	name, namespace := segments[0], segments[1]
 	return name, namespace, port, nil

--- a/pkg/plugins/policies/core/rules/resolve/targetref_test.go
+++ b/pkg/plugins/policies/core/rules/resolve/targetref_test.go
@@ -62,6 +62,33 @@ var _ = Describe("Resolve TargetRef", func() {
 		Expect(resolved[0].Identifier().String()).To(Equal("kri_msvc_mesh-1__kuma-demo_backend_"))
 	})
 
+	It("should treat plain underscore MeshService targetRef names as literal names", func() {
+		policyMeta := &test_model.ResourceMeta{
+			Name: "policy-1",
+			Mesh: "mesh-1",
+		}
+		targetRef := common_api.TargetRef{
+			Kind:      common_api.MeshService,
+			Name:      pointer.To("web_app_prod"),
+			Namespace: pointer.To("team-a"),
+		}
+		addResource(builders.MeshService().
+			WithName("web_app_prod").
+			WithMesh("mesh-1").
+			WithLabels(map[string]string{
+				"k8s.kuma.io/namespace": "team-a",
+				"kuma.io/display-name":  "web_app_prod",
+			}).
+			AddIntPortWithName(8080, 8081, core_meta.ProtocolTCP, "tcp-port").
+			Build(),
+		)
+
+		resolved := resolve.TargetRef(targetRef, policyMeta, resources)
+
+		Expect(resolved).To(HaveLen(1))
+		Expect(resolved[0].Identifier().String()).To(Equal("kri_msvc_mesh-1__team-a_web_app_prod_"))
+	})
+
 	It("should not resolve MeshService targetRef when there is no MeshService", func() {
 		// given 'policy-1' with targetRef (somewhere in its spec) to 'backend'
 		policyMeta := &test_model.ResourceMeta{

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -5,6 +5,7 @@ import (
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core/destinationname"
@@ -264,6 +265,10 @@ func handleRealResources(
 
 	if _, ok := protocols[port.GetProtocol()]; !ok {
 		return nil
+	}
+
+	if common_api.TargetRefKind(ref.Resource.ResourceType) == common_api.MeshService && ref.Resource.SectionName == "" {
+		ref.Resource = kri.WithSectionName(ref.Resource, port.GetName())
 	}
 
 	service := destinationname.MustResolve(false, dest, port)

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -158,9 +158,17 @@ func CollectServices(proxy *core_xds.Proxy, meshCtx xds_context.MeshContext) []D
 			continue
 		}
 
-		// skip outbounds when no port matches SectionName
-		if port, ok = svc.FindPortByName(outbound.Resource.SectionName); !ok {
-			continue
+		if outbound.Resource.SectionName == "" {
+			ports := svc.GetPorts()
+			if len(ports) != 1 {
+				continue
+			}
+			port = ports[0]
+		} else {
+			// skip outbounds when no port matches SectionName
+			if port, ok = svc.FindPortByName(outbound.Resource.SectionName); !ok {
+				continue
+			}
 		}
 
 		// determine protocol, default to TCP if unspecified
@@ -191,6 +199,14 @@ func DestinationPortFromRef(
 
 	if dest = meshCtx.GetServiceByKRI(ref.Resource); dest == nil {
 		return nil, nil, false
+	}
+
+	if ref.Resource.SectionName == "" {
+		ports := dest.GetPorts()
+		if len(ports) != 1 {
+			return nil, nil, false
+		}
+		return dest, ports[0], true
 	}
 
 	if port, ok = dest.FindPortByName(ref.Resource.SectionName); !ok {

--- a/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners_test.go
@@ -7,9 +7,12 @@ import (
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds/meshroute"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 )
 
 var _ = Describe("OutboundListenerTags", func() {
@@ -92,5 +95,56 @@ var _ = Describe("OutboundListenerTags", func() {
 
 		// then
 		Expect(tags).To(BeNil())
+	})
+})
+
+var _ = Describe("DestinationPortFromRef", func() {
+	It("returns the only port when a real backendRef has no section name", func() {
+		ms := builders.MeshService().
+			WithName("backend").
+			WithMesh("default").
+			WithLabels(map[string]string{
+				mesh_proto.DisplayName:      "backend",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			}).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			Build()
+
+		meshCtx := xds_builders.Context().
+			WithMeshLocalResources([]core_model.Resource{ms}).
+			Build().
+			Mesh
+
+		dest, port, ok := meshroute.DestinationPortFromRef(meshCtx, &resolve.RealResourceBackendRef{
+			Resource: kri.From(ms),
+		})
+
+		Expect(ok).To(BeTrue())
+		Expect(dest).To(Equal(ms))
+		Expect(port.GetValue()).To(Equal(int32(8080)))
+	})
+
+	It("does not guess a port when a real backendRef has multiple ports and no section name", func() {
+		ms := builders.MeshService().
+			WithName("backend").
+			WithMesh("default").
+			WithLabels(map[string]string{
+				mesh_proto.DisplayName:      "backend",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			}).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			AddIntPort(9090, 9090, core_meta.ProtocolHTTP).
+			Build()
+
+		meshCtx := xds_builders.Context().
+			WithMeshLocalResources([]core_model.Resource{ms}).
+			Build().
+			Mesh
+
+		_, _, ok := meshroute.DestinationPortFromRef(meshCtx, &resolve.RealResourceBackendRef{
+			Resource: kri.From(ms),
+		})
+
+		Expect(ok).To(BeFalse())
 	})
 })

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
@@ -96,6 +97,7 @@ func CompareMatch(a Match, b Match) int {
 
 type Route struct {
 	Name        string
+	Origin      kri.Identifier
 	Match       Match
 	Filters     []Filter
 	BackendRefs []resolve.ResolvedBackendRef

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -107,11 +107,19 @@ func generateFromService(
 		for _, filter := range route.Filters {
 			if filter.Type == api.RequestMirrorType {
 				// we need to create a split for the mirror backend
-				_ = meshroute_xds.MakeHTTPSplit(
-					clusterCache, servicesAcc,
-					[]resolve.ResolvedBackendRef{*resolve.NewResolvedBackendRef(pointer.To(resolve.LegacyBackendRef(filter.RequestMirror.BackendRef)))},
-					meshCtx,
-				)
+				if ref, ok := resolve.BackendRef(route.Origin, filter.RequestMirror.BackendRef, meshCtx.ResolveResourceIdentifier); ok {
+					_ = meshroute_xds.MakeHTTPSplit(
+						clusterCache,
+						servicesAcc,
+						[]resolve.ResolvedBackendRef{ref},
+						meshCtx,
+					)
+					if ref.ReferencesRealResource() {
+						if clusterName, found := clusterCache[common_api.BackendRefHash(ref.Resource().String())]; found {
+							clusterCache[filter.RequestMirror.BackendRef.Hash()] = clusterName
+						}
+					}
+				}
 			}
 		}
 		routes = append(routes, xds.OutboundRoute{
@@ -239,6 +247,7 @@ func prepareRoutes(
 				routes,
 				api.Route{
 					Name:        routeName,
+					Origin:      originID,
 					Match:       match,
 					Filters:     filters,
 					BackendRefs: refs,
@@ -263,8 +272,9 @@ func prepareRoutes(
 
 	if noCatchAll {
 		routes = append(routes, api.Route{
-			Match: catchAllMatch,
-			Name:  string(api.HashMatches([]api.Match{catchAllMatch})),
+			Match:  catchAllMatch,
+			Name:   string(api.HashMatches([]api.Match{catchAllMatch})),
+			Origin: svc.Outbound.Resource,
 		})
 	}
 

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 
@@ -104,30 +105,13 @@ func generateFromService(
 		if len(split) == 0 {
 			continue
 		}
-		for _, filter := range route.Filters {
-			if filter.Type == api.RequestMirrorType {
-				// we need to create a split for the mirror backend
-				if ref, ok := resolve.BackendRef(route.Origin, filter.RequestMirror.BackendRef, meshCtx.ResolveResourceIdentifier); ok {
-					_ = meshroute_xds.MakeHTTPSplit(
-						clusterCache,
-						servicesAcc,
-						[]resolve.ResolvedBackendRef{ref},
-						meshCtx,
-					)
-					if ref.ReferencesRealResource() {
-						if clusterName, found := clusterCache[common_api.BackendRefHash(ref.Resource().String())]; found {
-							clusterCache[filter.RequestMirror.BackendRef.Hash()] = clusterName
-						}
-					}
-				}
-			}
-		}
+		backendRefToClusterName := backendRefToClusterNameForRoute(clusterCache, servicesAcc, route, meshCtx)
 		routes = append(routes, xds.OutboundRoute{
 			Name:                    route.Name,
 			Match:                   route.Match,
 			Filters:                 route.Filters,
 			Split:                   split,
-			BackendRefToClusterName: clusterCache,
+			BackendRefToClusterName: backendRefToClusterName,
 		})
 	}
 
@@ -175,6 +159,47 @@ func generateListeners(
 	}
 
 	return resources, nil
+}
+
+func backendRefToClusterNameForRoute(
+	clusterCache map[common_api.BackendRefHash]string,
+	servicesAcc envoy_common.ServicesAccumulator,
+	route api.Route,
+	meshCtx xds_context.MeshContext,
+) map[common_api.BackendRefHash]string {
+	backendRefToClusterName := maps.Clone(clusterCache)
+
+	for _, filter := range route.Filters {
+		if filter.Type != api.RequestMirrorType || filter.RequestMirror == nil {
+			continue
+		}
+
+		// We need to create a split for the mirror backend.
+		ref, ok := resolve.BackendRef(route.Origin, filter.RequestMirror.BackendRef, meshCtx.ResolveResourceIdentifier)
+		if !ok {
+			continue
+		}
+		_ = meshroute_xds.MakeHTTPSplit(
+			clusterCache,
+			servicesAcc,
+			[]resolve.ResolvedBackendRef{ref},
+			meshCtx,
+		)
+		maps.Copy(backendRefToClusterName, clusterCache)
+
+		if clusterName, found := clusterCache[resolvedBackendRefHash(ref)]; found {
+			backendRefToClusterName[filter.RequestMirror.BackendRef.Hash()] = clusterName
+		}
+	}
+
+	return backendRefToClusterName
+}
+
+func resolvedBackendRefHash(ref resolve.ResolvedBackendRef) common_api.BackendRefHash {
+	if ref.ReferencesRealResource() {
+		return common_api.BackendRefHash(ref.Resource().String())
+	}
+	return common_api.BackendRef(*ref.LegacyBackendRef()).Hash()
 }
 
 func ComputeHTTPRouteConf(

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -5,21 +5,17 @@ import (
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
-	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
-	meshroute_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds/meshroute"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
-	test_policies "github.com/kumahq/kuma/v3/pkg/test/policies"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
 )
 
-func TestGenerateFromServiceUsesResolvedRequestMirrorBackendRefs(t *testing.T) {
+func TestBackendRefToClusterNameForRouteUsesResolvedRequestMirrorBackendRefs(t *testing.T) {
 	t.Parallel()
 
 	payments := builders.MeshService().
@@ -34,31 +30,8 @@ func TestGenerateFromServiceUsesResolvedRequestMirrorBackendRefs(t *testing.T) {
 
 	meshCtx := xds_builders.Context().
 		WithMeshLocalResources([]core_model.Resource{payments}).
-		AddServiceProtocol("backend", core_meta.ProtocolHTTP).
 		Build().
 		Mesh
-
-	proxy := xds_builders.Proxy().
-		WithDataplane(builders.Dataplane().
-			WithName("web-01").
-			WithAddress("192.168.0.2").
-			WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http"),
-		).
-		WithOutbounds(xds_types.Outbounds{
-			{
-				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
-					Port: 10001,
-					Tags: map[string]string{mesh_proto.ServiceTag: "backend"},
-				},
-			},
-		}).
-		Build()
-
-	svc := meshroute_xds.DestinationService{
-		Outbound:            proxy.Outbounds[0],
-		Protocol:            core_meta.ProtocolHTTP,
-		KumaServiceTagValue: "backend",
-	}
 
 	mirrorBackendRef := common_api.BackendRef{
 		TargetRef: common_api.TargetRef{
@@ -68,32 +41,81 @@ func TestGenerateFromServiceUsesResolvedRequestMirrorBackendRefs(t *testing.T) {
 		},
 	}
 
-	rules := core_rules.ToRules{
-		Rules: core_rules.Rules{
-			test_policies.NewRule(subsetutils.MeshService("backend"), api.PolicyDefault{
-				Rules: []api.Rule{{
-					Matches: []api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/"}}},
-					Default: api.RuleConf{
-						Filters: &[]api.Filter{{
-							Type: api.RequestMirrorType,
-							RequestMirror: &api.RequestMirror{
-								BackendRef: mirrorBackendRef,
-							},
-						}},
-					},
-				}},
-			}),
+	route := requestMirrorRoute("kuma-demo", mirrorBackendRef)
+
+	clusterCache := map[common_api.BackendRefHash]string{}
+	servicesAcc := envoy_common.NewServicesAccumulator(meshCtx.GetTLSReadiness())
+
+	backendRefToClusterName := backendRefToClusterNameForRoute(clusterCache, servicesAcc, route, meshCtx)
+
+	if got, want := backendRefToClusterName[mirrorBackendRef.Hash()], kri.From(payments).String(); got != want {
+		t.Fatalf("request-mirror backendRef hash %q resolved to cluster %q, want %q", mirrorBackendRef.Hash(), got, want)
+	}
+}
+
+func TestBackendRefToClusterNameForRouteScopesRequestMirrorBackendRefAliasesByOriginNamespace(t *testing.T) {
+	t.Parallel()
+
+	paymentsTeamA := builders.MeshService().
+		WithName("payments-team-a-hash").
+		WithMesh("default").
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName:      "payments",
+			mesh_proto.KubeNamespaceTag: "team-a",
+		}).
+		AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+		Build()
+
+	paymentsTeamB := builders.MeshService().
+		WithName("payments-team-b-hash").
+		WithMesh("default").
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName:      "payments",
+			mesh_proto.KubeNamespaceTag: "team-b",
+		}).
+		AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+		Build()
+
+	meshCtx := xds_builders.Context().
+		WithMeshLocalResources([]core_model.Resource{paymentsTeamA, paymentsTeamB}).
+		Build().
+		Mesh
+
+	mirrorBackendRef := common_api.BackendRef{
+		TargetRef: common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Name: pointer.To("payments"),
 		},
 	}
 
 	clusterCache := map[common_api.BackendRefHash]string{}
 	servicesAcc := envoy_common.NewServicesAccumulator(meshCtx.GetTLSReadiness())
 
-	if _, err := generateFromService(meshCtx, proxy, clusterCache, servicesAcc, rules, svc); err != nil {
-		t.Fatalf("generateFromService() error = %v", err)
-	}
+	teamABackendRefToClusterName := backendRefToClusterNameForRoute(clusterCache, servicesAcc, requestMirrorRoute("team-a", mirrorBackendRef), meshCtx)
+	teamBBackendRefToClusterName := backendRefToClusterNameForRoute(clusterCache, servicesAcc, requestMirrorRoute("team-b", mirrorBackendRef), meshCtx)
 
-	if _, found := clusterCache[mirrorBackendRef.Hash()]; !found {
-		t.Fatalf("expected request-mirror backendRef hash %q to resolve to a cluster", mirrorBackendRef.Hash())
+	hash := mirrorBackendRef.Hash()
+	if got, want := teamABackendRefToClusterName[hash], kri.From(paymentsTeamA).String(); got != want {
+		t.Fatalf("team-a request-mirror backendRef hash %q resolved to cluster %q, want %q", hash, got, want)
+	}
+	if got, want := teamBBackendRefToClusterName[hash], kri.From(paymentsTeamB).String(); got != want {
+		t.Fatalf("team-b request-mirror backendRef hash %q resolved to cluster %q, want %q", hash, got, want)
+	}
+}
+
+func requestMirrorRoute(namespace string, mirrorBackendRef common_api.BackendRef) api.Route {
+	return api.Route{
+		Origin: kri.Identifier{
+			ResourceType: api.MeshHTTPRouteType,
+			Mesh:         core_model.DefaultMesh,
+			Namespace:    namespace,
+			Name:         "web-route",
+		},
+		Filters: []api.Filter{{
+			Type: api.RequestMirrorType,
+			RequestMirror: &api.RequestMirror{
+				BackendRef: mirrorBackendRef,
+			},
+		}},
 	}
 }

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -48,7 +48,7 @@ func TestBackendRefToClusterNameForRouteUsesResolvedRequestMirrorBackendRefs(t *
 
 	backendRefToClusterName := backendRefToClusterNameForRoute(clusterCache, servicesAcc, route, meshCtx)
 
-	if got, want := backendRefToClusterName[mirrorBackendRef.Hash()], kri.From(payments).String(); got != want {
+	if got, want := backendRefToClusterName[mirrorBackendRef.Hash()], kri.WithSectionName(kri.From(payments), "8080").String(); got != want {
 		t.Fatalf("request-mirror backendRef hash %q resolved to cluster %q, want %q", mirrorBackendRef.Hash(), got, want)
 	}
 }
@@ -95,10 +95,10 @@ func TestBackendRefToClusterNameForRouteScopesRequestMirrorBackendRefAliasesByOr
 	teamBBackendRefToClusterName := backendRefToClusterNameForRoute(clusterCache, servicesAcc, requestMirrorRoute("team-b", mirrorBackendRef), meshCtx)
 
 	hash := mirrorBackendRef.Hash()
-	if got, want := teamABackendRefToClusterName[hash], kri.From(paymentsTeamA).String(); got != want {
+	if got, want := teamABackendRefToClusterName[hash], kri.WithSectionName(kri.From(paymentsTeamA), "8080").String(); got != want {
 		t.Fatalf("team-a request-mirror backendRef hash %q resolved to cluster %q, want %q", hash, got, want)
 	}
-	if got, want := teamBBackendRefToClusterName[hash], kri.From(paymentsTeamB).String(); got != want {
+	if got, want := teamBBackendRefToClusterName[hash], kri.WithSectionName(kri.From(paymentsTeamB), "8080").String(); got != want {
 		t.Fatalf("team-b request-mirror backendRef hash %q resolved to cluster %q, want %q", hash, got, want)
 	}
 }

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -1,0 +1,99 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
+	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
+	meshroute_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds/meshroute"
+	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	test_policies "github.com/kumahq/kuma/v3/pkg/test/policies"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
+)
+
+func TestGenerateFromServiceUsesResolvedRequestMirrorBackendRefs(t *testing.T) {
+	t.Parallel()
+
+	payments := builders.MeshService().
+		WithName("payments-hash").
+		WithMesh("default").
+		WithLabels(map[string]string{
+			mesh_proto.DisplayName:      "payments",
+			mesh_proto.KubeNamespaceTag: "kuma-demo",
+		}).
+		AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+		Build()
+
+	meshCtx := xds_builders.Context().
+		WithMeshLocalResources([]core_model.Resource{payments}).
+		AddServiceProtocol("backend", core_meta.ProtocolHTTP).
+		Build().
+		Mesh
+
+	proxy := xds_builders.Proxy().
+		WithDataplane(builders.Dataplane().
+			WithName("web-01").
+			WithAddress("192.168.0.2").
+			WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http"),
+		).
+		WithOutbounds(xds_types.Outbounds{
+			{
+				LegacyOutbound: &mesh_proto.Dataplane_Networking_Outbound{
+					Port: 10001,
+					Tags: map[string]string{mesh_proto.ServiceTag: "backend"},
+				},
+			},
+		}).
+		Build()
+
+	svc := meshroute_xds.DestinationService{
+		Outbound:            proxy.Outbounds[0],
+		Protocol:            core_meta.ProtocolHTTP,
+		KumaServiceTagValue: "backend",
+	}
+
+	mirrorBackendRef := common_api.BackendRef{
+		TargetRef: common_api.TargetRef{
+			Kind:      common_api.MeshService,
+			Name:      pointer.To("payments"),
+			Namespace: pointer.To("kuma-demo"),
+		},
+	}
+
+	rules := core_rules.ToRules{
+		Rules: core_rules.Rules{
+			test_policies.NewRule(subsetutils.MeshService("backend"), api.PolicyDefault{
+				Rules: []api.Rule{{
+					Matches: []api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/"}}},
+					Default: api.RuleConf{
+						Filters: &[]api.Filter{{
+							Type: api.RequestMirrorType,
+							RequestMirror: &api.RequestMirror{
+								BackendRef: mirrorBackendRef,
+							},
+						}},
+					},
+				}},
+			}),
+		},
+	}
+
+	clusterCache := map[common_api.BackendRefHash]string{}
+	servicesAcc := envoy_common.NewServicesAccumulator(meshCtx.GetTLSReadiness())
+
+	if _, err := generateFromService(meshCtx, proxy, clusterCache, servicesAcc, rules, svc); err != nil {
+		t.Fatalf("generateFromService() error = %v", err)
+	}
+
+	if _, found := clusterCache[mirrorBackendRef.Hash()]; !found {
+		t.Fatalf("expected request-mirror backendRef hash %q to resolve to a cluster", mirrorBackendRef.Hash())
+	}
+}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.clusters.golden.yaml
@@ -1,18 +1,4 @@
 resources:
-- name: backend
-  resource:
-    '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
-    edsClusterConfig:
-      edsConfig:
-        ads: {}
-        resourceApiVersion: V3
-    name: backend
-    type: EDS
-    typedExtensionProtocolOptions:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicitHttpConfig:
-          http2ProtocolOptions: {}
 - name: backend-c72efb5be46fae6b
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.endpoints.golden.yaml
@@ -1,38 +1,4 @@
 resources:
-- name: backend
-  resource:
-    '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
-    clusterName: backend
-    endpoints:
-    - lbEndpoints:
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.4
-              portValue: 8084
-        loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: eu
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: eu
-      - endpoint:
-          address:
-            socketAddress:
-              address: 192.168.0.5
-              portValue: 8084
-        loadBalancingWeight: 1
-        metadata:
-          filterMetadata:
-            envoy.lb:
-              kuma.io/protocol: http
-              region: us
-            envoy.transport_socket_match:
-              kuma.io/protocol: http
-              region: us
 - name: backend-c72efb5be46fae6b
   resource:
     '@type': type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice.listeners.golden.yaml
@@ -32,13 +32,13 @@ resources:
                   path: /v1
                 name: kri_mhttpr_default___test-origin_rule_0
                 route:
-                  cluster: backend
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
               - match:
                   prefix: /v1/
                 name: kri_mhttpr_default___test-origin_rule_0
                 route:
-                  cluster: backend
+                  cluster: kri_msvc_default___backend_test-port
                   timeout: 0s
               - match:
                   path: /v2

--- a/pkg/xds/context/destination_index.go
+++ b/pkg/xds/context/destination_index.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
@@ -50,24 +49,23 @@ func (di *DestinationIndex) GetReachableBackends(dataplane *core_mesh.DataplaneR
 	networking := dataplane.Spec.GetNetworking()
 
 	processRef := func(kind string, name string, namespace string, port *uint32, labels map[string]string) {
-		ids := di.resolveResourceIdentifiersForLabels(core_model.ResourceType(kind), labels)
-		if len(ids) == 0 {
-			ids = []kri.Identifier{
-				resolve.TargetRefToKRI(
-					kri.From(dataplane),
-					common_api.TargetRef{
-						Kind:      common_api.TargetRefKind(kind),
-						Name:      &name,
-						Namespace: &namespace,
-						Labels:    &labels,
-					},
-				),
-			}
+		selectorLabels, sectionName, ok := common_api.BackendRef{
+			TargetRef: common_api.TargetRef{
+				Kind:      common_api.TargetRefKind(kind),
+				Name:      &name,
+				Namespace: &namespace,
+				Labels:    &labels,
+			},
+			Port: port,
+		}.RealResourceSelector(dataplane.GetMeta().GetLabels()[mesh_proto.KubeNamespaceTag])
+		if !ok {
+			return
 		}
 
+		ids := di.resolveResourceIdentifiersForLabels(core_model.ResourceType(kind), selectorLabels)
 		for _, id := range ids {
-			if port != nil {
-				id = kri.WithSectionName(id, *port)
+			if sectionName != "" {
+				id = kri.WithSectionName(id, sectionName)
 			}
 
 			var dest core.Destination

--- a/pkg/xds/context/destination_index.go
+++ b/pkg/xds/context/destination_index.go
@@ -32,7 +32,7 @@ func NewDestinationIndex(resources ...[]core_model.Resource) *DestinationIndex {
 		for _, item := range destinations {
 			ri := kri.From(item)
 			destinationByIdentifier[ri] = item.(core.Destination)
-			buildLabelValueToServiceNames(ri, destinationsByLabelByValue, item.GetMeta().GetLabels())
+			buildLabelValueToServiceNames(ri, destinationsByLabelByValue, destinationIndexLabels(item.GetMeta()))
 		}
 	}
 
@@ -190,4 +190,20 @@ func buildLabelValueToServiceNames(ri kri.Identifier, resourceNamesByLabels labe
 			}
 		}
 	}
+}
+
+func destinationIndexLabels(meta core_model.ResourceMeta) map[string]string {
+	if meta == nil {
+		return nil
+	}
+
+	labels := map[string]string{}
+	for k, v := range meta.GetLabels() {
+		labels[k] = v
+	}
+	if labels[mesh_proto.DisplayName] == "" {
+		labels[mesh_proto.DisplayName] = core_model.GetDisplayName(meta)
+	}
+
+	return labels
 }

--- a/pkg/xds/context/destination_index.go
+++ b/pkg/xds/context/destination_index.go
@@ -49,11 +49,16 @@ func (di *DestinationIndex) GetReachableBackends(dataplane *core_mesh.DataplaneR
 	networking := dataplane.Spec.GetNetworking()
 
 	processRef := func(kind string, name string, namespace string, port *uint32, labels map[string]string) {
+		var targetNamespace *string
+		if namespace != "" {
+			targetNamespace = &namespace
+		}
+
 		selectorLabels, sectionName, ok := common_api.BackendRef{
 			TargetRef: common_api.TargetRef{
 				Kind:      common_api.TargetRefKind(kind),
 				Name:      &name,
-				Namespace: &namespace,
+				Namespace: targetNamespace,
 				Labels:    &labels,
 			},
 			Port: port,

--- a/pkg/xds/context/destination_index.go
+++ b/pkg/xds/context/destination_index.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"maps"
 	"time"
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
@@ -203,9 +204,7 @@ func destinationIndexLabels(meta core_model.ResourceMeta) map[string]string {
 	}
 
 	labels := map[string]string{}
-	for k, v := range meta.GetLabels() {
-		labels[k] = v
-	}
+	maps.Copy(labels, meta.GetLabels())
 	if labels[mesh_proto.DisplayName] == "" {
 		labels[mesh_proto.DisplayName] = core_model.GetDisplayName(meta)
 	}

--- a/pkg/xds/context/destination_index_test.go
+++ b/pkg/xds/context/destination_index_test.go
@@ -58,6 +58,38 @@ var _ = Describe("DestinationIndex", func() {
 			Expect(outbounds).To(HaveKey(expectedKRI))
 		})
 
+		It("should resolve MeshService name refs using display name derived from resource metadata", func() {
+			ms := builders.MeshService().
+				WithName("backend-svc").
+				AddIntPort(9000, 9000, metadata.ProtocolHTTP).
+				Build()
+
+			dp := builders.Dataplane().
+				WithName("dp-1").
+				WithAddress("127.0.0.1").
+				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
+				WithTransparentProxying(15001, 15006, "").
+				Build()
+
+			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
+				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
+					{
+						Kind: "MeshService",
+						Name: "backend-svc",
+					},
+				},
+			}
+
+			index := xds_context.NewDestinationIndex([]core_model.Resource{ms})
+			outbounds, matched := index.GetReachableBackends(dp)
+
+			Expect(matched).To(BeTrue())
+			Expect(outbounds).To(HaveLen(1))
+
+			expectedKRI := kri.WithSectionName(kri.From(ms), "9000")
+			Expect(outbounds).To(HaveKey(expectedKRI))
+		})
+
 		It("should fallback to dataplane namespace when namespace not specified", func() {
 			ms := builders.MeshService().
 				WithName("backend-svc-hash456").

--- a/pkg/xds/context/destination_index_test.go
+++ b/pkg/xds/context/destination_index_test.go
@@ -170,6 +170,40 @@ var _ = Describe("DestinationIndex", func() {
 			Expect(outbounds).To(HaveKey(kri.WithSectionName(kri.From(ms), "8080")))
 		})
 
+		It("should resolve user-defined outbound legacy MeshService name forms through derived labels", func() {
+			ms := builders.MeshService().
+				WithName("backend-svc-hash654").
+				WithLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-svc",
+					mesh_proto.KubeNamespaceTag: "other-ns",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				AddIntPort(8080, 8080, metadata.ProtocolHTTP).
+				Build()
+
+			dp := builders.Dataplane().
+				WithName("dp-1").
+				WithLabels(map[string]string{
+					mesh_proto.KubeNamespaceTag: "default",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				WithAddress("127.0.0.1").
+				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
+				AddOutbound(
+					builders.Outbound().
+						WithPort(10001).
+						WithMeshService("backend-svc_other-ns_svc_8080", 8080),
+				).
+				Build()
+
+			index := xds_context.NewDestinationIndex([]core_model.Resource{ms})
+			outbounds, matched := index.GetReachableBackends(dp)
+
+			Expect(matched).To(BeTrue())
+			Expect(outbounds).To(HaveLen(1))
+			Expect(outbounds).To(HaveKey(kri.WithSectionName(kri.From(ms), "8080")))
+		})
+
 		It("should not resolve when namespace does not match", func() {
 			ms := builders.MeshService().
 				WithName("backend-svc-hash789").

--- a/pkg/xds/context/destination_index_test.go
+++ b/pkg/xds/context/destination_index_test.go
@@ -99,6 +99,45 @@ var _ = Describe("DestinationIndex", func() {
 			Expect(outbounds).To(HaveKey(expectedKRI))
 		})
 
+		It("should resolve legacy MeshService name forms through derived labels", func() {
+			ms := builders.MeshService().
+				WithName("backend-svc-hash321").
+				WithLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-svc",
+					mesh_proto.KubeNamespaceTag: "other-ns",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				AddIntPort(8080, 8080, metadata.ProtocolHTTP).
+				Build()
+
+			dp := builders.Dataplane().
+				WithName("dp-1").
+				WithLabels(map[string]string{
+					mesh_proto.KubeNamespaceTag: "default",
+					mesh_proto.ZoneTag:          "zone-1",
+				}).
+				WithAddress("127.0.0.1").
+				WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http").
+				WithTransparentProxying(15001, 15006, "").
+				Build()
+
+			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
+				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
+					{
+						Kind: "MeshService",
+						Name: "backend-svc_other-ns_svc_8080",
+					},
+				},
+			}
+
+			index := xds_context.NewDestinationIndex([]core_model.Resource{ms})
+			outbounds, matched := index.GetReachableBackends(dp)
+
+			Expect(matched).To(BeTrue())
+			Expect(outbounds).To(HaveLen(1))
+			Expect(outbounds).To(HaveKey(kri.WithSectionName(kri.From(ms), "8080")))
+		})
+
 		It("should not resolve when namespace does not match", func() {
 			ms := builders.MeshService().
 				WithName("backend-svc-hash789").


### PR DESCRIPTION
## Motivation

Part of #17721 (labels-only targetRef). Prep step: stop *reading* `name`/`namespace`/`mesh` for backendRef routing so the fields can later be deleted from `TargetRef` (#17721 final step) without touching routing logic. Non-breaking on its own — the fields stay on the struct; only the internal resolution/serialization stops depending on them.

> Changelog: skip

## Implementation information

- `pkg/plugins/policies/core/rules/resolve/backendref.go`: `BackendRef()` now always resolves the destination via the `LabelResourceIdentifierResolver`, dropping the `TargetRefToKRI` name/namespace fallback.
- `api/common/v1alpha1/targetref.go`: `BackendRef.Hash()` and `ReferencesRealObject()` branch on labels (+kind/port/sectionName) instead of `name`/`mesh`.
- `pkg/plugins/policies/core/xds/meshroute/listeners.go` and `meshhttproute` plugin: cluster/endpoint naming switched to the resolved KRI/labels path.
- Golden fixtures updated to match.

## Supporting documentation

N/A

Closes https://github.com/kumahq/kuma/issues/17722