### PR TITLE
ci(actions): backport release SHA gate to 2.12

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -7,6 +7,9 @@ on:
       RUNNERS_BY_ARCH:
         required: true
         type: string
+      IS_RELEASE_TAG:
+        required: true
+        type: boolean
 permissions:
   contents: read
 env:
@@ -17,7 +20,7 @@ env:
 jobs:
   test_unit:
     timeout-minutes: 25
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
+    if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
     runs-on: ${{ vars.RUNS_ON_RELEASE_2_12_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -81,7 +84,7 @@ jobs:
             BASE_MATRIX_ALL=$(echo $BASE_MATRIX_ALL | jq -r '${{ env.OVERRIDE_JQ_CMD }}')
           fi
           # Skip e2e tests if the PR has the label "ci/skip-e2e-test" or "ci/skip-test"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}" == "true" ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG }}" == "true" ]]; then
             BASE_MATRIX_ALL='{}'
           fi
 

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -160,7 +160,6 @@ jobs:
         with:
           args: --fix=false --verbose
           version: v2.11.3 # TODO: automate this version update via Renovate
-
       # Lint and "make check" are redundant on a tag: release_sha_gate already
       # requires a green branch push run for this exact tree/SHA. We
       # intentionally keep metadata and SBOM/SCA on tag refs so release tags

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -18,7 +18,93 @@ concurrency:
   group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, github.event_name == 'push' && github.sha || github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'push' && false || true }}
 jobs:
+  release_sha_gate:
+    timeout-minutes: 5
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_12_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: "Verify tagged SHA has a trusted green push run"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${REF_TYPE}" != "tag" ]]; then
+            echo "Not a tag push; skipping release SHA gate."
+            exit 0
+          fi
+
+          WORKFLOW="build-test-distribute.yaml"
+
+          runs_ndjson="$(mktemp)"
+          if ! gh api --method GET "/repos/${REPO}/actions/workflows/${WORKFLOW}/runs" \
+              -f head_sha="${SHA}" -f status=completed -f event=push -f per_page=100 --paginate \
+              --jq '.workflow_runs[] | {id, conclusion, created_at, html_url}' \
+              > "${runs_ndjson}" 2>gate_runs_err.log; then
+            echo "::error title=release_sha_gate::gate could not query GitHub Actions for prior runs of ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_err.log)"
+            exit 1
+          fi
+
+          if ! selected_run="$(jq -s -r '
+              map(select(.conclusion == "success"))
+              | sort_by(.created_at)
+              | last
+              // empty
+            ' "${runs_ndjson}" 2>gate_runs_jq_err.log)"; then
+            echo "::error title=release_sha_gate::gate could not parse GitHub Actions run data for ${WORKFLOW} on SHA ${SHA}: $(cat gate_runs_jq_err.log)"
+            exit 1
+          fi
+
+          if [[ -z "${selected_run}" ]]; then
+            echo "::error title=release_sha_gate::No successful completed push run of ${WORKFLOW} found for tagged SHA ${SHA}. Every tag push requires a prior green branch push CI run for the tagged commit. Recovery: re-run the branch push CI on this SHA (re-tests and re-publishes the preview), then re-tag."
+            exit 1
+          fi
+
+          run_id="$(jq -r '.id' <<<"${selected_run}")"
+          run_url="$(jq -r '.html_url' <<<"${selected_run}")"
+
+          jobs_ndjson="$(mktemp)"
+          if ! gh api --method GET "/repos/${REPO}/actions/runs/${run_id}/jobs" -f per_page=100 --paginate \
+              --jq '.jobs[] | {name, conclusion}' \
+              > "${jobs_ndjson}" 2>gate_jobs_err.log; then
+            echo "::error title=release_sha_gate::gate could not query GitHub Actions for jobs of run ${run_url}: $(cat gate_jobs_err.log)"
+            exit 1
+          fi
+
+          if ! missing="$(jq -s -r '
+              def has_success($jobs; $pattern):
+                ($jobs | any(.[]; (.name | test($pattern)) and .conclusion == "success"));
+
+              . as $jobs
+              | [
+                  {label: "test / test_unit", pattern: "^test / test_unit$"},
+                  {label: "test / e2e ...", pattern: "^test / (test_)?e2e"},
+                  {label: "build_publish / digest-images", pattern: "^build_publish / digest-images$"},
+                  {label: "build_publish / build-binaries", pattern: "^build_publish / build-binaries$"},
+                  {label: "build_publish / build-images ...", pattern: "^build_publish / build-images"},
+                  {label: "build_publish / publish-helm", pattern: "^build_publish / publish-helm$"}
+                ]
+              | map(select(has_success($jobs; .pattern) | not))
+              | map(.label)
+              | join(", ")
+            ' "${jobs_ndjson}" 2>gate_jobs_jq_err.log)"; then
+            echo "::error title=release_sha_gate::gate could not parse GitHub Actions job data for run ${run_url}: $(cat gate_jobs_jq_err.log)"
+            exit 1
+          fi
+
+          if [[ -n "${missing}" ]]; then
+            echo "::error title=release_sha_gate::Selected run ${run_url} is missing required successful job(s): ${missing}. Recovery: re-run the branch push CI on SHA ${SHA}, then re-tag."
+            exit 1
+          fi
+
+          echo "Trusted source run: ${run_url}"
   check:
+    needs: ["release_sha_gate"]
     permissions:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
@@ -68,14 +154,22 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        if: ${{ github.ref_type != 'tag' }}
         env:
-          GOGC: "80" # run GC more aggressively
+          GOGC: "80"
         with:
           args: --fix=false --verbose
           version: v2.11.3 # TODO: automate this version update via Renovate
-      - run: |
+
+      # Lint and "make check" are redundant on a tag: release_sha_gate already
+      # requires a green branch push run for this exact tree/SHA. We
+      # intentionally keep metadata and SBOM/SCA on tag refs so release tags
+      # continue publishing security assets.
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make clean
-      - run: |
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
           make check
       - name: "Set metadata for downstream jobs"
         id: metadata
@@ -111,6 +205,7 @@ jobs:
     uses: ./.github/workflows/_test.yaml
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
+      IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
       # Per-arch lookup (each side independent):
       #   1. fork PR                          -> free GitHub-hosted runners (security)
       #   2. vars.RUNS_ON_RELEASE_2_12_<ARCH> -> per-branch + per-arch override
@@ -154,7 +249,7 @@ jobs:
       NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
       IMAGE_DIGESTS: ${{ needs.build_publish.outputs.IMAGE_DIGESTS }}
   distributions:
-    needs: ["build_publish", "check", "test", "provenance"]
+    needs: ["release_sha_gate", "build_publish", "check", "test", "provenance"]
     permissions:
       id-token: write
     timeout-minutes: 10


### PR DESCRIPTION
## Motivation

> Changelog: skip

release-2.12 is the only active branch missing the fail-hard
green-SHA release gate and tag-skip logic that every other active
branch (master, 2.7, 2.9, 2.11, 2.13, 2.14) already has. The
bot-generated backport PR for 2.12 stalled as a draft: its cherry-pick
choked on a merge conflict and committed the broken result with
literal unresolved `<<<<<<<`/`=======`/`>>>>>>>` markers left in the
YAML, and its DCO check failed (sign-off email didn't match commit
author email). Nobody followed up, so the PR sat open and unmerged.

## Implementation information

Hand-resolved this branch's version of the backport instead of reusing
the broken commit:

- Cherry-picked the release-2.13 backport (which was correctly
  hand-adapted and merged cleanly there) and resolved conflicts by
  keeping 2.12's own action pins and `RUNS_ON_RELEASE_2_12_*` runner
  vars unchanged, only merging in the new `release_sha_gate` job,
  `assert-tag-version` `needs:` wiring (the job itself already existed
  on this branch from an earlier backport), and the `IS_RELEASE_TAG`
  tag-skip logic for unit/e2e tests and lint/`make check`.
- Fixed the `release_sha_gate` job's `runs-on:` (the raw cherry-picked
  content pointed at `RUNS_ON_RELEASE_2_13_AMD64`).
- Used the widened e2e job-name pattern
  (`^test / (test_)?e2e`) from the start, since 2.12 already has the
  split `test_e2e`/`test_e2e_env` matrix jobs — this avoids landing
  the same bug fixed on release-2.13 in a separate PR.

## Supporting documentation

- Stalled/broken bot PR: https://github.com/kumahq/kuma/pull/17581
- Sibling backport this was adapted from: https://github.com/kumahq/kuma/pull/17577
- Related e2e-pattern fix on release-2.13: https://github.com/kumahq/kuma/pull/17743