### PR TITLE
feat(ca): increase default cert lifetime to 5 days

### DIFF
--- a/pkg/core/ca/issuer/issuer.go
+++ b/pkg/core/ca/issuer/issuer.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	DefaultAllowedClockSkew           = 10 * time.Second
-	DefaultWorkloadCertValidityPeriod = 24 * time.Hour
+	DefaultWorkloadCertValidityPeriod = 5 * 24 * time.Hour
 )
 
 type CertOptsFn = func(*x509.Certificate)

--- a/pkg/core/resources/apis/meshidentity/providers/bundled/bundled.go
+++ b/pkg/core/resources/apis/meshidentity/providers/bundled/bundled.go
@@ -52,7 +52,7 @@ const (
 	cacheExpirationTime = 5 * time.Second
 )
 
-var DefaultWorkloadCertValidityPeriod = k8s.Duration{Duration: 24 * time.Hour}
+var DefaultWorkloadCertValidityPeriod = k8s.Duration{Duration: 5 * 24 * time.Hour}
 
 var _ providers.IdentityProvider = &bundledIdentityProvider{}
 


### PR DESCRIPTION
## Motivation

The default dataplane certificate lifetime is 1 day. Renewal happens at 4/5 of the lifetime, so every proxy re-issues its identity roughly every 19 hours — aggressive churn on the control plane for no security benefit at this scale.

## Implementation information

Bumps `DefaultWorkloadCertValidityPeriod` from 24h to 5 days in both issuers: the legacy mesh mTLS path (`pkg/core/ca/issuer`) used by the builtin and provided CA plugins, and the MeshIdentity bundled provider. Rotation logic is untouched — both paths already renew at 4/5 of the certificate lifetime, so renewal now happens every ~4 days instead of ~19h. Explicit overrides (`dpCert.rotation.expiration` on Mesh, `certificateParameters.expiry` on MeshIdentity) keep taking precedence.

## Supporting documentation

Fixes https://github.com/kumahq/kuma/issues/16773