### PR TITLE
ci(actions): drop workflow-level contents write

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -31,7 +31,7 @@ on:
       IMAGE_DIGESTS:
         value: ${{ jobs.digest-images.outputs.DIGESTS }}
 permissions:
-  contents: write # needed to upload SBOM assets to GitHub releases
+  contents: read
 env:
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -10,7 +10,7 @@ concurrency:
   group: ${{github.workflow}}-${{ github.ref_name }} # group all runs by branch or tag
   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # only cancel previous runs on PRs, we want each commit to build on branches
 permissions:
-  contents: write # needed to upload SBOM assets to GitHub releases
+  contents: read
 env:
   KUMA_DIR: "."
   CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"


### PR DESCRIPTION
## Motivation

Both files grant `contents: write` at workflow level, and workflow-level grants reach every job. Only the jobs uploading SBOM release assets need write, and each already declares it.

This targets `release-2.7` directly because `master` already sets `contents: read` in both files, leaving nothing to backport.

## Implementation information

Narrows the workflow-level grant to `contents: read`. Every job-level block stays as it is.

The writes on `check`, `build_publish`, and `build-images` come from #14796, which added them so `anchore/sbom-action` and `Kong/public-shared-actions/security-actions/sca` can attach SBOMs to a published release. `build_publish` needs its own because a reusable-workflow caller caps what the callee may request.

## Supporting documentation

Three jobs stop inheriting write. `test` calls `_test.yaml`, which declares `contents: read`. `digest-images` downloads artifacts and runs `jq`. `publish-helm` commits locally without pushing, then releases the chart with a separate App token scoped to `charts`.

`master` runs all three under `contents: read` today, so both files now match its layout exactly.

`actionlint` reports the same 15 pre-existing shellcheck findings before and after.
