### PR TITLE
test(k8s): regenerate golden files and prune legacy tag tests

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1353,6 +1353,16 @@ Use `Metrics.Mesh.MinResyncInterval` (`KUMA_METRICS_MESH_MIN_RESYNC_INTERVAL`) a
 `MinResyncTimeout`/`MaxResyncTimeout` in YAML config and their environment variables are
 now silently ignored, since the config loader does not reject unknown fields.
 
+### Inbound `tags` removed from `Dataplane`
+
+The `networking.inbound[].tags` field has been removed from the `Dataplane` resource. Tags for an inbound must now be set through the `Dataplane`'s own `metadata.labels` (Kubernetes) or top-level `networking.inbound[].labels`-equivalent `labels` (Universal), not per-inbound. This only affects Universal: on Kubernetes the field was already ignored in favor of pod labels.
+
+**Action required**
+
+Move any per-inbound tags declared in hand-authored Universal `Dataplane` resources to `Dataplane` labels before upgrading.
+
+**Warning**: `networking.inbound[].tags` is silently dropped on deserialization, not rejected — the field is `reserved` in the proto and protos are unmarshalled with `AllowUnknownFields`, so it is simply ignored. Dataplanes still submitting it will upgrade without error, but any policy matching on those inbound tags stops matching, with nothing in the API to signal it.
+
 ## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1355,7 +1355,7 @@ now silently ignored, since the config loader does not reject unknown fields.
 
 ### Inbound `tags` removed from `Dataplane`
 
-The `networking.inbound[].tags` field has been removed from the `Dataplane` resource. Tags for an inbound must now be set through the `Dataplane`'s own `metadata.labels` (Kubernetes) or top-level `networking.inbound[].labels`-equivalent `labels` (Universal), not per-inbound. This only affects Universal: on Kubernetes the field was already ignored in favor of pod labels.
+The `networking.inbound[].tags` field has been removed from the `Dataplane` resource. Tags for an inbound must now be set through the `Dataplane`'s own `metadata.labels` (Kubernetes) or the `Dataplane`'s top-level `labels:` field (Universal), not per-inbound. This only affects Universal: on Kubernetes the field was already ignored in favor of pod labels.
 
 **Action required**
 

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -349,8 +349,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                   - port: 8080
                     address: 192.168.0.2
-                    tags:
-                      kuma.io/service: backend
 `,
 				expected: "192.168.0.1",
 			}),
@@ -359,11 +357,7 @@ var _ = Describe("Dataplane", func() {
                 networking:
                   inbound:
                   - interface: x.y.z.0
-                    tags:
-                      kuma.io/service: backend-https
                   - interface: 192.168.0.1:80:8080
-                    tags:
-                      kuma.io/service: backend
 `,
 				expected: "",
 			}),
@@ -405,8 +399,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                   - port: 8080
                     address: 192.168.0.2
-                    tags:
-                      kuma.io/service: backend
 `,
 				expected: false,
 			}),
@@ -417,8 +409,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                   - port: 8080
                     address: 192.168.0.2
-                    tags:
-                      kuma.io/service: backend
 `,
 				expected: true,
 			}),
@@ -427,11 +417,7 @@ var _ = Describe("Dataplane", func() {
                 networking:
                   inbound:
                   - interface: x.y.z.0
-                    tags:
-                      kuma.io/service: backend-https
                   - interface: 192.168.0.1:80:8080
-                    tags:
-                      kuma.io/service: backend
 `,
 				expected: false,
 			}),

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -35,9 +35,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -53,9 +50,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 127.0.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   address: 127.0.0.1
@@ -72,30 +66,9 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: ::1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   address: ::1
-                  tags:
-                    kuma.io/service: redis`,
-		),
-		Entry("dataplane with legacy outbounds", `
-            type: Dataplane
-            name: dp-1
-            mesh: default
-            networking:
-              address: 192.168.0.1
-              inbound:
-                - port: 8080
-                  servicePort: 7777
-                  address: 127.0.0.1
-                  tags:
-                    kuma.io/service: backend
-              outbound:
-                - port: 3333
-                  address: 127.0.0.1
                   tags:
                     kuma.io/service: redis`,
 		),
@@ -139,9 +112,6 @@ var _ = Describe("Dataplane", func() {
               address: example.com
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -155,9 +125,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -181,9 +148,6 @@ var _ = Describe("Dataplane", func() {
                     interval: 1s
                     unhealthyThreshold: 5
                     tcp: {}
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -199,9 +163,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 127.0.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   address: 127.0.0.1
@@ -219,9 +180,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 192.168.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   address: 192.168.0.1
@@ -235,9 +193,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   backendRef:
@@ -253,9 +208,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   backendRef:
@@ -270,9 +222,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               transparentProxying:
                 reachableBackends:
                   refs:
@@ -294,9 +243,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   backendRef:
@@ -335,8 +281,6 @@ var _ = Describe("Dataplane", func() {
               inbound:
                 - port: 8080
                   name: http
-                  tags:
-                    kuma.io/service: backend
               listeners:
                 - type: ZoneIngress
                   address: 192.168.0.1
@@ -416,9 +360,7 @@ var _ = Describe("Dataplane", func() {
                 networking:
                   address: 0.0.0.0
                   inbound:
-                    - port: 8080
-                      tags:
-                        kuma.io/service: backend`,
+                    - port: 8080`,
 			expected: `
                 violations:
                 - field: networking.address
@@ -432,9 +374,7 @@ var _ = Describe("Dataplane", func() {
                 networking:
                   address: "::"
                   inbound:
-                    - port: 8080
-                      tags:
-                        kuma.io/service: backend`,
+                    - port: 8080`,
 			expected: `
                 violations:
                 - field: networking.address
@@ -469,9 +409,6 @@ var _ = Describe("Dataplane", func() {
                 networking:
                   inbound:
                     - port: 8080
-                      tags:
-                        kuma.io/service: backend
-                        version: "1"
                   outbound:
                     - port: 3333
                       tags:
@@ -490,9 +427,6 @@ var _ = Describe("Dataplane", func() {
                   address: ..>_<..
                   inbound:
                     - port: 8080
-                      tags:
-                        kuma.io/service: backend
-                        version: "1"
                   outbound:
                     - port: 3333
                       tags:
@@ -512,9 +446,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       servicePort: 7777
-                      tags:
-                        kuma.io/service: backend
-                        version: "1"
                   gateway:
                     tags:
                       kuma.io/service: kong
@@ -576,8 +507,6 @@ var _ = Describe("Dataplane", func() {
                       kuma.io/service: kong
                   inbound:
                     - port: 3333
-                      tags:
-                        kuma.io/service: kong
                   listeners:
                     - type: ZoneEgress
                       address: 192.168.0.1
@@ -602,12 +531,8 @@ var _ = Describe("Dataplane", func() {
                 networking:
                   address: 192.168.0.1
                   inbound:
-                    - tags:
-                        kuma.io/service: backend
-                        version: "1"
+                    - {}
                     - port: 65536
-                      tags:
-                        kuma.io/service: sub-backend
                   outbound:
                     - port: 3333
                       tags:
@@ -629,8 +554,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 1234
                       servicePort: 65536
-                      tags:
-                        kuma.io/service: backend
                   outbound:
                     - port: 3333
                       tags:
@@ -650,8 +573,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 1234
                       address: invalid-address
-                      tags:
-                        kuma.io/service: backend
                   outbound:
                     - port: 3333
                       tags:
@@ -729,9 +650,6 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 1234
-                      tags:
-                        kuma.io/service: backend
-                        version: "v1"
                   outbound:
                     - port: 3333`,
 			expected: `
@@ -748,9 +666,6 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 1234
-                      tags:
-                        kuma.io/service: backend
-                        version: "v1"
                   outbound:
                     - port: 3333
                       tags:
@@ -769,9 +684,6 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 1234
-                      tags:
-                        kuma.io/service: backend
-                        version: "v1"
                   outbound:
                     - tags:
                         kuma.io/service: redis
@@ -794,9 +706,6 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 1234
-                      tags:
-                        kuma.io/service: backend
-                        version: "v1"
                   outbound:
                     - port: 3333
                       address: invalid
@@ -816,9 +725,6 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 1234
-                      tags:
-                        kuma.io/service: backend
-                        version: "v1"
                   outbound:
                     - port: 3333
                       address: invalid
@@ -840,9 +746,7 @@ var _ = Describe("Dataplane", func() {
                     - port: 10001
                       serviceAddress: 192.168.0.2
                       servicePort: 5050
-                      address: 1.1.1.1
-                      tags:
-                        kuma.io/service: backend`,
+                      address: 1.1.1.1`,
 		}),
 		Entry("inbound service address invalid", testCase{
 			dataplane: `
@@ -853,9 +757,7 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 10001
-                      serviceAddress: INVALID
-                      tags:
-                        kuma.io/service: backend`,
+                      serviceAddress: INVALID`,
 			expected: `
                 violations:
                 - field: networking.inbound[0].serviceAddress
@@ -870,9 +772,7 @@ var _ = Describe("Dataplane", func() {
                   address: 192.168.0.1
                   inbound:
                     - port: 10001
-                      serviceAddress: 192.168.0.1
-                      tags:
-                        kuma.io/service: backend`,
+                      serviceAddress: 192.168.0.1`,
 			expected: `
                 violations:
                 - field: networking.inbound[0].serviceAddress
@@ -888,9 +788,7 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 10001
                       address: 192.168.0.2
-                      serviceAddress: 192.168.0.2
-                      tags:
-                        kuma.io/service: backend`,
+                      serviceAddress: 192.168.0.2`,
 			expected: `
                 violations:
                 - field: networking.inbound[0].serviceAddress
@@ -907,9 +805,7 @@ var _ = Describe("Dataplane", func() {
                     - port: 10001
                       address: 192.168.0.2
                       serviceAddress: 192.168.0.2
-                      servicePort: 10002
-                      tags:
-                        kuma.io/service: backend`,
+                      servicePort: 10002`,
 		}),
 		Entry("dataplane with virtual probe", testCase{
 			dataplane: `
@@ -920,9 +816,6 @@ var _ = Describe("Dataplane", func() {
               address: 192.168.0.1
               inbound:
                 - port: 8080
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -969,9 +862,6 @@ var _ = Describe("Dataplane", func() {
                     healthyThreshold: 5
                     unhealthyThreshold: 0
                     tcp: {}
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -996,9 +886,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 127.0.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   address: 127.0.0.1
@@ -1022,9 +909,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 127.0.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   address: 127.0.0.1
@@ -1046,9 +930,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 192.168.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   backendRef: {}`,
@@ -1072,9 +953,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 192.168.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               outbound:
                 - port: 3333
                   tags:
@@ -1109,9 +987,6 @@ var _ = Describe("Dataplane", func() {
                 - port: 8080
                   servicePort: 7777
                   address: 192.168.0.1
-                  tags:
-                    kuma.io/service: backend
-                    version: "1"
               transparentProxying:
                 reachableBackends:
                   refs:
@@ -1161,8 +1036,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       name: http
-                      tags:
-                        kuma.io/service: backend
                   listeners:
                     - type: ZoneIngress
                       port: 10001
@@ -1182,8 +1055,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       name: http
-                      tags:
-                        kuma.io/service: backend
                   listeners:
                     - type: ZoneIngress
                       address: 192.168.0.1
@@ -1204,8 +1075,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       name: http
-                      tags:
-                        kuma.io/service: backend
                   listeners:
                     - type: ZoneIngress
                       address: 192.168.0.1
@@ -1226,8 +1095,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       name: http
-                      tags:
-                        kuma.io/service: backend
                   listeners:
                     - type: ZoneIngress
                       address: not-valid!
@@ -1248,8 +1115,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       name: http
-                      tags:
-                        kuma.io/service: backend
                   listeners:
                     - type: ZoneIngress
                       address: 192.168.0.1
@@ -1333,8 +1198,6 @@ var _ = Describe("Dataplane", func() {
                   inbound:
                     - port: 8080
                       name: http
-                      tags:
-                        kuma.io/service: backend
                   listeners:
                     - type: ZoneIngress
                       address: 192.168.0.1

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -80,7 +80,6 @@ func New(
 		Help: "Number of Dataplane label/tag keys dropped during MeshService generation.",
 	}, []string{"reason"})
 	droppedLabels.WithLabelValues("invalid")
-	droppedLabels.WithLabelValues("inbound_conflict")
 	if err := metrics.Register(droppedLabels); err != nil {
 		return nil, err
 	}
@@ -155,7 +154,7 @@ func (g *Generator) workloadMeshServiceForDataplane(dataplane *core_mesh.Datapla
 
 	contributions := map[string]map[string]string{}
 	if g.labelPropagationEnabled {
-		contributions[workloadName] = dpContribution(dataplane, inbounds, g.allowSet, g.droppedLabels, g.logger, workloadName)
+		contributions[workloadName] = dpContribution(dataplane, g.allowSet, g.droppedLabels, g.logger, workloadName)
 	}
 
 	return meshServicesResult{

--- a/pkg/core/resources/apis/meshservice/generate/generator.go
+++ b/pkg/core/resources/apis/meshservice/generate/generator.go
@@ -77,7 +77,7 @@ func New(
 	}
 	droppedLabels := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "component_meshservice_generator_dropped_labels_total",
-		Help: "Number of Dataplane label/tag keys dropped during MeshService generation.",
+		Help: "Number of Dataplane label keys dropped during MeshService generation.",
 	}, []string{"reason"})
 	droppedLabels.WithLabelValues("invalid")
 	if err := metrics.Register(droppedLabels); err != nil {

--- a/pkg/core/resources/apis/meshservice/generate/labels.go
+++ b/pkg/core/resources/apis/meshservice/generate/labels.go
@@ -79,7 +79,6 @@ func extractPropagatedKeys(labels map[string]string) func(string) bool {
 // It never mutates its inputs and always returns a non-nil map.
 func dpContribution(
 	dp *core_mesh.DataplaneResource,
-	inbounds []*mesh_proto.Dataplane_Networking_Inbound,
 	allowSet map[string]struct{},
 	droppedLabels *prometheus.CounterVec,
 	log logr.Logger,
@@ -110,9 +109,6 @@ func dpContribution(
 			"key", key,
 		)
 	}
-
-	// Inbound labels are gone; keep the parameter for the shared call shape.
-	_ = inbounds
 
 	// Validate and write DP resource labels.
 	for k, v := range dp.GetMeta().GetLabels() {

--- a/pkg/core/resources/apis/meshservice/generate/labels_test.go
+++ b/pkg/core/resources/apis/meshservice/generate/labels_test.go
@@ -15,7 +15,6 @@ import (
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/generate"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
-	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 )
 
@@ -23,7 +22,7 @@ func newDroppedLabels() *prometheus.CounterVec {
 	return prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_dropped"}, []string{"reason"})
 }
 
-func dpWith(name string, labels map[string]string, created time.Time, inbounds ...*mesh_proto.Dataplane_Networking_Inbound) *core_mesh.DataplaneResource {
+func dpWith(name string, labels map[string]string, created time.Time) *core_mesh.DataplaneResource {
 	return &core_mesh.DataplaneResource{
 		Meta: &test_model.ResourceMeta{
 			Name:         name,
@@ -34,14 +33,9 @@ func dpWith(name string, labels map[string]string, created time.Time, inbounds .
 		Spec: &mesh_proto.Dataplane{
 			Networking: &mesh_proto.Dataplane_Networking{
 				Address: "127.0.0.1",
-				Inbound: inbounds,
 			},
 		},
 	}
-}
-
-func inboundWithTags(tags map[string]string) *mesh_proto.Dataplane_Networking_Inbound {
-	return builders.Inbound().WithPort(80).WithServicePort(8080).WithTags(tags).Build()
 }
 
 func identityFor(key string) func(*core_mesh.DataplaneResource) map[string]string {
@@ -67,7 +61,7 @@ func sliceOf(n1 int, v1 string, t1 time.Time, n2 int, v2 string, t2 time.Time) f
 }
 
 var _ = DescribeTable("dpContribution",
-	func(dpLabels map[string]string, inboundTags []map[string]string, allow []string, want map[string]string, wantDrops map[string]float64) {
+	func(dpLabels map[string]string, allow []string, want map[string]string, wantDrops map[string]float64) {
 		var allowSet map[string]struct{}
 		if allow != nil {
 			allowSet = map[string]struct{}{}
@@ -75,19 +69,15 @@ var _ = DescribeTable("dpContribution",
 				allowSet[k] = struct{}{}
 			}
 		}
-		var ins []*mesh_proto.Dataplane_Networking_Inbound
-		for _, t := range inboundTags {
-			ins = append(ins, inboundWithTags(t))
-		}
-		dp := dpWith("dp-1", dpLabels, time.Unix(0, 0), ins...)
+		dp := dpWith("dp-1", dpLabels, time.Unix(0, 0))
 		c := newDroppedLabels()
-		got := generate.DpContribution(dp, ins, allowSet, c, logr.Discard(), "backend")
+		got := generate.DpContribution(dp, allowSet, c, logr.Discard(), "backend")
 		Expect(got).To(Equal(want))
 
 		for reason, n := range wantDrops {
 			Expect(testutil.ToFloat64(c.WithLabelValues(reason))).To(Equal(n))
 		}
-		for _, reason := range []string{"invalid", "inbound_conflict", "not_allowed"} {
+		for _, reason := range []string{"invalid", "not_allowed"} {
 			if _, ok := wantDrops[reason]; ok {
 				continue
 			}
@@ -96,94 +86,42 @@ var _ = DescribeTable("dpContribution",
 	},
 	Entry("1: single dataplane label propagates",
 		map[string]string{"appci": "jeffy"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
 		nil,
 		map[string]string{"appci": "jeffy"}, nil),
 	Entry("2: DP resource label propagates",
 		map[string]string{"color": "blu"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
 		nil,
 		map[string]string{"color": "blu"}, nil),
-	Entry("3: DP label beats inbound tag",
-		map[string]string{"color": "blu"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend", "color": "red"}},
+	Entry("5: no dataplane labels propagate nothing",
 		nil,
-		map[string]string{"color": "blu"}, nil),
-	Entry("4: inbounds are ignored, dataplane label still propagates",
-		map[string]string{"appci": "jeffy"},
-		[]map[string]string{
-			{mesh_proto.ServiceTag: "backend", "appci": "jeffy"},
-			{mesh_proto.ServiceTag: "backend", "appci": "jeffy"},
-		},
-		nil,
-		map[string]string{"appci": "jeffy"}, nil),
-	Entry("5: disagreeing inbounds are ignored",
-		nil,
-		[]map[string]string{
-			{mesh_proto.ServiceTag: "backend", "appci": "jeffy"},
-			{mesh_proto.ServiceTag: "backend", "appci": "bob"},
-		},
-		nil,
-		map[string]string{}, nil),
-	Entry("5b: disagreeing inbounds on multiple keys are ignored",
-		nil,
-		[]map[string]string{
-			{mesh_proto.ServiceTag: "backend", "appci": "jeffy", "team": "blue"},
-			{mesh_proto.ServiceTag: "backend", "appci": "bob", "team": "red"},
-		},
-		nil,
-		map[string]string{}, nil),
-	Entry("6: kuma.io/protocol reserved → not propagated",
-		nil,
-		[]map[string]string{{mesh_proto.ServiceTag: "backend", mesh_proto.ProtocolTag: "http"}},
-		nil,
-		map[string]string{}, nil),
-	Entry("7: k8s.kuma.io/* reserved → not propagated",
-		nil,
-		[]map[string]string{{mesh_proto.ServiceTag: "backend", mesh_proto.KubeNamespaceTag: "foo"}},
 		nil,
 		map[string]string{}, nil),
 	Entry("8: invalid dataplane label key skipped, others propagate",
 		map[string]string{"BAD!KEY": "x", "team": "payments"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
 		nil,
 		map[string]string{"team": "payments"}, map[string]float64{"invalid": 1.0}),
 	Entry("8b: invalid dataplane label value → drop + metric",
 		map[string]string{"appci": "bad value with space"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
 		nil,
 		map[string]string{}, map[string]float64{"invalid": 1.0}),
 	Entry("9: allow-list filters non-listed dataplane labels (no metric, debug-only)",
 		map[string]string{"appci": "jeffy", "team": "payments"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
 		[]string{"appci"},
 		map[string]string{"appci": "jeffy"}, nil),
-	Entry("9a: reserved DP label does NOT override valid inbound",
+	Entry("9a: reserved DP label is not propagated, other valid label is",
 		map[string]string{mesh_proto.ZoneTag: "evil-override", "color": "blu"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend", "color": "red"}},
 		nil,
 		map[string]string{"color": "blu"}, nil),
-	Entry("9b: invalid DP label key drops + metric, inbound value remains",
+	Entry("9b: invalid DP label key drops + metric, other DP label remains",
 		map[string]string{"BAD!KEY": "x", "color": "blu"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend", "color": "red"}},
 		nil,
 		map[string]string{"color": "blu"}, map[string]float64{"invalid": 1.0}),
 	Entry("9c: DP label outside allow-list dropped (no metric, debug-only), allow-listed dataplane value wins",
 		map[string]string{"team": "infra", "appci": "jeffy"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
 		[]string{"appci"},
 		map[string]string{"appci": "jeffy"}, nil),
-	Entry("9d: invalid DP label value → drop + metric",
-		map[string]string{"appci": "bad value with space"},
-		[]map[string]string{{mesh_proto.ServiceTag: "backend"}},
-		nil,
-		map[string]string{}, map[string]float64{"invalid": 1.0}),
 	Entry("9e: mixed invalid dataplane key + valid dataplane label",
 		map[string]string{"BAD!KEY": "x", "appci": "jeffy"},
-		[]map[string]string{
-			{mesh_proto.ServiceTag: "backend", "BAD!KEY": "x", "appci": "jeffy"},
-			{mesh_proto.ServiceTag: "backend", "BAD!KEY": "x", "appci": "bob"},
-		},
 		nil,
 		map[string]string{"appci": "jeffy"}, map[string]float64{"invalid": 1.0}),
 )
@@ -330,24 +268,11 @@ func tagsMap(tags []any) map[any]any {
 }
 
 var _ = Describe("log emission", func() {
-	It("does not emit logs for ignored inbound tags", func() {
-		log, root := newFakeLogger()
-		c := newDroppedLabels()
-		ins := []*mesh_proto.Dataplane_Networking_Inbound{
-			inboundWithTags(map[string]string{mesh_proto.ServiceTag: "backend", "appci": "a"}),
-			inboundWithTags(map[string]string{mesh_proto.ServiceTag: "backend", "appci": "b"}),
-		}
-		dp := dpWith("dp-1", nil, time.Unix(0, 0), ins...)
-		_ = generate.DpContribution(dp, ins, nil, c, log, "backend")
-
-		Expect(root.messages).To(BeEmpty())
-	})
-
 	It("emits warn-log on invalid dataplane label key", func() {
 		log, root := newFakeLogger()
 		c := newDroppedLabels()
 		dp := dpWith("dp-1", map[string]string{"BAD!KEY": "x"}, time.Unix(0, 0))
-		_ = generate.DpContribution(dp, nil, nil, c, log, "backend")
+		_ = generate.DpContribution(dp, nil, c, log, "backend")
 
 		Expect(root.messages).To(HaveLen(1))
 		kv := tagsMap(root.messages[0].tags)
@@ -359,7 +284,7 @@ var _ = Describe("log emission", func() {
 		log, root := newFakeLogger()
 		c := newDroppedLabels()
 		dp := dpWith("dp-1", map[string]string{"appci": "bad value with space"}, time.Unix(0, 0))
-		_ = generate.DpContribution(dp, nil, nil, c, log, "backend")
+		_ = generate.DpContribution(dp, nil, c, log, "backend")
 
 		Expect(root.messages).To(HaveLen(1))
 		kv := tagsMap(root.messages[0].tags)
@@ -369,20 +294,16 @@ var _ = Describe("log emission", func() {
 })
 
 var _ = Describe("helper purity", func() {
-	It("dpContribution does not mutate inbounds, dp labels, or allowSet", func() {
+	It("dpContribution does not mutate dp labels or allowSet", func() {
 		dpLabels := map[string]string{"color": "blu"}
 		dpLabelsSnap := maps.Clone(dpLabels)
-		inTags := map[string]string{mesh_proto.ServiceTag: "backend", "appci": "jeffy"}
-		inTagsSnap := maps.Clone(inTags)
 		allow := map[string]struct{}{"appci": {}}
 		allowSnap := maps.Clone(allow)
 
-		in := inboundWithTags(inTags)
-		dp := dpWith("dp-1", dpLabels, time.Unix(0, 0), in)
-		_ = generate.DpContribution(dp, []*mesh_proto.Dataplane_Networking_Inbound{in}, allow, newDroppedLabels(), logr.Discard(), "backend")
+		dp := dpWith("dp-1", dpLabels, time.Unix(0, 0))
+		_ = generate.DpContribution(dp, allow, newDroppedLabels(), logr.Discard(), "backend")
 
 		Expect(dpLabels).To(Equal(dpLabelsSnap))
-		Expect(inTags).To(Equal(inTagsSnap))
 		Expect(allow).To(Equal(allowSnap))
 	})
 

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.existing-dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.existing-dataplane.yaml
@@ -11,14 +11,6 @@ spec:
     address: 10.244.0.25
     inbound:
       - port: 80
-        tags:
-          app: test-app
-          pod-template-hash: 8646b8bbc8
-          kuma.io/service: test-app_playground_svc_80
       - port: 443
-        tags:
-          app: test-app
-          pod-template-hash: 8646b8bbc8
-          kuma.io/service: test-app_playground_svc_443
     transparentProxying:
       redirectPort: 15001


### PR DESCRIPTION
## Motivation

Deprecate inbound tags support. Universal users must migrate from hand-authored inbound tags to labels; this updates tests and documentation to reflect the removal of tag support.

## Implementation information

- Regenerated ~137 golden dataplane YAML files to remove tag references
- Updated topology test expectations (`outbound_test.go`, `ingress_outbound_test.go`)
- Regenerated 4 plugin golden files
- Pruned legacy test cases for inbound tags (InboundTagsForService in pod_converter, dataplane_validator/helpers, meshservice generator/controller)
- Updated `UPGRADE.md` with 3.0 migration guidance for removing inbound tags

Closes https://github.com/kumahq/kuma/issues/17696

_Generated by Sybra harness_