### PR TITLE
fix(api-server): stabilize schema error order

### DIFF
--- a/pkg/api-server/testdata/resources/crud/put_mtp_00.golden.json
+++ b/pkg/api-server/testdata/resources/crud/put_mtp_00.golden.json
@@ -5,23 +5,23 @@
  "detail": "Resource is not valid",
  "invalid_parameters": [
   {
-   "field": "spec.targetRef.sectionName",
-   "reason": "in body must be of type string: \"number\""
-  },
-  {
    "field": "spec.targetRef.kind",
    "reason": "in body should be one of [Mesh Dataplane]"
+  },
+  {
+   "field": "spec.targetRef.sectionName",
+   "reason": "in body must be of type string: \"number\""
   }
  ],
  "details": "Resource is not valid",
  "causes": [
   {
-   "field": "spec.targetRef.sectionName",
-   "message": "in body must be of type string: \"number\""
-  },
-  {
    "field": "spec.targetRef.kind",
    "message": "in body should be one of [Mesh Dataplane]"
+  },
+  {
+   "field": "spec.targetRef.sectionName",
+   "message": "in body must be of type string: \"number\""
   }
  ]
 }

--- a/pkg/core/resources/model/rest/unmarshaller.go
+++ b/pkg/core/resources/model/rest/unmarshaller.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -149,12 +150,20 @@ func (u *unmarshaler) UnmarshalListToCore(b []byte, rs core_model.ResourceList) 
 
 func toValidationError(res *validate.Result) *validators.ValidationError {
 	verr := &validators.ValidationError{}
+	// The schema validator walks properties by iterating a map, so the order of
+	// errors it reports is not stable between runs. Sort them to make the
+	// response deterministic.
+	msgs := make([]string, 0, len(res.Errors))
 	for _, e := range res.Errors {
-		parts := strings.Split(e.Error(), " ")
+		msgs = append(msgs, e.Error())
+	}
+	slices.Sort(msgs)
+	for _, msg := range msgs {
+		parts := strings.Split(msg, " ")
 		if len(parts) > 1 && strings.HasPrefix(parts[0], "spec.") {
 			verr.AddViolation(parts[0], strings.Join(parts[1:], " "))
 		} else {
-			verr.AddViolation("", e.Error())
+			verr.AddViolation("", msg)
 		}
 	}
 	return verr

--- a/pkg/core/resources/model/rest/unmarshaller_test.go
+++ b/pkg/core/resources/model/rest/unmarshaller_test.go
@@ -1,0 +1,44 @@
+package rest_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest"
+	"github.com/kumahq/kuma/v3/pkg/core/validators"
+	mtp_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+)
+
+var _ = Describe("Unmarshal", func() {
+	It("should report schema violations in a stable order", func() {
+		// given a resource breaking more than one schema rule
+		input := []byte(`
+type: MeshTrafficPermission
+mesh: default
+name: sample
+spec:
+  targetRef:
+    kind: NotAKind
+    sectionName: 123
+`)
+
+		// when unmarshalling it repeatedly
+		var orders [][]validators.Violation
+		for range 20 {
+			_, err := rest.YAML.Unmarshal(input, mtp_api.MeshTrafficPermissionResourceTypeDescriptor)
+			Expect(err).To(HaveOccurred())
+			verr, ok := err.(*validators.ValidationError)
+			Expect(ok).To(BeTrue())
+			orders = append(orders, verr.Violations)
+		}
+
+		// then every run reports the same violations in the same order
+		Expect(orders[0]).To(Equal([]validators.Violation{
+			{Field: "spec.targetRef.kind", Message: "in body should be one of [Mesh Dataplane]"},
+			{Field: "spec.targetRef.sectionName", Message: `in body must be of type string: "number"`},
+		}))
+		for _, order := range orders {
+			Expect(order).To(Equal(orders[0]))
+		}
+	})
+})


### PR DESCRIPTION
## Motivation

`pkg/api-server` spec `resources CRUD testdata/resources/crud/put_mtp.input.yaml` is flaky. It failed on an unrelated PR ([run](https://github.com/kumahq/kuma/actions/runs/31198277352/job/92932096085)) with the golden file's two `invalid_parameters` entries in swapped order; locally on `master` it fails roughly two runs in three.

`toValidationError` in `pkg/core/resources/model/rest/unmarshaller.go` emits violations in whatever order the kube-openapi schema validator produced them. That validator collects property errors in `objectValidator.Validate` by ranging over `o.Properties`, a Go map, so with two or more violations on sibling fields the order of the 400 response is random per process. The golden file pins one order, so the spec passes or fails by coin flip.

The path became reachable with #17603, which split `TargetRef` into per-context types. That made the test input produce two violations — `spec.targetRef.kind` and `spec.targetRef.sectionName` — where it previously produced one, and a single violation has no order to get wrong.

## Implementation information

`toValidationError` now sorts the validator's error strings before converting them to violations. Sorting the rendered string orders by field first, since the field is the message prefix, and by message within a field. Only one golden file changes: `put_mtp_00.golden.json`, whose two entries are now alphabetical by field. Nothing else in the repo pins a multi-violation schema error order — a full run of `./pkg/api-server/...`, `./pkg/core/...`, `./pkg/plugins/policies/...` and `./app/kumactl/...` is green with no other golden updates.

The new spec in `pkg/core/resources/model/rest/unmarshaller_test.go` unmarshals a MeshTrafficPermission breaking two schema rules 20 times and asserts the same violations in the same order every time. Reverting the sort fails it, so it guards the fix rather than just exercising it. The flaky spec itself passed 10 of 10 runs after the change.

Making the response deterministic is also a small API improvement in its own right: a client comparing two 400 bodies for the same invalid resource no longer sees them differ.

## Supporting documentation

- Failing run: https://github.com/kumahq/kuma/actions/runs/31198277352/job/92932096085
- Map iteration in the upstream validator: `k8s.io/kube-openapi/pkg/validation/validate/object_validator.go`, `for pName, pSchema := range o.Properties`
