### PR TITLE
ci(actions): fix release gate e2e job pattern

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -85,7 +85,7 @@ jobs:
               . as $jobs
               | [
                   {label: "test / test_unit", pattern: "^test / test_unit$"},
-                  {label: "test / e2e ...", pattern: "^test / e2e"},
+                  {label: "test / e2e ...", pattern: "^test / (test_)?e2e"},
                   {label: "build_publish / digest-images", pattern: "^build_publish / digest-images$"},
                   {label: "build_publish / build-binaries", pattern: "^build_publish / build-binaries$"},
                   {label: "build_publish / build-images ...", pattern: "^build_publish / build-images"},


### PR DESCRIPTION
## Motivation

> Changelog: skip

The `release_sha_gate` job added to `build-test-distribute.yaml` blocks
every tag push on this branch. It requires a prior successful push run
with a job matching `^test / e2e`, but the e2e job was split into
`test_e2e` and `test_e2e_env` (sharded matrix jobs), so job names are
now `test / test_e2e (...) / e2e (N)` and `test / test_e2e_env (...) /
e2e (N)`. Neither matches the old anchored pattern, so the gate always
reports the required job missing even when the referenced run is fully
green (confirmed on the v2.13.10 tag push, run 30530480561, whose
source run 30479261280 was all-green).

## Implementation information

Widen the pattern to `^test / (test_)?e2e` so it matches both the old
single `e2e` job name and the current split `test_e2e`/`test_e2e_env`
names.

## Supporting documentation

https://github.com/kumahq/kuma/actions/runs/30530480561/job/90831372335