### PR TITLE
ci(actions): speed up build and publish jobs

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -45,10 +45,15 @@ env:
 jobs:
   assert-tag-version:
     # Tag check lives on the steps, not the job, so this job always reports
-    # success/failure and never "skipped". That lets build-binaries and
-    # build-images depend on it with a plain `needs:` and GitHub's default
-    # job-status semantics, which correctly cascade to digest-images and
-    # publish-helm further down the chain and correctly stop on cancellation.
+    # success/failure and never "skipped". That lets the build jobs depend on it
+    # with a plain `needs:` and GitHub's default job-status semantics, which
+    # correctly cascade to digest-images and publish-helm further down the chain
+    # and correctly stop on cancellation.
+    #
+    # This gate only compares the version the build would stamp against the tag,
+    # so it needs no compilation. That the binary actually carries that version
+    # (i.e. the -X ldflags paths are still correct) is asserted in build-binaries
+    # on the binary it already built, before anything is published.
     timeout-minutes: 10
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
@@ -57,24 +62,27 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Cache Go build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: ${{ github.ref_type == 'tag' }}
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            go-build-${{ runner.os }}-
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         if: ${{ github.ref_type == 'tag' }}
         with:
           version: 2026.7.7
-      - name: Assert built binary reports tag version
+      - name: Assert computed version matches tag
         if: ${{ github.ref_type == 'tag' }}
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          make build/assert-tag-version
+          # Non-version tags legitimately build as previews, only gate version tags.
+          if ! printf '%s' "${TAG_NAME}" | grep -qE '^v?[0-9]'; then
+            echo "Tag '${TAG_NAME}' is not a version tag, skipping"
+            exit 0
+          fi
+          expected="${TAG_NAME#v}"
+          actual="$(make build/info/version)"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
+            exit 1
+          fi
+          echo "build correctly reports tag version '${actual}'"
   build-binaries:
     needs: [assert-tag-version]
     timeout-minutes: 70
@@ -92,14 +100,16 @@ jobs:
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           version: 2026.7.7
-      - run: |
-          make build
       - id: annotate-image-tag
         name: Image tag
         run: |
           echo "::notice title=Image tag::$(make build/info/version)"
       - run: |
-          make -j build/distributions
+          make -j"$(nproc)" build/distributions
+      - name: Assert built binary reports tag version
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          make check/binary-version
       - id: inspect-binary-output
         run: |
           for i in build/distributions/out/*.tar.gz; do echo "$i"; tar -tvf "$i"; done

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -78,19 +78,15 @@ jobs:
       - run: |
           make -j"$(nproc)" build/distributions
       # Gates publishing, not building: a wrong version must never reach Pulp or
-      # Cloudsmith, but there is no reason to hold the build back for it.
-      - name: Assert version matches tag
+      # Cloudsmith, but there is no reason to hold the build back for it. Asserting
+      # the binary against the tag also covers this checkout computing the version
+      # wrong, since that is where the binary got stamped from.
+      - name: Assert built binary reports tag version
         if: ${{ github.ref_type == 'tag' }}
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          expected="${TAG_NAME#v}"
-          actual="$(make build/info/version)"
-          if [ "${actual}" != "${expected}" ]; then
-            echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
-            exit 1
-          fi
-          make check/binary-version
+          make check/binary-version EXPECTED_VERSION="${TAG_NAME#v}"
       - id: inspect-binary-output
         run: |
           for i in build/distributions/out/*.tar.gz; do echo "$i"; tar -tvf "$i"; done

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -182,18 +182,23 @@ jobs:
           skip_cis_scan: false
         # TODO in the future we may want to have prerelease images and use `regctl image copy` to move them to their final location
       # Gates the push, not the build: a wrong version must never reach the registry.
-      - name: Assert version matches tag
-        if: ${{ github.ref_type == 'tag' }}
+      # kuma-cni has no version subcommand (a CNI plugin binary, not a CLI), so
+      # there's nothing to assert for it.
+      - name: Assert built binary reports tag version
+        if: ${{ github.ref_type == 'tag' && matrix.image != 'kuma-cni' }}
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          expected="${TAG_NAME#v}"
-          actual="$(make build/info/version)"
-          if [ "${actual}" != "${expected}" ]; then
-            echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
-            exit 1
-          fi
-          echo "build correctly reports tag version '${actual}'"
+          case "${{ matrix.image }}" in
+            kuma-init) binary=kumactl ;;
+            kuma-universal) binary=kuma-cp ;;
+            *) binary="${{ matrix.image }}" ;;
+          esac
+          for arch in $(make -s docker/info/enabled-arches); do
+            make check/binary-version \
+              BINARY_PATH="build/artifacts-linux-${arch}/${binary}/${binary}" \
+              EXPECTED_VERSION="${TAG_NAME#v}"
+          done
       - name: publish images
         id: release_images
         env:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -43,48 +43,7 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
-  assert-tag-version:
-    # Tag check lives on the steps, not the job, so this job always reports
-    # success/failure and never "skipped". That lets the build jobs depend on it
-    # with a plain `needs:` and GitHub's default job-status semantics, which
-    # correctly cascade to digest-images and publish-helm further down the chain
-    # and correctly stop on cancellation.
-    #
-    # This gate only compares the version the build would stamp against the tag,
-    # so it needs no compilation. That the binary actually carries that version
-    # (i.e. the -X ldflags paths are still correct) is asserted in build-binaries
-    # on the binary it already built, before anything is published.
-    timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ github.ref_type == 'tag' }}
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
-        if: ${{ github.ref_type == 'tag' }}
-        with:
-          version: 2026.7.7
-      - name: Assert computed version matches tag
-        if: ${{ github.ref_type == 'tag' }}
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          # Non-version tags legitimately build as previews, only gate version tags.
-          if ! printf '%s' "${TAG_NAME}" | grep -qE '^v?[0-9]'; then
-            echo "Tag '${TAG_NAME}' is not a version tag, skipping"
-            exit 0
-          fi
-          expected="${TAG_NAME#v}"
-          actual="$(make build/info/version)"
-          if [ "${actual}" != "${expected}" ]; then
-            echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
-            exit 1
-          fi
-          echo "build correctly reports tag version '${actual}'"
   build-binaries:
-    needs: [assert-tag-version]
     timeout-minutes: 70
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
@@ -118,9 +77,22 @@ jobs:
           echo "::notice title=Image tag::$(make build/info/version)"
       - run: |
           make -j"$(nproc)" build/distributions
-      - name: Assert built binary reports tag version
+      # Gates publishing, not building: a wrong version must never reach Pulp or
+      # Cloudsmith, but there is no reason to hold the build back for it.
+      - name: Assert version matches tag
         if: ${{ github.ref_type == 'tag' }}
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
+          # Non-version tags legitimately build as previews, only gate version tags.
+          if printf '%s' "${TAG_NAME}" | grep -qE '^v?[0-9]'; then
+            expected="${TAG_NAME#v}"
+            actual="$(make build/info/version)"
+            if [ "${actual}" != "${expected}" ]; then
+              echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
+              exit 1
+            fi
+          fi
           make check/binary-version
       - id: inspect-binary-output
         run: |
@@ -152,7 +124,6 @@ jobs:
         run: |
           make publish/pulp
   build-images:
-    needs: [assert-tag-version]
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
@@ -217,6 +188,24 @@ jobs:
           upload-sbom-release-assets: true
           skip_cis_scan: false
         # TODO in the future we may want to have prerelease images and use `regctl image copy` to move them to their final location
+      # Gates the push, not the build: a wrong version must never reach the registry.
+      - name: Assert version matches tag
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Non-version tags legitimately build as previews, only gate version tags.
+          if ! printf '%s' "${TAG_NAME}" | grep -qE '^v?[0-9]'; then
+            echo "Tag '${TAG_NAME}' is not a version tag, skipping"
+            exit 0
+          fi
+          expected="${TAG_NAME#v}"
+          actual="$(make build/info/version)"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
+            exit 1
+          fi
+          echo "build correctly reports tag version '${actual}'"
       - name: publish images
         id: release_images
         env:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -84,14 +84,11 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          # Non-version tags legitimately build as previews, only gate version tags.
-          if printf '%s' "${TAG_NAME}" | grep -qE '^v?[0-9]'; then
-            expected="${TAG_NAME#v}"
-            actual="$(make build/info/version)"
-            if [ "${actual}" != "${expected}" ]; then
-              echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
-              exit 1
-            fi
+          expected="${TAG_NAME#v}"
+          actual="$(make build/info/version)"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error title=Version mismatch::build reports version '${actual}', expected tag version '${expected}'"
+            exit 1
           fi
           make check/binary-version
       - id: inspect-binary-output
@@ -194,11 +191,6 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          # Non-version tags legitimately build as previews, only gate version tags.
-          if ! printf '%s' "${TAG_NAME}" | grep -qE '^v?[0-9]'; then
-            echo "Tag '${TAG_NAME}' is not a version tag, skipping"
-            exit 0
-          fi
           expected="${TAG_NAME#v}"
           actual="$(make build/info/version)"
           if [ "${actual}" != "${expected}" ]; then

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -97,6 +97,18 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      # `check` and `build_check` run before this job and already saved this key for
+      # this exact go.sum. Restore-only: the publish jobs would otherwise each write
+      # a multi-GB cross-compile cache and evict everyone else from the repo budget.
+      - name: Restore Go cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
       - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
           version: 2026.7.7
@@ -155,6 +167,15 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Restore Go cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
       - name: Install dependencies for cross builds
         if: ${{ fromJSON(inputs.FULL_MATRIX) }}
         run: |

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -71,16 +71,20 @@ build/info/short:
 build/info/version:
 	@echo $(BUILD_INFO_VERSION)
 
+# Override to assert against something other than what this checkout computes,
+# e.g. a tag name in CI, which then also covers the checkout computing it wrong.
+EXPECTED_VERSION ?= $(BUILD_INFO_VERSION)
+
 # Assert on an already built binary, so callers that just built it (e.g. `build/distributions`)
 # don't pay for a rebuild: every `build/artifacts-*` target is .PHONY.
 .PHONY: check/binary-version
-check/binary-version: ## Dev: Assert the already built kuma-cp binary reports the expected version
+check/binary-version: ## Dev: Assert the already built kuma-cp binary reports $(EXPECTED_VERSION)
 	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$NF}'); \
-	if [ -z "$$actual" ] || [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
-		echo "kuma-cp binary reports version '$$actual', expected version '$(BUILD_INFO_VERSION)'"; \
+	if [ -z "$$actual" ] || [ "$$actual" != "$(EXPECTED_VERSION)" ]; then \
+		echo "kuma-cp binary reports version '$$actual', expected version '$(EXPECTED_VERSION)'"; \
 		exit 1; \
 	fi; \
-	echo "kuma-cp binary correctly reports version '$(BUILD_INFO_VERSION)'"
+	echo "kuma-cp binary correctly reports version '$(EXPECTED_VERSION)'"
 
 .PHONY: build/assert-tag-version
 build/assert-tag-version: build/kuma-cp ## Dev: Build kuma-cp and assert it reports the tag version

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -71,14 +71,20 @@ build/info/short:
 build/info/version:
 	@echo $(BUILD_INFO_VERSION)
 
-.PHONY: build/assert-tag-version
-build/assert-tag-version: build/kuma-cp ## Dev: Assert the built kuma-cp binary reports the tag version
+# Assert on an already built binary, so callers that just built it (e.g. `build/distributions`)
+# don't pay for a rebuild: every `build/artifacts-*` target is .PHONY.
+.PHONY: check/binary-version
+check/binary-version: ## Dev: Assert the already built kuma-cp binary reports the expected version
 	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$NF}'); \
 	if [ -z "$$actual" ] || [ "$$actual" != "$(BUILD_INFO_VERSION)" ]; then \
-		echo "kuma-cp binary reports version '$$actual', expected tag version '$(BUILD_INFO_VERSION)'"; \
+		echo "kuma-cp binary reports version '$$actual', expected version '$(BUILD_INFO_VERSION)'"; \
 		exit 1; \
 	fi; \
-	echo "kuma-cp binary correctly reports tag version '$(BUILD_INFO_VERSION)'"
+	echo "kuma-cp binary correctly reports version '$(BUILD_INFO_VERSION)'"
+
+.PHONY: build/assert-tag-version
+build/assert-tag-version: build/kuma-cp ## Dev: Build kuma-cp and assert it reports the tag version
+	@$(MAKE) check/binary-version
 
 .PHONY: build
 build: build/release build/test ## Dev: Build all binaries

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -75,16 +75,20 @@ build/info/version:
 # e.g. a tag name in CI, which then also covers the checkout computing it wrong.
 EXPECTED_VERSION ?= $(BUILD_INFO_VERSION)
 
+# Override for a binary other than the native kuma-cp build, e.g. a cross-compiled
+# binary from `build-images` (build/artifacts-linux-$(GOARCH)/<binary>/<binary>).
+BINARY_PATH ?= $(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp
+
 # Assert on an already built binary, so callers that just built it (e.g. `build/distributions`)
 # don't pay for a rebuild: every `build/artifacts-*` target is .PHONY.
 .PHONY: check/binary-version
-check/binary-version: ## Dev: Assert the already built kuma-cp binary reports $(EXPECTED_VERSION)
-	@actual=$$($(BUILD_ARTIFACTS_DIR)/kuma-cp/kuma-cp version | awk '{print $$NF}'); \
+check/binary-version: ## Dev: Assert the already built binary at $(BINARY_PATH) reports $(EXPECTED_VERSION)
+	@actual=$$($(BINARY_PATH) version | awk '{print $$NF}'); \
 	if [ -z "$$actual" ] || [ "$$actual" != "$(EXPECTED_VERSION)" ]; then \
-		echo "kuma-cp binary reports version '$$actual', expected version '$(EXPECTED_VERSION)'"; \
+		echo "$(BINARY_PATH) binary reports version '$$actual', expected version '$(EXPECTED_VERSION)'"; \
 		exit 1; \
 	fi; \
-	echo "kuma-cp binary correctly reports version '$(EXPECTED_VERSION)'"
+	echo "$(BINARY_PATH) binary correctly reports version '$(EXPECTED_VERSION)'"
 
 .PHONY: build/assert-tag-version
 build/assert-tag-version: build/kuma-cp ## Dev: Build kuma-cp and assert it reports the tag version

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -146,6 +146,10 @@ images/test: $(addprefix images/,$(IMAGES_TEST)) ## Dev: Rebuild test Docker ima
 docker/info/registry: ## Output the Docker registry
 	@echo $(DOCKER_REGISTRY)
 
+.PHONY: docker/info/enabled-arches
+docker/info/enabled-arches: ## Output the arches `images/<name>` builds for
+	@echo $(ENABLED_GOARCHES)
+
 # The awk command is ok because we're passing a list of container image names which won't contain ' ' or '"'
 # This outputs something like: ["docker.io/kumahq/kuma-cp:0.0.0-preview.vlocal-build","docker.io/kumahq/kuma-dp:0.0.0-preview.vlocal-build","docker.io/kumahq/kumactl:0.0.0-preview.vlocal-build","docker.io/kumahq/kuma-init:0.0.0-preview.vlocal-build","docker.io/kumahq/kuma-cni:0.0.0-preview.vlocal-build"]
 .PHONY: manifests/json/release


### PR DESCRIPTION
## Motivation

`build_publish / build-binaries` takes ~30 min on a full matrix, and most of it
is the same work done twice.

Example run (Kong Mesh, same workflow, 4 platforms):

| step | duration |
|---|---|
| `make build` | 17m17s |
| `make -j build/distributions` | 9m09s |
| everything else | ~3.5m |

`make build` cross-compiles 8 binaries x 4 platforms serially. `make -j
build/distributions` then rebuilds kumactl/kuma-cp/kuma-dp for all 4 platforms
again, because every `build/artifacts-$(os)-$(arch)/<bin>` target is `.PHONY`,
so nothing is ever skipped.

Nothing in the job consumes `make build`'s output:

- `build/distributions/$(os)-$(arch)/...` declares kumactl, kuma-cp and kuma-dp
  as its own prerequisites and sub-makes coredns/envoy, so it is self-sufficient
  (`make -n build/distributions` on a clean tree emits the full set of builds).
- The tarball contains only coredns, envoy, kuma-cp, kuma-dp, kumactl.
- The later steps use `build/distributions/out` only, and so does
  `make publish/pulp`.
- kuma-cni, install-cni and test-server never ship here; the `build-images`
  jobs compile what they need themselves, and e2e runs its own `make build`.

The only thing lost is a darwin/arm cross-compile check of linux-only CNI
binaries and of test binaries.

`assert-tag-version` has a related problem: it exists to gate publishing, but
to do so it compiles its own kuma-cp, which is the same binary `build-binaries`
is about to build.

> Changelog: skip

## Implementation information

- Drop the `make build` step from `build-binaries`.
- Bound the parallelism: `make -j"$(nproc)" build/distributions`. Bare `-j`
  fires all 12 links (100-150 MB binaries each) at once.
- Split `build/assert-tag-version` into `check/binary-version`, which asserts on
  an already built binary, plus the existing target which builds and then
  delegates to it. Local behaviour of `make build/assert-tag-version` is
  unchanged.
- Dropped the `assert-tag-version` job. It existed to stop a mistagged release
  from being published, but it did that by blocking `build-binaries` and
  `build-images` with `needs:`, gating the build as well as the publish. The
  assertions now sit immediately before each publishing step: `build-binaries`
  checks the computed version against the tag and runs `check/binary-version` on
  the binary it just built, before uploading to Pulp/Cloudsmith; `build-images`
  checks the version before `docker/push`. Builds start immediately, and nothing
  mistagged can reach a registry.

Coverage is the same as before, split across the two assertions: the tag/version
comparison catches a checkout whose tag doesn't produce the expected version, and
`check/binary-version` catches ldflags that no longer land in the binary (e.g.
after a module path bump).

Expected: ~30 min -> ~15 min for `build-binaries` on a full matrix, and the
tag-only kuma-cp build disappears from release runs entirely.

## Supporting documentation

Verified locally: `make build/assert-tag-version` builds kuma-cp and reports
`kuma-cp binary correctly reports version '...'`; `make check/binary-version`
then passes in ~1s against the existing binary and fails cleanly when the binary
is missing. `actionlint` passes on the modified workflow.

## Follow-up in this PR: Go cache in the publish jobs

`build-binaries` and every `build-images` job ran with no Go cache at all — the
binaries job logged 292 `go: downloading …` lines, and the ten image jobs each
repeat the same downloads and compiles.

`check` and `build_check` already save `~/.cache/go-build` + `~/go/pkg/mod`
under `go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}`, and
`build_publish` needs both, so an entry for this exact go.sum is guaranteed to
exist when these jobs start. Added `actions/cache/restore` (read-only) to
`build-binaries` and `build-images`.

The assertion runs on every tag: preview builds come from branch pushes, which
never reach these steps, and all 295 tags in this repo are version tags.

Restore-only is deliberate: those jobs cross-compile for up to four
GOOS/GOARCH combinations, so a cache they *wrote* would be several GB, and
eleven jobs writing it would evict the `check` and `test_unit` caches from the
shared repo-wide budget. `publish-helm` is untouched since it compiles nothing.
