### PR TITLE
test(gateway): scope MHR backendRef to namespace

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshhttproute.go
@@ -74,9 +74,10 @@ spec:
         kind: MeshService
         labels:
           kuma.io/display-name: test-server
+          k8s.kuma.io/namespace: %[3]s
       rules:
         - matches:
-            - path: 
+            - path:
                 type: PathPrefix
                 value: /
           default:
@@ -84,6 +85,7 @@ spec:
               - kind: MeshService
                 labels:
                   kuma.io/display-name: test-server
+                  k8s.kuma.io/namespace: %[3]s
                 port: 80
                 weight: 50
               - kind: MeshExternalService
@@ -92,7 +94,7 @@ spec:
                   k8s.kuma.io/namespace: %[1]s
                 port: 80
                 weight: 50
-`, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
+`, config.CpNamespace, config.Mesh, config.Namespace))(kubernetes.Cluster)).To(Succeed())
 
 			// then receive responses from 'test-server_delegated-gateway_svc_80'
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
## Motivation

`MeshHTTPRoute should split traffic between internal and external services` flakes — the gateway sends 100% of traffic to the MeshExternalService.

Broken by #17761, which migrated the MeshService backendRef to labels but dropped the namespace qualifier. `realResourceSelector` then defaults `k8s.kuma.io/namespace` to the policy's namespace (`kuma-system`), which never matches the real MeshService in `delegated-gateway-ms`. `resolve.BackendRef` returns `ok=false` and the ref is silently dropped, leaving the extsvc ref at 100%.

It passes sometimes because a route whose refs *all* fail to resolve falls back to the outbound's own service. If the first request lands in the ~2.5s window before the MeshExternalService gets its VIP, that fallback answers with `test-server`.

## Implementation information

Add `k8s.kuma.io/namespace` to the backendRef and `to.targetRef`, as `MeshHTTPRouteMeshService` already does.

Audited the rest of `test/e2e_env`: universal manifests are unaffected (no policy namespace, so the defaulting is a no-op) and the multizone Kubernetes cases co-locate policy and target. Leftover `name:` backendRefs remain in `gateway/delegated/meshtcproute.go` (dead code, not in the test matrix) and `universal/meshretry/http.go` (falls back to the service it names) — inert, left for follow-up.

Separately worth fixing: dropping an unresolvable backendRef silently reweights the survivors to 100%, with no log and nothing on the policy status.

## Supporting documentation

- Broken by https://github.com/kumahq/kuma/pull/17761
- Failing run: https://github.com/kumahq/kuma/actions/runs/30808221441
