### PR TITLE
chore(xds): reuse go-control-plane helpers

### DIFF
--- a/pkg/hds/tracker/reconciler.go
+++ b/pkg/hds/tracker/reconciler.go
@@ -27,7 +27,7 @@ func (r *reconciler) Reconcile(ctx context.Context, node *envoy_config_core_v3.N
 	switch {
 	case oldSnapshot == nil:
 		snap = newSnapshot
-	case !util_xds_v3.SingleTypeSnapshotEqual(oldSnapshot, newSnapshot):
+	case !util_xds_v3.SingleTypeSnapshotEqual(newSnapshot, oldSnapshot):
 		snap = newSnapshot
 	default:
 		snap = oldSnapshot

--- a/pkg/mads/v1/reconcile/reconciler.go
+++ b/pkg/mads/v1/reconcile/reconciler.go
@@ -44,7 +44,7 @@ func (r *reconciler) Reconcile(ctx context.Context) error {
 		switch {
 		case oldSnapshot == nil:
 			snap = newSnapshot
-		case !util_xds_v3.SingleTypeSnapshotEqual(oldSnapshot, newSnapshot):
+		case !util_xds_v3.SingleTypeSnapshotEqual(newSnapshot, oldSnapshot):
 			snap = newSnapshot
 		default:
 			snap = oldSnapshot

--- a/pkg/util/xds/v3/single_type_snapshot.go
+++ b/pkg/util/xds/v3/single_type_snapshot.go
@@ -125,18 +125,25 @@ func (s *SingleTypeSnapshot) ConstructVersionMap() error {
 }
 
 // SingleTypeSnapshotEqual checks value equality of 2 snapshots that contain a single type.
-// This will panic if there is more than 1 type in the snapshot, it assumes the snapshots are equivalent
+// Snapshots that aren't a *SingleTypeSnapshot are always reported as different, so the
+// caller replaces them with the new one.
 func SingleTypeSnapshotEqual(newSnap, oldSnap envoy_cache.ResourceSnapshot) bool {
-	var typeURL string
-	if stsnap, ok := newSnap.(*SingleTypeSnapshot); ok {
-		typeURL = stsnap.TypeUrl
+	snap, ok := newSnap.(*SingleTypeSnapshot)
+	if !ok {
+		return false
 	}
-	if typeURL == "" {
-		panic("couldn't extract type from snapshot is this not a SingleTypeSnapshot?")
+	return snap.Equal(oldSnap)
+}
+
+// Equal checks value equality against another snapshot, comparing the resources
+// of this snapshot's single type.
+func (s *SingleTypeSnapshot) Equal(other envoy_cache.ResourceSnapshot) bool {
+	if other == nil {
+		return false
 	}
 	// For now there's a single resourceType so the diff is easy
-	newResources := newSnap.GetResources(typeURL)
-	oldResources := oldSnap.GetResources(typeURL)
+	newResources := s.GetResources(s.TypeUrl)
+	oldResources := other.GetResources(s.TypeUrl)
 	if len(newResources) != len(oldResources) {
 		return false
 	}

--- a/pkg/xds/server/v3/reconcile.go
+++ b/pkg/xds/server/v3/reconcile.go
@@ -27,6 +27,20 @@ import (
 
 var reconcileLog = core.Log.WithName("xds").WithName("reconcile")
 
+// resourceTypeNames are the metric label values for each snapshot resource index.
+var resourceTypeNames = [envoy_types.UnknownType]string{
+	envoy_types.Endpoint:        "Endpoint",
+	envoy_types.Cluster:         "Cluster",
+	envoy_types.Route:           "Route",
+	envoy_types.ScopedRoute:     "ScopedRoute",
+	envoy_types.VirtualHost:     "VirtualHost",
+	envoy_types.Listener:        "Listener",
+	envoy_types.Secret:          "Secret",
+	envoy_types.Runtime:         "Runtime",
+	envoy_types.ExtensionConfig: "ExtensionConfig",
+	envoy_types.RateLimitConfig: "RateLimitConfig",
+}
+
 var _ xds_sync.SnapshotReconciler = &reconciler{}
 
 type reconciler struct {
@@ -107,18 +121,6 @@ func (r *reconciler) Reconcile(ctx context.Context, xdsCtx xds_context.Context, 
 	}
 
 	if r.metrics != nil {
-		resourceTypeNames := [envoy_types.UnknownType]string{
-			envoy_types.Endpoint:        "Endpoint",
-			envoy_types.Cluster:         "Cluster",
-			envoy_types.Route:           "Route",
-			envoy_types.ScopedRoute:     "ScopedRoute",
-			envoy_types.VirtualHost:     "VirtualHost",
-			envoy_types.Listener:        "Listener",
-			envoy_types.Secret:          "Secret",
-			envoy_types.Runtime:         "Runtime",
-			envoy_types.ExtensionConfig: "ExtensionConfig",
-			envoy_types.RateLimitConfig: "RateLimitConfig",
-		}
 		for i, resources := range snapshot.Resources {
 			name := resourceTypeNames[i]
 			if name == "" || len(resources.Items) == 0 {
@@ -257,31 +259,14 @@ func constructVersionMap(s *envoy_cache.Snapshot) error {
 	return nil
 }
 
+// resourceTypeURL maps a snapshot resource index to its type URL, returning ""
+// for indexes that don't correspond to a known xDS type.
 func resourceTypeURL(i int) string {
-	switch envoy_types.ResponseType(i) {
-	case envoy_types.Endpoint:
-		return envoy_resource.EndpointType
-	case envoy_types.Cluster:
-		return envoy_resource.ClusterType
-	case envoy_types.Route:
-		return envoy_resource.RouteType
-	case envoy_types.ScopedRoute:
-		return envoy_resource.ScopedRouteType
-	case envoy_types.VirtualHost:
-		return envoy_resource.VirtualHostType
-	case envoy_types.Listener:
-		return envoy_resource.ListenerType
-	case envoy_types.Secret:
-		return envoy_resource.SecretType
-	case envoy_types.Runtime:
-		return envoy_resource.RuntimeType
-	case envoy_types.ExtensionConfig:
-		return envoy_resource.ExtensionConfigType
-	case envoy_types.RateLimitConfig:
-		return envoy_resource.RateLimitConfigType
-	default:
+	typeURL, err := envoy_cache.GetResponseTypeURL(envoy_types.ResponseType(i))
+	if err != nil {
 		return ""
 	}
+	return typeURL
 }
 
 // mixVersions combines two version strings into a single xxHash64 hash.


### PR DESCRIPTION
> Changelog: skip

## Motivation

Follow-up cleanup for #4926. The vendored `go-control-plane` cache is long gone (removed in #11590 and #11516), but two leftovers still shadow upstream code: `resourceTypeURL` in the xDS reconciler reimplements `envoy_cache.GetResponseTypeURL` (the upstream helper is already used in `pkg/core/xds/inspect/config.go`), and `SingleTypeSnapshotEqual` type-asserts its argument back to `*SingleTypeSnapshot` and panics when that fails.

## Implementation information

`resourceTypeURL` now delegates to `envoy_cache.GetResponseTypeURL` and keeps returning `""` for indexes without a known xDS type, so both call sites behave as before. The metric label table it sits next to moved to a package-level var instead of being rebuilt on every reconcile; label values are unchanged.

The comparison moved to a `(*SingleTypeSnapshot).Equal` method that takes the other snapshot as the upstream `ResourceSnapshot` interface. `SingleTypeSnapshotEqual` stays as a thin wrapper for callers that hold the interface: instead of panicking on a foreign snapshot it reports the two as different, so the caller replaces the cached one. Generator signatures are unchanged.

No behaviour change. `go build`, `gofmt`, and the `pkg/hds`, `pkg/mads`, `pkg/util/xds`, `pkg/xds/server` suites are green.

## Supporting documentation

What remains after this is Kuma-specific glue over upstream interfaces, not vendored code: `SingleTypeSnapshot` and `pkg/kds/v2/cache.Snapshot` implement `cache.ResourceSnapshot`, and neither can move to `LinearCache` because HDS (per node) and MADS (per client id) need per-client snapshots. The remaining fork debt is separate: `kumahq/go-control-plane` is one commit ahead of upstream (delta EDS-after-CDS force push), held via the `replace` directives in `go.mod`.
