### PR TITLE
feat(mads): restrict to universal deployment mode

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,22 @@ Remove `KUMA_MESH_TRAFFIC_PERMISSION_DISABLE_CLIQUES_ALGORITHM` from control
 plane deployments, Helm values, and any other runtime configuration before or
 after upgrading. Leaving it set no longer has any effect in Kuma 3.0.0.
 
+### MADS is universal-only on Kubernetes
+
+The Monitoring Assignment Discovery Service (MADS) server no longer starts on
+Kubernetes control planes, regardless of `KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED`
+or `controlPlane.madsServer.enabled`. It remains fully supported in universal
+deployment mode, including universal-on-Kubernetes
+(`controlPlane.environment: universal`). The Helm chart no longer renders the
+`mads-server` Service port (5676) when `controlPlane.environment` is
+`kubernetes`.
+
+**Action required**
+
+Kubernetes users relying on MADS must migrate to `MeshMetric` with Prometheus
+Kubernetes service discovery before upgrading. `controlPlane.madsServer.enabled`
+now only applies when `controlPlane.environment` is `universal`.
+
 ### `advertisedAddress` removed from `Dataplane` networking
 
 The `networking.advertisedAddress` field has been removed from the `Dataplane` resource. Proxies behind NAT or a private network (e.g. Docker) that relied on it to advertise a routable address to other proxies must now be reachable directly via `networking.address`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,7 +20,7 @@ Remove `KUMA_MESH_TRAFFIC_PERMISSION_DISABLE_CLIQUES_ALGORITHM` from control
 plane deployments, Helm values, and any other runtime configuration before or
 after upgrading. Leaving it set no longer has any effect in Kuma 3.0.0.
 
-### MADS is universal-only on Kubernetes
+### MADS restricted to universal deployment mode
 
 The Monitoring Assignment Discovery Service (MADS) server no longer starts on
 Kubernetes control planes, regardless of `KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED`

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -557,9 +557,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -798,7 +795,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -8898,9 +8898,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -9027,7 +9024,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -138,7 +138,7 @@ controlPlane:
   injectorFailurePolicy: Fail
 
   madsServer:
-    # -- Whether the Monitoring Assignment Discovery Service (MADS) server is enabled
+    # -- Whether the Monitoring Assignment Discovery Service (MADS) server is enabled. Only applies when controlPlane.environment is "universal"
     enabled: true
 
   service:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -8898,9 +8898,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -9027,7 +9024,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -585,7 +582,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpc://192.168.0.1:5685"
             - name: KUMA_MULTIZONE_ZONE_KDS_ROOT_CA_FILE

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.skip-crds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.skip-crds.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -8898,9 +8898,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -9027,7 +9024,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpcs://foo.com"
             - name: KUMA_MULTIZONE_ZONE_NAME

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
@@ -210,6 +210,8 @@ spec:
               value: "/tmp/kuma"
             - name: KUMA_MODE
               value: "zone"
+            - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
+              value: "true"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpcs://192.168.0.1:5685"
             - name: KUMA_MULTIZONE_ZONE_NAME
@@ -256,6 +258,8 @@ spec:
               value: "/tmp/kuma"
             - name: KUMA_MODE
               value: "zone"
+            - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
+              value: "true"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpcs://192.168.0.1:5685"
             - name: KUMA_MULTIZONE_ZONE_NAME

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpcs://192.168.0.1:5685"
             - name: KUMA_MULTIZONE_ZONE_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
@@ -209,9 +209,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -338,7 +335,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -586,7 +583,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -578,7 +575,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -583,7 +580,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -557,9 +557,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -800,7 +797,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -557,9 +557,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -818,7 +815,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -474,9 +474,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -605,7 +602,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -460,9 +460,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -591,7 +588,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpcs://foo.com:3456"
             - name: KUMA_MULTIZONE_ZONE_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -559,9 +559,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -804,7 +801,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS
               value: "grpcs://localhost:5678"
             - name: KUMA_MULTIZONE_ZONE_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -453,9 +453,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -582,7 +579,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
@@ -472,9 +472,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -645,7 +642,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
@@ -472,9 +472,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -645,7 +642,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
@@ -472,9 +472,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -645,7 +642,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -494,9 +494,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -711,7 +708,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
@@ -484,9 +484,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -657,7 +654,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
@@ -472,9 +472,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -651,7 +648,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
@@ -472,9 +472,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -650,7 +647,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -579,7 +576,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -469,9 +469,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -598,7 +595,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -450,9 +450,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -580,7 +577,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
@@ -120,9 +120,6 @@ spec:
       name: https-admission-server
       targetPort: 5443
       appProtocol: https
-    - port: 5676
-      name: mads-server
-      appProtocol: https
     - port: 5678
       name: dp-server
       appProtocol: https
@@ -249,7 +246,7 @@ spec:
             - name: KUMA_MODE
               value: "zone"
             - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-              value: "true"
+              value: "false"
             - name: KUMA_PLUGIN_POLICIES_ENABLED
               value: "meshaccesslogs,meshcircuitbreakers,meshfaultinjections,meshhealthchecks,meshhttproutes,meshloadbalancingstrategies,meshmetrics,meshpassthroughs,meshproxypatches,meshratelimits,meshretries,meshtcproutes,meshtimeouts,meshtlses,meshtraces,meshtrafficpermissions"
             - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_CERT_DIR

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -45,7 +45,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.topologySpreadConstraints | string | `nil` | Topology spread constraints rule for the Kuma Control Plane pods. This is rendered as a template, so you can use variables to generate match labels. |
 | controlPlane.priorityClassName | string | `""` | Priority Class Name of the Kuma Control Plane |
 | controlPlane.injectorFailurePolicy | string | `"Fail"` | Failure policy of the mutating webhook implemented by the Kuma Injector component |
-| controlPlane.madsServer.enabled | bool | `true` | Whether the Monitoring Assignment Discovery Service (MADS) server is enabled |
+| controlPlane.madsServer.enabled | bool | `true` | Whether the Monitoring Assignment Discovery Service (MADS) server is enabled. Only applies when controlPlane.environment is "universal" |
 | controlPlane.service.apiServer.http.nodePort | int | `30681` | Port on which Http api server Service is exposed on Node for service of type NodePort |
 | controlPlane.service.apiServer.https.nodePort | int | `30682` | Port on which Https api server Service is exposed on Node for service of type NodePort |
 | controlPlane.service.enabled | bool | `true` | Whether to create a service resource. |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -213,7 +213,7 @@ env:
 - name: KUMA_DP_SERVER_HDS_ENABLED
   value: "false"
 - name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
-  value: {{ .Values.controlPlane.madsServer.enabled | quote }}
+  value: "false"
 - name: KUMA_API_SERVER_READ_ONLY
   value: "true"
 - name: KUMA_RUNTIME_KUBERNETES_ADMISSION_SERVER_PORT
@@ -320,6 +320,8 @@ env:
   value: "{{ .Values.postgres.port }}"
 - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
   value: {{ .Values.controlPlane.defaults.skipMeshCreation | quote }}
+- name: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
+  value: {{ .Values.controlPlane.madsServer.enabled | quote }}
 {{ if and (eq .Values.controlPlane.mode "zone") .Values.controlPlane.tls.general.secretName }}
 - name: KUMA_GENERAL_TLS_CERT_FILE
   value: /var/run/secrets/kuma.io/tls-cert/tls.crt

--- a/deployments/charts/kuma/templates/cp-service.yaml
+++ b/deployments/charts/kuma/templates/cp-service.yaml
@@ -35,7 +35,7 @@ spec:
       targetPort: {{ .Values.controlPlane.admissionServerPort | default "5443" }}
       appProtocol: https
     {{- end }}
-    {{- if .Values.controlPlane.madsServer.enabled }}
+    {{- if and (eq .Values.controlPlane.environment "universal") .Values.controlPlane.madsServer.enabled }}
     - port: 5676
       name: mads-server
       appProtocol: https

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -138,7 +138,7 @@ controlPlane:
   injectorFailurePolicy: Fail
 
   madsServer:
-    # -- Whether the Monitoring Assignment Discovery Service (MADS) server is enabled
+    # -- Whether the Monitoring Assignment Discovery Service (MADS) server is enabled. Only applies when controlPlane.environment is "universal"
     enabled: true
 
   service:

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -138,7 +138,7 @@ controlPlane:
   injectorFailurePolicy: Fail
 
   madsServer:
-    # -- Whether the Monitoring Assignment Discovery Service (MADS) server is enabled
+    # -- Whether the Monitoring Assignment Discovery Service (MADS) server is enabled. Only applies when controlPlane.environment is "universal"
     enabled: true
 
   service:

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -113,7 +113,8 @@ bootstrapServer:
     xdsGrpcMaxReceiveMessageBytes: 4194304 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_GRPC_MAX_RECEIVE_MESSAGE_BYTES
 #  Monitoring Assignment Discovery Service (MADS) server configuration
 monitoringAssignmentServer:
-  # Whether the MADS server is enabled
+  # Whether the MADS server is enabled. MADS is only supported in universal
+  # deployment mode; this setting is ignored on Kubernetes.
   enabled: true # ENV: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
   # Port of a gRPC server that serves Monitoring Assignment Discovery Service (MADS).
   port: 5676 # ENV: KUMA_MONITORING_ASSIGNMENT_SERVER_PORT

--- a/pkg/config/app/kuma-cp/deprecate.go
+++ b/pkg/config/app/kuma-cp/deprecate.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/kumahq/kuma/v3/pkg/config"
-	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 )
 
 var deprecations = []config.Deprecation{
@@ -44,26 +43,6 @@ var deprecations = []config.Deprecation{
 			return "Metrics.Mesh.MaxResyncTimeout", true
 		},
 		ConfigValueMsg: "Use Metrics.Mesh.FullResyncInterval instead.",
-	},
-	{
-		Env:    "",
-		EnvMsg: "",
-		ConfigValuePath: func(cfg config.Config) (string, bool) {
-			kumaCPConfig, ok := cfg.(*Config)
-			if !ok {
-				panic("wrong config type")
-			}
-			if kumaCPConfig.MonitoringAssignmentServer == nil {
-				return "", false
-			}
-			if kumaCPConfig.MonitoringAssignmentServer.Enabled &&
-				kumaCPConfig.Environment == config_core.KubernetesEnvironment {
-				return "MonitoringAssignmentServer", true
-			}
-			return "", false
-		},
-		ConfigValueMsg: "MADS is enabled on Kubernetes. It will be removed on Kubernetes in Kuma 3.0. " +
-			"Set KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED=false to disable it.",
 	},
 }
 

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -113,7 +113,8 @@ bootstrapServer:
     xdsGrpcMaxReceiveMessageBytes: 4194304 # ENV: KUMA_BOOTSTRAP_SERVER_PARAMS_XDS_GRPC_MAX_RECEIVE_MESSAGE_BYTES
 #  Monitoring Assignment Discovery Service (MADS) server configuration
 monitoringAssignmentServer:
-  # Whether the MADS server is enabled
+  # Whether the MADS server is enabled. MADS is only supported in universal
+  # deployment mode; this setting is ignored on Kubernetes.
   enabled: true # ENV: KUMA_MONITORING_ASSIGNMENT_SERVER_ENABLED
   # Port of a gRPC server that serves Monitoring Assignment Discovery Service (MADS).
   port: 5676 # ENV: KUMA_MONITORING_ASSIGNMENT_SERVER_PORT

--- a/pkg/config/mads/config.go
+++ b/pkg/config/mads/config.go
@@ -29,7 +29,8 @@ func DefaultMonitoringAssignmentServerConfig() *MonitoringAssignmentServerConfig
 type MonitoringAssignmentServerConfig struct {
 	config.BaseConfig
 
-	// Enabled if true starts the MADS server.
+	// Enabled if true starts the MADS server. MADS is only supported in universal
+	// deployment mode; this flag is ignored on Kubernetes.
 	Enabled bool `json:"enabled" envconfig:"kuma_monitoring_assignment_server_enabled"`
 	// Port of the server that serves Monitoring Assignment Discovery Service (MADS)
 	// over both grpc and http.

--- a/pkg/mads/server/server.go
+++ b/pkg/mads/server/server.go
@@ -120,6 +120,10 @@ func SetupServer(rt core_runtime.Runtime) error {
 	if rt.Config().Mode == config_core.Global {
 		return nil
 	}
+	if rt.Config().Environment == config_core.KubernetesEnvironment {
+		log.Info("MADS is not supported on Kubernetes, use MeshMetric with Prometheus Kubernetes service discovery instead")
+		return nil
+	}
 	if !rt.Config().MonitoringAssignmentServer.Enabled {
 		log.Info("MADS server is disabled")
 		return nil

--- a/pkg/mads/server/server_test.go
+++ b/pkg/mads/server/server_test.go
@@ -147,6 +147,6 @@ var _ = Describe("MADS Server on Kubernetes", func() {
 		}
 
 		Expect(server.SetupServer(rt)).To(Succeed())
-		Expect(rt.components).To(HaveLen(0))
+		Expect(rt.components).To(BeEmpty())
 	})
 })

--- a/pkg/mads/server/server_test.go
+++ b/pkg/mads/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/common/config"
 
 	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/config/mads"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/runtime"
@@ -128,5 +129,24 @@ var _ = Describe("MADS Server", func() {
 				g.Expect(response.Body.Close()).To(Succeed())
 			}
 		}, "10s", "100ms").Should(Succeed())
+	})
+})
+
+var _ = Describe("MADS Server on Kubernetes", func() {
+	It("should not register any component", func() {
+		m, err := metrics.NewMetrics("zone-1")
+		Expect(err).ToNot(HaveOccurred())
+
+		rt := &testRuntime{
+			rm: manager.NewResourceManager(memory.NewStore()),
+			config: kuma_cp.Config{
+				Environment:                config_core.KubernetesEnvironment,
+				MonitoringAssignmentServer: mads.DefaultMonitoringAssignmentServerConfig(),
+			},
+			metrics: m,
+		}
+
+		Expect(server.SetupServer(rt)).To(Succeed())
+		Expect(rt.components).To(HaveLen(0))
 	})
 })

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -1,14 +1,12 @@
 package meshmetric
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	mads "github.com/kumahq/kuma/v3/api/observability/v1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	. "github.com/kumahq/kuma/v3/test/framework"
 	"github.com/kumahq/kuma/v3/test/framework/client"
@@ -115,66 +113,6 @@ spec:
           tls:
             mode: Disabled
 `, policyName, Config.KumaNamespace, mesh, firstPrometheus, secondPrometheus)
-	return YamlK8s(meshMetric)
-}
-
-func MeshMetricWithSpecificPrometheusClientId(policyName string, mesh string, clientId string) InstallFunc {
-	meshMetric := fmt.Sprintf(`
-apiVersion: kuma.io/v1alpha1
-kind: MeshMetric
-metadata:
-  name: %s
-  namespace: %s
-  labels:
-    kuma.io/mesh: %s
-spec:
-  targetRef:
-    kind: Mesh
-  default:
-    sidecar:
-      profiles:
-        appendProfiles:
-          - name: All
-    backends:
-      - type: Prometheus
-        prometheus: 
-          clientId: %s
-          port: 8080
-          path: /metrics
-          tls:
-            mode: Disabled
-`, policyName, Config.KumaNamespace, mesh, clientId)
-	return YamlK8s(meshMetric)
-}
-
-func MeshMetricWithSpecificPrometheusBackendForMeshService(mesh string, clientId string, appName string) InstallFunc {
-	meshMetric := fmt.Sprintf(`
-apiVersion: kuma.io/v1alpha1
-kind: MeshMetric
-metadata:
-  name: mesh-metric-2
-  namespace: %s
-  labels:
-    kuma.io/mesh: %s
-spec:
-  targetRef:
-    kind: Dataplane
-    labels:
-      app: %s
-  default:
-    sidecar:
-      profiles:
-        appendProfiles:
-          - name: All
-    backends:
-      - type: Prometheus
-        prometheus:
-          clientId: %s
-          port: 8080
-          path: /metrics
-          tls:
-            mode: Disabled
-`, Config.KumaNamespace, mesh, appName, clientId)
 	return YamlK8s(meshMetric)
 }
 
@@ -551,98 +489,6 @@ func MeshMetric() {
 		}, "1m", "1s").Should(Succeed())
 	})
 
-	It("MADS server response contains DPPs from all meshes when prometheus client id is empty", func() {
-		// given
-		Expect(kubernetes.Cluster.Install(BasicMeshMetricForMesh("main-mesh-policy", mainMesh))).To(Succeed())
-		Expect(kubernetes.Cluster.Install(BasicMeshMetricForMesh("secondary-mesh-policy", secondaryMesh))).To(Succeed())
-
-		// then
-		Eventually(func(g Gomega) {
-			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(mainPrometheusId)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			madsResponse := MonitoringAssignmentResponse{}
-			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
-			// all DPPs from both meshes in single MADS response
-			g.Expect(getServicesFrom(madsResponse)).To(ConsistOf(
-				"test-server-0", "test-server-1", "test-server-2", "test-server-3",
-			))
-		}).Should(Succeed())
-
-		// and same response for secondary backend
-		Eventually(func(g Gomega) {
-			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(secondaryPrometheusId)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			madsResponse := MonitoringAssignmentResponse{}
-			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
-			// all DPPs from both meshes in single MADS response
-			g.Expect(getServicesFrom(madsResponse)).To(ConsistOf(
-				"test-server-0", "test-server-1", "test-server-2", "test-server-3",
-			))
-		}).Should(Succeed())
-	})
-
-	It("MADS server response contains DPPs from corresponding meshes when prometheus client id is set", func() {
-		// given
-		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusClientId("main-mesh-policy", mainMesh, mainPrometheusId))).To(Succeed())
-		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusClientId("secondary-mesh-policy", secondaryMesh, secondaryPrometheusId))).To(Succeed())
-
-		// then
-		Eventually(func(g Gomega) {
-			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(mainPrometheusId)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			madsResponse := MonitoringAssignmentResponse{}
-			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
-			// all DPPs from primaryMesh for primary Prometheus backend
-			g.Expect(getServicesFrom(madsResponse)).To(ConsistOf(
-				"test-server-0", "test-server-1",
-			))
-		}).Should(Succeed())
-
-		// and
-		Eventually(func(g Gomega) {
-			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(secondaryPrometheusId)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			madsResponse := MonitoringAssignmentResponse{}
-			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
-			// all DPPs from secondaryMesh for secondary Prometheus backend
-			g.Expect(getServicesFrom(madsResponse)).To(ConsistOf(
-				"test-server-2", "test-server-3",
-			))
-		}).Should(Succeed())
-	})
-
-	It("override MADS response for single DPP in mesh", func() {
-		// given
-		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusClientId("main-mesh-policy", mainMesh, mainPrometheusId))).To(Succeed())
-		Expect(kubernetes.Cluster.Install(MeshMetricWithSpecificPrometheusBackendForMeshService(mainMesh, secondaryPrometheusId, "test-server-1"))).To(Succeed())
-
-		// then
-		Eventually(func(g Gomega) {
-			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(mainPrometheusId)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			madsResponse := MonitoringAssignmentResponse{}
-			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
-			// two DPPs configured by Mesh targetRef
-			g.Expect(getServicesFrom(madsResponse)).To(ConsistOf("test-server-0"))
-		}).Should(Succeed())
-
-		// and
-		Eventually(func(g Gomega) {
-			assignment, err := kubernetes.Cluster.GetKuma().GetMonitoringAssignment(secondaryPrometheusId)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			madsResponse := MonitoringAssignmentResponse{}
-			g.Expect(json.Unmarshal([]byte(assignment), &madsResponse)).To(Succeed())
-			// single DPP overridden by MeshService targetRef
-			g.Expect(getServicesFrom(madsResponse)).To(ConsistOf("test-server-1"))
-		}).Should(Succeed())
-	})
-
 	XIt("MeshMetric with OpenTelemetry enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
@@ -734,16 +580,4 @@ func MeshMetric() {
 			g.Expect(stdout).To(ContainSubstring("envoy_cluster_external_upstream_rq_time_bucket"))
 		}, "3m", "5s").Should(Succeed())
 	})
-}
-
-func getServicesFrom(response MonitoringAssignmentResponse) []string {
-	var services []string
-	for _, assignment := range response.Resources {
-		services = append(services, assignment.Service)
-	}
-	return services
-}
-
-type MonitoringAssignmentResponse struct {
-	Resources []*mads.MonitoringAssignment `json:"resources"`
 }

--- a/test/framework/envs/kubernetes/env.go
+++ b/test/framework/envs/kubernetes/env.go
@@ -40,7 +40,6 @@ func SetupAndGetState() []byte {
 
 	state := framework.K8sNetworkingState{
 		KumaCp: Cluster.GetKuma().(*framework.K8sControlPlane).PortFwd(),
-		MADS:   Cluster.GetKuma().(*framework.K8sControlPlane).MadsPortFwd(),
 	}
 
 	bytes, err := json.Marshal(state)
@@ -72,7 +71,7 @@ func RestoreState(bytes []byte) {
 		1,
 		nil, // headers were not configured in setup
 	)
-	Expect(cp.FinalizeAddWithPortFwd(state.KumaCp, state.MADS)).To(Succeed())
+	Expect(cp.FinalizeAddWithPortFwd(state.KumaCp)).To(Succeed())
 	Cluster.SetCP(cp)
 }
 

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -178,11 +178,9 @@ func SetupAndGetState() []byte {
 		UniZone2: UniZone2.GetUniversalNetworkingState(),
 		KubeZone1: K8sNetworkingState{
 			KumaCp: KubeZone1.GetKuma().(*K8sControlPlane).PortFwd(),
-			MADS:   KubeZone1.GetKuma().(*K8sControlPlane).MadsPortFwd(),
 		},
 		KubeZone2: K8sNetworkingState{
 			KumaCp: KubeZone2.GetKuma().(*K8sControlPlane).PortFwd(),
-			MADS:   KubeZone2.GetKuma().(*K8sControlPlane).MadsPortFwd(),
 		},
 	}
 	// govet complains of marshaling with mutex, we know what we're doing here
@@ -203,7 +201,7 @@ func restoreKubeZone(clusterName string, networkingState *K8sNetworkingState) *K
 		1,
 		nil,
 	)
-	Expect(kubeCp.FinalizeAddWithPortFwd(networkingState.KumaCp, networkingState.KumaCp)).To(Succeed())
+	Expect(kubeCp.FinalizeAddWithPortFwd(networkingState.KumaCp)).To(Succeed())
 	zone.SetCP(kubeCp)
 	return zone
 }

--- a/test/framework/envs/multizone/env.go
+++ b/test/framework/envs/multizone/env.go
@@ -183,8 +183,7 @@ func SetupAndGetState() []byte {
 			KumaCp: KubeZone2.GetKuma().(*K8sControlPlane).PortFwd(),
 		},
 	}
-	// govet complains of marshaling with mutex, we know what we're doing here
-	bytes, err := json.Marshal(state) //nolint:govet
+	bytes, err := json.Marshal(&state)
 	Expect(err).ToNot(HaveOccurred())
 	return bytes
 }

--- a/test/framework/interface.go
+++ b/test/framework/interface.go
@@ -647,7 +647,6 @@ type ControlPlane interface {
 	GetName() string
 	Mode() core.CpMode
 	GetMetrics() (string, error)
-	GetMonitoringAssignment(clientId string) (string, error)
 	GetKDSServerAddress() string
 	GetKDSInsecureServerAddress() string
 	GetXDSServerAddress() string

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -46,7 +46,6 @@ import (
 
 type K8sNetworkingState struct {
 	KumaCp portforward.Tunnel `json:"kumaCp"`
-	MADS   portforward.Tunnel `json:"mads"`
 }
 
 type K8sCluster struct {

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -38,7 +38,6 @@ type K8sControlPlane struct {
 	kumactl    *kumactl.KumactlOptions
 	cluster    *K8sCluster
 	portFwd    portforward.Tunnel
-	madsFwd    portforward.Tunnel
 	verbose    bool
 	replicas   int
 	apiHeaders []string
@@ -104,20 +103,11 @@ func (c *K8sControlPlane) PortForwardKumaCP() error {
 		return errors.Wrapf(err, "failed to start port-forward to API Server (port %d)", 5681)
 	}
 
-	if c.mode != core.Global {
-		if c.madsFwd, err = c.cluster.PortForward(k8s.ResourceTypeService, kumaCpSvc.Name, kumaCpSvc.Namespace, 5676); err != nil {
-			return errors.Wrapf(err, "failed to start port-forward to MADS (port: %d)", 5676)
-		}
-	}
-
 	return nil
 }
 
 func (c *K8sControlPlane) ClosePortForwards() {
 	c.portFwd.Close()
-	if c.mode != core.Global {
-		c.madsFwd.Close()
-	}
 }
 
 func (c *K8sControlPlane) RefreshPortForwards() error {
@@ -219,24 +209,18 @@ func (c *K8sControlPlane) PortFwd() portforward.Tunnel {
 	return c.portFwd
 }
 
-func (c *K8sControlPlane) MadsPortFwd() portforward.Tunnel {
-	return c.madsFwd
-}
-
 func (c *K8sControlPlane) FinalizeAdd() error {
 	if err := c.PortForwardKumaCP(); err != nil {
 		return err
 	}
 
-	return c.FinalizeAddWithPortFwd(c.portFwd, c.madsFwd)
+	return c.FinalizeAddWithPortFwd(c.portFwd)
 }
 
 func (c *K8sControlPlane) FinalizeAddWithPortFwd(
 	portFwd portforward.Tunnel,
-	madsPortForward portforward.Tunnel,
 ) error {
 	c.portFwd = portFwd
-	c.madsFwd = madsPortForward
 	if !c.cluster.opts.setupKumactl {
 		return nil
 	}
@@ -423,25 +407,6 @@ func (c *K8sControlPlane) GetMetrics() (string, error) {
 		return "", fmt.Errorf("CP metrics returned %d: %s", resp.StatusCode, string(body))
 	}
 	return string(body), nil
-}
-
-func (c *K8sControlPlane) GetMonitoringAssignment(clientId string) (string, error) {
-	if c.madsFwd.Endpoint == "" {
-		return "", errors.New("MADS port forward wasn't setup!")
-	}
-
-	return http_helper.HTTPDoWithRetryContextE(
-		c.t,
-		context.Background(),
-		http.MethodPost,
-		fmt.Sprintf("http://%s/v3/discovery:monitoringassignments", c.madsFwd.Endpoint),
-		fmt.Appendf(nil, `{"type_url": "type.googleapis.com/kuma.observability.v1.MonitoringAssignment","node": {"id": %q}}`, clientId),
-		map[string]string{"content-type": "application/json"},
-		200,
-		DefaultRetries,
-		DefaultTimeout,
-		&tls.Config{MinVersion: tls.VersionTLS12},
-	)
 }
 
 func (c *K8sControlPlane) Exec(cmd ...string) (string, string, error) {


### PR DESCRIPTION
## Motivation

MADS (Monitoring Assignment Discovery Service) is deprecated on Kubernetes, where native Kubernetes service discovery and MeshMetric provide the replacement. However, MADS remains essential on universal deployments as the Prometheus DP-discovery mechanism. Currently MADS runs on all deployment modes by default; this change restricts it to universal deployments only.

## Implementation information

- Added `Environment != Kubernetes` gate to `SetupServer` to prevent MADS initialization on Kubernetes clusters
- Changed Helm defaults for Kubernetes deployments to disable MADS (`values.yaml`, `_helpers.tpl`, `cp-service.yaml`)
- Removed the MADS deprecation warning from `deprecate.go` since MADS is now hard-gated on Kubernetes
- Regenerated generated documentation

Closes https://github.com/kumahq/kuma/issues/17765

_Generated by Sybra harness_