### PR TITLE
refactor(api): remove SourceIP from MeshLoadBalancingStrategy

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2205,10 +2205,10 @@ If you're using Kubernetes mode, and you did not specify `default.passthroughMod
 
 ### MeshLoadBalancingStrategy
 
-#### Deprecation of `hashPolicies.type: SourceIP` and `maglev.type: SourceIP`
+#### Removal of `hashPolicies.type: SourceIP`
 
-The documentation did not mention the `SourceIP` type, but it was possible to create a policy using it instead of `Connection`. Since `SourceIP` 
-is not a correct value, we have decided to deprecate it. If you are using `SourceIP` in your policy, please update it to use `Connection` instead.
+The `SourceIP` hash policy type has been removed. If you are using `type: SourceIP` in your `MeshLoadBalancingStrategy` policy, update it to use
+`type: Connection` with `connection.sourceIP: true` instead.
 
 ### Built-in MeshGateway policy targeting
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1354,7 +1354,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1354,7 +1354,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1354,7 +1354,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -3771,7 +3771,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -180,7 +180,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -9526,7 +9526,6 @@ components:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                               type: string

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -180,7 +180,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
@@ -198,14 +198,13 @@ type RingHash struct {
 	MaxRingSize *uint32 `json:"maxRingSize,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Header;Cookie;Connection;SourceIP;QueryParameter;FilterState
+// +kubebuilder:validation:Enum=Header;Cookie;Connection;QueryParameter;FilterState
 type HashPolicyType string
 
 const (
 	HeaderType         HashPolicyType = "Header"
 	CookieType         HashPolicyType = "Cookie"
 	ConnectionType     HashPolicyType = "Connection"
-	SourceIPType       HashPolicyType = "SourceIP"
 	QueryParameterType HashPolicyType = "QueryParameter"
 	FilterStateType    HashPolicyType = "FilterState"
 )

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -278,7 +278,6 @@ components:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                               type: string

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -214,7 +214,7 @@ func validateHashPolicies(conf *[]HashPolicy) validators.ValidationError {
 			if policy.FilterState == nil {
 				verr.AddViolationAt(path.Field("filterState"), validators.MustBeDefined)
 			}
-		case ConnectionType, SourceIPType:
+		case ConnectionType:
 			if policy.Connection == nil {
 				verr.AddViolationAt(path.Field("connection"), validators.MustBeDefined)
 			}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -218,6 +218,8 @@ func validateHashPolicies(conf *[]HashPolicy) validators.ValidationError {
 			if policy.Connection == nil {
 				verr.AddViolationAt(path.Field("connection"), validators.MustBeDefined)
 			}
+		default:
+			verr.AddViolationAt(path.Field("type"), "unrecognized type")
 		}
 	}
 	return verr

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -293,10 +293,6 @@ to:
 					Message: "must be defined",
 				},
 				{
-					Field:   "spec.to[0].default.hashPolicies[2].connection",
-					Message: "must be defined",
-				},
-				{
 					Field:   "spec.to[0].default.hashPolicies[3].queryParameter",
 					Message: "must be defined",
 				},
@@ -320,7 +316,9 @@ to:
       hashPolicies:
         - type: Header
         - type: Cookie
-        - type: SourceIP
+        - type: Connection
+          connection:
+            sourceIP: true
         - type: QueryParameter
         - type: FilterState
 `),

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -323,6 +323,29 @@ to:
         - type: FilterState
 `),
 		ErrorCases(
+			"removed SourceIP hashPolicies type",
+			[]validators.Violation{
+				{
+					Field:   "spec.to[0].default.hashPolicies[0].type",
+					Message: "unrecognized type",
+				},
+			},
+			`
+type: MeshLoadBalancingStrategy
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: MeshService
+      labels:
+        kuma.io/display-name: svc-2
+    default:
+      hashPolicies:
+        - type: SourceIP
+`),
+		ErrorCases(
 			"MeshHTTPRoute with loadBalancer",
 			[]validators.Violation{
 				{

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -180,7 +180,6 @@ spec:
                                 - Header
                                 - Cookie
                                 - Connection
-                                - SourceIP
                                 - QueryParameter
                                 - FilterState
                                 type: string

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mtlbs.input.yaml
@@ -19,6 +19,6 @@ spec:
         type: RingHash
         ringHash:
           hashPolicies:
-          - type: SourceIP
+          - type: Connection
             connection:
               sourceIP: true

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_create_mlbs.input.yaml
@@ -20,6 +20,6 @@ spec:
         type: RingHash
         ringHash:
           hashPolicies:
-          - type: SourceIP
+          - type: Connection
             connection:
               sourceIP: true


### PR DESCRIPTION
## Motivation

Remove the deprecated `SourceIP` value from `MeshLoadBalancingStrategy` as scheduled.

## Implementation information

- Removed `SourceIP` from the `MeshLoadBalancingStrategy` type.

Closes https://github.com/kumahq/kuma/issues/12145

_Generated by Sybra harness_