### PR TITLE
ci(actions): add installer check to release tasks

### DIFF
--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -4,9 +4,10 @@ name: "trigger-release-tasks"
 # the per-version post-build release tasks in parallel:
 #   - smoke: the downstream enterprise smoke-test workflow (cross-repo dispatch)
 #   - verify: this repo's own release workflow with check=true (same-repo)
+#   - installer: runs this repo's own installer.sh end-to-end for the version
+#     (kuma.io here; developer.konghq.com/mesh once synced into kong-mesh)
 # Per-branch/event-driven, not a batch fan-out over all versions. A single guard
-# job decides "is this a real release tag?" once; both tasks read its outputs.
-# workflow_dispatch re-runs one version by hand (toggle either task off).
+# job decides "is this a real release tag?" once; all three tasks read it.
 on:
   workflow_run:
     workflows: ["build-test-distribute"]
@@ -29,6 +30,11 @@ on:
         default: true
       run_verify:
         description: "Dispatch artifact verification (release check=true)"
+        required: false
+        type: boolean
+        default: true
+      run_installer:
+        description: "Run the installer.sh verification"
         required: false
         type: boolean
         default: true
@@ -198,3 +204,43 @@ jobs:
             --ref "${DEFAULT_BRANCH}" \
             --field release="${PRODUCT_VERSION}" \
             --field check=true
+
+  installer:
+    needs: guard
+    # see smoke job: run_installer only gates the manual path.
+    if: >-
+      needs.guard.outputs.should_dispatch == 'true' &&
+      (github.event_name != 'workflow_dispatch' || inputs.run_installer)
+    timeout-minutes: 5
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    permissions: {}
+    steps:
+      - name: "Run installer.sh for the released version"
+        env:
+          PRODUCT_VERSION: ${{ needs.guard.outputs.product_version }}
+        run: |
+          set -euo pipefail
+          # developer.konghq.com/mesh/installer.sh is a thin wrapper that pipes
+          # back through kuma.io/installer.sh with PRODUCT_NAME/REPO overrides,
+          # so hitting the right host is what actually exercises each product's
+          # own published binaries.
+          case "${GITHUB_REPOSITORY}" in
+            */kong-mesh) INSTALLER_URL="https://developer.konghq.com/mesh/installer.sh" ;;
+            *)           INSTALLER_URL="https://kuma.io/installer.sh" ;;
+          esac
+
+          # installer.sh itself exits non-zero (via its `err` helper) when the
+          # version's binary isn't published, so a clean run is the assertion;
+          # still grep its "has been downloaded!" line as a positive check that
+          # it actually reached and confirmed PRODUCT_VERSION rather than
+          # exiting 0 some other way.
+          if ! OUTPUT="$(curl --fail --silent --show-error --location "${INSTALLER_URL}" | VERSION="${PRODUCT_VERSION}" sh - 2>&1)"; then
+            echo "${OUTPUT}"
+            echo "installer.sh failed for version ${PRODUCT_VERSION} via ${INSTALLER_URL}" >&2
+            exit 1
+          fi
+          echo "${OUTPUT}"
+          if ! grep -qF "${PRODUCT_VERSION} has been downloaded" <<< "${OUTPUT}"; then
+            echo "installer.sh did not confirm ${PRODUCT_VERSION} was downloaded via ${INSTALLER_URL}" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Motivation

Post-release installer checks are hand-run `curl … | VERSION=x sh -` per
version today, once per Kuma/Kong Mesh release (see Kong/team-mesh#724,
Kong/team-mesh#719).

> Changelog: skip

## Implementation information

Adds an `installer` job to `trigger-release-tasks.yaml`, alongside the
existing `smoke`/`verify` fan-out that already runs on `build-test-distribute`
completion. Reuses the same `guard` job's resolved `product_version`, so it
inherits the v-prefix handling and tag-verification already in place.

`developer.konghq.com/mesh/installer.sh` is actually a thin wrapper that pipes
back through `kuma.io/installer.sh` with `PRODUCT_NAME`/`REPO` overrides —
same script, different host + env. So the job case-switches on
`GITHUB_REPOSITORY` (same pattern the `smoke`/`verify` jobs already use) to
hit `kuma.io/installer.sh` here, and `developer.konghq.com/mesh/installer.sh`
once this file syncs into `Kong/kong-mesh` via the existing `sync_ci.sh`
`copy_action trigger-release-tasks.yaml` — no changes needed on the
`kong-mesh` side.

`installer.sh` already exits non-zero when a version's binary isn't published,
so a clean run is most of the assertion; the job also greps its
`"<VERSION> has been downloaded!"` line as a positive confirmation. Verified
both paths manually against the real endpoint: a real published version
(2.14.2) downloads and matches, a nonexistent one (99.99.99) fails cleanly.

Adds a `run_installer` workflow_dispatch toggle to match `run_smoke`/`run_verify`.

## Supporting documentation

- Kong/team-mesh#724 (installer verification loop)
- Kong/team-mesh#719 (umbrella: automate the patch/minor release process)
- Kong/team-mesh#694 (manual release checklist this replaces the installer step of)