### PR TITLE
ci(actions): drop read-all from dep update job

### DIFF
--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -3,7 +3,8 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: 0 3 * * *
-permissions: read-all
+permissions:
+  contents: read
 env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:


### PR DESCRIPTION
## Motivation

`read-all` grants read on every scope. This workflow needs one.

Workflow-level grants reach every job, so the default belongs at the minimum.

## Implementation information

Narrows `permissions: read-all` to `contents: read`.

Nothing here asks for more. `actions/checkout` reads the repo with `persist-credentials: false`, `jdx/mise-action` uses `github.token` to download tool releases, and the `active-branches` job calls `_get-active-branches.yaml`, which already declares `contents: read`. `osv-scanner` queries the OSV database, and `make update-vulnerable-dependencies` resolves modules through the Go module proxy.

The write path never used `GITHUB_TOKEN`. `Create Pull Request` authenticates with a GitHub App token, so narrowing `GITHUB_TOKEN` leaves it alone.

## Supporting documentation

GitHub's [workflow `permissions` syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions), which documents the inheritance this relies on
