### PR TITLE
fix(kds): avoid ERROR log for benign ZoneInsight flush race on Zone rename

### DIFF
--- a/pkg/kds/status/status_sink.go
+++ b/pkg/kds/status/status_sink.go
@@ -109,9 +109,12 @@ func (s *zoneInsightSink) Start(ctx context.Context, stop <-chan struct{}) {
 		}
 
 		if err := s.store.Upsert(gracefulCtx, zone, currentState); err != nil {
-			if store.IsAlreadyExists(err) || store.IsConflict(err) {
+			switch {
+			case store.IsAlreadyExists(err), store.IsConflict(err):
 				log.V(1).Info("failed to flush ZoneInsight because it was updated in other place. Will retry in the next tick", "zone", zone)
-			} else {
+			case store.IsNotFound(err):
+				log.V(1).Info("failed to flush ZoneInsight because the owning Zone does not exist yet. Will retry in the next tick", "zone", zone)
+			default:
 				log.Error(err, "failed to flush zone status", "zone", zone)
 			}
 		} else {

--- a/pkg/kds/status/status_sink_test.go
+++ b/pkg/kds/status/status_sink_test.go
@@ -1,0 +1,96 @@
+package status_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
+	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
+	config_store "github.com/kumahq/kuma/v3/pkg/config/core/resources/store"
+	"github.com/kumahq/kuma/v3/pkg/core/managers/apis/zoneinsight"
+	core_store "github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	"github.com/kumahq/kuma/v3/pkg/kds/status"
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
+)
+
+var _ = Describe("ZoneInsightSink", func() {
+	It("should not log an ERROR when the owning Zone does not exist yet, only retry on the next tick", func() {
+		// given a ZoneInsight store backed by the real manager, but the "zone-fed" Zone was not created yet
+		// (reproduces the startup race between the "defaults" component creating the Zone and the KDS status
+		// flusher trying to upsert its ZoneInsight)
+		resManager := zoneinsight.NewZoneInsightManager(memory.NewStore(), &kuma_cp.ZoneMetrics{})
+		zoneInsightStore := status.NewZonesInsightStore(resManager, config_store.UpsertConfig{}, false, core_store.NoTransactions{})
+
+		recorded := &recordingLogSink{}
+		log := logr.New(recorded)
+
+		ticks := make(chan time.Time)
+		sink := status.NewZoneInsightSink(
+			&staticStatusAccessor{zone: "zone-fed", subscription: &system_proto.KDSSubscription{Id: "sub-1"}},
+			func() *time.Ticker { return &time.Ticker{C: ticks} },
+			func() *time.Ticker { return &time.Ticker{C: make(chan time.Time)} },
+			time.Millisecond,
+			zoneInsightStore,
+			log,
+			context.Background(),
+		)
+
+		stop := make(chan struct{})
+		defer close(stop)
+		go sink.Start(context.Background(), stop)
+
+		// when the flusher runs before the owning Zone exists
+		ticks <- time.Now()
+
+		// then it retries quietly instead of logging an ERROR
+		Eventually(func() []string {
+			recorded.mu.Lock()
+			defer recorded.mu.Unlock()
+			return recorded.infoMsgs
+		}, "1s", "5ms").Should(ContainElement("failed to flush ZoneInsight because the owning Zone does not exist yet. Will retry in the next tick"))
+
+		recorded.mu.Lock()
+		defer recorded.mu.Unlock()
+		Expect(recorded.errorMsgs).To(BeEmpty())
+	})
+})
+
+type staticStatusAccessor struct {
+	zone         string
+	subscription *system_proto.KDSSubscription
+}
+
+func (s *staticStatusAccessor) GetStatus() (string, *system_proto.KDSSubscription) {
+	return s.zone, s.subscription
+}
+
+type recordingLogSink struct {
+	mu        sync.Mutex
+	infoMsgs  []string
+	errorMsgs []string
+}
+
+func (r *recordingLogSink) Init(_ logr.RuntimeInfo) {}
+
+func (r *recordingLogSink) Enabled(_ int) bool { return true }
+
+func (r *recordingLogSink) Info(_ int, msg string, _ ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.infoMsgs = append(r.infoMsgs, msg)
+}
+
+func (r *recordingLogSink) Error(_ error, msg string, _ ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errorMsgs = append(r.errorMsgs, msg)
+}
+
+func (r *recordingLogSink) WithValues(_ ...any) logr.LogSink { return r }
+
+func (r *recordingLogSink) WithName(_ string) logr.LogSink { return r }

--- a/pkg/kds/status/status_suite_test.go
+++ b/pkg/kds/status/status_suite_test.go
@@ -1,0 +1,9 @@
+package status_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestStatus(t *testing.T) { test.RunSpecs(t, "KDS Status Suite") }


### PR DESCRIPTION
## Motivation

Following the [federation guide](https://kuma.io/docs/2.8.x/guides/federate/), users see a
misleading `ERROR failed to flush zone status` log entry on the zone CP right after
federating, even though the zone ends up healthy and policies sync correctly in both
directions. This is confusing and looks like a real failure when it isn't.

## Implementation information

Root cause: during federation, the `defaults` component renames the `Zone` resource
(deletes the old one, creates the new one), while the KDS status flusher
(`zoneInsightSink` in `pkg/kds/status/status_sink.go`) concurrently tries to upsert the
`ZoneInsight` for the newly-named zone. Both are leader-elected components that start
with no ordering guarantee between them. If the flusher's upsert races ahead of
`defaults` creating the renamed `Zone`, `zoneInsightManager.Create` fails with a
"resource not found" error (it does an explicit `Get` of the owning `Zone` before
creating the `ZoneInsight`), and the flush loop logged that as an `ERROR`, even though
the next tick succeeds once `defaults` has created the `Zone`.

The fix treats `store.IsNotFound(err)` on the owning `Zone` the same way the flush loop
already treats `AlreadyExists`/`Conflict` errors on the line above: log at `V(1)` and
let it retry on the next tick, instead of `log.Error(...)`. The only source of a
`NotFound` error on this specific code path is `zoneInsightManager.Create`'s `Get` of
the owning `Zone`, so this cannot mask an unrelated `NotFound` error being logged as an
`ERROR` elsewhere.

User-visible behavior (zone health, policy sync) is unchanged before and after this
change; the only effect is removing a noisy, misleading `ERROR` log line during a
transient startup race.

Alternative considered (from the issue discussion): ordering/atomically guaranteeing the
`Zone` exists before the KDS flusher starts. This was flagged as higher-risk and not
pursued here; the maintainer triage explicitly asked for "the lower risk change" (logging
adjustment), which is what this PR implements.

## Supporting documentation

Root-caused and the fix approach agreed in the issue thread comments (a detailed
investigation confirmed the race and proposed this exact "lowest-risk" fix, and a
maintainer triage comment approved doing "the lower risk change").

Fix #11768

Validation: added `pkg/kds/status/status_sink_test.go`, which wires the real
`ZoneInsightManager` and `ZonesInsightStore` against an in-memory store without creating
the owning `Zone` first, reproducing the exact race, and asserts no `ERROR` log is
recorded. Confirmed the test fails without the fix (times out waiting for the new log
message) and passes with it. Also ran `go build ./...`,
`go test ./pkg/kds/status/... ./pkg/core/managers/apis/zoneinsight/... ./pkg/kds/...`,
and `golangci-lint run ./pkg/kds/status/...`, all green. This is a unit-level fix
validated with a targeted failing-then-passing test; a live multi-zone federation setup
was not run against this change.

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->