### PR TITLE
ci(actions): dedicated PAT for smoke dispatch

### DIFF
--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -132,15 +132,14 @@ jobs:
     steps:
       - name: "Trigger downstream smoke test"
         env:
-          # smoke.yaml has no repository_dispatch trigger and cross-org
-          # workflow_dispatch needs a PAT with actions:write on the target repo
-          # that nobody's provisioned (see PR history). Reuse the
-          # repository_dispatch path pr-merged.yaml already proves works
-          # cross-org (NOTIFY_BOT_PAT_TOKEN/NOTIFY_OWNER) instead: kong-mesh-smoke
-          # listens for KUMA_SMOKE_TEST via dispatch-kuma-smoke.yaml and forwards
-          # to smoke.yaml with the default GITHUB_TOKEN (same-repo, no cross-org
-          # auth needed on that side).
-          GH_TOKEN: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
+          # smoke.yaml has no repository_dispatch trigger, so this dispatches
+          # via repository_dispatch to kong-mesh-smoke instead, which listens
+          # for KUMA_SMOKE_TEST via dispatch-kuma-smoke.yaml and forwards to
+          # smoke.yaml with the default GITHUB_TOKEN (same-repo, no cross-org
+          # auth needed on that side). Needs a classic PAT with `repo` scope,
+          # SSO-authorized for the Kong org - fine-grained PATs aren't enabled
+          # there for cross-org repo selection.
+          GH_TOKEN: ${{ secrets.KONG_MESH_SMOKE_DISPATCH_TOKEN }}
           NOTIFY_OWNER: ${{ secrets.NOTIFY_OWNER }}
           SMOKE_REPO: kong-mesh-smoke
           PRODUCT_VERSION: ${{ needs.guard.outputs.product_version }}


### PR DESCRIPTION
## Motivation

Follow-up to #17814: the smoke job's cross-org repository_dispatch call
404'd against Kong/kong-mesh-smoke using NOTIFY_BOT_PAT_TOKEN. That PAT's
access is scoped to kong-mesh only, not kong-mesh-smoke.

> Changelog: skip

## Implementation information

Points the smoke job at a new dedicated secret,
KONG_MESH_SMOKE_DISPATCH_TOKEN (classic PAT, `repo` scope, SSO-authorized
for the Kong org), instead of NOTIFY_BOT_PAT_TOKEN.

## Supporting documentation

Manually dispatched from this branch to confirm the full chain works:
trigger-release-tasks.yaml -> repository_dispatch on Kong/kong-mesh-smoke
-> dispatch-kuma-smoke.yaml -> smoke.yaml queued
(https://github.com/Kong/kong-mesh-smoke/actions/runs/30990095167,
cancelled immediately after confirming it queued since it was a
fake 0.0.1 test version).