### PR TITLE
docs(MeshTrace): document splitService no-op on zone-proxy Dataplanes

### DIFF
--- a/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtraces.yaml
@@ -76,6 +76,9 @@ spec:
                                 `backend` service that communicates with a couple of databases, you would
                                 get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
                                 `backend_OUTBOUND_db2` in Datadog.
+                                This setting has no effect on zone-proxy-only Dataplanes (zone-ingress,
+                                zone-egress): traffic direction is not tracked for those listeners, so the
+                                service name is never suffixed regardless of this value.
                               type: boolean
                             url:
                               description: |-

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -12473,6 +12473,15 @@ components:
                               `backend_OUTBOUND_db1`, and
 
                               `backend_OUTBOUND_db2` in Datadog.
+
+                              This setting has no effect on zone-proxy-only
+                              Dataplanes (zone-ingress,
+
+                              zone-egress): traffic direction is not tracked for
+                              those listeners, so the
+
+                              service name is never suffixed regardless of this
+                              value.
                             type: boolean
                           url:
                             description: >-

--- a/docs/generated/raw/crds/kuma.io_meshtraces.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtraces.yaml
@@ -76,6 +76,9 @@ spec:
                                 `backend` service that communicates with a couple of databases, you would
                                 get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
                                 `backend_OUTBOUND_db2` in Datadog.
+                                This setting has no effect on zone-proxy-only Dataplanes (zone-ingress,
+                                zone-egress): traffic direction is not tracked for those listeners, so the
+                                service name is never suffixed regardless of this value.
                               type: boolean
                             url:
                               description: |-

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go
@@ -98,6 +98,9 @@ type DatadogBackend struct {
 	// `backend` service that communicates with a couple of databases, you would
 	// get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
 	// `backend_OUTBOUND_db2` in Datadog.
+	// This setting has no effect on zone-proxy-only Dataplanes (zone-ingress,
+	// zone-egress): traffic direction is not tracked for those listeners, so the
+	// service name is never suffixed regardless of this value.
 	// +kubebuilder:default=false
 	// +kubebuilder:validation:Optional
 	SplitService bool `json:"splitService"`

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -178,6 +178,9 @@ components:
                               `backend` service that communicates with a couple of databases, you would
                               get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
                               `backend_OUTBOUND_db2` in Datadog.
+                              This setting has no effect on zone-proxy-only Dataplanes (zone-ingress,
+                              zone-egress): traffic direction is not tracked for those listeners, so the
+                              service name is never suffixed regardless of this value.
                             type: boolean
                           url:
                             description: |-

--- a/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
+++ b/pkg/plugins/policies/meshtrace/k8s/crd/kuma.io_meshtraces.yaml
@@ -76,6 +76,9 @@ spec:
                                 `backend` service that communicates with a couple of databases, you would
                                 get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
                                 `backend_OUTBOUND_db2` in Datadog.
+                                This setting has no effect on zone-proxy-only Dataplanes (zone-ingress,
+                                zone-egress): traffic direction is not tracked for those listeners, so the
+                                service name is never suffixed regardless of this value.
                               type: boolean
                             url:
                               description: |-


### PR DESCRIPTION
## Motivation

The Datadog `splitService` field on `MeshTrace` is documented as splitting the Datadog service name by traffic direction and destination (e.g. `backend_INBOUND`, `backend_OUTBOUND_db1`).

Since #16601, `applyToZoneProxyListeners` intentionally passes `TrafficDirection_UNSPECIFIED` for zone-proxy listeners (zone-ingress, zone-egress) so the misleading `_INBOUND` suffix is skipped on zone-egress spans (a zone-egress hop is wire-level INBOUND but represents a cross-zone egress). `createDatadogServiceName` in `pkg/plugins/policies/meshtrace/plugin/xds/configurer.go` falls through to `default: return c.Service` for any direction other than `INBOUND`/`OUTBOUND`.

The side effect: for zone-proxy-only Dataplanes, `splitService` is a silent no-op. An operator setting it to `true` or `false` on a `MeshTrace` that matches zone-proxy Dataplanes sees no difference in the resulting Envoy tracing config, with no validator warning or log to explain why.

## Implementation information

Per the triage comment on the linked issue, the lowest-cost fix (documenting the behavior) is enough here, rather than adding a webhook warning or a debug log.

- Updated the doc comment on `DatadogBackend.SplitService` in `pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go` to explain that the field has no effect on zone-proxy-only Dataplanes.
- Regenerated the derived artifacts so they stay in sync with the Go doc comment:
  - `make generate/policy/meshtrace` (`rest.yaml`, CRD yaml)
  - `make generate/policy-helm` (Helm chart CRD copy)
  - `make docs/generated/openapi.yaml` (bundled OpenAPI docs, validated via `make validate/openapi-generated-docs`)
  - `docs/generated/raw/crds/kuma.io_meshtraces.yaml` updated to match the regenerated CRD (plain copy, as done by `make docs/generated/raw`)

No runtime behavior changes; this is a documentation-only change.

## Supporting documentation

Fixes #16603

## Test plan

- `go build ./pkg/plugins/policies/meshtrace/...` — passes
- `go vet ./pkg/plugins/policies/meshtrace/...` — clean
- `gofmt -l pkg/plugins/policies/meshtrace/api/v1alpha1/meshtrace.go` — clean
- `go test ./pkg/plugins/policies/meshtrace/...` — all passing:
  ```
  ok  	github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrace/api/v1alpha1
  ok  	github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrace/plugin/v1alpha1
  ```
- `make validate/openapi-generated-docs` — passes against the regenerated `docs/generated/openapi.yaml`