### PR TITLE
ci(actions): allow SBOM upload to releases on 2.9

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON_RELEASE_2_9_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-22.04' }}
     permissions:
       id-token: write # Required for image signing
-      contents: read
+      contents: write # needed to upload SBOM assets to GitHub releases
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -103,7 +103,7 @@ jobs:
   check:
     needs: ["release_sha_gate"]
     permissions:
-      contents: read
+      contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
     timeout-minutes: 25
     runs-on: ${{ vars.RUNS_ON_RELEASE_2_9_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
@@ -177,7 +177,7 @@ jobs:
     secrets: inherit
   build_publish:
     permissions:
-      contents: read
+      contents: write # needed to upload SBOM assets to GitHub releases
       id-token: write # Required for image signing
     needs: ["check", "test"]
     uses: ./.github/workflows/_build_publish.yaml


### PR DESCRIPTION
## Motivation

SBOM files are not attached to `release-2.9` releases. The jobs that generate them run with `contents: read`, so when a published release already exists the upload fails with "Resource not accessible by integration".

This branch never received #14796, which fixed the same problem on `master` by granting write to exactly the three jobs that upload. Nothing on `master` is left to backport, so this targets `release-2.9` directly.

## Implementation information

Grants `contents: write` to the three jobs that attach SBOMs, matching `master`: `check` and `build_publish` in `build-test-distribute.yaml`, and `build-images` in `_build_publish.yaml`.

`build_publish` needs it because a reusable-workflow caller caps what the called workflow can request, so without it `build-images` cannot hold write either.

## Supporting documentation

`check` runs `Kong/public-shared-actions/security-actions/sca` and `build-images` runs `scan-docker-image` twice, all three with `upload-sbom-release-assets: true`, which is what requires write.

Workflow-level `permissions` stays `contents: read` in both files, so no other job gains write. After this change the permissions layout for both files matches `master`.

`actionlint` reports the same finding counts before and after in both files.
