### PR TITLE
refactor(k8s): collapse inbound conversion to tag-free path

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/egress_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/egress_converter.go
@@ -19,10 +19,7 @@ func (p *PodConverter) EgressFor(
 	if len(services) != 1 {
 		return errors.Errorf("egress should be matched by exactly one service. Matched %d services", len(services))
 	}
-	ifaces, err := p.InboundConverter.InboundInterfacesFor(ctx, pod, services)
-	if err != nil {
-		return errors.Wrap(err, "could not generate inbound interfaces")
-	}
+	ifaces := p.InboundConverter.InboundInterfacesFor(pod, services)
 	if len(ifaces) != 1 {
 		return errors.Errorf("generated %d inbound interfaces, expected 1. Interfaces: %v", len(ifaces), ifaces)
 	}

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -132,26 +132,13 @@ func (ic *InboundConverter) inboundForServiceless(pod *kube_core.Pod) *mesh_prot
 	}
 }
 
-// Deprecated: LegacyInboundInterfacesFor is used for delegated gateway, to not
-// change order of inbounds. For gateway we pick first inbound to take tags
-// from. Delegated gateway identity relies on this.
-// TODO: We should revisit this when we rework identity. More in https://github.com/kumahq/kuma/issues/3339
-func (ic *InboundConverter) LegacyInboundInterfacesFor(ctx context.Context, pod *kube_core.Pod, services []*kube_core.Service) ([]*mesh_proto.Dataplane_Networking_Inbound, error) {
-	return ic.inboundInterfacesFor(pod, services)
-}
-
 // InboundInterfacesFor deduplicates inbounds by address and port.
 // Since inbounds carry no tags we can safely deduplicate them.
 func (ic *InboundConverter) InboundInterfacesFor(ctx context.Context, pod *kube_core.Pod, services []*kube_core.Service) ([]*mesh_proto.Dataplane_Networking_Inbound, error) {
-	inbounds, err := ic.inboundInterfacesFor(pod, services)
-	if err != nil {
-		return nil, err
-	}
-
-	return deduplicateInboundsByAddressAndPort(inbounds), nil
+	return deduplicateInboundsByAddressAndPort(ic.inboundInterfacesFor(pod, services)), nil
 }
 
-func (ic *InboundConverter) inboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service) ([]*mesh_proto.Dataplane_Networking_Inbound, error) {
+func (ic *InboundConverter) inboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service) []*mesh_proto.Dataplane_Networking_Inbound {
 	var ifaces []*mesh_proto.Dataplane_Networking_Inbound
 	for _, svc := range services {
 		// Services of ExternalName type should not have any selectors.
@@ -168,7 +155,7 @@ func (ic *InboundConverter) inboundInterfacesFor(pod *kube_core.Pod, services []
 	if len(ifaces) == 0 {
 		ifaces = append(ifaces, ic.inboundForServiceless(pod))
 	}
-	return ifaces, nil
+	return ifaces
 }
 
 func deduplicateInboundsByAddressAndPort(ifaces []*mesh_proto.Dataplane_Networking_Inbound) []*mesh_proto.Dataplane_Networking_Inbound {

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -134,8 +134,8 @@ func (ic *InboundConverter) inboundForServiceless(pod *kube_core.Pod) *mesh_prot
 
 // InboundInterfacesFor deduplicates inbounds by address and port.
 // Since inbounds carry no tags we can safely deduplicate them.
-func (ic *InboundConverter) InboundInterfacesFor(ctx context.Context, pod *kube_core.Pod, services []*kube_core.Service) ([]*mesh_proto.Dataplane_Networking_Inbound, error) {
-	return deduplicateInboundsByAddressAndPort(ic.inboundInterfacesFor(pod, services)), nil
+func (ic *InboundConverter) InboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service) []*mesh_proto.Dataplane_Networking_Inbound {
+	return deduplicateInboundsByAddressAndPort(ic.inboundInterfacesFor(pod, services))
 }
 
 func (ic *InboundConverter) inboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service) []*mesh_proto.Dataplane_Networking_Inbound {

--- a/pkg/plugins/runtime/k8s/controllers/ingress_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/ingress_converter.go
@@ -27,10 +27,7 @@ func (p *PodConverter) IngressFor(
 	if len(services) != 1 {
 		return errors.Errorf("ingress should be matched by exactly one service. Matched %d services", len(services))
 	}
-	ifaces, err := p.InboundConverter.InboundInterfacesFor(ctx, pod, services)
-	if err != nil {
-		return errors.Wrap(err, "could not generate inbound interfaces")
-	}
+	ifaces := p.InboundConverter.InboundInterfacesFor(pod, services)
 	if len(ifaces) != 1 {
 		return errors.Errorf("generated %d inbound interfaces, expected 1. Interfaces: %v", len(ifaces), ifaces)
 	}

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -307,11 +307,7 @@ func (p *PodConverter) dataplaneFor(
 		// (has zone proxy services but no regular services) to avoid the
 		// serviceless inbound fallback in InboundInterfacesFor.
 		if len(regularServices) > 0 || len(zoneProxyServices) == 0 {
-			ifaces, err := p.InboundConverter.InboundInterfacesFor(ctx, pod, regularServices)
-			if err != nil {
-				return nil, err
-			}
-			dataplane.Networking.Inbound = ifaces
+			dataplane.Networking.Inbound = p.InboundConverter.InboundInterfacesFor(pod, regularServices)
 		}
 
 		// portSvc tracks which service already claimed each address:port to produce

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -607,10 +607,9 @@ var _ = Describe("InboundConverter.InboundInterfacesFor(..)", func() {
 			}
 
 			// when
-			inbounds, err := (&InboundConverter{}).InboundInterfacesFor(context.Background(), pod, []*kube_core.Service{svc})
+			inbounds := (&InboundConverter{}).InboundInterfacesFor(pod, []*kube_core.Service{svc})
 
 			// expect
-			Expect(err).ToNot(HaveOccurred())
 			Expect(inbounds).To(HaveLen(1))
 			Expect(inbounds[0].Port).To(Equal(uint32(8080)))
 			Expect(inbounds[0].Tags).To(Equal(map[string]string{}))
@@ -741,9 +740,8 @@ var _ = Describe("InboundConverter.InboundInterfacesFor(..)", func() {
 			},
 		}
 
-		inbounds, err := (&InboundConverter{}).InboundInterfacesFor(context.Background(), pod, services)
+		inbounds := (&InboundConverter{}).InboundInterfacesFor(pod, services)
 
-		Expect(err).ToNot(HaveOccurred())
 		Expect(inbounds).To(HaveLen(1))
 		Expect(inbounds[0].State).To(Equal(mesh_proto.Dataplane_Networking_Inbound_Ready))
 		Expect(inbounds[0].Health).To(Equal(&mesh_proto.Dataplane_Networking_Inbound_Health{Ready: true}))


### PR DESCRIPTION
## Motivation

Simplify K8s Pod→Dataplane inbound conversion by consolidating to a single tag-free code path. This is part of #17685 Stage 1 effort to reduce complexity in inbound processing.

## Implementation information

- Deleted tag-related helper functions (`tagsOrEmpty`, `InboundTagsForService`, `InboundTagsForPod`) from `inbound_converter.go`
- Consolidated inbound processing: `InboundInterfacesFor` is now the sole regular inbound path; `deduplicateInboundsByAddressAndPort` is the only deduplication step
- Updated `pod_converter.go` to always fetch node labels onto Dataplane labels; removed Legacy/dedup branch and obsolete comments
- Removed `LegacyInboundInterfacesFor`; delegated gateway identity handling deferred to S9/S10

Closes https://github.com/kumahq/kuma/issues/17689

_Generated by Sybra harness_