### PR TITLE
refactor(kds): graduate event-based watchdog from experimental

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -859,8 +859,21 @@ The following configuration has been removed:
 **Action required**
 
 Remove the settings above from your control plane config and environment if
-set. KDS snapshot generation is event-driven, with periodic full resync
-controlled by `experimental.kdsEventBasedWatchdog.fullResyncInterval`.
+set. KDS snapshot generation remains event-driven, but the timing config moved
+to the stable multizone KDS config:
+
+- Global control plane: `multizone.global.kds.eventBasedWatchdog.flushInterval`
+  (`KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL`),
+  `multizone.global.kds.eventBasedWatchdog.fullResyncInterval`
+  (`KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL`), and
+  `multizone.global.kds.eventBasedWatchdog.delayFullResync`
+  (`KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC`).
+- Zone control plane: `multizone.zone.kds.eventBasedWatchdog.flushInterval`
+  (`KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL`),
+  `multizone.zone.kds.eventBasedWatchdog.fullResyncInterval`
+  (`KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL`), and
+  `multizone.zone.kds.eventBasedWatchdog.delayFullResync`
+  (`KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC`).
 
 ### `TrafficTrace` no longer affects generated Envoy config
 

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -589,6 +589,14 @@ multizone:
       responseBackoff: 0s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_RESPONSE_BACKOFF
       # If true, Global CP logs full DeltaDiscoveryResponse payloads received from Zone CPs at V(1) instead of compact summaries.
       logPayloads: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_LOG_PAYLOADS
+      # Event-based snapshot watchdog timing for Global KDS.
+      eventBasedWatchdog:
+        # How often changed resources are flushed to a KDS snapshot.
+        flushInterval: 1s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+        # How often a full KDS resync is scheduled.
+        fullResyncInterval: 1s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
+        # If true, the initial full resync is delayed by a random duration up to FullResyncInterval.
+        delayFullResync: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC
       tracing:
         # Defines whether tracing is enabled for all gRPC methods
         # of GlobalKDSServer and KDSSyncService or completely disabled
@@ -616,6 +624,14 @@ multizone:
       responseBackoff: 0s # ENV: KUMA_MULTIZONE_ZONE_KDS_RESPONSE_BACKOFF
       # If true, Zone CP logs full DeltaDiscoveryResponse payloads received from Global CP at V(1) instead of compact summaries.
       logPayloads: false # ENV: KUMA_MULTIZONE_ZONE_KDS_LOG_PAYLOADS
+      # Event-based snapshot watchdog timing for Zone KDS.
+      eventBasedWatchdog:
+        # How often changed resources are flushed to a KDS snapshot.
+        flushInterval: 1s # ENV: KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+        # How often a full KDS resync is scheduled.
+        fullResyncInterval: 1s # ENV: KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
+        # If true, the initial full resync is delayed by a random duration up to FullResyncInterval.
+        delayFullResync: false # ENV: KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC
     # disableOriginLabelValidation disables validation of the origin label when applying resources on Zone CP
     disableOriginLabelValidation: false # ENV: KUMA_MULTIZONE_ZONE_DISABLE_ORIGIN_LABEL_VALIDATION
 # Diagnostics configuration
@@ -815,14 +831,6 @@ experimental:
   # The drawback is that you cannot use filtered out tags for traffic routing.
   # If empty, no filter is applied.
   ingressTagFilters: [] # ENV: KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS
-  # KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
-  kdsEventBasedWatchdog:
-    # How often we flush changes when experimental event based watchdog is used.
-    flushInterval: 1s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
-    # How often we schedule full KDS resync when experimental event based watchdog is used.
-    fullResyncInterval: 1s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
-    # If true, then initial full resync is going to be delayed by 0 to FullResyncInterval.
-    delayFullResync: false # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC
 tracing:
   openTelemetry:
     endpoint: "" # e.g. otel-collector:4317

--- a/pkg/config/app/kuma-cp/config.go
+++ b/pkg/config/app/kuma-cp/config.go
@@ -276,11 +276,6 @@ var DefaultConfig = func() Config {
 		Access:      access.DefaultAccessConfig(),
 		Experimental: ExperimentalConfig{
 			IngressTagFilters: []string{},
-			KDSEventBasedWatchdog: ExperimentalKDSEventBasedWatchdog{
-				FlushInterval:      config_types.Duration{Duration: 1 * time.Second},
-				FullResyncInterval: config_types.Duration{Duration: 1 * time.Second},
-				DelayFullResync:    false,
-			},
 		},
 		InterCp:       intercp.DefaultInterCpConfig(),
 		EventBus:      eventbus.Default(),
@@ -478,17 +473,6 @@ type ExperimentalConfig struct {
 	// The drawback is that you cannot use filtered out tags for traffic routing.
 	// If empty, no filter is applied.
 	IngressTagFilters []string `json:"ingressTagFilters" envconfig:"KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS"`
-	// KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
-	KDSEventBasedWatchdog ExperimentalKDSEventBasedWatchdog `json:"kdsEventBasedWatchdog"`
-}
-
-type ExperimentalKDSEventBasedWatchdog struct {
-	// How often we flush changes when experimental event based watchdog is used.
-	FlushInterval config_types.Duration `json:"flushInterval" envconfig:"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL"`
-	// How often we schedule full KDS resync when experimental event based watchdog is used.
-	FullResyncInterval config_types.Duration `json:"fullResyncInterval" envconfig:"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL"`
-	// If true, then initial full resync is going to be delayed by 0 to FullResyncInterval.
-	DelayFullResync bool `json:"delayFullResync" envconfig:"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC"`
 }
 
 type IPAMConfig struct {

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -589,6 +589,14 @@ multizone:
       responseBackoff: 0s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_RESPONSE_BACKOFF
       # If true, Global CP logs full DeltaDiscoveryResponse payloads received from Zone CPs at V(1) instead of compact summaries.
       logPayloads: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_LOG_PAYLOADS
+      # Event-based snapshot watchdog timing for Global KDS.
+      eventBasedWatchdog:
+        # How often changed resources are flushed to a KDS snapshot.
+        flushInterval: 1s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+        # How often a full KDS resync is scheduled.
+        fullResyncInterval: 1s # ENV: KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
+        # If true, the initial full resync is delayed by a random duration up to FullResyncInterval.
+        delayFullResync: false # ENV: KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC
       tracing:
         # Defines whether tracing is enabled for all gRPC methods
         # of GlobalKDSServer and KDSSyncService or completely disabled
@@ -616,6 +624,14 @@ multizone:
       responseBackoff: 0s # ENV: KUMA_MULTIZONE_ZONE_KDS_RESPONSE_BACKOFF
       # If true, Zone CP logs full DeltaDiscoveryResponse payloads received from Global CP at V(1) instead of compact summaries.
       logPayloads: false # ENV: KUMA_MULTIZONE_ZONE_KDS_LOG_PAYLOADS
+      # Event-based snapshot watchdog timing for Zone KDS.
+      eventBasedWatchdog:
+        # How often changed resources are flushed to a KDS snapshot.
+        flushInterval: 1s # ENV: KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
+        # How often a full KDS resync is scheduled.
+        fullResyncInterval: 1s # ENV: KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
+        # If true, the initial full resync is delayed by a random duration up to FullResyncInterval.
+        delayFullResync: false # ENV: KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC
     # disableOriginLabelValidation disables validation of the origin label when applying resources on Zone CP
     disableOriginLabelValidation: false # ENV: KUMA_MULTIZONE_ZONE_DISABLE_ORIGIN_LABEL_VALIDATION
 # Diagnostics configuration
@@ -815,14 +831,6 @@ experimental:
   # The drawback is that you cannot use filtered out tags for traffic routing.
   # If empty, no filter is applied.
   ingressTagFilters: [] # ENV: KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS
-  # KDS event based watchdog settings. It is a more optimal way to generate KDS snapshot config.
-  kdsEventBasedWatchdog:
-    # How often we flush changes when experimental event based watchdog is used.
-    flushInterval: 1s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL
-    # How often we schedule full KDS resync when experimental event based watchdog is used.
-    fullResyncInterval: 1s # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL
-    # If true, then initial full resync is going to be delayed by 0 to FullResyncInterval.
-    delayFullResync: false # ENV: KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC
 tracing:
   openTelemetry:
     endpoint: "" # e.g. otel-collector:4317

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -649,6 +649,10 @@ multizone:
       nackBackoff: 11s
       responseBackoff: 1s
       logPayloads: true
+      eventBasedWatchdog:
+        flushInterval: 10s
+        fullResyncInterval: 15s
+        delayFullResync: true
       zoneHealthCheck:
         pollInterval: 11s
         timeout: 110s
@@ -667,6 +671,10 @@ multizone:
       nackBackoff: 21s
       responseBackoff: 2s
       logPayloads: true
+      eventBasedWatchdog:
+        flushInterval: 11s
+        fullResyncInterval: 16s
+        delayFullResync: true
       tlsSkipVerify: true
       labels:
         skipPrefixes: ["argocd.argoproj.io"]
@@ -786,19 +794,6 @@ experimental:
   ingressTagFilters: ["kuma.io/service"]
   generateMeshServices: true
   skipPersistedVIPs: true
-multizone:
-  global:
-    kds:
-      eventBasedWatchdog:
-        flushInterval: 10s
-        fullResyncInterval: 15s
-        delayFullResync: true
-  zone:
-    kds:
-      eventBasedWatchdog:
-        flushInterval: 11s
-        fullResyncInterval: 16s
-        delayFullResync: true
 eventBus:
   bufferSize: 30
 coreResources:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -372,9 +372,12 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Access.Static.ControlPlaneMetadata.Groups).To(Equal([]string{"cp-group1", "cp-group2"}))
 
 			Expect(cfg.Experimental.IngressTagFilters).To(ContainElements("kuma.io/service"))
-			Expect(cfg.Experimental.KDSEventBasedWatchdog.FlushInterval.Duration).To(Equal(10 * time.Second))
-			Expect(cfg.Experimental.KDSEventBasedWatchdog.FullResyncInterval.Duration).To(Equal(15 * time.Second))
-			Expect(cfg.Experimental.KDSEventBasedWatchdog.DelayFullResync).To(BeTrue())
+			Expect(cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval.Duration).To(Equal(10 * time.Second))
+			Expect(cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval.Duration).To(Equal(15 * time.Second))
+			Expect(cfg.Multizone.Global.KDS.EventBasedWatchdog.DelayFullResync).To(BeTrue())
+			Expect(cfg.Multizone.Zone.KDS.EventBasedWatchdog.FlushInterval.Duration).To(Equal(11 * time.Second))
+			Expect(cfg.Multizone.Zone.KDS.EventBasedWatchdog.FullResyncInterval.Duration).To(Equal(16 * time.Second))
+			Expect(cfg.Multizone.Zone.KDS.EventBasedWatchdog.DelayFullResync).To(BeTrue())
 
 			Expect(cfg.EventBus.BufferSize).To(Equal(uint(30)))
 
@@ -781,12 +784,21 @@ access:
 experimental:
   cniApp: "kuma-cni"
   ingressTagFilters: ["kuma.io/service"]
-  kdsEventBasedWatchdog:
-    flushInterval: 10s
-    fullResyncInterval: 15s
-    delayFullResync: true
   generateMeshServices: true
   skipPersistedVIPs: true
+multizone:
+  global:
+    kds:
+      eventBasedWatchdog:
+        flushInterval: 10s
+        fullResyncInterval: 15s
+        delayFullResync: true
+  zone:
+    kds:
+      eventBasedWatchdog:
+        flushInterval: 11s
+        fullResyncInterval: 16s
+        delayFullResync: true
 eventBus:
   bufferSize: 30
 coreResources:
@@ -1106,9 +1118,12 @@ meshService:
 				"KUMA_ACCESS_STATIC_CONTROL_PLANE_METADATA_USERS":                                          "cp-admin1,cp-admin2",
 				"KUMA_ACCESS_STATIC_CONTROL_PLANE_METADATA_GROUPS":                                         "cp-group1,cp-group2",
 				"KUMA_EXPERIMENTAL_INGRESS_TAG_FILTERS":                                                    "kuma.io/service",
-				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL":                                "10s",
-				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL":                          "15s",
-				"KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC":                             "true",
+				"KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL":                            "10s",
+				"KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL":                      "15s",
+				"KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC":                         "true",
+				"KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL":                              "11s",
+				"KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL":                        "16s",
+				"KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC":                           "true",
 				"KUMA_BOOTSTRAP_SERVER_PARAMS_ENVOY_ADMIN_UNIX_SOCKET":                                     "true",
 				"KUMA_TRACING_OPENTELEMETRY_ENDPOINT":                                                      "otel-collector:4317",
 				"KUMA_TRACING_OPENTELEMETRY_ENABLED":                                                       "true",

--- a/pkg/config/multizone/kds.go
+++ b/pkg/config/multizone/kds.go
@@ -40,6 +40,8 @@ type KdsServerConfig struct {
 	ResponseBackoff config_types.Duration `json:"responseBackoff" envconfig:"kuma_multizone_global_kds_response_backoff"`
 	// If true, Global CP logs full DeltaDiscoveryResponse payloads received from Zone CPs at V(1) instead of compact summaries.
 	LogPayloads bool `json:"logPayloads" envconfig:"kuma_multizone_global_kds_log_payloads"`
+	// EventBasedWatchdog configures KDS event-based snapshot flushing and full resync timing.
+	EventBasedWatchdog GlobalEventBasedWatchdogConfig `json:"eventBasedWatchdog"`
 	// ZoneHealthCheck holds config for ensuring zones are online
 	ZoneHealthCheck ZoneHealthCheckConfig `json:"zoneHealthCheck"`
 	Tracing         KDSServerTracing      `json:"tracing"`
@@ -60,6 +62,9 @@ func (c *KdsServerConfig) Validate() error {
 	}
 	if c.ZoneInsightFlushInterval.Duration <= 0 {
 		errs = multierr.Append(errs, errors.New(".ZoneInsightFlushInterval must be positive"))
+	}
+	if err := c.EventBasedWatchdog.Validate(); err != nil {
+		errs = multierr.Append(errs, errors.Wrap(err, "invalid eventBasedWatchdog config"))
 	}
 	if c.TlsCertFile == "" && c.TlsKeyFile != "" {
 		errs = multierr.Append(errs, errors.New(".TlsCertFile cannot be empty if TlsKeyFile has been set"))
@@ -102,6 +107,8 @@ type KdsClientConfig struct {
 	ResponseBackoff config_types.Duration `json:"responseBackoff" envconfig:"kuma_multizone_zone_kds_response_backoff"`
 	// If true, Zone CP logs full DeltaDiscoveryResponse payloads received from Global CP at V(1) instead of compact summaries.
 	LogPayloads bool `json:"logPayloads" envconfig:"kuma_multizone_zone_kds_log_payloads"`
+	// EventBasedWatchdog configures KDS event-based snapshot flushing and full resync timing.
+	EventBasedWatchdog ZoneEventBasedWatchdogConfig `json:"eventBasedWatchdog"`
 	// Labels allows for customizing label handling
 	Labels ZoneLabels `json:"labels"`
 }
@@ -109,6 +116,75 @@ type KdsClientConfig struct {
 var _ config.Config = &KdsClientConfig{}
 
 var _ config.Config = ZoneHealthCheckConfig{}
+
+func (c *KdsClientConfig) Validate() error {
+	if err := c.EventBasedWatchdog.Validate(); err != nil {
+		return errors.Wrap(err, "invalid eventBasedWatchdog config")
+	}
+	return nil
+}
+
+type EventBasedWatchdogConfig struct {
+	config.BaseConfig
+
+	// How often changed resources are flushed to a KDS snapshot.
+	FlushInterval config_types.Duration `json:"flushInterval"`
+	// How often a full KDS resync is scheduled.
+	FullResyncInterval config_types.Duration `json:"fullResyncInterval"`
+	// If true, the initial full resync is delayed by a random duration up to FullResyncInterval.
+	DelayFullResync bool `json:"delayFullResync"`
+}
+
+func (c EventBasedWatchdogConfig) Validate() error {
+	var errs error
+	if c.FlushInterval.Duration <= 0 {
+		errs = multierr.Append(errs, errors.New(".FlushInterval must be positive"))
+	}
+	if c.FullResyncInterval.Duration <= 0 {
+		errs = multierr.Append(errs, errors.New(".FullResyncInterval must be positive"))
+	}
+	return errs
+}
+
+type GlobalEventBasedWatchdogConfig struct {
+	config.BaseConfig
+
+	FlushInterval      config_types.Duration `json:"flushInterval" envconfig:"kuma_multizone_global_kds_event_based_watchdog_flush_interval"`
+	FullResyncInterval config_types.Duration `json:"fullResyncInterval" envconfig:"kuma_multizone_global_kds_event_based_watchdog_full_resync_interval"`
+	DelayFullResync    bool                  `json:"delayFullResync" envconfig:"kuma_multizone_global_kds_event_based_watchdog_delay_full_resync"`
+}
+
+func (c GlobalEventBasedWatchdogConfig) Validate() error {
+	return c.AsRuntimeConfig().Validate()
+}
+
+func (c GlobalEventBasedWatchdogConfig) AsRuntimeConfig() EventBasedWatchdogConfig {
+	return EventBasedWatchdogConfig{
+		FlushInterval:      c.FlushInterval,
+		FullResyncInterval: c.FullResyncInterval,
+		DelayFullResync:    c.DelayFullResync,
+	}
+}
+
+type ZoneEventBasedWatchdogConfig struct {
+	config.BaseConfig
+
+	FlushInterval      config_types.Duration `json:"flushInterval" envconfig:"kuma_multizone_zone_kds_event_based_watchdog_flush_interval"`
+	FullResyncInterval config_types.Duration `json:"fullResyncInterval" envconfig:"kuma_multizone_zone_kds_event_based_watchdog_full_resync_interval"`
+	DelayFullResync    bool                  `json:"delayFullResync" envconfig:"kuma_multizone_zone_kds_event_based_watchdog_delay_full_resync"`
+}
+
+func (c ZoneEventBasedWatchdogConfig) Validate() error {
+	return c.AsRuntimeConfig().Validate()
+}
+
+func (c ZoneEventBasedWatchdogConfig) AsRuntimeConfig() EventBasedWatchdogConfig {
+	return EventBasedWatchdogConfig{
+		FlushInterval:      c.FlushInterval,
+		FullResyncInterval: c.FullResyncInterval,
+		DelayFullResync:    c.DelayFullResync,
+	}
+}
 
 type ZoneHealthCheckConfig struct {
 	config.BaseConfig

--- a/pkg/config/multizone/kds_test.go
+++ b/pkg/config/multizone/kds_test.go
@@ -1,0 +1,27 @@
+package multizone
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	config_types "github.com/kumahq/kuma/v3/pkg/config/types"
+)
+
+func TestEventBasedWatchdogConfigValidateRejectsNonPositiveIntervals(t *testing.T) {
+	cfg := EventBasedWatchdogConfig{
+		FlushInterval:      config_types.Duration{Duration: 0},
+		FullResyncInterval: config_types.Duration{Duration: -1 * time.Second},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), ".FlushInterval must be positive") {
+		t.Fatalf("expected flush interval validation error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), ".FullResyncInterval must be positive") {
+		t.Fatalf("expected full resync validation error, got %v", err)
+	}
+}

--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -46,6 +46,11 @@ func DefaultGlobalConfig() *GlobalConfig {
 			TlsCipherSuites:          []string{},
 			NackBackoff:              config_types.Duration{Duration: 5 * time.Second},
 			LogPayloads:              false,
+			EventBasedWatchdog: GlobalEventBasedWatchdogConfig{
+				FlushInterval:      config_types.Duration{Duration: 1 * time.Second},
+				FullResyncInterval: config_types.Duration{Duration: 1 * time.Second},
+				DelayFullResync:    false,
+			},
 			Tracing: KDSServerTracing{
 				Enabled: true,
 			},
@@ -124,6 +129,11 @@ func DefaultZoneConfig() *ZoneConfig {
 			MsgSendTimeout: config_types.Duration{Duration: 60 * time.Second},
 			NackBackoff:    config_types.Duration{Duration: 5 * time.Second},
 			LogPayloads:    false,
+			EventBasedWatchdog: ZoneEventBasedWatchdogConfig{
+				FlushInterval:      config_types.Duration{Duration: 1 * time.Second},
+				FullResyncInterval: config_types.Duration{Duration: 1 * time.Second},
+				DelayFullResync:    false,
+			},
 		},
 		DisableOriginLabelValidation: false,
 	}

--- a/pkg/config/multizone/multizone_suite_test.go
+++ b/pkg/config/multizone/multizone_suite_test.go
@@ -1,0 +1,11 @@
+package multizone_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestMultizone(t *testing.T) {
+	test.RunSpecs(t, "Multizone Config Suite")
+}

--- a/pkg/config/watchdog_loader_test.go
+++ b/pkg/config/watchdog_loader_test.go
@@ -1,0 +1,85 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kumahq/kuma/v3/pkg/config"
+	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
+)
+
+func TestLoadStableKDSEventBasedWatchdogFromYAML(t *testing.T) {
+	cfg := kuma_cp.DefaultConfig()
+
+	err := config.NewLoader(&cfg).WithValidation().LoadBytes([]byte(`
+multizone:
+  global:
+    kds:
+      eventBasedWatchdog:
+        flushInterval: 10s
+        fullResyncInterval: 15s
+        delayFullResync: true
+  zone:
+    kds:
+      eventBasedWatchdog:
+        flushInterval: 11s
+        fullResyncInterval: 16s
+        delayFullResync: true
+`))
+	if err != nil {
+		t.Fatalf("load YAML: %v", err)
+	}
+
+	if got := cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval.Duration; got != 10*time.Second {
+		t.Fatalf("global flushInterval = %s, want 10s", got)
+	}
+	if got := cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval.Duration; got != 15*time.Second {
+		t.Fatalf("global fullResyncInterval = %s, want 15s", got)
+	}
+	if !cfg.Multizone.Global.KDS.EventBasedWatchdog.DelayFullResync {
+		t.Fatal("global delayFullResync = false, want true")
+	}
+	if got := cfg.Multizone.Zone.KDS.EventBasedWatchdog.FlushInterval.Duration; got != 11*time.Second {
+		t.Fatalf("zone flushInterval = %s, want 11s", got)
+	}
+	if got := cfg.Multizone.Zone.KDS.EventBasedWatchdog.FullResyncInterval.Duration; got != 16*time.Second {
+		t.Fatalf("zone fullResyncInterval = %s, want 16s", got)
+	}
+	if !cfg.Multizone.Zone.KDS.EventBasedWatchdog.DelayFullResync {
+		t.Fatal("zone delayFullResync = false, want true")
+	}
+}
+
+func TestLoadStableKDSEventBasedWatchdogFromEnv(t *testing.T) {
+	t.Setenv("KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL", "10s")
+	t.Setenv("KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL", "15s")
+	t.Setenv("KUMA_MULTIZONE_GLOBAL_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC", "true")
+	t.Setenv("KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FLUSH_INTERVAL", "11s")
+	t.Setenv("KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_FULL_RESYNC_INTERVAL", "16s")
+	t.Setenv("KUMA_MULTIZONE_ZONE_KDS_EVENT_BASED_WATCHDOG_DELAY_FULL_RESYNC", "true")
+
+	cfg := kuma_cp.DefaultConfig()
+	err := config.NewLoader(&cfg).WithEnvVarsLoading("").WithValidation().LoadBytes([]byte("{}"))
+	if err != nil {
+		t.Fatalf("load env: %v", err)
+	}
+
+	if got := cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval.Duration; got != 10*time.Second {
+		t.Fatalf("global flushInterval = %s, want 10s", got)
+	}
+	if got := cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval.Duration; got != 15*time.Second {
+		t.Fatalf("global fullResyncInterval = %s, want 15s", got)
+	}
+	if !cfg.Multizone.Global.KDS.EventBasedWatchdog.DelayFullResync {
+		t.Fatal("global delayFullResync = false, want true")
+	}
+	if got := cfg.Multizone.Zone.KDS.EventBasedWatchdog.FlushInterval.Duration; got != 11*time.Second {
+		t.Fatalf("zone flushInterval = %s, want 11s", got)
+	}
+	if got := cfg.Multizone.Zone.KDS.EventBasedWatchdog.FullResyncInterval.Duration; got != 16*time.Second {
+		t.Fatalf("zone fullResyncInterval = %s, want 16s", got)
+	}
+	if !cfg.Multizone.Zone.KDS.EventBasedWatchdog.DelayFullResync {
+		t.Fatal("zone delayFullResync = false, want true")
+	}
+}

--- a/pkg/kds/context/full_sync_test.go
+++ b/pkg/kds/context/full_sync_test.go
@@ -61,8 +61,8 @@ var _ = Describe("Full sync tests", func() {
 		cfg.Multizone.Global.KDS.GrpcPort = uint32(globalPort)
 		cfg.Multizone.Global.KDS.TlsEnabled = false
 		cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
-		cfg.Experimental.KDSEventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
-		cfg.Experimental.KDSEventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+		cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+		cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 		cfg.Mode = config_core.Global
 		rt := setup.NewTestRuntime(ctx, cfg, globalStore)
 		Expect(global.Setup(rt)).To(Succeed())
@@ -94,8 +94,8 @@ var _ = Describe("Full sync tests", func() {
 			cfg.Multizone.Zone.Name = zoneName
 			cfg.Multizone.Zone.GlobalAddress = fmt.Sprintf("grpc://localhost:%d", globalPort)
 			cfg.Multizone.Global.KDS.ZoneInsightFlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
-			cfg.Experimental.KDSEventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
-			cfg.Experimental.KDSEventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+			cfg.Multizone.Zone.KDS.EventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+			cfg.Multizone.Zone.KDS.EventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 			rt := setup.NewTestRuntime(ctx, cfg, zoneStore)
 			Expect(zone.Setup(rt)).To(Succeed())
 			wg.Go(func() {

--- a/pkg/kds/global/components.go
+++ b/pkg/kds/global/components.go
@@ -34,6 +34,7 @@ func Setup(rt runtime.Runtime) error {
 		rt.KDSContext().GlobalProvidedFilter,
 		rt.KDSContext().GlobalResourceMapper,
 		rt.Config().Multizone.Global.KDS.NackBackoff.Duration,
+		rt.Config().Multizone.Global.KDS.EventBasedWatchdog.AsRuntimeConfig(),
 	)
 	if err != nil {
 		return err

--- a/pkg/kds/mux/client.go
+++ b/pkg/kds/mux/client.go
@@ -22,7 +22,6 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/config"
-	config_kumacp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
 	"github.com/kumahq/kuma/v3/pkg/config/core/resources/store"
 	"github.com/kumahq/kuma/v3/pkg/config/multizone"
 	"github.com/kumahq/kuma/v3/pkg/core"
@@ -46,7 +45,6 @@ type client struct {
 	globalURL           string
 	clientID            string
 	config              multizone.KdsClientConfig
-	experimantalConfig  config_kumacp.ExperimentalConfig
 	metrics             metrics.Metrics
 	ctx                 context.Context
 	envoyAdminProcessor service.EnvoyAdminProcessor
@@ -61,7 +59,6 @@ func NewClient(
 	globalURL string,
 	clientID string,
 	config multizone.KdsClientConfig,
-	experimantalConfig config_kumacp.ExperimentalConfig,
 	metrics metrics.Metrics,
 	envoyAdminProcessor service.EnvoyAdminProcessor,
 	resourceSyncer kds_sync_store.ResourceSyncer,
@@ -73,7 +70,6 @@ func NewClient(
 		globalURL:           globalURL,
 		clientID:            clientID,
 		config:              config,
-		experimantalConfig:  experimantalConfig,
 		metrics:             metrics,
 		envoyAdminProcessor: envoyAdminProcessor,
 		resourceSyncer:      resourceSyncer,

--- a/pkg/kds/mux/client_test.go
+++ b/pkg/kds/mux/client_test.go
@@ -164,7 +164,6 @@ var _ = Describe("Client", func() {
 				"grpc://"+lis.Addr().String(),
 				"zone-1",
 				*rt.Config().Multizone.Zone.KDS,
-				rt.Config().Experimental,
 				metrics,
 				service.NewEnvoyAdminProcessor(rt.ReadOnlyResourceManager(), rt.EnvoyAdminClient()),
 				resourceSyncer,

--- a/pkg/kds/server/components.go
+++ b/pkg/kds/server/components.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
-	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
+	"github.com/kumahq/kuma/v3/pkg/config/multizone"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_runtime "github.com/kumahq/kuma/v3/pkg/core/runtime"
 	"github.com/kumahq/kuma/v3/pkg/events"
@@ -35,6 +35,7 @@ func New(
 	filter kds_reconcile.ResourceFilter,
 	mapper kds_reconcile.ResourceMapper,
 	nackBackoff time.Duration,
+	eventBasedWatchdogCfg multizone.EventBasedWatchdogConfig,
 ) (delta.Server, *Metrics, error) {
 	hasher, cache := newKDSContext(log)
 	generator := kds_reconcile.NewSnapshotGenerator(rt.ReadOnlyResourceManager(), filter, mapper)
@@ -47,7 +48,7 @@ func New(
 		kds_reconcile.NewReconciler(hasher, cache, generator, rt.GetMode(), statsCallbacks, rt.Tenants(), providedTypes),
 		rt.Metrics(),
 		rt.EventBus(),
-		rt.Config().Experimental.KDSEventBasedWatchdog,
+		eventBasedWatchdogCfg,
 		rt.Extensions(),
 	)
 	if err != nil {
@@ -74,7 +75,7 @@ func newSyncTracker(
 	reconciler kds_reconcile.Reconciler,
 	metrics core_metrics.Metrics,
 	eventBus events.EventBus,
-	experimentalWatchdogCfg kuma_cp.ExperimentalKDSEventBasedWatchdog,
+	eventBasedWatchdogCfg multizone.EventBasedWatchdogConfig,
 	extensions context.Context,
 ) (envoy_xds.Callbacks, *Metrics, error) {
 	kdsMetrics, err := NewMetrics(metrics)
@@ -96,16 +97,16 @@ func newSyncTracker(
 			Metrics:       kdsMetrics,
 			Log:           log,
 			NewFlushTicker: func() *time.Ticker {
-				return time.NewTicker(experimentalWatchdogCfg.FlushInterval.Duration)
+				return time.NewTicker(eventBasedWatchdogCfg.FlushInterval.Duration)
 			},
 			NewFullResyncTicker: func() (*time.Ticker, context.CancelFunc) {
-				return newFullResyncTicker(experimentalWatchdogCfg)
+				return newFullResyncTicker(eventBasedWatchdogCfg)
 			},
 		}, nil
 	}), kdsMetrics, nil
 }
 
-func newFullResyncTicker(cfg kuma_cp.ExperimentalKDSEventBasedWatchdog) (*time.Ticker, context.CancelFunc) {
+func newFullResyncTicker(cfg multizone.EventBasedWatchdogConfig) (*time.Ticker, context.CancelFunc) {
 	if !cfg.DelayFullResync {
 		return time.NewTicker(cfg.FullResyncInterval.Duration), func() {}
 	}

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -33,6 +33,7 @@ func Setup(rt core_runtime.Runtime) error {
 		kdsCtx.ZoneProvidedFilter,
 		kdsCtx.ZoneResourceMapper,
 		rt.Config().Multizone.Zone.KDS.NackBackoff.Duration,
+		rt.Config().Multizone.Zone.KDS.EventBasedWatchdog.AsRuntimeConfig(),
 	)
 	if err != nil {
 		return err

--- a/pkg/kds/zone/components.go
+++ b/pkg/kds/zone/components.go
@@ -49,7 +49,6 @@ func Setup(rt core_runtime.Runtime) error {
 		rt.Config().Multizone.Zone.GlobalAddress,
 		zone,
 		*rt.Config().Multizone.Zone.KDS,
-		rt.Config().Experimental,
 		rt.Metrics(),
 		service.NewEnvoyAdminProcessor(
 			rt.ReadOnlyResourceManager(),

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -280,6 +280,8 @@ func NewKdsServerBuilder(store store.ResourceStore) *KdsServerBuilder {
 func (b *KdsServerBuilder) AsZone(name string) *KdsServerBuilder {
 	b.rt.cfg.Multizone.Zone.Name = name
 	b.rt.cfg.Mode = config_core.Zone
+	b.rt.cfg.Multizone.Zone.KDS.EventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+	b.rt.cfg.Multizone.Zone.KDS.EventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 	b.providedTypes = registry.Global().ObjectTypes(model.SentFromZoneToGlobal())
 	b.rt.RuntimeInfo = runtime.NewRuntimeInfo("zone-cp", b.rt.cfg.Mode)
 	return b

--- a/pkg/test/kds/setup/server.go
+++ b/pkg/test/kds/setup/server.go
@@ -267,8 +267,8 @@ func NewTestRuntime(ctx context.Context, cfg kuma_cp.Config, store store.Resourc
 func NewKdsServerBuilder(store store.ResourceStore) *KdsServerBuilder {
 	cfg := kuma_cp.DefaultConfig()
 	cfg.Mode = config_core.Global
-	cfg.Experimental.KDSEventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
-	cfg.Experimental.KDSEventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+	cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval = config_types.Duration{Duration: 100 * time.Millisecond}
+	cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: 100 * time.Millisecond}
 	return &KdsServerBuilder{
 		rt:             NewTestRuntime(context.Background(), cfg, store),
 		providedMapper: kds_reconcile.NoopResourceMapper,
@@ -297,6 +297,10 @@ func (b *KdsServerBuilder) WithTypes(types []model.ResourceType) *KdsServerBuild
 }
 
 func (b *KdsServerBuilder) Delta() (delta.Server, error) {
-	srv, _, err := kds_server.New(core.Log.WithName("kds-delta").WithName(b.rt.GetMode()), b.rt, b.providedTypes, b.rt.Config().Multizone.Zone.Name, b.providedFilter, b.providedMapper, 1*time.Second)
+	watchdogCfg := b.rt.Config().Multizone.Global.KDS.EventBasedWatchdog.AsRuntimeConfig()
+	if b.rt.Config().Mode == config_core.Zone {
+		watchdogCfg = b.rt.Config().Multizone.Zone.KDS.EventBasedWatchdog.AsRuntimeConfig()
+	}
+	srv, _, err := kds_server.New(core.Log.WithName("kds-delta").WithName(b.rt.GetMode()), b.rt, b.providedTypes, b.rt.Config().Multizone.Zone.Name, b.providedFilter, b.providedMapper, 1*time.Second, watchdogCfg)
 	return srv, err
 }

--- a/pkg/test/kds/setup/server_test.go
+++ b/pkg/test/kds/setup/server_test.go
@@ -1,0 +1,28 @@
+package setup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
+)
+
+func TestKdsServerBuilderUsesFastEventBasedWatchdogIntervals(t *testing.T) {
+	builder := NewKdsServerBuilder(memory.NewStore())
+
+	if got := builder.rt.cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval.Duration; got != 100*time.Millisecond {
+		t.Fatalf("expected global flush interval to be 100ms, got %s", got)
+	}
+	if got := builder.rt.cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval.Duration; got != 100*time.Millisecond {
+		t.Fatalf("expected global full resync interval to be 100ms, got %s", got)
+	}
+
+	builder.AsZone("zone-1")
+
+	if got := builder.rt.cfg.Multizone.Zone.KDS.EventBasedWatchdog.FlushInterval.Duration; got != 100*time.Millisecond {
+		t.Fatalf("expected zone flush interval to be 100ms, got %s", got)
+	}
+	if got := builder.rt.cfg.Multizone.Zone.KDS.EventBasedWatchdog.FullResyncInterval.Duration; got != 100*time.Millisecond {
+		t.Fatalf("expected zone full resync interval to be 100ms, got %s", got)
+	}
+}

--- a/pkg/test/kds/setup/setup_suite_test.go
+++ b/pkg/test/kds/setup/setup_suite_test.go
@@ -1,0 +1,11 @@
+package setup_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestSetup(t *testing.T) {
+	test.RunSpecs(t, "KDS Setup Suite")
+}


### PR DESCRIPTION
## Motivation

The KDS event-based watchdog was already the only implementation—there is no poll-based fallback and no feature toggle. Moving its configuration out of the experimental block allows the feature to graduate to stable, officially supporting its production use.

## Implementation information

- Moved `KDSEventBasedWatchdog` config from `ExperimentalConfig` into the multizone KDS config block
- Renamed env vars: `KUMA_EXPERIMENTAL_KDS_EVENT_BASED_WATCHDOG_*` → `KUMA_MULTIZONE_{GLOBAL|ZONE}_KDS_EVENT_BASED_WATCHDOG_*` under `multizone.{global|zone}.kds.eventBasedWatchdog` (breaking change)
- Updated `pkg/kds/server/components.go`, `pkg/kds/global/components.go`, `pkg/kds/zone/components.go`, and test setup references to use the new config path
- Removed unused `experimentalConfig` field from `pkg/kds/mux/client.go` (dead code)
- Regenerated `docs/generated/*`

Closes https://github.com/kumahq/kuma/issues/17810

_Generated by Sybra harness_