### PR TITLE
fix(helm): clear stale subchart on release

### DIFF
--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -39,7 +39,7 @@ function update_version {
     yq -i ".version = \"${kuma_version}\"" "${dir}/Chart.yaml"
 
     local chart
-    for chart in $(yq e '.dependencies[].name' "${dir}/Chart.yaml"); do
+    for chart in $(yq e '.dependencies[]?.name' "${dir}/Chart.yaml"); do
         if [ ! -d "${dir}/charts/${chart}" ]; then
             continue
         fi

--- a/tools/releases/helm.sh
+++ b/tools/releases/helm.sh
@@ -17,11 +17,12 @@ GH_PAGES_BRANCH="gh-pages"
 #  appVersion equal to the kuma version
 #  version:
 #    using version.sh logic
-#  dependencies (with non-empty first argument):
-#    for any dependency $chart where charts/$chart exists, it deletes $chart from
-#    .dependencies so that the embedded $chart is used and not the one fetched
-#    from the repository. `cr` fetches explicit dependencies and they take
-#    precedence over embedded files.
+#  dependencies:
+#    dev builds keep the embedded charts/$chart and drop it from
+#    .dependencies to avoid the network. Release builds do the opposite:
+#    they remove the embedded charts/$chart dir, since it's always a stale
+#    vendored copy and cr/helm don't reliably prefer a freshly fetched
+#    dependency over a same-named embedded directory.
 function update_version {
   local dev=${1}
   for dir in "${CHARTS_DIR}"/*; do
@@ -37,15 +38,17 @@ function update_version {
     yq -i ".appVersion = \"${kuma_version}\"" "${dir}/Chart.yaml"
     yq -i ".version = \"${kuma_version}\"" "${dir}/Chart.yaml"
 
-    if [ -n "${dev}" ]; then
-      local chart
-      for chart in $(yq e '.dependencies[].name' "${dir}/Chart.yaml"); do
-          if [ ! -d "${dir}/charts/${chart}" ]; then
-              continue
-          fi
+    local chart
+    for chart in $(yq e '.dependencies[].name' "${dir}/Chart.yaml"); do
+        if [ ! -d "${dir}/charts/${chart}" ]; then
+            continue
+        fi
+        if [ -n "${dev}" ]; then
           yq -i e "del(.dependencies[] | select(.name == \"${chart}\"))" "${dir}/Chart.yaml"
-      done
-    fi
+        else
+          rm -rf "${dir}/charts/${chart}"
+        fi
+    done
 
     make helm-docs
   done


### PR DESCRIPTION
## Motivation

Downstream chart releases (e.g. kong-mesh) that embed a vendored copy
of a dependency chart under `charts/$dep/` can ship it with a stale
placeholder version instead of the real one `verify_packaged` expects
(kuma#16589), even though the dependency is correctly listed in
`Chart.yaml` and gets fetched by `cr` at packaging time.

Root cause: `update_version`'s dev-mode branch already knows about this
case - when `charts/$chart` exists, it deletes the `.dependencies` entry
so the embedded copy is used deliberately, without hitting the network.
Release mode does nothing symmetric: it leaves both the embedded
directory and the dependency entry in place, trusting `cr`'s fetch to
overwrite the embedded copy. It doesn't reliably do that - `cr`
downloads the real chart into `charts/` alongside the stale directory,
and Helm's dependency loader doesn't reliably prefer the freshly
fetched one over the same-named embedded directory. The result is
non-deterministic: whichever the downstream consumer happens to load
wins, so it fails intermittently rather than every time (this is what
kuma#16589's report of "5 of the last 10 downstream chart releases"
actually was).

> Changelog: skip

## Implementation information

- In `update_version`, release mode now removes the embedded
  `charts/$chart` directory (mirroring the dev-mode branch, which
  removes the dependency entry instead) whenever a same-named
  dependency exists, so only the freshly fetched chart remains for
  `cr` to package.

## Supporting documentation

Reproduced via kong-mesh's v2.11.18 build:
https://github.com/Kong/kong-mesh/actions/runs/30653851464