### PR TITLE
feat(kuma-cp): make control plane deployment strategy configurable

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -31,7 +31,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.restartPolicy | string | `"Always"` | Pod restart policy for the Control Plane. |
 | controlPlane.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created pod should be ready for it to be considered available. |
 | controlPlane.deploymentAnnotations | object | `{}` | Annotations applied only to the `Deployment` resource |
-| controlPlane.deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | Deployment update strategy for the control plane. Note: setting this to `{}` does not disable the default strategy (Helm re-merges the chart default); use `type: Recreate` to fully replace the rolling update strategy. |
+| controlPlane.deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | Deployment update strategy for the control plane. Note: `{}` does not disable the strategy (Helm re-merges the chart default); use `type: Recreate` to fully replace it. Setting it to `null` removes the default entirely, falling back to Kubernetes' own default strategy. |
 | controlPlane.podAnnotations | object | `{}` | Annotations applied only to the `Pod` resource |
 | controlPlane.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
 | controlPlane.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -31,7 +31,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.restartPolicy | string | `"Always"` | Pod restart policy for the Control Plane. |
 | controlPlane.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created pod should be ready for it to be considered available. |
 | controlPlane.deploymentAnnotations | object | `{}` | Annotations applied only to the `Deployment` resource |
-| controlPlane.deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | Deployment update strategy for the control plane |
+| controlPlane.deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | Deployment update strategy for the control plane. Note: setting this to `{}` does not disable the default strategy (Helm re-merges the chart default); use `type: Recreate` to fully replace the rolling update strategy. |
 | controlPlane.podAnnotations | object | `{}` | Annotations applied only to the `Pod` resource |
 | controlPlane.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
 | controlPlane.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -31,6 +31,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.restartPolicy | string | `"Always"` | Pod restart policy for the Control Plane. |
 | controlPlane.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created pod should be ready for it to be considered available. |
 | controlPlane.deploymentAnnotations | object | `{}` | Annotations applied only to the `Deployment` resource |
+| controlPlane.deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | Deployment update strategy for the control plane |
 | controlPlane.podAnnotations | object | `{}` | Annotations applied only to the `Pod` resource |
 | controlPlane.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |
 | controlPlane.autoscaling.minReplicas | int | `2` | The minimum CP pods to allow |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -66,12 +66,17 @@ spec:
   replicas: {{ .Values.controlPlane.replicas }}
   {{- end }}
   minReadySeconds: {{ .Values.controlPlane.minReadySeconds }}
+  {{- $strategy := .Values.controlPlane.deploymentStrategy }}
+  {{- if not (kindIs "map" $strategy) }}
+  {{- $strategy = dict }}
+  {{- end }}
+  {{- if eq ($strategy.type | default "RollingUpdate") "Recreate" }}
   strategy:
-    {{- if eq (.Values.controlPlane.deploymentStrategy.type | default "RollingUpdate") "Recreate" }}
     type: Recreate
-    {{- else }}
-    {{- toYaml .Values.controlPlane.deploymentStrategy | nindent 4 }}
-    {{- end }}
+  {{- else if $strategy }}
+  strategy:
+    {{- toYaml $strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kuma.selectorLabels" . | nindent 6 }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -71,8 +71,8 @@ spec:
   {{- $strategy = dict }}
   {{- end }}
   {{- $strategyType := toString ($strategy.type | default "RollingUpdate") }}
-  {{- if and $strategy.type (not (has $strategyType (list "Recreate" "RollingUpdate"))) }}
-  {{- fail (printf "controlPlane.deploymentStrategy.type must be Recreate or RollingUpdate, got %q" $strategyType) }}
+  {{- if and (hasKey $strategy "type") (not (has (toString $strategy.type) (list "Recreate" "RollingUpdate"))) }}
+  {{- fail (printf "controlPlane.deploymentStrategy.type must be Recreate or RollingUpdate, got %q" (toString $strategy.type)) }}
   {{- end }}
   {{- if eq $strategyType "Recreate" }}
   strategy:

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -70,7 +70,11 @@ spec:
   {{- if not (kindIs "map" $strategy) }}
   {{- $strategy = dict }}
   {{- end }}
-  {{- if eq ($strategy.type | default "RollingUpdate") "Recreate" }}
+  {{- $strategyType := toString ($strategy.type | default "RollingUpdate") }}
+  {{- if and $strategy.type (not (has $strategyType (list "Recreate" "RollingUpdate"))) }}
+  {{- fail (printf "controlPlane.deploymentStrategy.type must be Recreate or RollingUpdate, got %q" $strategyType) }}
+  {{- end }}
+  {{- if eq $strategyType "Recreate" }}
   strategy:
     type: Recreate
   {{- else if $strategy }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -67,9 +67,7 @@ spec:
   {{- end }}
   minReadySeconds: {{ .Values.controlPlane.minReadySeconds }}
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    {{- toYaml .Values.controlPlane.deploymentStrategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kuma.selectorLabels" . | nindent 6 }}

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -67,7 +67,11 @@ spec:
   {{- end }}
   minReadySeconds: {{ .Values.controlPlane.minReadySeconds }}
   strategy:
+    {{- if eq (.Values.controlPlane.deploymentStrategy.type | default "RollingUpdate") "Recreate" }}
+    type: Recreate
+    {{- else }}
     {{- toYaml .Values.controlPlane.deploymentStrategy | nindent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "kuma.selectorLabels" . | nindent 6 }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -65,9 +65,10 @@ controlPlane:
   # -- Annotations applied only to the `Deployment` resource
   deploymentAnnotations: {}
 
-  # -- Deployment update strategy for the control plane. Note: setting this to
-  # `{}` does not disable the default strategy (Helm re-merges the chart
-  # default); use `type: Recreate` to fully replace the rolling update strategy.
+  # -- Deployment update strategy for the control plane. Note: `{}` does not
+  # disable the strategy (Helm re-merges the chart default); use `type: Recreate`
+  # to fully replace it. Setting it to `null` removes the default entirely,
+  # falling back to Kubernetes' own default strategy.
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 1

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -65,7 +65,9 @@ controlPlane:
   # -- Annotations applied only to the `Deployment` resource
   deploymentAnnotations: {}
 
-  # -- Deployment update strategy for the control plane
+  # -- Deployment update strategy for the control plane. Note: setting this to
+  # `{}` does not disable the default strategy (Helm re-merges the chart
+  # default); use `type: Recreate` to fully replace the rolling update strategy.
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 1

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -65,6 +65,12 @@ controlPlane:
   # -- Annotations applied only to the `Deployment` resource
   deploymentAnnotations: {}
 
+  # -- Deployment update strategy for the control plane
+  deploymentStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
   # -- Annotations applied only to the `Pod` resource
   podAnnotations: {}
 


### PR DESCRIPTION
## Motivation

The Kuma Control Plane `Deployment` update strategy was hardcoded in
`cp-deployment.yaml` (`rollingUpdate` with `maxSurge: 1` and
`maxUnavailable: 0`). Users had no way to change it, for example to switch
to `Recreate`, or to change the rolling parameters for resource-constrained
clusters where the extra surge capacity is not available.

## Implementation information

- `values.yaml`: added `controlPlane.deploymentStrategy`, defaulting to the
  previously hardcoded values (`rollingUpdate` / `maxSurge: 1` /
  `maxUnavailable: 0`).
- `templates/cp-deployment.yaml`: the strategy is now rendered from the new
  value via `toYaml` instead of being hardcoded.
- `README.md`: added the corresponding helm-docs row by hand, in place, to
  keep the diff minimal. Note: regenerating helm-docs locally also rewrites
  several unrelated rows (the committed `README.md` appears to already be
  slightly out of sync with `values.yaml`), so I intentionally added only the
  single new row rather than committing a full regeneration. Happy to open a
  separate PR to fix that pre-existing drift if useful.

The default was kept identical to the previous hardcoded strategy so the
change is non-breaking: existing installations render exactly the same
`Deployment`. Users who need a different behaviour can now override the whole
block (e.g. `type: Recreate`).

Verified with `helm template`:

- Defaults (unchanged):
  ```
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
  ```
- Override to `Recreate` :

  ```bash
    helm template . \
      --set controlPlane.deploymentStrategy.type=Recreate \
      --set controlPlane.deploymentStrategy.rollingUpdate=null
  ```
 - Result:
    ```
    strategy:
      type: Recreate
    ```

## Supporting documentation

Fix #16644