### PR TITLE
refactor(cp): remove deprecated standalone mode

### DIFF
--- a/.github/instructions/config.instructions.md
+++ b/.github/instructions/config.instructions.md
@@ -212,15 +212,13 @@ const (
 
 // Mode
 const (
-    Standalone CpMode = "standalone"  // Single-zone
-    Global     CpMode = "global"      // Multi-zone coordinator
-    Zone       CpMode = "zone"        // Multi-zone member
+    Global CpMode = "global"      // Multi-zone coordinator
+    Zone   CpMode = "zone"        // Multi-zone member
 )
 
 switch cfg.Mode {
 case core.Zone:      // Requires XdsServer, GlobalAddress
 case core.Global:    // Requires KDS server
-case core.Standalone:// No multizone deps
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -130,8 +130,7 @@ rejects `mode=global` with `environment=kubernetes`, and it also rejects
 with `environment=universal` backed by a non-Kubernetes store such as
 PostgreSQL, even if `kuma-cp` itself is deployed on Kubernetes. The Helm chart
 no longer renders the `Service`/config needed for the old Kubernetes-native
-setup. Zone and Standalone control planes on Kubernetes (`mode`
-`zone`/`standalone`) are unaffected.
+setup. Zone control planes on Kubernetes (`mode` `zone`) are unaffected.
 
 **Action required**
 
@@ -139,8 +138,19 @@ If you currently run the Global control plane on Kubernetes, migrate it to
 Universal (non-Kubernetes) infrastructure before upgrading: deploy `kuma-cp`
 in `global` mode on Universal, backed by PostgreSQL, and keep your Kubernetes
 clusters as Zone control planes connecting to that Global control plane over
-KDS. Kubernetes clusters running `zone` or `standalone` mode require no
-changes.
+KDS. Kubernetes clusters running `zone` mode require no changes.
+
+### `standalone` mode removed
+
+The deprecated `standalone` control plane mode has been removed. `KUMA_MODE`/
+`controlPlane.mode` no longer accept `standalone`: `kuma-cp` fails config
+validation at startup, and the Helm chart fails at template time.
+
+**Action required**
+
+Rename `standalone` to `zone` in `KUMA_MODE`, `controlPlane.mode`, and any
+other runtime configuration before upgrading. `standalone` and `zone` were
+already behaviourally identical, so no other changes are required.
 
 ### `meshServices` removed from the `Mesh` schema
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -143,7 +143,7 @@ KDS. Kubernetes clusters running `zone` mode require no changes.
 ### `standalone` mode removed
 
 The deprecated `standalone` control plane mode has been removed. `KUMA_MODE`/
-`controlPlane.mode` no longer accept `standalone`: `kuma-cp` fails config
+`controlPlane.mode` no longer accepts `standalone`: `kuma-cp` fails config
 validation at startup, and the Helm chart fails at template time.
 
 **Action required**

--- a/app/kuma-cp/cmd/run.go
+++ b/app/kuma-cp/cmd/run.go
@@ -10,7 +10,6 @@ import (
 	kuma_cmd "github.com/kumahq/kuma/v3/pkg/cmd"
 	"github.com/kumahq/kuma/v3/pkg/config"
 	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
-	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/core/bootstrap"
 	meshidentity_status "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshidentity/status"
 	meshservice_generate "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/generate"
@@ -57,11 +56,6 @@ func newRunCmdWithOpts(opts kuma_cmd.RunCmdOpts) *cobra.Command {
 				return err
 			}
 
-			//nolint:staticcheck
-			if cfg.Mode == config_core.Standalone {
-				runLog.Info(`[WARNING] "standalone" mode is deprecated. Changing it to "zone". Set KUMA_MODE to "zone" as "standalone" will be removed in the future.`)
-				cfg.Mode = config_core.Zone
-			}
 			kuma_cp.PrintDeprecations(&cfg, cmd.OutOrStdout())
 
 			gracefulCtx, ctx, _ := opts.SetupSignalHandler()

--- a/app/kumactl/cmd/install/install_control_plane.go
+++ b/app/kumactl/cmd/install/install_control_plane.go
@@ -257,7 +257,7 @@ This command requires that the KUBECONFIG environment is set`,
 	cmd.Flags().StringVar(&args.Cni_bin_dir, "cni-bin-dir", args.Cni_bin_dir, "set the CNI binary directory")
 	cmd.Flags().StringVar(&args.Cni_conf_name, "cni-conf-name", args.Cni_conf_name, "set the CNI configuration name")
 	cmd.Flags().StringToStringVar(&args.Cni_nodeSelector, "cni-node-selector", args.Cni_nodeSelector, "node selector for CNI deployment")
-	cmd.Flags().StringVar(&args.ControlPlane_mode, "mode", args.ControlPlane_mode, kuma_cmd.UsageOptions("kuma cp modes", "standalone", "zone"))
+	cmd.Flags().StringVar(&args.ControlPlane_mode, "mode", args.ControlPlane_mode, kuma_cmd.UsageOptions("kuma cp modes", "zone"))
 	cmd.Flags().StringVar(&args.ControlPlane_zone, "zone", args.ControlPlane_zone, "set the Kuma zone name")
 	cmd.Flags().BoolVar(&args.UseNodePort, "use-node-port", false, "use NodePort instead of LoadBalancer")
 	cmd.Flags().StringToStringVar(&args.Hooks_nodeSelector, "hooks-node-selector", args.Hooks_nodeSelector, "node selector for Helm hooks")

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -258,9 +258,9 @@ controlPlane:
 			extraArgs: []string{"--kds-global-address", "http://192.168.0.1:1234", "--mode", "zone", "--zone", "zone-1"},
 			errorMsg:  "controlPlane.kdsGlobalAddress must be a url with scheme grpcs:// or grpc:// got:'http://192.168.0.1:1234'",
 		}),
-		Entry("--kds-global-address is used with standalone", errTestCase{
+		Entry("--mode standalone is no longer supported", errTestCase{
 			extraArgs: []string{"--kds-global-address", "192.168.0.1:1234", "--mode", "standalone"},
-			errorMsg:  "Can't specify a controlPlane.kdsGlobalAddress when controlPlane.mode!='zone'",
+			errorMsg:  "controlPlane.mode invalid got:'standalone'",
 		}),
 		Entry("--tls-general-secret without --tls-general-ca-bundle", errTestCase{
 			extraArgs: []string{"--tls-general-secret", "sec"},

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -44,7 +44,7 @@ controlPlane:
   # -- Kuma CP log output path: Defaults to /dev/stdout
   logOutputPath: ""
 
-  # -- Kuma CP modes: one of zone,standalone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
+  # -- Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
   mode: "zone"
 
   # -- (string) Kuma CP zone, if running multizone

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -24,7 +24,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.extraLabels | object | `{}` | Labels to add to resources in addition to default labels |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
 | controlPlane.logOutputPath | string | `""` | Kuma CP log output path: Defaults to /dev/stdout |
-| controlPlane.mode | string | `"zone"` | Kuma CP modes: one of zone,standalone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart |
+| controlPlane.mode | string | `"zone"` | Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |
 | controlPlane.kdsGlobalAddress | string | `""` | Only used in `zone` mode |
 | controlPlane.replicas | int | `1` | Number of replicas of the Kuma CP. Ignored when autoscaling is enabled |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -7,10 +7,10 @@
 {{ end }}
 
 {{ if eq .Values.controlPlane.mode "global" }}
-  {{ fail "Kubernetes-native Global Control Plane is not supported: controlPlane.mode=global cannot be deployed with this Helm chart. Deploy Zone or Standalone control planes on Kubernetes; run the Global Control Plane on non-Kubernetes (Universal) infrastructure instead" }}
+  {{ fail "Kubernetes-native Global Control Plane is not supported: controlPlane.mode=global cannot be deployed with this Helm chart. Deploy Zone control planes on Kubernetes; run the Global Control Plane on non-Kubernetes (Universal) infrastructure instead" }}
 {{ end }}
-{{ if not (or (eq .Values.controlPlane.mode "zone") (eq .Values.controlPlane.mode "standalone")) }}
-  {{ $msg := printf "controlPlane.mode invalid got:'%s' supported values: zone,standalone" .Values.controlPlane.mode }}
+{{ if ne .Values.controlPlane.mode "zone" }}
+  {{ $msg := printf "controlPlane.mode invalid got:'%s' supported values: zone" .Values.controlPlane.mode }}
   {{ fail $msg }}
 {{ end }}
 {{ if eq .Values.controlPlane.mode "zone" }}

--- a/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
+++ b/deployments/charts/kuma/templates/mesh-zoneproxy-deployment.yaml
@@ -15,7 +15,7 @@
 
 {{- /* Validate mode only when deploying zone proxies */ -}}
 {{- if $roles }}
-{{- if or (eq $.Values.controlPlane.mode "global") (eq $.Values.controlPlane.mode "standalone") }}
+{{- if eq $.Values.controlPlane.mode "global" }}
 {{- fail (printf "meshes[%s]: mesh-scoped zone proxies require controlPlane.mode=zone" $meshName) }}
 {{- end }}
 {{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -44,7 +44,7 @@ controlPlane:
   # -- Kuma CP log output path: Defaults to /dev/stdout
   logOutputPath: ""
 
-  # -- Kuma CP modes: one of zone,standalone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
+  # -- Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
   mode: "zone"
 
   # -- (string) Kuma CP zone, if running multizone

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -44,7 +44,7 @@ controlPlane:
   # -- Kuma CP log output path: Defaults to /dev/stdout
   logOutputPath: ""
 
-  # -- Kuma CP modes: one of zone,standalone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
+  # -- Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
   mode: "zone"
 
   # -- (string) Kuma CP zone, if running multizone

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -1,6 +1,6 @@
 # Environment type. Available values are: "kubernetes" or "universal"
 environment: universal # ENV: KUMA_ENVIRONMENT
-# Mode in which Kuma CP is running. Available values are: "global", "zone", "standalone" (deprecated, use "zone")
+# Mode in which Kuma CP is running. Available values are: "global", "zone"
 mode: zone # ENV: KUMA_MODE
 # Resource Store configuration
 store:

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -142,7 +142,7 @@ type Config struct {
 	General *GeneralConfig `json:"general,omitempty"`
 	// Environment Type, can be either "kubernetes" or "universal"
 	Environment core.EnvironmentType `json:"environment,omitempty" envconfig:"kuma_environment"`
-	// Mode in which Kuma CP is running. Available values are: "standalone", "global", "zone"
+	// Mode in which Kuma CP is running. Available values are: "global", "zone"
 	Mode core.CpMode `json:"mode" envconfig:"kuma_mode"`
 	// Resource Store configuration
 	Store *store.StoreConfig `json:"store,omitempty"`

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -1,6 +1,6 @@
 # Environment type. Available values are: "kubernetes" or "universal"
 environment: universal # ENV: KUMA_ENVIRONMENT
-# Mode in which Kuma CP is running. Available values are: "global", "zone", "standalone" (deprecated, use "zone")
+# Mode in which Kuma CP is running. Available values are: "global", "zone"
 mode: zone # ENV: KUMA_MODE
 # Resource Store configuration
 store:

--- a/pkg/config/core/config.go
+++ b/pkg/config/core/config.go
@@ -14,16 +14,14 @@ const (
 type CpMode = string
 
 const (
-	// Deprecated: use zone
-	Standalone CpMode = "standalone"
-	Zone       CpMode = "zone"
-	Global     CpMode = "global"
+	Zone   CpMode = "zone"
+	Global CpMode = "global"
 )
 
 // ValidateCpMode to check modes of kuma-cp
 func ValidateCpMode(mode CpMode) error {
-	if mode != Standalone && mode != Zone && mode != Global {
-		return errors.Errorf("invalid mode. Available modes: %s, %s, %s", Standalone, Zone, Global)
+	if mode != Zone && mode != Global {
+		return errors.Errorf("invalid mode. Available modes: %s, %s", Zone, Global)
 	}
 	return nil
 }

--- a/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
+++ b/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
@@ -92,8 +92,7 @@ func (c *ResourceAdmissionChecker) validateLabels(r core_model.Resource, ns stri
 		if !c.DisableOriginLabelValidation && originPresent && resourceOrigin == mesh_proto.ZoneResourceOrigin {
 			return forbiddenResponse(labelsNotAllowedMsg(mesh_proto.ResourceOriginLabel, string(mesh_proto.GlobalResourceOrigin), string(resourceOrigin)))
 		}
-	//nolint:staticcheck
-	case core.Zone, core.Standalone:
+	case core.Zone:
 		resourceOrigin, originPresent := core_model.ResourceOrigin(r.GetMeta())
 		if !c.DisableOriginLabelValidation && ns == c.SystemNamespace {
 			if !originPresent || resourceOrigin != mesh_proto.ZoneResourceOrigin {


### PR DESCRIPTION
## Motivation

The `standalone` control plane mode has been deprecated and is currently a dead alias—it silently remaps to `zone` at startup with a deprecation warning. This refactor removes the unused code and references, cleaning up technical debt. Users are already aware of the migration path (rename `standalone` → `zone`) from the long-standing deprecation warning.

## Implementation information

- Removed the `Standalone` constant from `pkg/config/core/config.go`
- Updated `ValidateCpMode` to reject `standalone` as a hard error instead of allowing it
- Removed the startup remap and deprecation warning from `app/kuma-cp/cmd/run.go`
- Removed `Standalone` from the case statement in `pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go`
- Updated Helm templates (`templates/ingress-service.yaml`, `cp-deployment.yaml`, `mesh-zoneproxy-deployment.yaml`)
- Updated Helm values and documentation (`values.yaml`, `README.md`)
- Updated kumactl install control plane command usage string
- Regenerated documentation

Closes https://github.com/kumahq/kuma/issues/17763

_Generated by Sybra harness_