### PR TITLE
fix(xds): hash MeshZoneAddress address and port

### DIFF
--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash.go
@@ -1,0 +1,23 @@
+package v1alpha1
+
+import (
+	"hash/fnv"
+	"strconv"
+
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+)
+
+// Hash returns a content-based hash of the MeshZoneAddress. The address is
+// hashed on top of the meta because the mesh context stores it after DNS
+// resolution: a load balancer hostname keeps the same resourceVersion while
+// resolving to a new IP, and meta-only hashing would keep serving the stale
+// endpoint.
+func (m *MeshZoneAddressResource) Hash() []byte {
+	hasher := fnv.New128a()
+	_, _ = hasher.Write(core_model.HashMeta(m))
+	if m.Spec != nil {
+		_, _ = hasher.Write([]byte(m.Spec.Address))
+		_, _ = hasher.Write([]byte(strconv.Itoa(int(m.Spec.Port))))
+	}
+	return hasher.Sum(nil)
+}

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"hash/fnv"
+	"net"
 	"strconv"
 
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
@@ -16,8 +17,10 @@ func (m *MeshZoneAddressResource) Hash() []byte {
 	hasher := fnv.New128a()
 	_, _ = hasher.Write(core_model.HashMeta(m))
 	if m.Spec != nil {
-		_, _ = hasher.Write([]byte(m.Spec.Address))
-		_, _ = hasher.Write([]byte(strconv.Itoa(int(m.Spec.Port))))
+		// address and port are joined instead of written back to back so that
+		// distinct pairs can't serialize to the same bytes, e.g. ("10.0.0.1", 23)
+		// and ("10.0.0.12", 3)
+		_, _ = hasher.Write([]byte(net.JoinHostPort(m.Spec.Address, strconv.Itoa(int(m.Spec.Port)))))
 	}
 	return hasher.Sum(nil)
 }

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash_test.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash_test.go
@@ -1,61 +1,65 @@
 package v1alpha1_test
 
 import (
-	"bytes"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
-	api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1"
+	meshzoneaddress_api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1"
 	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
 )
 
-func meshZoneAddress(version string, address string, port int32) *api.MeshZoneAddressResource {
-	return &api.MeshZoneAddressResource{
+func meshZoneAddress(version string, address string, port int32) *meshzoneaddress_api.MeshZoneAddressResource {
+	return &meshzoneaddress_api.MeshZoneAddressResource{
 		Meta: &test_model.ResourceMeta{
 			Mesh:    "default",
 			Name:    "zone-proxy-east",
 			Version: version,
 		},
-		Spec: &api.MeshZoneAddress{
+		Spec: &meshzoneaddress_api.MeshZoneAddress{
 			Address: address,
 			Port:    port,
 		},
 	}
 }
 
-func TestMeshZoneAddressHashTracksResolvedAddress(t *testing.T) {
-	first := meshZoneAddress("1", "10.0.0.1", 10001)
-	sameContent := meshZoneAddress("1", "10.0.0.1", 10001)
-	rotatedIP := meshZoneAddress("1", "10.0.0.2", 10001)
-	changedPort := meshZoneAddress("1", "10.0.0.1", 10002)
+var _ = Describe("Hash", func() {
+	It("should be stable for identical resources", func() {
+		Expect(meshZoneAddress("1", "10.0.0.1", 10001).Hash()).
+			To(Equal(meshZoneAddress("1", "10.0.0.1", 10001).Hash()))
+	})
 
-	if !bytes.Equal(first.Hash(), sameContent.Hash()) {
-		t.Fatal("expected MeshZoneAddress Hash to be stable for identical resources")
-	}
 	// the mesh context stores the address after DNS resolution, so a load balancer
 	// hostname keeps the same resourceVersion while resolving to a new IP
-	if bytes.Equal(first.Hash(), rotatedIP.Hash()) {
-		t.Fatal("expected MeshZoneAddress Hash to change when the address changes")
-	}
-	if bytes.Equal(first.Hash(), changedPort.Hash()) {
-		t.Fatal("expected MeshZoneAddress Hash to change when the port changes")
-	}
-}
+	It("should change when the address changes", func() {
+		Expect(meshZoneAddress("1", "10.0.0.1", 10001).Hash()).
+			ToNot(Equal(meshZoneAddress("1", "10.0.0.2", 10001).Hash()))
+	})
 
-func TestMeshZoneAddressHashTracksVersion(t *testing.T) {
-	first := meshZoneAddress("1", "10.0.0.1", 10001)
-	newVersion := meshZoneAddress("2", "10.0.0.1", 10001)
+	It("should change when the port changes", func() {
+		Expect(meshZoneAddress("1", "10.0.0.1", 10001).Hash()).
+			ToNot(Equal(meshZoneAddress("1", "10.0.0.1", 10002).Hash()))
+	})
 
-	if bytes.Equal(first.Hash(), newVersion.Hash()) {
-		t.Fatal("expected MeshZoneAddress Hash to change when the version changes")
-	}
-}
+	It("should change when the version changes", func() {
+		Expect(meshZoneAddress("1", "10.0.0.1", 10001).Hash()).
+			ToNot(Equal(meshZoneAddress("2", "10.0.0.1", 10001).Hash()))
+	})
 
-func TestMeshZoneAddressHashHandlesNilSpec(t *testing.T) {
-	withNilSpec := &api.MeshZoneAddressResource{
-		Meta: &test_model.ResourceMeta{Mesh: "default", Name: "zone-proxy-east"},
-	}
+	It("should not collide when the address and port boundary shifts", func() {
+		Expect(meshZoneAddress("1", "10.0.0.1", 23).Hash()).
+			ToNot(Equal(meshZoneAddress("1", "10.0.0.12", 3).Hash()))
+	})
 
-	if len(withNilSpec.Hash()) == 0 {
-		t.Fatal("expected MeshZoneAddress Hash to be computed for a nil spec")
-	}
-}
+	It("should not collide for an IPv6 address ending in digits", func() {
+		Expect(meshZoneAddress("1", "fd00::1", 23).Hash()).
+			ToNot(Equal(meshZoneAddress("1", "fd00::12", 3).Hash()))
+	})
+
+	It("should be computed for a nil spec", func() {
+		withNilSpec := &meshzoneaddress_api.MeshZoneAddressResource{
+			Meta: &test_model.ResourceMeta{Mesh: "default", Name: "zone-proxy-east"},
+		}
+
+		Expect(withNilSpec.Hash()).ToNot(BeEmpty())
+	})
+})

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash_test.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/hash_test.go
@@ -1,0 +1,61 @@
+package v1alpha1_test
+
+import (
+	"bytes"
+	"testing"
+
+	api "github.com/kumahq/kuma/v2/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1"
+	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
+)
+
+func meshZoneAddress(version string, address string, port int32) *api.MeshZoneAddressResource {
+	return &api.MeshZoneAddressResource{
+		Meta: &test_model.ResourceMeta{
+			Mesh:    "default",
+			Name:    "zone-proxy-east",
+			Version: version,
+		},
+		Spec: &api.MeshZoneAddress{
+			Address: address,
+			Port:    port,
+		},
+	}
+}
+
+func TestMeshZoneAddressHashTracksResolvedAddress(t *testing.T) {
+	first := meshZoneAddress("1", "10.0.0.1", 10001)
+	sameContent := meshZoneAddress("1", "10.0.0.1", 10001)
+	rotatedIP := meshZoneAddress("1", "10.0.0.2", 10001)
+	changedPort := meshZoneAddress("1", "10.0.0.1", 10002)
+
+	if !bytes.Equal(first.Hash(), sameContent.Hash()) {
+		t.Fatal("expected MeshZoneAddress Hash to be stable for identical resources")
+	}
+	// the mesh context stores the address after DNS resolution, so a load balancer
+	// hostname keeps the same resourceVersion while resolving to a new IP
+	if bytes.Equal(first.Hash(), rotatedIP.Hash()) {
+		t.Fatal("expected MeshZoneAddress Hash to change when the address changes")
+	}
+	if bytes.Equal(first.Hash(), changedPort.Hash()) {
+		t.Fatal("expected MeshZoneAddress Hash to change when the port changes")
+	}
+}
+
+func TestMeshZoneAddressHashTracksVersion(t *testing.T) {
+	first := meshZoneAddress("1", "10.0.0.1", 10001)
+	newVersion := meshZoneAddress("2", "10.0.0.1", 10001)
+
+	if bytes.Equal(first.Hash(), newVersion.Hash()) {
+		t.Fatal("expected MeshZoneAddress Hash to change when the version changes")
+	}
+}
+
+func TestMeshZoneAddressHashHandlesNilSpec(t *testing.T) {
+	withNilSpec := &api.MeshZoneAddressResource{
+		Meta: &test_model.ResourceMeta{Mesh: "default", Name: "zone-proxy-east"},
+	}
+
+	if len(withNilSpec.Hash()) == 0 {
+		t.Fatal("expected MeshZoneAddress Hash to be computed for a nil spec")
+	}
+}

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/suite_test.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/suite_test.go
@@ -1,0 +1,11 @@
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestMeshZoneAddress(t *testing.T) {
+	test.RunSpecs(t, "MeshZoneAddress")
+}


### PR DESCRIPTION
## Motivation

`MeshZoneAddress` has no `Hash()`, so the mesh context hashes it with `HashMeta` - resource identity plus `resourceVersion`. The mesh context stores the address after DNS resolution (#17843), and a load balancer hostname keeps the same `resourceVersion` while resolving to a new IP, so meta-only hashing keeps serving the stale endpoint until an unrelated write bumps the version.

## Implementation information

`MeshZoneAddressResource.Hash()` writes `spec.address` and `spec.port` on top of `HashMeta`, mirroring what `ZoneIngressResource.Hash()` already does for its resolved advertised address. Backport of the `MeshZoneAddress` hash from #17823, adapted to this branch, which has a single `Hash()` instead of the `Hash()`/`XDSHash()` split.

## Supporting documentation

Depends on #17843 for the resolution that makes the stored address differ from the authored spec.