### PR TITLE
ci(build-publish): bump assert-tag-version timeout

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -49,7 +49,7 @@ jobs:
     # build-images depend on it with a plain `needs:` and GitHub's default
     # job-status semantics, which correctly cascade to digest-images and
     # publish-helm further down the chain and correctly stop on cancellation.
-    timeout-minutes: 10
+    timeout-minutes: 30
     runs-on: ${{ vars.RUNS_ON_RELEASE_2_12_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Motivation

Tag builds on release-2.12 keep timing out at 10 minutes on
`assert-tag-version` (v2.12.14, run 30634859282), even with the
new Go build cache in place. Bumping the timeout to 30 minutes as
a stopgap so releases aren't blocked while the cache behavior is
investigated properly.

> Changelog: skip

## Implementation information

- Bump `assert-tag-version`'s `timeout-minutes` from 10 to 30.

## Supporting documentation

https://github.com/kumahq/kuma/actions/runs/30634859282