### PR TITLE
chore(kuma-dp)!: remove deprecated ConfigDir and SocketDir

### DIFF
--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -132,15 +132,14 @@ jobs:
     steps:
       - name: "Trigger downstream smoke test"
         env:
-          # smoke.yaml has no repository_dispatch trigger and cross-org
-          # workflow_dispatch needs a PAT with actions:write on the target repo
-          # that nobody's provisioned (see PR history). Reuse the
-          # repository_dispatch path pr-merged.yaml already proves works
-          # cross-org (NOTIFY_BOT_PAT_TOKEN/NOTIFY_OWNER) instead: kong-mesh-smoke
-          # listens for KUMA_SMOKE_TEST via dispatch-kuma-smoke.yaml and forwards
-          # to smoke.yaml with the default GITHUB_TOKEN (same-repo, no cross-org
-          # auth needed on that side).
-          GH_TOKEN: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
+          # smoke.yaml has no repository_dispatch trigger, so this dispatches
+          # via repository_dispatch to kong-mesh-smoke instead, which listens
+          # for KUMA_SMOKE_TEST via dispatch-kuma-smoke.yaml and forwards to
+          # smoke.yaml with the default GITHUB_TOKEN (same-repo, no cross-org
+          # auth needed on that side). Needs a classic PAT with `repo` scope,
+          # SSO-authorized for the Kong org - fine-grained PATs aren't enabled
+          # there for cross-org repo selection.
+          GH_TOKEN: ${{ secrets.KONG_MESH_SMOKE_DISPATCH_TOKEN }}
           NOTIFY_OWNER: ${{ secrets.NOTIFY_OWNER }}
           SMOKE_REPO: kong-mesh-smoke
           PRODUCT_VERSION: ${{ needs.guard.outputs.product_version }}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1264,6 +1264,21 @@ spec:
 
 Zones without a `MeshZoneAddress` are not reachable cross-zone: their `MeshService` destinations get no endpoints in other zones. The control plane logs `no MeshZoneAddress found for zone` when this happens.
 
+### kuma-dp `configDir` / `socketDir` removed
+
+The deprecated `configDir` and `socketDir` `dataplaneRuntime` config fields (and their
+`KUMA_DATAPLANE_RUNTIME_CONFIG_DIR` / `KUMA_DATAPLANE_RUNTIME_SOCKET_DIR` environment
+variables) have been removed from `kuma-dp`. The `--config-dir` flag has also been removed.
+
+**Action required**
+
+Use `workDir` (`KUMA_DATAPLANE_RUNTIME_WORK_DIR` / `--work-dir`) instead. `--config-dir` now
+fails with `unknown flag`, so any script or deployment passing it will error immediately.
+`configDir`/`socketDir` in YAML config and `KUMA_DATAPLANE_RUNTIME_CONFIG_DIR` /
+`KUMA_DATAPLANE_RUNTIME_SOCKET_DIR` are silently ignored, since the config loader does not
+reject unknown fields — proxies still relying on them will silently fall back to a
+generated temporary directory instead of erroring.
+
 ## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -186,7 +186,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				runLog.Info("generated configurations will be stored in a temporary directory", "dir", tmpDir)
 			} else {
 				if err := os.MkdirAll(cfg.DataplaneRuntime.WorkDir, 0o711); err != nil { // #nosec G302 -- deliberate: traverse-only for UDS access
-					runLog.Error(err, "unable to create work directory")
+					runLog.Error(err, "unable to create work directory", "dir", cfg.DataplaneRuntime.WorkDir)
 					return err
 				}
 			}

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -166,22 +166,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				cfg.Dataplane.Name = proxyResource.GetMeta().GetName()
 			}
 
-			//nolint:staticcheck // SA1019 Backward compatibility: migrate deprecated ConfigDir to WorkDir
-			if cfg.DataplaneRuntime.WorkDir == "" && cfg.DataplaneRuntime.ConfigDir != "" {
-				runLog.Info("ConfigDir is deprecated, please use WorkDir instead")
-				//nolint:staticcheck // SA1019 Backward compatibility: migrate deprecated ConfigDir to WorkDir
-				cfg.DataplaneRuntime.WorkDir = cfg.DataplaneRuntime.ConfigDir
-			}
-			//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir for migration
-			if cfg.DataplaneRuntime.SocketDir != "" {
-				runLog.Info("SocketDir is deprecated, please use WorkDir instead")
-			} else {
-				//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir for migration
-				cfg.DataplaneRuntime.SocketDir = cfg.DataplaneRuntime.WorkDir
-			}
-
-			//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir for fallback
-			if cfg.DataplaneRuntime.WorkDir == "" || cfg.DataplaneRuntime.SocketDir == "" {
+			if cfg.DataplaneRuntime.WorkDir == "" {
 				tmpDir, err = os.MkdirTemp("", "kuma-dp-")
 				if err != nil {
 					runLog.Error(err, "unable to create a temporary directory to store generated configuration")
@@ -196,23 +181,12 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 					return err
 				}
 
-				if cfg.DataplaneRuntime.WorkDir == "" {
-					cfg.DataplaneRuntime.WorkDir = tmpDir
-				}
-
-				//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir for fallback
-				if cfg.DataplaneRuntime.SocketDir == "" {
-					//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir for fallback
-					cfg.DataplaneRuntime.SocketDir = tmpDir
-				}
+				cfg.DataplaneRuntime.WorkDir = tmpDir
 
 				runLog.Info("generated configurations will be stored in a temporary directory", "dir", tmpDir)
-			}
-
-			//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir for migration
-			if cfg.DataplaneRuntime.SocketDir != "" && cfg.DataplaneRuntime.SocketDir != tmpDir {
-				if err := os.MkdirAll(cfg.DataplaneRuntime.SocketDir, 0o711); err != nil { // #nosec G302 -- deliberate: traverse-only for UDS access
-					runLog.Error(err, "unable to create socket directory")
+			} else {
+				if err := os.MkdirAll(cfg.DataplaneRuntime.WorkDir, 0o711); err != nil { // #nosec G302 -- deliberate: traverse-only for UDS access
+					runLog.Error(err, "unable to create work directory")
 					return err
 				}
 			}
@@ -324,8 +298,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			opts.AdminSocketPath = adminSocketPath
 
 			confFetcher := configfetcher.NewConfigFetcher(
-				//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir
-				core_xds.MeshMetricsDynamicConfigurationSocketName(cfg.DataplaneRuntime.SocketDir),
+				core_xds.MeshMetricsDynamicConfigurationSocketName(cfg.DataplaneRuntime.WorkDir),
 				time.NewTicker(cfg.DataplaneRuntime.DynamicConfiguration.RefreshInterval.Duration),
 				cfg.DataplaneRuntime.DynamicConfiguration.RefreshInterval.Duration,
 			)
@@ -474,8 +447,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&cfg.ControlPlane.TlsSkipVerify, "skip-verify", cfg.ControlPlane.TlsSkipVerify, "Skip TLS verification of the Control Plane certificate (insecure, for development/testing only)")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.BinaryPath, "binary-path", cfg.DataplaneRuntime.BinaryPath, "Binary path of Envoy executable")
 	cmd.PersistentFlags().Uint32Var(&cfg.DataplaneRuntime.Concurrency, "concurrency", cfg.DataplaneRuntime.Concurrency, "Number of Envoy worker threads")
-	//nolint:staticcheck // SA1019 Backward compatibility: preserve deprecated ConfigDir flag for migration
-	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.ConfigDir, "config-dir", cfg.DataplaneRuntime.ConfigDir, "Directory in which Envoy config will be generated")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.WorkDir, "work-dir", cfg.DataplaneRuntime.WorkDir, "Directory in which Kuma DP config will be generated")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.TokenPath, "dataplane-token-file", cfg.DataplaneRuntime.TokenPath, "Path to a file with dataplane token (use 'kumactl generate dataplane-token' to get one)")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.Token, "dataplane-token", cfg.DataplaneRuntime.Token, "Dataplane Token")
@@ -502,10 +473,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			"Later values override earlier ones when merging. "+
 			"Use this flag to pass detailed transparent proxy settings to kuma-dp.",
 	)
-
-	if err := cmd.PersistentFlags().MarkDeprecated("config-dir", "use --work-dir instead"); err != nil {
-		runLog.Error(err, "could not mark config-dir as deprecated")
-	}
 
 	return cmd
 }
@@ -563,8 +530,7 @@ func setupObservability(
 	accessLogStreamer := component.NewResilientComponent(
 		runLog.WithName("access-log-streamer"),
 		accesslogs.NewAccessLogStreamer(
-			//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir
-			core_xds.AccessLogSocketName(cfg.DataplaneRuntime.SocketDir, cfg.Dataplane.Name, cfg.Dataplane.Mesh),
+			core_xds.AccessLogSocketName(cfg.DataplaneRuntime.WorkDir, cfg.Dataplane.Name, cfg.Dataplane.Mesh),
 		),
 		cfg.Dataplane.ResilientComponentBaseBackoff.Duration,
 		cfg.Dataplane.ResilientComponentMaxBackoff.Duration,
@@ -578,8 +544,7 @@ func setupObservability(
 		kuma_version.Build.Version,
 	)
 	metricsServer := metrics.New(
-		//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir
-		core_xds.MetricsHijackerSocketName(cfg.DataplaneRuntime.SocketDir, cfg.Dataplane.Name, cfg.Dataplane.Mesh),
+		core_xds.MetricsHijackerSocketName(cfg.DataplaneRuntime.WorkDir, cfg.Dataplane.Name, cfg.Dataplane.Mesh),
 		baseApplicationsToScrape,
 		tpEnabled,
 		openTelemetryProducer,

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -221,20 +221,20 @@ var _ = Describe("run", func() {
 					"KUMA_DATAPLANE_NAME":                "example",
 					"KUMA_DATAPLANE_MESH":                "default",
 					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH": filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					// Notice: KUMA_DATAPLANE_RUNTIME_CONFIG_DIR is not set in order to let `kuma-dp` to create a temporary directory
+					// Notice: KUMA_DATAPLANE_RUNTIME_WORK_DIR is not set in order to let `kuma-dp` to create a temporary directory
 				},
 				args:         []string{},
 				expectedFile: "",
 			}
 		}),
-		Entry("can be launched with env vars and given config dir", func() testCase {
+		Entry("can be launched with env vars and given work dir", func() testCase {
 			return testCase{
 				envVars: map[string]string{
 					"KUMA_CONTROL_PLANE_API_SERVER_URL":  "http://localhost:1234",
 					"KUMA_DATAPLANE_NAME":                "example",
 					"KUMA_DATAPLANE_MESH":                "default",
 					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH": filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":  tmpDir,
+					"KUMA_DATAPLANE_RUNTIME_WORK_DIR":    tmpDir,
 				},
 				args:         []string{},
 				expectedFile: filepath.Join(tmpDir, "bootstrap.yaml"),
@@ -248,22 +248,9 @@ var _ = Describe("run", func() {
 					"--name", "example",
 					"--mesh", "default",
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					// Notice: --config-dir is not set in order to let `kuma-dp` to create a temporary directory
+					// Notice: --work-dir is not set in order to let `kuma-dp` to create a temporary directory
 				},
 				expectedFile: "",
-			}
-		}),
-		Entry("can be launched with args and given config dir", func() testCase {
-			return testCase{
-				envVars: map[string]string{},
-				args: []string{
-					"--cp-address", "http://localhost:1234",
-					"--name", "example",
-					"--mesh", "default",
-					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					"--config-dir", tmpDir,
-				},
-				expectedFile: filepath.Join(tmpDir, "bootstrap.yaml"),
 			}
 		}),
 		Entry("can be launched with args and given work dir", func() testCase {
@@ -279,7 +266,7 @@ var _ = Describe("run", func() {
 				expectedFile: filepath.Join(tmpDir, "bootstrap.yaml"),
 			}
 		}),
-		Entry("can be launched with args and given config dir", func() testCase {
+		Entry("can be launched with args and given work dir that does not exist yet", func() testCase {
 			return testCase{
 				envVars: map[string]string{},
 				args: []string{
@@ -287,10 +274,9 @@ var _ = Describe("run", func() {
 					"--name", "example",
 					"--mesh", "default",
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					"--config-dir", filepath.Join(tmpDir, "config-dir"),
-					"--work-dir", tmpDir,
+					"--work-dir", filepath.Join(tmpDir, "nested"),
 				},
-				expectedFile: filepath.Join(tmpDir, "bootstrap.yaml"),
+				expectedFile: filepath.Join(tmpDir, "nested", "bootstrap.yaml"),
 			}
 		}),
 		Entry("can be launched with args and dataplane token", func() testCase {
@@ -302,7 +288,7 @@ var _ = Describe("run", func() {
 					"--mesh", "default",
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
 					"--dataplane-token-file", filepath.Join("testdata", "token"),
-					// Notice: --config-dir is not set in order to let `kuma-dp` to create a temporary directory
+					// Notice: --work-dir is not set in order to let `kuma-dp` to create a temporary directory
 				},
 				expectedFile: "",
 			}
@@ -314,7 +300,7 @@ var _ = Describe("run", func() {
 					"KUMA_DATAPLANE_NAME":                "example",
 					"KUMA_DATAPLANE_MESH":                "default",
 					"KUMA_DATAPLANE_RUNTIME_BINARY_PATH": filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					// Notice: KUMA_DATAPLANE_RUNTIME_CONFIG_DIR is not set in order to let `kuma-dp` to create a temporary directory
+					// Notice: KUMA_DATAPLANE_RUNTIME_WORK_DIR is not set in order to let `kuma-dp` to create a temporary directory
 				},
 				args:         []string{},
 				expectedFile: "",
@@ -328,7 +314,7 @@ var _ = Describe("run", func() {
 					"--name", "example",
 					"--mesh", "default",
 					"--binary-path", filepath.Join("testdata", "envoy-mock.sleep.sh"),
-					// Notice: --config-dir is not set in order to let `kuma-dp` to create a temporary directory
+					// Notice: --work-dir is not set in order to let `kuma-dp` to create a temporary directory
 				},
 				expectedFile: "",
 			}

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go
@@ -222,8 +222,7 @@ func (b *remoteBootstrapClient) requestForBootstrap(ctx context.Context, client 
 		OperatingSystem:      b.operatingSystem,
 		Features:             features,
 		Resources:            resources,
-		//nolint:staticcheck // SA1019 Backward compatibility: support deprecated SocketDir
-		Workdir: opts.Config.DataplaneRuntime.SocketDir,
+		Workdir:              opts.Config.DataplaneRuntime.WorkDir,
 		MetricsResources: types.MetricsResources{
 			CertPath: opts.Config.DataplaneRuntime.Metrics.CertPath,
 			KeyPath:  opts.Config.DataplaneRuntime.Metrics.KeyPath,

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -392,7 +392,6 @@ func newOptsBuilder() optsBuilder {
 	cfg.Dataplane.Name = "sample"
 	cfg.DataplaneRuntime.Token = "token"
 	cfg.DataplaneRuntime.BinaryPath = filepath.Join("testdata", "envoy-mock.exit-0.sh")
-	//nolint:staticcheck // SA1019 Backward compatibility test: verify deprecated SocketDir still works
-	cfg.DataplaneRuntime.SocketDir = "/tmp"
+	cfg.DataplaneRuntime.WorkDir = "/tmp"
 	return optsBuilder{Config: cfg}
 }

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -189,7 +189,8 @@ type DataplaneRuntime struct {
 
 	// Path to Envoy binary.
 	BinaryPath string `json:"binaryPath,omitempty" envconfig:"kuma_dataplane_runtime_binary_path"`
-	// WorkDir is the directory to store auto-generated Envoy bootstrap config.
+	// WorkDir is the directory to store auto-generated Envoy bootstrap config,
+	// Unix domain sockets, and the dataplane token file.
 	WorkDir string `json:"workDir,omitempty" envconfig:"kuma_dataplane_runtime_work_dir"`
 	// Concurrency specifies how to generate the Envoy concurrency flag.
 	Concurrency uint32 `json:"concurrency,omitempty" envconfig:"kuma_dataplane_runtime_concurrency"`

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -189,13 +189,8 @@ type DataplaneRuntime struct {
 
 	// Path to Envoy binary.
 	BinaryPath string `json:"binaryPath,omitempty" envconfig:"kuma_dataplane_runtime_binary_path"`
-	// ConfigDir was used to store Envoy bootstrap config.
-	//
-	// Deprecated: use WorkDir instead.
-	ConfigDir string `json:"configDir,omitempty" envconfig:"kuma_dataplane_runtime_config_dir" deprecated:"use WorkDir instead"`
 	// WorkDir is the directory to store auto-generated Envoy bootstrap config.
-	// It overrides values from deprecated ConfigDir and SocketDir.
-	WorkDir string `json:"workDir,omitempty" envconfig:"kuma_dataplane_runtime_work_dir" overrides:"ConfigDir,SocketDir"`
+	WorkDir string `json:"workDir,omitempty" envconfig:"kuma_dataplane_runtime_work_dir"`
 	// Concurrency specifies how to generate the Envoy concurrency flag.
 	Concurrency uint32 `json:"concurrency,omitempty" envconfig:"kuma_dataplane_runtime_concurrency"`
 	// Path to a file with dataplane token (use 'kumactl generate dataplane-token' to get one)
@@ -217,10 +212,6 @@ type DataplaneRuntime struct {
 	EnvoyComponentLogLevel string `json:"envoyComponentLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_component_log_level"`
 	// Resources defines the resources for this proxy.
 	Resources DataplaneResources `json:"resources,omitempty"`
-	// SocketDir dir to store socket used between Envoy and the dp process
-	//
-	// Deprecated: use WorkDir instead
-	SocketDir string `json:"socketDir,omitempty" envconfig:"kuma_dataplane_runtime_socket_dir"`
 	// Metrics defines properties of metrics
 	Metrics Metrics `json:"metrics,omitempty"`
 	// DynamicConfiguration defines properties of dataplane dynamic configuration

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -59,8 +59,6 @@ var _ = Describe("Config", func() {
 				"KUMA_DATAPLANE_PROXY_TYPE":                                     "dataplane",
 				"KUMA_READINESS_PORT":                                           "9902",
 				"KUMA_DATAPLANE_RUNTIME_BINARY_PATH":                            "envoy.sh",
-				"KUMA_DATAPLANE_RUNTIME_CONFIG_DIR":                             "/var/run/envoy",
-				"KUMA_DATAPLANE_RUNTIME_SOCKET_DIR":                             "/var/run/envoy",
 				"KUMA_DATAPLANE_RUNTIME_WORK_DIR":                               "/var/run/envoy",
 				"KUMA_DATAPLANE_RUNTIME_TOKEN_PATH":                             "/tmp/token",
 				"KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL":                        "trace",
@@ -90,8 +88,6 @@ var _ = Describe("Config", func() {
 			Expect(cfg.Dataplane.Name).To(Equal("example"))
 			Expect(cfg.Dataplane.DrainTime.Duration).To(Equal(60 * time.Second))
 			Expect(cfg.DataplaneRuntime.BinaryPath).To(Equal("envoy.sh"))
-			Expect(cfg.DataplaneRuntime.ConfigDir).To(Equal("/var/run/envoy"))
-			Expect(cfg.DataplaneRuntime.SocketDir).To(Equal("/var/run/envoy"))
 			Expect(cfg.DataplaneRuntime.WorkDir).To(Equal("/var/run/envoy"))
 			Expect(cfg.DataplaneRuntime.TokenPath).To(Equal("/tmp/token"))
 			Expect(cfg.DataplaneRuntime.EnvoyLogLevel).To(Equal("trace"))

--- a/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
+++ b/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
@@ -11,5 +11,4 @@ dataplane:
   readinessPort: 9902
 dataplaneRuntime:
   binaryPath: envoy.sh
-  configDir: /var/run/envoy
   envoyLogLevel: trace

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -101,14 +101,14 @@ func SetupSidecarCluster() {
 		Install(DemoClientUniversal("demo-client", meshName,
 			WithTransparentProxy(true),
 			WithDpEnvs(map[string]string{
-				"KUMA_DATAPLANE_RUNTIME_SOCKET_DIR":   "/tmp",
+				"KUMA_DATAPLANE_RUNTIME_WORK_DIR":     "/tmp",
 				"KUMA_DATAPLANE_RUNTIME_IPV6_ENABLED": "false",
 			})),
 		).
 		Install(TestServerUniversal("test-server", meshName,
 			WithArgs([]string{"echo", "--instance", "universal-1"}),
 			WithDpEnvs(map[string]string{
-				"KUMA_DATAPLANE_RUNTIME_SOCKET_DIR":   "/tmp",
+				"KUMA_DATAPLANE_RUNTIME_WORK_DIR":     "/tmp",
 				"KUMA_DATAPLANE_RUNTIME_IPV6_ENABLED": "false",
 			}),
 		),

--- a/test/e2e_env/universal/envoyconfig/zoneproxies.go
+++ b/test/e2e_env/universal/envoyconfig/zoneproxies.go
@@ -41,12 +41,12 @@ const (
 	zoneProxyEgressDP  = "zone-proxy-egress"
 )
 
-// zoneProxyDpEnvs pins the kuma-dp socket directory to /tmp. Without this,
+// zoneProxyDpEnvs pins the kuma-dp work directory to /tmp. Without this,
 // kuma-dp creates a randomized /tmp/kuma-dp-<N>/ directory each run and that
 // random suffix would leak into the generated socket paths in the goldens,
 // making the test flaky.
 var dppEnvs = map[string]string{
-	"KUMA_DATAPLANE_RUNTIME_SOCKET_DIR":   "/tmp",
+	"KUMA_DATAPLANE_RUNTIME_WORK_DIR":     "/tmp",
 	"KUMA_DATAPLANE_RUNTIME_IPV6_ENABLED": "false",
 }
 
@@ -200,7 +200,7 @@ spec:
 			WithServiceName("zone-proxy-test-server-no-reusable-ports"),
 			WithWorkload("zone-proxy-test-server-no-reusable-ports"),
 			WithDpEnvs(map[string]string{
-				"KUMA_DATAPLANE_RUNTIME_SOCKET_DIR":         "/tmp",
+				"KUMA_DATAPLANE_RUNTIME_WORK_DIR":           "/tmp",
 				"KUMA_DATAPLANE_RUNTIME_IPV6_ENABLED":       "false",
 				"KUMA_DATAPLANE_RUNTIME_REUSE_PORT_ENABLED": "false",
 			})),

--- a/test/e2e_env/universal/envoyconfig/zoneproxies.go
+++ b/test/e2e_env/universal/envoyconfig/zoneproxies.go
@@ -41,7 +41,7 @@ const (
 	zoneProxyEgressDP  = "zone-proxy-egress"
 )
 
-// zoneProxyDpEnvs pins the kuma-dp work directory to /tmp. Without this,
+// dppEnvs pins the kuma-dp work directory to /tmp. Without this,
 // kuma-dp creates a randomized /tmp/kuma-dp-<N>/ directory each run and that
 // random suffix would leak into the generated socket paths in the goldens,
 // making the test flaky.


### PR DESCRIPTION
## Motivation

ConfigDir and SocketDir were deprecated in favor of WorkDir (introduced in #9522). WorkDir already overrides both fields, making them redundant. Removing this deprecated configuration surface reduces maintenance burden and clarifies the runtime configuration API.

## Implementation information

- Removed `ConfigDir` (`KUMA_DATAPLANE_RUNTIME_CONFIG_DIR`) and `SocketDir` (`KUMA_DATAPLANE_RUNTIME_SOCKET_DIR`) fields from the kuma-dp runtime configuration
- Removed fallback branches and `//nolint:staticcheck` directives in `app/kuma-dp/cmd/run.go` that handled these deprecated fields
- Removed fallback logic in `app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap.go`
- Removed the `--config-dir` CLI flag
- Regenerated `docs/generated/*`

Users relying on these options should migrate to `workDir` / `KUMA_DATAPLANE_RUNTIME_WORK_DIR`.

Closes https://github.com/kumahq/kuma/issues/17766

_Generated by Sybra harness_