### PR TITLE
fix(ci): retry release checks and scope concurrency by release version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: "release"
 run-name: Release${{ inputs.check && ' and check' || '' }} ${{ inputs.release }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.release }}
   cancel-in-progress: false
 on:
   schedule:
@@ -72,13 +72,33 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         if: fromJSON(env.CHECK)
         run: |
-          release-tool release binaries --repo ${{ github.repository }} --release ${{ env.RELEASE }} --binaries ${{ env.BINARIES }}
+          max_retries=5
+          retry_count=0
+          until release-tool release binaries --repo ${{ github.repository }} --release ${{ env.RELEASE }} --binaries ${{ env.BINARIES }}; do
+            retry_count=$((retry_count + 1))
+            if [[ "$retry_count" -ge "$max_retries" ]]; then
+              echo "check-binaries failed after $max_retries attempts"
+              exit 1
+            fi
+            echo "Attempt $retry_count: check-binaries failed, retrying in 30 seconds..."
+            sleep 30
+          done
       - name: check-docker
         env:
           GITHUB_TOKEN: ${{ github.token }}
         if: fromJSON(env.CHECK)
         run: |
-          release-tool release docker --repo ${{ github.repository }} --release ${{ env.RELEASE }} --docker-repo ${{env.DOCKER_REPO }} --images ${{ env.DOCKER_IMAGES }}
+          max_retries=5
+          retry_count=0
+          until release-tool release docker --repo ${{ github.repository }} --release ${{ env.RELEASE }} --docker-repo ${{env.DOCKER_REPO }} --images ${{ env.DOCKER_IMAGES }}; do
+            retry_count=$((retry_count + 1))
+            if [[ "$retry_count" -ge "$max_retries" ]]; then
+              echo "check-docker failed after $max_retries attempts"
+              exit 1
+            fi
+            echo "Attempt $retry_count: check-docker failed, retrying in 30 seconds..."
+            sleep 30
+          done
       - name: update-active-branches.json
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: "release"
 run-name: Release${{ inputs.check && ' and check' || '' }} ${{ inputs.release }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.release }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.release || '0.0.0' }}
   cancel-in-progress: false
 on:
   schedule:


### PR DESCRIPTION
Motivation:
Manual release.yaml --check=true dispatches were flaking during the
2026-07-29 patch release. Docker images are pushed by
build-test-distribute.yaml (triggered by the tag push), and there is a
propagation gap between that workflow reporting success and the images
becoming resolvable on Docker Hub; running check-docker during that
window 404s on all 5 images even though the release is fine (confirmed
by rerunning the same check minutes later with no other change, on
2.13.10, 2.11.18, and 2.7.29). check-binaries carries the same risk.

Separately, the top-level concurrency group
(${{ github.workflow }}-${{ github.ref }}) does not include the
release input, so two workflow_dispatch runs checking different
versions land in the same group. With cancel-in-progress: false a
third dispatch cancels a previously queued run for an unrelated
version, as happened when dispatching checks for 2.13.10, 2.11.18, and
2.7.29 in quick succession.

This is a CI-only change to the manual release *verification* tooling
(the check-* steps only run when the check input is true, separate
from the create-release/changelog/version-file steps that actually
publish). It does not change what gets released, only removes false
negatives and mis-cancellations in the check step.

Approach:
- Wrap check-binaries and check-docker in a retry loop (5 attempts,
  30s backoff) so transient propagation lag self-heals instead of
  requiring a manual rerun, matching the retry pattern already used in
  ci-stability-master.yaml.
- Scope the concurrency group by inputs.release so dispatches for
  different versions no longer collide.

Validation:
Ran the same two linters this repo's CI applies to workflow-file
changes (.github/workflows/validate-workflows-and-scripts.yaml):
  actionlint .github/workflows/release.yaml
  actionlint -shellcheck "$(which shellcheck)" .github/workflows/release.yaml
Both exit 0. A live re-dispatch of the release workflow against a real
tag was not performed (out of scope for a local change); the fix
mirrors the exact retry/backoff and concurrency-scoping approach the
issue reporter validated by hand against three real occurrences during
the 2026-07-29 patch release.

Report: https://github.com/kumahq/kuma/issues/17779
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #17779