### PR TITLE
test(xds): drop removed advertisedAddress field

### DIFF
--- a/pkg/xds/context/mesh_context_builder_test.go
+++ b/pkg/xds/context/mesh_context_builder_test.go
@@ -464,8 +464,6 @@ status:
 				switch host {
 				case "backend.dns.name":
 					return []net.IP{net.ParseIP("192.168.0.10")}, nil
-				case "backend.advertised.dns.name":
-					return []net.IP{net.ParseIP("192.168.0.11")}, nil
 				default:
 					return []net.IP{net.ParseIP(host)}, nil
 				}
@@ -483,7 +481,6 @@ name: dp-1
 mesh: mesh-1
 networking:
   address: backend.dns.name
-  advertisedAddress: backend.advertised.dns.name
   inbound:
     - port: 8080
       tags:
@@ -498,11 +495,10 @@ networking:
 		dataplanes := meshCtx.Resources.Dataplanes().Items
 		Expect(dataplanes).To(HaveLen(1))
 		Expect(dataplanes[0].Spec.GetNetworking().GetAddress()).To(Equal("192.168.0.10"))
-		Expect(dataplanes[0].Spec.GetNetworking().GetAdvertisedAddress()).To(Equal("192.168.0.11"))
 
 		// and so is the endpoint Envoy EDS gets, since it only accepts IPs
 		Expect(meshCtx.EndpointMap["backend"]).To(HaveLen(1))
-		Expect(meshCtx.EndpointMap["backend"][0].Target).To(Equal("192.168.0.11"))
+		Expect(meshCtx.EndpointMap["backend"][0].Target).To(Equal("192.168.0.10"))
 	})
 
 	It("returns an error instead of panicking when listing resources fails", func() {


### PR DESCRIPTION
## Motivation

`master` does not compile: `pkg/xds/context/mesh_context_builder_test.go` fails with `Dataplane_Networking has no field or method GetAdvertisedAddress`.

Two PRs landed within hours of each other and neither saw the other. #17853 removed `Dataplane.networking.advertisedAddress` (proto field 7 now reserved), while #17836 added a mesh-context test asserting on that field. Each was green against the base it was tested on; the merge of both is broken.

## Implementation information

Dropped `advertisedAddress` from the test Dataplane fixture, removed the `backend.advertised.dns.name` entry from the lookup stub, and removed the `GetAdvertisedAddress()` assertion. The expected `EndpointMap` target changes from `192.168.0.11` to `192.168.0.10`, since `networking.address` is now the only address resolved.

The test purpose is unchanged: a Dataplane whose `networking.address` is a hostname must reach EDS as an IP.

## Supporting documentation

- #17853 removed the field
- #17836 added the test

> Changelog: skip