### PR TITLE
fix(k8s): honour falsy zone proxy helm values

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -835,6 +835,16 @@ zoneProxyImage:
 # meshes[].ingress.service or meshes[].egress.service fields are not set.
 meshZoneProxyDefaults:
   ingress:
+    # -- Default number of replicas for zone ingress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone ingress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone ingress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone ingress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone ingress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone ingress.
       type: LoadBalancer
@@ -844,6 +854,16 @@ meshZoneProxyDefaults:
       # zone proxy binary is reconfigured.
       targetPort: 10001
   egress:
+    # -- Default number of replicas for zone egress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone egress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone egress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone egress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone egress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
@@ -865,6 +885,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.ingress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone ingress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
@@ -884,8 +918,9 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
-        replicas: 1
+        # -- (int) Number of replicas. Ignored when hpa.enabled is true. Falls back
+        # to meshZoneProxyDefaults.<role>.replicas when unset.
+        replicas:
         # -- Annotations to add to the Deployment resource.
         annotations: {}
         # -- Labels to add to the Deployment resource.
@@ -913,6 +948,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.egress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.egress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone egress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
@@ -932,8 +981,9 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
-        replicas: 1
+        # -- (int) Number of replicas. Ignored when hpa.enabled is true. Falls back
+        # to meshZoneProxyDefaults.<role>.replicas when unset.
+        replicas:
         # -- Annotations to add to the Deployment resource.
         annotations: {}
         # -- Labels to add to the Deployment resource.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -835,6 +835,16 @@ zoneProxyImage:
 # meshes[].ingress.service or meshes[].egress.service fields are not set.
 meshZoneProxyDefaults:
   ingress:
+    # -- Default number of replicas for zone ingress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone ingress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone ingress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone ingress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone ingress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone ingress.
       type: LoadBalancer
@@ -844,6 +854,16 @@ meshZoneProxyDefaults:
       # zone proxy binary is reconfigured.
       targetPort: 10001
   egress:
+    # -- Default number of replicas for zone egress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone egress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone egress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone egress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone egress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
@@ -865,6 +885,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.ingress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone ingress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
@@ -884,7 +918,8 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
+        # -- Number of replicas. Ignored when hpa.enabled is true. Falls back to
+        # meshZoneProxyDefaults.<role>.replicas when unset.
         replicas: 1
         # -- Annotations to add to the Deployment resource.
         annotations: {}
@@ -913,6 +948,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.egress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.egress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone egress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
@@ -932,7 +981,8 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
+        # -- Number of replicas. Ignored when hpa.enabled is true. Falls back to
+        # meshZoneProxyDefaults.<role>.replicas when unset.
         replicas: 1
         # -- Annotations to add to the Deployment resource.
         annotations: {}

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
@@ -1,0 +1,1201 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuma-system
+  labels:
+    kuma.io/sidecar-injection: "false"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+imagePullSecrets:
+  - name: "image-secret"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-default-ingress
+  namespace: kuma-system
+  labels: 
+    app: kuma-default-ingress
+    kuma.io/mesh: default
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    foo: '{"baz": "ingress"}'
+    ping: ingress
+imagePullSecrets:
+  - name: "image-secret"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuma-default-egress
+  namespace: kuma-system
+  labels: 
+    app: kuma-default-egress
+    kuma.io/mesh: default
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    foo: '{"baz": "egress"}'
+    ping: egress
+imagePullSecrets:
+  - name: "image-secret"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuma-control-plane-config
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+data:
+  config.yaml: |
+    # use this file to override default configuration of `kuma-cp`
+    #
+    # see conf/kuma-cp.conf.yml for available settings
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuma-control-plane
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  # Kubernetes resources
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: # Gateway API
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: # Gateway API legacy finalizer cleanup during upgrade
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - kuma.io
+    resources:
+      - dataplanes
+      - dataplaneinsights
+      - meshes
+      - zones
+      - zoneinsights
+      - zoneingresses
+      - zoneingressinsights
+      - zoneegresses
+      - zoneegressinsights
+      - meshinsights
+      - serviceinsights
+      - proxytemplates
+      - ratelimits
+      - trafficpermissions
+      - trafficroutes
+      - timeouts
+      - retries
+      - circuitbreakers
+      - virtualoutbounds
+      - containerpatches
+      - faultinjections
+      - healthchecks
+      - trafficlogs
+      - traffictraces
+      - meshaccesslogs
+      - meshcircuitbreakers
+      - meshfaultinjections
+      - meshhealthchecks
+      - meshhttproutes
+      - meshloadbalancingstrategies
+      - meshmetrics
+      - meshpassthroughs
+      - meshproxypatches
+      - meshratelimits
+      - meshretries
+      - meshtcproutes
+      - meshtimeouts
+      - meshtlses
+      - meshtraces
+      - meshtrafficpermissions
+      - hostnamegenerators
+      - meshexternalservices
+      - meshidentities
+      - meshmultizoneservices
+      - meshopentelemetrybackends
+      - meshservices
+      - meshtrusts
+      - meshzoneaddresses
+      - workloads
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - kuma.io
+    resources:
+      - meshes/finalizers
+      - dataplanes/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  # validate k8s token before issuing mTLS cert
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuma-control-plane-workloads
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+    # required by MeshGateway
+      - "apps"
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    # required by MeshGateway
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+    # Gateway API
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuma-control-plane-workloads
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuma-control-plane-workloads
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - delete
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  # leader-for-life election deletes Pods in some circumstances
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kuma-control-plane
+subjects:
+  - kind: ServiceAccount
+    name: kuma-control-plane
+    namespace: kuma-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations:
+    prometheus.io/port: "5680"
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5680
+      name: diagnostics
+      appProtocol: http
+    - port: 5681
+      name: http-api-server
+      appProtocol: http
+    - port: 5682
+      name: https-api-server
+      appProtocol: https
+    - port: 443
+      name: https-admission-server
+      targetPort: 5443
+      appProtocol: https
+    - port: 5676
+      name: mads-server
+      appProtocol: https
+    - port: 5678
+      name: dp-server
+      appProtocol: https
+  selector:
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-default-ingress
+  namespace: kuma-system
+  labels:
+    app: kuma-default-ingress
+    kuma.io/mesh: default
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+    k8s.kuma.io/zone-proxy-type: ingress
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      protocol: TCP
+      targetPort: 10001
+  selector:
+    app: kuma-default-ingress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuma-default-egress
+  namespace: kuma-system
+  labels:
+    app: kuma-default-egress
+    kuma.io/mesh: default
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+    k8s.kuma.io/zone-proxy-type: egress
+spec:
+  type: ClusterIP
+  ports:
+    - port: 10002
+      protocol: TCP
+      targetPort: 10002
+  selector:
+    app: kuma-default-egress
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-control-plane
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+  annotations: 
+    
+spec:
+  replicas: 1
+  minReadySeconds: 0
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+      app: kuma-control-plane
+  template:
+    metadata:
+      annotations:
+        checksum/config: fd9d1d8386f97f2bd49e50f476520816168a1c9f60bbc43dec1347a64d239155
+        checksum/tls-secrets: e553765cc791cdd1dced7872505a2c7f6a1e034f9454ce4a107d9cc9a4f2b7c9
+      labels: 
+        app: kuma-control-plane
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+    spec:
+      affinity: 
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - 'kuma'
+                - key: app
+                  operator: In
+                  values:
+                  - 'kuma-control-plane'
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kuma-control-plane
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      nodeSelector:
+        
+        kubernetes.io/os: linux
+      hostNetwork: false
+      terminationGracePeriodSeconds: 30
+      
+      containers:
+        - name: control-plane
+          image: "docker.io/kumahq/kuma-cp:0.0.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
+              value: "false"
+            - name: KUMA_API_SERVER_READ_ONLY
+              value: "true"
+            - name: KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET
+              value: "true"
+            - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
+              value: "false"
+            - name: KUMA_DP_SERVER_HDS_ENABLED
+              value: "false"
+            - name: KUMA_ENVIRONMENT
+              value: "kubernetes"
+            - name: KUMA_GENERAL_TLS_CERT_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/tls.crt"
+            - name: KUMA_GENERAL_TLS_KEY_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/tls.key"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_IMAGE
+              value: "docker.io/kumahq/kuma-init:0.0.1"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "50M"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "20m"
+            - name: KUMA_INJECTOR_INIT_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "20M"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "512Mi"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "50m"
+            - name: KUMA_INJECTOR_SIDECAR_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "64Mi"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_LIMITS_CPU
+              value: "0"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_LIMITS_MEMORY
+              value: "50M"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_REQUESTS_CPU
+              value: "20m"
+            - name: KUMA_INJECTOR_VALIDATION_CONTAINER_RESOURCES_REQUESTS_MEMORY
+              value: "20M"
+            - name: KUMA_MODE
+              value: "zone"
+            - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
+              value: "true"
+            - name: KUMA_PLUGIN_POLICIES_ENABLED
+              value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
+            - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR
+              value: "/var/run/secrets/kuma.io/tls-cert"
+            - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
+              value: "5443"
+            - name: KUMA_RUNTIME_KUBERNETES_ALLOWED_USERS
+              value: "system:serviceaccount:kuma-system:kuma-control-plane"
+            - name: KUMA_RUNTIME_KUBERNETES_CONTROL_PLANE_SERVICE_NAME
+              value: "kuma-control-plane"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CA_CERT_FILE
+              value: "/var/run/secrets/kuma.io/tls-cert/ca.crt"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_CNI_ENABLED
+              value: "false"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_SIDECAR_CONTAINER_IMAGE
+              value: "docker.io/kumahq/kuma-dp:0.0.1"
+            - name: KUMA_RUNTIME_KUBERNETES_INJECTOR_UNIFIED_RESOURCE_NAMING_ENABLED
+              value: "true"
+            - name: KUMA_STORE_KUBERNETES_SYSTEM_NAMESPACE
+              value: "kuma-system"
+            - name: KUMA_STORE_TYPE
+              value: "kubernetes"
+            - name: KUMA_INTER_CP_CATALOG_INSTANCE_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: control-plane
+                  resource: limits.memory
+                  divisor: "1"
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: control-plane
+                  resource: limits.cpu
+                  divisor: "1"
+          args:
+            - run
+            - --log-level=info
+            - --log-output-path=
+            - --config-file=/etc/kuma.io/kuma-control-plane/config.yaml
+          ports:
+            - containerPort: 5680
+              name: diagnostics
+              protocol: TCP
+            - containerPort: 5681
+            - containerPort: 5682
+            - containerPort: 5443
+            - containerPort: 5678
+          livenessProbe:
+            timeoutSeconds: 10
+            httpGet:
+              path: /healthy
+              port: 5680
+          readinessProbe:
+            timeoutSeconds: 10
+            httpGet:
+              path: /ready
+              port: 5680
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          
+          volumeMounts:
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/tls.crt
+              subPath: tls.crt
+              readOnly: true
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/tls.key
+              subPath: tls.key
+              readOnly: true
+            - name: general-tls-cert
+              mountPath: /var/run/secrets/kuma.io/tls-cert/ca.crt
+              subPath: ca.crt
+              readOnly: true
+            - name: kuma-control-plane-config
+              mountPath: /etc/kuma.io/kuma-control-plane
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: general-tls-cert
+          secret:
+            secretName: general-tls-secret
+        - name: kuma-control-plane-config
+          configMap:
+            name: kuma-control-plane-config
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-default-ingress
+  namespace: kuma-system
+  labels:
+    app: kuma-default-ingress
+    kuma.io/mesh: default
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 0
+  selector:
+    matchLabels:
+      app: kuma-default-ingress
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+  template:
+    metadata:
+      annotations:
+        kuma.io/reachable-backends: '{"refs":[]}'
+      labels:
+        app: kuma-default-ingress
+        kuma.io/mesh: default
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+        kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: ingress
+    spec:
+      securityContext:
+        runAsUser: 5678
+        runAsGroup: 5678
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kuma-default-ingress
+      automountServiceAccountToken: false
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: pause
+          image: "registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
+          imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 16Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuma-default-egress
+  namespace: kuma-system
+  labels:
+    app: kuma-default-egress
+    kuma.io/mesh: default
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuma-default-egress
+      app.kubernetes.io/name: kuma
+      app.kubernetes.io/instance: kuma
+  template:
+    metadata:
+      annotations:
+        kuma.io/reachable-backends: '{"refs":[]}'
+      labels:
+        app: kuma-default-egress
+        kuma.io/mesh: default
+        app.kubernetes.io/name: kuma
+        app.kubernetes.io/instance: kuma
+        kuma.io/sidecar-injection: enabled
+        k8s.kuma.io/zone-proxy-type: egress
+    spec:
+      securityContext:
+        runAsUser: 5678
+        runAsGroup: 5678
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kuma-default-egress
+      automountServiceAccountToken: true
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 15
+      containers:
+        - name: pause
+          image: "registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 16Mi
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kuma-admission-mutating-webhook-configuration
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+webhooks:
+  - name: mesh.defaulter.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /default-kuma-io-v1alpha1-mesh
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - meshes
+          - dataplanes
+          - dataplaneinsights
+          - zoneingresses
+          - zoneingressinsights
+          - zoneegresses
+          - zoneegressinsights
+          - serviceinsights
+          - zone
+          - zoneinsights
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+    sideEffects: None
+  - name: owner-reference.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /owner-reference-kuma-io-v1alpha1
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - circuitbreakers
+          - faultinjections
+          - healthchecks
+          - proxytemplates
+          - ratelimits
+          - retries
+          - timeouts
+          - trafficlogs
+          - trafficpermissions
+          - trafficroutes
+          - traffictraces
+          - virtualoutbounds
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+  
+      
+    sideEffects: None
+  - name: namespace-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: In
+          values:
+          - enabled
+          - "true"
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: pods-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    objectSelector:
+      matchLabels:
+        kuma.io/sidecar-injection: enabled
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - name: mesh-zoneproxy-kuma-injector.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - kuma-system
+    objectSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: In
+          values:
+            - enabled
+        - key: kuma.io/mesh
+          operator: Exists
+        - key: k8s.kuma.io/zone-proxy-type
+          operator: Exists
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /inject-sidecar
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kuma-validating-webhook-configuration
+  namespace: kuma-system
+  labels: 
+    app: kuma-control-plane
+    app.kubernetes.io/name: kuma
+    app.kubernetes.io/instance: kuma
+webhooks:
+  - name: validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-kuma-io-v1alpha1
+    rules:
+      - apiGroups:
+          - kuma.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - circuitbreakers
+          - dataplanes
+          - faultinjections
+          - healthchecks
+          - meshes
+          - proxytemplates
+          - ratelimits
+          - retries
+          - trafficlogs
+          - trafficpermissions
+          - trafficroutes
+          - traffictraces
+          - virtualoutbounds
+          - zones
+          - containerpatches
+          - meshaccesslogs
+          - meshcircuitbreakers
+          - meshfaultinjections
+          - meshhealthchecks
+          - meshhttproutes
+          - meshloadbalancingstrategies
+          - meshmetrics
+          - meshpassthroughs
+          - meshproxypatches
+          - meshratelimits
+          - meshretries
+          - meshtcproutes
+          - meshtimeouts
+          - meshtlses
+          - meshtraces
+          - meshtrafficpermissions
+          - hostnamegenerators
+          - meshexternalservices
+          - meshidentities
+          - meshmultizoneservices
+          - meshopentelemetrybackends
+          - meshservices
+          - meshtrusts
+          - meshzoneaddresses
+          - workloads
+    
+      
+    sideEffects: None
+  - name: secret.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - kuma-system
+    failurePolicy: Ignore
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1-secret
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - secrets
+    sideEffects: None
+  - name: pod.validator.kuma-admission.kuma.io
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kuma.io/sidecar-injection
+          operator: Exists
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kuma-system
+    failurePolicy: Fail
+    clientConfig:
+      caBundle: XYZ
+      service:
+        namespace: kuma-system
+        name: kuma-control-plane
+        path: /validate-v1-pod
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+    sideEffects: None

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.values.yaml
@@ -1,0 +1,34 @@
+# Zone ingress exercises the falsy overrides (replicas: 0,
+# terminationGracePeriodSeconds: 0, automountServiceAccountToken: false).
+# Zone egress overrides terminationGracePeriodSeconds with a non-falsy value
+# and leaves replicas, restartPolicy and imagePullPolicy unset so the
+# meshZoneProxyDefaults fallback is covered too.
+global:
+  imagePullSecrets: [image-secret]
+meshes:
+  - name: default
+    ingress:
+      enabled: true
+      image:
+        registry: registry.k8s.io
+        repository: pause
+        tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
+      imagePullPolicy: Always
+      terminationGracePeriodSeconds: 0
+      automountServiceAccountToken: false
+      serviceAccountAnnotations:
+        foo: '{"baz": "ingress"}'
+        ping: "ingress"
+      deployment:
+        replicas: 0
+    egress:
+      enabled: true
+      image:
+        registry: registry.k8s.io
+        repository: pause
+        tag: "3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"
+      terminationGracePeriodSeconds: 15
+      automountServiceAccountToken: true
+      serviceAccountAnnotations:
+        foo: '{"baz": "egress"}'
+        ping: "egress"

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -228,23 +228,38 @@ A Helm chart for the Kuma Control Plane
 | zoneProxyImage.registry | string | `"registry.k8s.io"` | The pause image registry |
 | zoneProxyImage.repository | string | `"pause"` | The pause image repository |
 | zoneProxyImage.tag | string | `"3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"` | The pause image tag |
+| meshZoneProxyDefaults.ingress.replicas | int | `1` | Default number of replicas for zone ingress. Ignored when hpa.enabled is true. |
+| meshZoneProxyDefaults.ingress.restartPolicy | string | `"Always"` | Default pod restart policy for zone ingress. |
+| meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds | int | `40` | Default number of seconds to wait before force killing the zone ingress pod. |
+| meshZoneProxyDefaults.ingress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for zone ingress. Optionally set to false |
+| meshZoneProxyDefaults.ingress.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy for the zone ingress pause container. |
 | meshZoneProxyDefaults.ingress.service.type | string | `"LoadBalancer"` | Default Service type for zone ingress. |
 | meshZoneProxyDefaults.ingress.service.port | int | `10001` | Default port for zone ingress Service. |
 | meshZoneProxyDefaults.ingress.service.targetPort | int | `10001` | Container port the zone ingress listens on. Do not change unless the zone proxy binary is reconfigured. |
+| meshZoneProxyDefaults.egress.replicas | int | `1` | Default number of replicas for zone egress. Ignored when hpa.enabled is true. |
+| meshZoneProxyDefaults.egress.restartPolicy | string | `"Always"` | Default pod restart policy for zone egress. |
+| meshZoneProxyDefaults.egress.terminationGracePeriodSeconds | int | `40` | Default number of seconds to wait before force killing the zone egress pod. |
+| meshZoneProxyDefaults.egress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for zone egress. Optionally set to false |
+| meshZoneProxyDefaults.egress.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy for the zone egress pause container. |
 | meshZoneProxyDefaults.egress.service.type | string | `"ClusterIP"` | Default Service type for zone egress. |
 | meshZoneProxyDefaults.egress.service.port | int | `10002` | Default port for zone egress Service. |
 | meshZoneProxyDefaults.egress.service.targetPort | int | `10002` | Container port the zone egress listens on. Do not change unless the zone proxy binary is reconfigured. |
 | meshes[0].name | string | `"default"` | The mesh must already exist or be created separately; this Helm chart will not create it. |
 | meshes[0].ingress.enabled | bool | `false` | Deploy a zone ingress for this mesh. |
 | meshes[0].ingress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
+| meshes[0].ingress.restartPolicy | string | `nil` | Per-mesh override for pod restart policy. Falls back to meshZoneProxyDefaults.ingress.restartPolicy when unset. |
+| meshes[0].ingress.terminationGracePeriodSeconds | int | `nil` | Per-mesh override for the pod termination grace period. Falls back to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset. |
+| meshes[0].ingress.automountServiceAccountToken | bool | `nil` | Per-mesh override for automountServiceAccountToken. Falls back to meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset. |
+| meshes[0].ingress.imagePullPolicy | string | `nil` | Per-mesh override for the pause container image pull policy. Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset. |
+| meshes[0].ingress.serviceAccountAnnotations | object | `{}` | Annotations to add to the zone ingress Service Account. |
 | meshes[0].ingress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride) |
 | meshes[0].ingress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.ingress.service.type when unset. |
 | meshes[0].ingress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.ingress.service.port when unset. |
 | meshes[0].ingress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
 | meshes[0].ingress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
 | meshes[0].ingress.service.labels | object | `{}` | Labels to add to the Service resource. |
-| meshes[0].ingress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":1}` | Deployment-level settings. |
-| meshes[0].ingress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
+| meshes[0].ingress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":null}` | Deployment-level settings. |
+| meshes[0].ingress.deployment.replicas | int | `nil` | Number of replicas. Ignored when hpa.enabled is true. Falls back to meshZoneProxyDefaults.<role>.replicas when unset. |
 | meshes[0].ingress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].ingress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
 | meshes[0].ingress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext, resources,  containerResources). |
@@ -252,14 +267,19 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].ingress.pdb | object | `{"enabled":false,"maxUnavailable":1}` | Pod Disruption Budget settings. |
 | meshes[0].egress.enabled | bool | `false` | Deploy a zone egress for this mesh. |
 | meshes[0].egress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
+| meshes[0].egress.restartPolicy | string | `nil` | Per-mesh override for pod restart policy. Falls back to meshZoneProxyDefaults.egress.restartPolicy when unset. |
+| meshes[0].egress.terminationGracePeriodSeconds | int | `nil` | Per-mesh override for the pod termination grace period. Falls back to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset. |
+| meshes[0].egress.automountServiceAccountToken | bool | `nil` | Per-mesh override for automountServiceAccountToken. Falls back to meshZoneProxyDefaults.egress.automountServiceAccountToken when unset. |
+| meshes[0].egress.imagePullPolicy | string | `nil` | Per-mesh override for the pause container image pull policy. Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset. |
+| meshes[0].egress.serviceAccountAnnotations | object | `{}` | Annotations to add to the zone egress Service Account. |
 | meshes[0].egress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride) |
 | meshes[0].egress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.egress.service.type when unset. |
 | meshes[0].egress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.egress.service.port when unset. |
 | meshes[0].egress.service.spec | object | `{}` | Additional Service spec fields (externalIPs, loadBalancerIP, loadBalancerSourceRanges, etc.). Merged directly into the Service spec. |
 | meshes[0].egress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
 | meshes[0].egress.service.labels | object | `{}` | Labels to add to the Service resource. |
-| meshes[0].egress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":1}` | Deployment-level settings. |
-| meshes[0].egress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
+| meshes[0].egress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":null}` | Deployment-level settings. |
+| meshes[0].egress.deployment.replicas | int | `nil` | Number of replicas. Ignored when hpa.enabled is true. Falls back to meshZoneProxyDefaults.<role>.replicas when unset. |
 | meshes[0].egress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].egress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
 | meshes[0].egress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext, resources,  containerResources). |

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -228,15 +228,30 @@ A Helm chart for the Kuma Control Plane
 | zoneProxyImage.registry | string | `"registry.k8s.io"` | The pause image registry |
 | zoneProxyImage.repository | string | `"pause"` | The pause image repository |
 | zoneProxyImage.tag | string | `"3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a"` | The pause image tag |
+| meshZoneProxyDefaults.ingress.replicas | int | `1` | Default number of replicas for zone ingress. Ignored when hpa.enabled is true. |
+| meshZoneProxyDefaults.ingress.restartPolicy | string | `"Always"` | Default pod restart policy for zone ingress. |
+| meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds | int | `40` | Default number of seconds to wait before force killing the zone ingress pod. |
+| meshZoneProxyDefaults.ingress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for zone ingress. Optionally set to false |
+| meshZoneProxyDefaults.ingress.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy for the zone ingress pause container. |
 | meshZoneProxyDefaults.ingress.service.type | string | `"LoadBalancer"` | Default Service type for zone ingress. |
 | meshZoneProxyDefaults.ingress.service.port | int | `10001` | Default port for zone ingress Service. |
 | meshZoneProxyDefaults.ingress.service.targetPort | int | `10001` | Container port the zone ingress listens on. Do not change unless the zone proxy binary is reconfigured. |
+| meshZoneProxyDefaults.egress.replicas | int | `1` | Default number of replicas for zone egress. Ignored when hpa.enabled is true. |
+| meshZoneProxyDefaults.egress.restartPolicy | string | `"Always"` | Default pod restart policy for zone egress. |
+| meshZoneProxyDefaults.egress.terminationGracePeriodSeconds | int | `40` | Default number of seconds to wait before force killing the zone egress pod. |
+| meshZoneProxyDefaults.egress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for zone egress. Optionally set to false |
+| meshZoneProxyDefaults.egress.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy for the zone egress pause container. |
 | meshZoneProxyDefaults.egress.service.type | string | `"ClusterIP"` | Default Service type for zone egress. |
 | meshZoneProxyDefaults.egress.service.port | int | `10002` | Default port for zone egress Service. |
 | meshZoneProxyDefaults.egress.service.targetPort | int | `10002` | Container port the zone egress listens on. Do not change unless the zone proxy binary is reconfigured. |
 | meshes[0].name | string | `"default"` | The mesh must already exist or be created separately; this Helm chart will not create it. |
 | meshes[0].ingress.enabled | bool | `false` | Deploy a zone ingress for this mesh. |
 | meshes[0].ingress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
+| meshes[0].ingress.restartPolicy | string | `nil` | Per-mesh override for pod restart policy. Falls back to meshZoneProxyDefaults.ingress.restartPolicy when unset. |
+| meshes[0].ingress.terminationGracePeriodSeconds | int | `nil` | Per-mesh override for the pod termination grace period. Falls back to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset. |
+| meshes[0].ingress.automountServiceAccountToken | bool | `nil` | Per-mesh override for automountServiceAccountToken. Falls back to meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset. |
+| meshes[0].ingress.imagePullPolicy | string | `nil` | Per-mesh override for the pause container image pull policy. Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset. |
+| meshes[0].ingress.serviceAccountAnnotations | object | `{}` | Annotations to add to the zone ingress Service Account. |
 | meshes[0].ingress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride) |
 | meshes[0].ingress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.ingress.service.type when unset. |
 | meshes[0].ingress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.ingress.service.port when unset. |
@@ -244,7 +259,7 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].ingress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
 | meshes[0].ingress.service.labels | object | `{}` | Labels to add to the Service resource. |
 | meshes[0].ingress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":1}` | Deployment-level settings. |
-| meshes[0].ingress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
+| meshes[0].ingress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. Falls back to meshZoneProxyDefaults.<role>.replicas when unset. |
 | meshes[0].ingress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].ingress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
 | meshes[0].ingress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext, resources,  containerResources). |
@@ -252,6 +267,11 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].ingress.pdb | object | `{"enabled":false,"maxUnavailable":1}` | Pod Disruption Budget settings. |
 | meshes[0].egress.enabled | bool | `false` | Deploy a zone egress for this mesh. |
 | meshes[0].egress.image | object | `{}` | Per-mesh override for the pause container image. Falls back to .Values.zoneProxyImage when unset. Partial overrides inherit the remaining registry/repository/tag fields from the chart-level default. |
+| meshes[0].egress.restartPolicy | string | `nil` | Per-mesh override for pod restart policy. Falls back to meshZoneProxyDefaults.egress.restartPolicy when unset. |
+| meshes[0].egress.terminationGracePeriodSeconds | int | `nil` | Per-mesh override for the pod termination grace period. Falls back to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset. |
+| meshes[0].egress.automountServiceAccountToken | bool | `nil` | Per-mesh override for automountServiceAccountToken. Falls back to meshZoneProxyDefaults.egress.automountServiceAccountToken when unset. |
+| meshes[0].egress.imagePullPolicy | string | `nil` | Per-mesh override for the pause container image pull policy. Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset. |
+| meshes[0].egress.serviceAccountAnnotations | object | `{}` | Annotations to add to the zone egress Service Account. |
 | meshes[0].egress.service.name | string | `""` | Override the auto-generated Service name (max 63 chars). Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride) |
 | meshes[0].egress.service.type | string | `nil` | Per-mesh override for Service type. Falls back to meshZoneProxyDefaults.egress.service.type when unset. |
 | meshes[0].egress.service.port | int | `nil` | Per-mesh override for Service port. Falls back to meshZoneProxyDefaults.egress.service.port when unset. |
@@ -259,7 +279,7 @@ A Helm chart for the Kuma Control Plane
 | meshes[0].egress.service.annotations | object | `{}` | Annotations to add to the Service resource. |
 | meshes[0].egress.service.labels | object | `{}` | Labels to add to the Service resource. |
 | meshes[0].egress.deployment | object | `{"annotations":{},"labels":{},"podSpec":{},"replicas":1}` | Deployment-level settings. |
-| meshes[0].egress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. |
+| meshes[0].egress.deployment.replicas | int | `1` | Number of replicas. Ignored when hpa.enabled is true. Falls back to meshZoneProxyDefaults.<role>.replicas when unset. |
 | meshes[0].egress.deployment.annotations | object | `{}` | Annotations to add to the Deployment resource. |
 | meshes[0].egress.deployment.labels | object | `{}` | Labels to add to the Deployment resource. |
 | meshes[0].egress.deployment.podSpec | object | `{}` | Subset of Kubernetes PodSpec fields applied to the pod template (nodeSelector, tolerations, affinity, topologySpreadConstraints,  priorityClassName, securityContext, containerSecurityContext, resources,  containerResources). |

--- a/deployments/charts/kuma/templates/_mesh-helpers.tpl
+++ b/deployments/charts/kuma/templates/_mesh-helpers.tpl
@@ -44,6 +44,23 @@ app: {{ include "kuma.mesh.zoneproxy.name" . }}
 {{- end -}}
 
 {{/*
+Resolve a scalar setting for a per-mesh zone proxy component.
+An override on meshes[].ingress.<field> / meshes[].egress.<field> wins over
+the chart-level default at .Values.meshZoneProxyDefaults.<role>.<field>. The
+override is detected by presence rather than truthiness, so an explicit
+false or 0 is honoured.
+params: { cfg: <map holding the override>, defaults: <meshZoneProxyDefaults.<role>>, field: string }
+*/}}
+{{- define "kuma.mesh.zoneproxy.setting" -}}
+{{- $override := index (.cfg | default dict) .field -}}
+{{- if kindIs "invalid" $override -}}
+{{- index .defaults .field -}}
+{{- else -}}
+{{- $override -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Resolve the pause container image for a per-mesh zone proxy component.
 Per-field override on meshes[].ingress.image / meshes[].egress.image falls
 back to the chart-level default at .Values.zoneProxyImage so users enabling

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
@@ -4,13 +4,13 @@
 {{- fail "each meshes entry must have a name" }}
 {{- end }}
 
-{{- /* Build list of enabled roles */ -}}
+{{- /* Build list of enabled roles with their defaults from meshZoneProxyDefaults */ -}}
 {{- $roles := list }}
 {{- if and $meshEntry.ingress $meshEntry.ingress.enabled }}
-{{- $roles = append $roles (dict "role" "ingress" "cfg" $meshEntry.ingress) }}
+{{- $roles = append $roles (dict "role" "ingress" "cfg" $meshEntry.ingress "defaults" $.Values.meshZoneProxyDefaults.ingress) }}
 {{- end }}
 {{- if and $meshEntry.egress $meshEntry.egress.enabled }}
-{{- $roles = append $roles (dict "role" "egress" "cfg" $meshEntry.egress) }}
+{{- $roles = append $roles (dict "role" "egress" "cfg" $meshEntry.egress "defaults" $.Values.meshZoneProxyDefaults.egress) }}
 {{- end }}
 
 {{- /* Validate mode only when deploying zone proxies */ -}}
@@ -23,7 +23,9 @@
 {{- range $roleEntry := $roles }}
 {{- $role := $roleEntry.role }}
 {{- $cfg := $roleEntry.cfg }}
+{{- $defaults := $roleEntry.defaults }}
 {{- $dep := $cfg.deployment | default dict }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,7 +47,7 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
   {{- if not (and $cfg.hpa $cfg.hpa.enabled) }}
-  replicas: {{ default 1 $dep.replicas }}
+  replicas: {{ include "kuma.mesh.zoneproxy.setting" (dict "cfg" $dep "defaults" $defaults "field" "replicas") }}
   {{- end }}
   selector:
     matchLabels:
@@ -82,8 +84,8 @@ spec:
           type: RuntimeDefault
       {{- end }}
       serviceAccountName: {{ include "kuma.mesh.zoneproxy.name" (dict "root" $ "meshName" $meshName "role" $role) }}
-      automountServiceAccountToken: {{ default true $cfg.automountServiceAccountToken }}
-      restartPolicy: {{ default "Always" $cfg.restartPolicy }}
+      automountServiceAccountToken: {{ include "kuma.mesh.zoneproxy.setting" (dict "cfg" $cfg "defaults" $defaults "field" "automountServiceAccountToken") }}
+      restartPolicy: {{ include "kuma.mesh.zoneproxy.setting" (dict "cfg" $cfg "defaults" $defaults "field" "restartPolicy") }}
       {{- with (and $dep.podSpec $dep.podSpec.nodeSelector) }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}
@@ -92,11 +94,11 @@ spec:
       tolerations:
       {{ toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ default 40 $cfg.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ include "kuma.mesh.zoneproxy.setting" (dict "cfg" $cfg "defaults" $defaults "field" "terminationGracePeriodSeconds") }}
       containers:
         - name: pause
           image: {{ include "kuma.mesh.zoneproxy.image" (dict "root" $ "cfg" $cfg "meshName" $meshName "role" $role) | quote }}
-          imagePullPolicy: {{ default "IfNotPresent" $cfg.imagePullPolicy }}
+          imagePullPolicy: {{ include "kuma.mesh.zoneproxy.setting" (dict "cfg" $cfg "defaults" $defaults "field" "imagePullPolicy") }}
           {{- if and $dep.podSpec $dep.podSpec.containerSecurityContext }}
           securityContext:
           {{- toYaml $dep.podSpec.containerSecurityContext | trim | nindent 12 }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -835,6 +835,16 @@ zoneProxyImage:
 # meshes[].ingress.service or meshes[].egress.service fields are not set.
 meshZoneProxyDefaults:
   ingress:
+    # -- Default number of replicas for zone ingress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone ingress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone ingress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone ingress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone ingress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone ingress.
       type: LoadBalancer
@@ -844,6 +854,16 @@ meshZoneProxyDefaults:
       # zone proxy binary is reconfigured.
       targetPort: 10001
   egress:
+    # -- Default number of replicas for zone egress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone egress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone egress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone egress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone egress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
@@ -865,6 +885,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.ingress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone ingress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
@@ -884,8 +918,9 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
-        replicas: 1
+        # -- (int) Number of replicas. Ignored when hpa.enabled is true. Falls back
+        # to meshZoneProxyDefaults.<role>.replicas when unset.
+        replicas:
         # -- Annotations to add to the Deployment resource.
         annotations: {}
         # -- Labels to add to the Deployment resource.
@@ -913,6 +948,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.egress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.egress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone egress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
@@ -932,8 +981,9 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
-        replicas: 1
+        # -- (int) Number of replicas. Ignored when hpa.enabled is true. Falls back
+        # to meshZoneProxyDefaults.<role>.replicas when unset.
+        replicas:
         # -- Annotations to add to the Deployment resource.
         annotations: {}
         # -- Labels to add to the Deployment resource.

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -835,6 +835,16 @@ zoneProxyImage:
 # meshes[].ingress.service or meshes[].egress.service fields are not set.
 meshZoneProxyDefaults:
   ingress:
+    # -- Default number of replicas for zone ingress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone ingress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone ingress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone ingress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone ingress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone ingress.
       type: LoadBalancer
@@ -844,6 +854,16 @@ meshZoneProxyDefaults:
       # zone proxy binary is reconfigured.
       targetPort: 10001
   egress:
+    # -- Default number of replicas for zone egress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone egress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone egress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone egress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone egress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
@@ -865,6 +885,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.ingress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone ingress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
@@ -884,7 +918,8 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
+        # -- Number of replicas. Ignored when hpa.enabled is true. Falls back to
+        # meshZoneProxyDefaults.<role>.replicas when unset.
         replicas: 1
         # -- Annotations to add to the Deployment resource.
         annotations: {}
@@ -913,6 +948,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.egress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.egress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone egress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
@@ -932,7 +981,8 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
+        # -- Number of replicas. Ignored when hpa.enabled is true. Falls back to
+        # meshZoneProxyDefaults.<role>.replicas when unset.
         replicas: 1
         # -- Annotations to add to the Deployment resource.
         annotations: {}

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -835,6 +835,16 @@ zoneProxyImage:
 # meshes[].ingress.service or meshes[].egress.service fields are not set.
 meshZoneProxyDefaults:
   ingress:
+    # -- Default number of replicas for zone ingress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone ingress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone ingress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone ingress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone ingress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone ingress.
       type: LoadBalancer
@@ -844,6 +854,16 @@ meshZoneProxyDefaults:
       # zone proxy binary is reconfigured.
       targetPort: 10001
   egress:
+    # -- Default number of replicas for zone egress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone egress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone egress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone egress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone egress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
@@ -865,6 +885,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.ingress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone ingress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
@@ -884,8 +918,9 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
-        replicas: 1
+        # -- (int) Number of replicas. Ignored when hpa.enabled is true. Falls back
+        # to meshZoneProxyDefaults.<role>.replicas when unset.
+        replicas:
         # -- Annotations to add to the Deployment resource.
         annotations: {}
         # -- Labels to add to the Deployment resource.
@@ -913,6 +948,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.egress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.egress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone egress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
@@ -932,8 +981,9 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
-        replicas: 1
+        # -- (int) Number of replicas. Ignored when hpa.enabled is true. Falls back
+        # to meshZoneProxyDefaults.<role>.replicas when unset.
+        replicas:
         # -- Annotations to add to the Deployment resource.
         annotations: {}
         # -- Labels to add to the Deployment resource.

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -835,6 +835,16 @@ zoneProxyImage:
 # meshes[].ingress.service or meshes[].egress.service fields are not set.
 meshZoneProxyDefaults:
   ingress:
+    # -- Default number of replicas for zone ingress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone ingress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone ingress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone ingress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone ingress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone ingress.
       type: LoadBalancer
@@ -844,6 +854,16 @@ meshZoneProxyDefaults:
       # zone proxy binary is reconfigured.
       targetPort: 10001
   egress:
+    # -- Default number of replicas for zone egress. Ignored when hpa.enabled is true.
+    replicas: 1
+    # -- Default pod restart policy for zone egress.
+    restartPolicy: Always
+    # -- Default number of seconds to wait before force killing the zone egress pod.
+    terminationGracePeriodSeconds: 40
+    # -- Whether to automountServiceAccountToken for zone egress. Optionally set to false
+    automountServiceAccountToken: true
+    # -- Default image pull policy for the zone egress pause container.
+    imagePullPolicy: IfNotPresent
     service:
       # -- Default Service type for zone egress.
       type: ClusterIP
@@ -865,6 +885,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.ingress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.ingress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.ingress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.ingress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone ingress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-ingress (where <name> is the chart name or nameOverride)
@@ -884,7 +918,8 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
+        # -- Number of replicas. Ignored when hpa.enabled is true. Falls back to
+        # meshZoneProxyDefaults.<role>.replicas when unset.
         replicas: 1
         # -- Annotations to add to the Deployment resource.
         annotations: {}
@@ -913,6 +948,20 @@ meshes:
       # .Values.zoneProxyImage when unset. Partial overrides inherit the
       # remaining registry/repository/tag fields from the chart-level default.
       image: {}
+      # -- (string) Per-mesh override for pod restart policy. Falls back to
+      # meshZoneProxyDefaults.egress.restartPolicy when unset.
+      restartPolicy:
+      # -- (int) Per-mesh override for the pod termination grace period. Falls back
+      # to meshZoneProxyDefaults.egress.terminationGracePeriodSeconds when unset.
+      terminationGracePeriodSeconds:
+      # -- (bool) Per-mesh override for automountServiceAccountToken. Falls back to
+      # meshZoneProxyDefaults.egress.automountServiceAccountToken when unset.
+      automountServiceAccountToken:
+      # -- (string) Per-mesh override for the pause container image pull policy.
+      # Falls back to meshZoneProxyDefaults.egress.imagePullPolicy when unset.
+      imagePullPolicy:
+      # -- Annotations to add to the zone egress Service Account.
+      serviceAccountAnnotations: {}
       service:
         # -- Override the auto-generated Service name (max 63 chars).
         # Auto-generated: <name>-<mesh>-egress (where <name> is the chart name or nameOverride)
@@ -932,7 +981,8 @@ meshes:
         labels: {}
       # -- Deployment-level settings.
       deployment:
-        # -- Number of replicas. Ignored when hpa.enabled is true.
+        # -- Number of replicas. Ignored when hpa.enabled is true. Falls back to
+        # meshZoneProxyDefaults.<role>.replicas when unset.
         replicas: 1
         # -- Annotations to add to the Deployment resource.
         annotations: {}


### PR DESCRIPTION
## Motivation

Sprig's `default` substitutes the fallback whenever the value is *empty*, and `false`, `0` and `""` all count as empty — it cannot tell "unset" from "explicitly falsy". Three mesh-scoped zone proxy settings were defaulted that way, so a falsy value was silently discarded:

- `automountServiceAccountToken: false` rendered `true`
- `deployment.replicas: 0` rendered `1`
- `terminationGracePeriodSeconds: 0` rendered `40`

Nothing regressed: these branches were never reachable from a test or a `values.yaml` default, so they have been wrong since the mesh-scoped model landed.

## Implementation information

Defaults now live in `values.yaml` under `meshZoneProxyDefaults.{ingress,egress}`, next to the `service.*` defaults already there. The per-mesh override resolves in a new `kuma.mesh.zoneproxy.setting` helper — a sibling of the existing `kuma.mesh.zoneproxy.image` — which detects an override by presence rather than truthiness. Values merging alone cannot do this: `meshes` is a list, and Helm replaces a user-supplied list wholesale instead of merging its entries.

New `meshZoneProxyPodOverrides` test case covers both directions in one golden: zone ingress sets the falsy values, zone egress leaves them unset to assert the fallback.

## Supporting documentation

- Found while reviewing #17772, which removes the legacy `ingress`/`egress` deployments along with `fix7824` — the only coverage that exercised these fields.
- #17242 — umbrella issue for unifying ZoneIngress/ZoneEgress into the mesh-scoped Zone Proxy
