### PR TITLE
ci(actions): retry release checks; fix concurrency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,11 @@ name: "release"
 run-name: Release${{ inputs.check && ' and check' || '' }} ${{ inputs.release }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # `github.ref` is the ref a workflow_dispatch was dispatched from (always `master`),
+  # so it does not distinguish releases. Without the release input, dispatches for
+  # different versions share one group and GitHub cancels whatever is already queued
+  # behind the pending run.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.release || '0.0.0' }}
   cancel-in-progress: false
 on:
   schedule:
@@ -33,7 +37,8 @@ permissions:
   contents: read
 jobs:
   release:
-    timeout-minutes: 30
+    # Headroom for the retried checks below (up to 5 attempts x 3 checks).
+    timeout-minutes: 45
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -61,24 +66,42 @@ jobs:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           release-tool release changelog --repo ${{ github.repository }} --release ${{ env.RELEASE }}
+      # The three checks below are read-only existence probes against artifact stores
+      # (charts repo releases, packages.konghq.com, hub.docker.com) that are published
+      # by other workflows. Each store lags behind the publishing workflow reporting
+      # success, so a check run right after a tag push sees a 404 for artifacts that
+      # are fine minutes later. Retry so that propagation lag self-heals instead of
+      # needing a manual rerun.
       - name: check-helm
         if: env.RELEASE != '0.0.0' && fromJSON(env.CHECK)
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          release-tool release helm-chart --repo ${{ github.repository }} --charts-repo ${{ env.CHARTS_REPO }} --release ${{ env.RELEASE }}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 60
+          timeout_minutes: 1
+          command: release-tool release helm-chart --repo "$GITHUB_REPOSITORY" --charts-repo "$CHARTS_REPO" --release "$RELEASE"
       - name: check-binaries
+        if: fromJSON(env.CHECK)
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        if: fromJSON(env.CHECK)
-        run: |
-          release-tool release binaries --repo ${{ github.repository }} --release ${{ env.RELEASE }} --binaries ${{ env.BINARIES }}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 60
+          timeout_minutes: 1
+          command: release-tool release binaries --repo "$GITHUB_REPOSITORY" --release "$RELEASE" --binaries "$BINARIES"
       - name: check-docker
+        if: fromJSON(env.CHECK)
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        if: fromJSON(env.CHECK)
-        run: |
-          release-tool release docker --repo ${{ github.repository }} --release ${{ env.RELEASE }} --docker-repo ${{env.DOCKER_REPO }} --images ${{ env.DOCKER_IMAGES }}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 60
+          timeout_minutes: 1
+          command: release-tool release docker --repo "$GITHUB_REPOSITORY" --release "$RELEASE" --docker-repo "$DOCKER_REPO" --images "$DOCKER_IMAGES"
       - name: update-active-branches.json
         env:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}


### PR DESCRIPTION
## Motivation

Fixes #17779, both found while running the manual `release.yaml --check=true` dispatches during the 2026-07-29 patch release (six versions in one round).

> Changelog: skip

**`check-*` steps race the publish pipelines.** `release-tool release {helm-chart,binaries,docker}` are read-only existence probes: a GraphQL query for a charts-repo release, an `http.Get` against `packages.konghq.com`, and an `http.Head` against `hub.docker.com`. Each store lags behind the workflow that publishes into it reporting success, so a check dispatched right after the tag push 404s on artifacts that resolve fine a few minutes later. `2.13.10`, `2.11.18` and `2.7.29` all failed this way and all passed on rerun with no other change.

**The concurrency group did not distinguish releases.** For a `workflow_dispatch`, `github.ref` is the ref the run was dispatched from — always `master` — so dispatches for different versions landed in the same group. With `cancel-in-progress: false` GitHub keeps at most *one* run pending, so a third dispatch cancelled the previously queued one. That auto-cancelled the `2.11.18` run for reasons unrelated to its release state.

## Implementation information

- All three `check-*` steps now run under `nick-fields/retry` (already pinned in this repo for `.github/actions/run-e2e`): 5 attempts, 60s backoff, 1min per-attempt timeout — roughly 4 minutes of propagation lag absorbed. The probes are read-only and idempotent, so retrying them is safe. `check-helm` is included because it is the same class of probe against the same class of eventually-consistent store, even though the issue only named docker and binaries.
- Commands now reference the workflow `env` through shell variables (`"$RELEASE"`, `"$DOCKER_IMAGES"`, …) instead of `${{ }}` interpolation.
- `concurrency.group` gains `${{ inputs.release || '0.0.0' }}`, mirroring how `env.RELEASE` already defaults for the scheduled run. Scheduled runs keep sharing one group; dispatches for different versions no longer collide, and two dispatches for the *same* version still serialize.
- Job `timeout-minutes` 30 → 45, so a genuinely broken release that burns the full retry budget fails on the check rather than on the job timeout.

One follow-up worth noting, not fixed here: now that runs for different versions can execute concurrently, their `update-*` / `Create Pull Request` steps can overlap. `peter-evans/create-pull-request` pushes `chore/update-changelog` with `--force-with-lease`, so a fetch/push interleaving can reject one run's push. The window is a few seconds and the regenerated content is convergent (all three files are pure functions of GitHub release state, and the cron run regenerates them daily anyway), so the exposure is small — but hard-serializing it would mean splitting verification into its own workflow, which is outside the scope the issue set for this change.

## Supporting documentation

- https://github.com/kumahq/kuma/issues/17779
- `release-tool` probe implementations: https://github.com/kumahq/ci-tools/blob/main/cmd/release-tool/release.go
