### PR TITLE
fix(core): length-prefix hashed string fields

### DIFF
--- a/pkg/core/resources/apis/mesh/zone_ingress_helpers.go
+++ b/pkg/core/resources/apis/mesh/zone_ingress_helpers.go
@@ -47,7 +47,7 @@ func (r *ZoneIngressResource) AdminAddress(defaultAdminPort uint32) string {
 func (r *ZoneIngressResource) Hash() []byte {
 	hasher := fnv.New128a()
 	_, _ = hasher.Write(model.HashMeta(r))
-	_, _ = hasher.Write([]byte(r.Spec.GetNetworking().GetAddress()))
-	_, _ = hasher.Write([]byte(r.Spec.GetNetworking().GetAdvertisedAddress()))
+	model.WriteLenPrefixed(hasher, r.Spec.GetNetworking().GetAddress())
+	model.WriteLenPrefixed(hasher, r.Spec.GetNetworking().GetAdvertisedAddress())
 	return hasher.Sum(nil)
 }

--- a/pkg/core/resources/apis/mesh/zone_ingress_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/zone_ingress_helpers_test.go
@@ -1,0 +1,45 @@
+package mesh_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+)
+
+func zoneIngress(address string, advertisedAddress string) *core_mesh.ZoneIngressResource {
+	return &core_mesh.ZoneIngressResource{
+		Meta: &test_model.ResourceMeta{
+			Mesh:    "default",
+			Name:    "zone-ingress-east",
+			Version: "1",
+		},
+		Spec: &mesh_proto.ZoneIngress{
+			Networking: &mesh_proto.ZoneIngress_Networking{
+				Address:           address,
+				AdvertisedAddress: advertisedAddress,
+			},
+		},
+	}
+}
+
+var _ = Describe("ZoneIngress Hash", func() {
+	It("should be stable for identical resources", func() {
+		Expect(zoneIngress("10.0.0.1", "192.168.0.1").Hash()).
+			To(Equal(zoneIngress("10.0.0.1", "192.168.0.1").Hash()))
+	})
+
+	It("should change when the advertised address changes", func() {
+		Expect(zoneIngress("10.0.0.1", "192.168.0.1").Hash()).
+			ToNot(Equal(zoneIngress("10.0.0.1", "192.168.0.2").Hash()))
+	})
+
+	// the address and the advertised address are written back to back, so without
+	// length prefixes the pair boundary can shift without changing the hash
+	It("should not collide when the address boundary shifts", func() {
+		Expect(zoneIngress("10.0.0.1", "1.2.3.4").Hash()).
+			ToNot(Equal(zoneIngress("10.0.0.11", ".2.3.4").Hash()))
+	})
+})

--- a/pkg/core/resources/model/hash_test.go
+++ b/pkg/core/resources/model/hash_test.go
@@ -1,0 +1,53 @@
+package model_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+)
+
+func dataplane(mesh string, name string, version string) *core_mesh.DataplaneResource {
+	return &core_mesh.DataplaneResource{
+		Meta: &test_model.ResourceMeta{
+			Mesh:    mesh,
+			Name:    name,
+			Version: version,
+		},
+		Spec: &mesh_proto.Dataplane{},
+	}
+}
+
+var _ = Describe("HashMeta", func() {
+	It("should be stable for the same meta", func() {
+		Expect(core_model.HashMeta(dataplane("default", "backend", "1"))).
+			To(Equal(core_model.HashMeta(dataplane("default", "backend", "1"))))
+	})
+
+	It("should change when the version changes", func() {
+		Expect(core_model.HashMeta(dataplane("default", "backend", "1"))).
+			ToNot(Equal(core_model.HashMeta(dataplane("default", "backend", "2"))))
+	})
+
+	// the mesh and the name are written back to back, so without length prefixes
+	// a resource named "bc" in mesh "a" hashes the same as "c" in mesh "ab"
+	It("should not collide when the mesh and name boundary shifts", func() {
+		Expect(core_model.HashMeta(dataplane("a", "bc", "1"))).
+			ToNot(Equal(core_model.HashMeta(dataplane("ab", "c", "1"))))
+	})
+})
+
+var _ = Describe("HashMetaIdentity", func() {
+	It("should ignore the version", func() {
+		Expect(core_model.HashMetaIdentity(dataplane("default", "backend", "1"))).
+			To(Equal(core_model.HashMetaIdentity(dataplane("default", "backend", "2"))))
+	})
+
+	It("should not collide when the mesh and name boundary shifts", func() {
+		Expect(core_model.HashMetaIdentity(dataplane("a", "bc", "1"))).
+			ToNot(Equal(core_model.HashMetaIdentity(dataplane("ab", "c", "1"))))
+	})
+})

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -123,9 +123,19 @@ func HashMetaIdentity(r Resource) []byte {
 
 func writeMetaIdentity(hasher hash.Hash, r Resource) {
 	meta := r.GetMeta()
-	_, _ = hasher.Write([]byte(r.Descriptor().Name))
-	_, _ = hasher.Write([]byte(meta.GetMesh()))
-	_, _ = hasher.Write([]byte(meta.GetName()))
+	WriteLenPrefixed(hasher, string(r.Descriptor().Name))
+	WriteLenPrefixed(hasher, meta.GetMesh())
+	WriteLenPrefixed(hasher, meta.GetName())
+}
+
+// WriteLenPrefixed writes s into hasher prefixed with its length, so that
+// consecutive writes of variable-length strings can't produce the same byte
+// stream for different values, e.g. ("a", "bc") and ("ab", "c").
+func WriteLenPrefixed(hasher hash.Hash, s string) {
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(s)))
+	_, _ = hasher.Write(lenBuf[:])
+	_, _ = hasher.Write([]byte(s))
 }
 
 // WriteSortedLabels writes labels into hasher in a deterministic,
@@ -138,16 +148,9 @@ func WriteSortedLabels(hasher hash.Hash, labels map[string]string) {
 	}
 	sort.Strings(keys)
 
-	var lenBuf [8]byte
-	writeLenPrefixed := func(s string) {
-		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(s)))
-		_, _ = hasher.Write(lenBuf[:])
-		_, _ = hasher.Write([]byte(s))
-	}
-
 	for _, k := range keys {
-		writeLenPrefixed(k)
-		writeLenPrefixed(labels[k])
+		WriteLenPrefixed(hasher, k)
+		WriteLenPrefixed(hasher, labels[k])
 	}
 }
 

--- a/pkg/xds/cache/mesh/cache_test.go
+++ b/pkg/xds/cache/mesh/cache_test.go
@@ -147,7 +147,7 @@ var _ = Describe("MeshSnapshot Cache", func() {
 		By("getting Hash for the first time")
 		meshCtx, err := meshCache.GetMeshContext(context.Background(), "mesh-0")
 		Expect(err).ToNot(HaveOccurred())
-		expectedHash := "Bb0BH8ZeIPLSjv+XpGp8zQ=="
+		expectedHash := "PdiOFa9oSIXtI/olZKtvcA=="
 		Expect(meshCtx.Hash).To(Equal(expectedHash))
 		Expect(countingManager.getQueries).To(Equal(1)) // one Get to obtain Mesh
 		Expect(countingManager.listQueries).To(MatchAllKeys(Keys{
@@ -178,7 +178,7 @@ var _ = Describe("MeshSnapshot Cache", func() {
 
 		meshCtx, err = meshCache.GetMeshContext(context.Background(), "mesh-0")
 		Expect(err).ToNot(HaveOccurred())
-		expectedHash = "Z/dsGlHEKi4Q8VwhEHwvpQ=="
+		expectedHash = "8itDC1SYpXnmhsOh/IJWDg=="
 		Expect(meshCtx.Hash).To(Equal(expectedHash))
 		Expect(countingManager.getQueries).To(Equal(2))
 		Expect(countingManager.listQueries).To(MatchAllKeys(Keys{
@@ -278,7 +278,7 @@ var _ = Describe("MeshSnapshot Cache", func() {
 		countingManager.reset()
 		meshCtx, err = meshCache.GetMeshContext(context.Background(), "mesh-0")
 		Expect(err).ToNot(HaveOccurred())
-		expectedHash := "Bb0BH8ZeIPLSjv+XpGp8zQ=="
+		expectedHash := "PdiOFa9oSIXtI/olZKtvcA=="
 		Expect(meshCtx.Hash).To(Equal(expectedHash))
 		Expect(countingManager.getQueries).To(Equal(1)) // one Get to obtain Mesh
 		Expect(countingManager.listQueries).To(MatchAllKeys(Keys{

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -500,7 +500,7 @@ func (m *meshContextBuilder) hash(globalContext *GlobalContext, baseMeshContext 
 	}
 
 	for _, m := range maps.SortedKeys(resources.CrossMeshResources) {
-		_, _ = hasher.Write([]byte(m))
+		core_model.WriteLenPrefixed(hasher, m)
 		_, _ = hasher.Write(resources.CrossMeshResources[m].Hash())
 	}
 	return hasher.Sum(nil)
@@ -535,7 +535,7 @@ func (m *meshContextBuilder) computePolicyMatchingHash(globalContext *GlobalCont
 		}
 	}
 	for _, meshName := range maps.SortedKeys(resources.CrossMeshResources) {
-		_, _ = hasher.Write([]byte(meshName))
+		core_model.WriteLenPrefixed(hasher, meshName)
 		crossMesh := resources.CrossMeshResources[meshName]
 		for _, resType := range maps.SortedKeys(crossMesh) {
 			if affectsPolicyMatching(resType) {


### PR DESCRIPTION
## Motivation

Resource hashes concatenate variable-length strings straight into the hasher, so a byte-boundary shift between two adjacent fields produces the same byte stream for different resources. `writeMetaIdentity` writes type, mesh and name back to back, so a Dataplane named `bc` in mesh `a` hashes identically to `c` in mesh `ab`; `ZoneIngressResource.Hash()` does the same with the address and the advertised address. Colliding hashes are read as "nothing changed", so the mesh context keeps serving stale xDS until an unrelated write moves the hash.

The same class of bug was flagged on #17845, where `MeshZoneAddress` hashed `address` and `strconv.Itoa(port)` back to back. `WriteSortedLabels` already length-prefixes its keys and values for exactly this reason - the rest of the hashing path never got the same treatment.

## Implementation information

The length-prefixed writer inside `WriteSortedLabels` is promoted to an exported `core_model.WriteLenPrefixed` and used wherever variable-length strings are hashed consecutively: `writeMetaIdentity` (type, mesh, name), `ZoneIngressResource.Hash()` (address, advertised address), and the cross-mesh loops in `meshContextBuilder.hash` and `computePolicyMatchingHash`. Hash values change, which costs one mesh context recomputation on rollout and nothing else - these hashes are runtime change-detection only, never persisted. The two hardcoded expectations in `pkg/xds/cache/mesh/cache_test.go` are updated accordingly.

## Supporting documentation

The new specs in `pkg/core/resources/model/hash_test.go` and `pkg/core/resources/apis/mesh/zone_ingress_helpers_test.go` fail on master and pass with the fix.