### PR TITLE
perf(rules): cut allocations in rule building

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
@@ -8,6 +8,7 @@ import (
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
+	core_apis "github.com/kumahq/kuma/v2/pkg/core/resources/apis"
 	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies"

--- a/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
@@ -21,6 +21,7 @@ import (
 // Benchmarks don't go through test.RunSpecs, which is what normally registers the
 // policy plugins, so the resource types have to be registered here.
 var initPolicyPlugins = sync.OnceFunc(func() {
+	core_plugins.InitAll(core_apis.NameToModule)
 	core_plugins.InitAll(policies.NameToModule)
 })
 

--- a/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
@@ -1,0 +1,209 @@
+package matchers_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
+	core_mesh "github.com/kumahq/kuma/v2/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/plugins/policies"
+	"github.com/kumahq/kuma/v2/pkg/plugins/policies/core/matchers"
+	meshtrafficpermission_api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/util/pointer"
+	xds_context "github.com/kumahq/kuma/v2/pkg/xds/context"
+)
+
+// Benchmarks don't go through test.RunSpecs, which is what normally registers the
+// policy plugins, so the resource types have to be registered here.
+var initPolicyPlugins = sync.OnceFunc(func() {
+	core_plugins.InitAll(policies.NameToModule)
+})
+
+// This benchmark reproduces the shape of data seen on a large zone control plane
+// where Kubernetes Services in a namespace use selectors that are wider than the
+// Deployment they front. Every Service then selects every pod in the namespace, so
+// each Dataplane ends up with one inbound per Service rather than one per container
+// port. The inbounds that do not correspond to a real port on the pod stay in the
+// Ignored state, and since Ignored inbounds are matched like any other, the cost of
+// MatchedPolicies grows with the inflated inbound count.
+//
+// All names, namespaces and identities below are synthetic.
+const (
+	benchMesh      = "mesh-a"
+	benchNamespace = "ns-a"
+	benchZone      = "zone-a"
+)
+
+// benchInboundShape describes how many inbounds a Dataplane carries.
+// The tight variant is what a correctly scoped Service selector produces: one
+// inbound per real container port. The wide variant is what a namespace-wide
+// selector produces: the same real ports plus one Ignored inbound per unrelated
+// Service in the namespace.
+type benchInboundShape struct {
+	name    string
+	ready   int
+	ignored int
+}
+
+var benchInboundShapes = []benchInboundShape{
+	{name: "inbounds2_tight_selectors", ready: 2, ignored: 0},
+	{name: "inbounds6_wide_selectors", ready: 2, ignored: 4},
+}
+
+var benchPolicyCounts = []int{100, 500, 2000}
+
+// benchDataplane builds a Dataplane with `ready` Ready inbounds and `ignored`
+// Ignored inbounds, mimicking a pod picked up by more Services than it has ports.
+func benchDataplane(shape benchInboundShape) *core_mesh.DataplaneResource {
+	inbounds := make([]*mesh_proto.Dataplane_Networking_Inbound, 0, shape.ready+shape.ignored)
+	port := uint32(8080)
+	for range shape.ready {
+		inbounds = append(inbounds, &mesh_proto.Dataplane_Networking_Inbound{
+			Port:        port,
+			Name:        fmt.Sprintf("port-%d", port),
+			State:       mesh_proto.Dataplane_Networking_Inbound_Ready,
+			ServicePort: port,
+		})
+		port++
+	}
+	for range shape.ignored {
+		inbounds = append(inbounds, &mesh_proto.Dataplane_Networking_Inbound{
+			Port:        port,
+			Name:        fmt.Sprintf("port-%d", port),
+			State:       mesh_proto.Dataplane_Networking_Inbound_Ignored,
+			ServicePort: port,
+		})
+		port++
+	}
+
+	return &core_mesh.DataplaneResource{
+		Meta: &test_model.ResourceMeta{
+			Mesh: benchMesh,
+			Name: "app-a-6bf4654569-cxq49",
+			Labels: map[string]string{
+				mesh_proto.KubeNamespaceTag:    benchNamespace,
+				mesh_proto.ZoneTag:             benchZone,
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+				"app":                          "app-a",
+			},
+		},
+		Spec: &mesh_proto.Dataplane{
+			Networking: &mesh_proto.Dataplane_Networking{
+				Address: "10.0.0.1",
+				Inbound: inbounds,
+			},
+		},
+	}
+}
+
+// benchPolicies builds `n` MeshTrafficPermissions in the shape a per-service
+// dependency allow-list produces: mostly Dataplane-scoped policies that name a
+// single workload, plus a small number of mesh-wide baseline policies.
+func benchPolicies(n int) xds_context.Resources {
+	items := make([]*meshtrafficpermission_api.MeshTrafficPermissionResource, 0, n)
+	for i := range n {
+		var targetRef *common_api.TargetRef
+		switch {
+		case i%50 == 0:
+			// mesh-wide baseline policy
+			targetRef = &common_api.TargetRef{Kind: common_api.Mesh}
+		case i%10 == 1:
+			// policy that selects the Dataplane under test
+			targetRef = &common_api.TargetRef{
+				Kind:   common_api.Dataplane,
+				Labels: pointer.To(map[string]string{"app": "app-a"}),
+			}
+		default:
+			// policy that selects some other workload in the mesh
+			targetRef = &common_api.TargetRef{
+				Kind:   common_api.Dataplane,
+				Labels: pointer.To(map[string]string{"app": fmt.Sprintf("app-%d", i)}),
+			}
+		}
+
+		items = append(items, &meshtrafficpermission_api.MeshTrafficPermissionResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh: benchMesh,
+				Name: fmt.Sprintf("mtp-%d", i),
+				Labels: map[string]string{
+					mesh_proto.ZoneTag: benchZone,
+				},
+			},
+			Spec: &meshtrafficpermission_api.MeshTrafficPermission{
+				TargetRef: targetRef,
+				Rules: &[]meshtrafficpermission_api.Rule{{
+					Default: meshtrafficpermission_api.RuleConf{
+						Allow: &[]common_api.Match{{
+							SpiffeID: &common_api.SpiffeIDMatch{
+								Type:  common_api.ExactMatchType,
+								Value: fmt.Sprintf("spiffe://%s/ns/%s/sa/caller-%d", benchMesh, benchNamespace, i),
+							},
+						}},
+					},
+				}},
+			},
+		})
+	}
+
+	return xds_context.Resources{
+		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+			meshtrafficpermission_api.MeshTrafficPermissionType: &meshtrafficpermission_api.MeshTrafficPermissionResourceList{
+				Items: items,
+			},
+		},
+	}
+}
+
+func BenchmarkMatchedPoliciesInboundFanout(b *testing.B) {
+	initPolicyPlugins()
+
+	for _, shape := range benchInboundShapes {
+		for _, policyCount := range benchPolicyCounts {
+			dpp := benchDataplane(shape)
+			resources := benchPolicies(policyCount)
+
+			b.Run(fmt.Sprintf("%s/policies%d", shape.name, policyCount), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if _, err := matchers.MatchedPolicies(
+						meshtrafficpermission_api.MeshTrafficPermissionType,
+						dpp,
+						resources,
+					); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkDppSelectedByPolicy isolates the per-policy selection step that
+// MatchedPolicies calls once per policy, so the cost attributable to the inbound
+// count alone is visible without the surrounding rule building.
+func BenchmarkDppSelectedByPolicy(b *testing.B) {
+	initPolicyPlugins()
+
+	meshRef := common_api.TargetRef{Kind: common_api.Mesh}
+
+	for _, shape := range benchInboundShapes {
+		dpp := benchDataplane(shape)
+		meta := &test_model.ResourceMeta{Mesh: benchMesh, Name: "mtp-mesh-wide"}
+
+		b.Run(shape.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, _, _, err := matchers.DppSelectedByPolicy(meta, meshRef, dpp, nil, xds_context.Resources{}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugins/policies/core/rules/cliques_bench_test.go
+++ b/pkg/plugins/policies/core/rules/cliques_bench_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
 
-// These benchmarks exercise the legacy `from`-list rule builder that release-2.11
+// These benchmarks exercise the legacy `from`-list rule builder that this branch
 // uses for MeshTrafficPermission. BuildFromRules flattens the `from` entries of
 // every matched policy into one list per inbound listener, then BuildRules turns
 // that list into an intersection graph, enumerates maximal cliques

--- a/pkg/plugins/policies/core/rules/cliques_bench_test.go
+++ b/pkg/plugins/policies/core/rules/cliques_bench_test.go
@@ -8,10 +8,12 @@ import (
 	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
 	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
 	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
+	core_apis "github.com/kumahq/kuma/v2/pkg/core/resources/apis"
 	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/plugins/policies"
 	core_rules "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules"
 	meshtrafficpermission_api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
 	"github.com/kumahq/kuma/v2/pkg/util/pointer"
 )
@@ -54,7 +56,6 @@ var (
 // 1 is the common `kuma.io/service` case, 2 adds a version dimension.
 func benchMTPList(fromItems int, tagsPerCaller int) core_model.ResourceList {
 	items := make([]*meshtrafficpermission_api.MeshTrafficPermissionResource, 0, fromItems)
-	action := meshtrafficpermission_api.Allow
 
 	for i := range fromItems {
 		tags := map[string]string{
@@ -64,23 +65,19 @@ func benchMTPList(fromItems int, tagsPerCaller int) core_model.ResourceList {
 			tags["version"] = fmt.Sprintf("v%d", i%3)
 		}
 
-		items = append(items, &meshtrafficpermission_api.MeshTrafficPermissionResource{
-			Meta: &test_model.ResourceMeta{
-				Mesh:   benchMesh,
-				Name:   fmt.Sprintf("mtp-%d", i),
-				Labels: map[string]string{mesh_proto.ZoneTag: benchZone},
-			},
-			Spec: &meshtrafficpermission_api.MeshTrafficPermission{
-				TargetRef: &common_api.TargetRef{Kind: common_api.Mesh},
-				From: &[]meshtrafficpermission_api.From{{
-					TargetRef: common_api.TargetRef{
-						Kind: common_api.MeshSubset,
-						Tags: pointer.To(tags),
-					},
-					Default: meshtrafficpermission_api.Conf{Action: &action},
-				}},
-			},
-		})
+		res := builders.MeshTrafficPermission().
+			WithMesh(benchMesh).
+			WithName(fmt.Sprintf("mtp-%d", i)).
+			WithTargetRef(common_api.TargetRef{Kind: common_api.Mesh}).
+			AddFrom(common_api.TargetRef{
+				Kind: common_api.MeshSubset,
+				Tags: pointer.To(tags),
+			}, meshtrafficpermission_api.Allow).
+			Build()
+		// The builder has no setter for labels, and matching needs the zone.
+		res.Meta.(*test_model.ResourceMeta).Labels = map[string]string{mesh_proto.ZoneTag: benchZone}
+
+		items = append(items, res)
 	}
 
 	return &meshtrafficpermission_api.MeshTrafficPermissionResourceList{Items: items}

--- a/pkg/plugins/policies/core/rules/cliques_bench_test.go
+++ b/pkg/plugins/policies/core/rules/cliques_bench_test.go
@@ -38,6 +38,7 @@ const (
 // Benchmarks don't go through test.RunSpecs, which is what normally registers the
 // policy plugins, so the resource types have to be registered here.
 var initPolicyPlugins = sync.OnceFunc(func() {
+	core_plugins.InitAll(core_apis.NameToModule)
 	core_plugins.InitAll(policies.NameToModule)
 })
 

--- a/pkg/plugins/policies/core/rules/cliques_bench_test.go
+++ b/pkg/plugins/policies/core/rules/cliques_bench_test.go
@@ -1,0 +1,123 @@
+package rules_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	common_api "github.com/kumahq/kuma/v2/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v2/api/mesh/v1alpha1"
+	core_plugins "github.com/kumahq/kuma/v2/pkg/core/plugins"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/plugins/policies"
+	core_rules "github.com/kumahq/kuma/v2/pkg/plugins/policies/core/rules"
+	meshtrafficpermission_api "github.com/kumahq/kuma/v2/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
+	test_model "github.com/kumahq/kuma/v2/pkg/test/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/util/pointer"
+)
+
+// These benchmarks exercise the legacy `from`-list rule builder that release-2.11
+// uses for MeshTrafficPermission. BuildFromRules flattens the `from` entries of
+// every matched policy into one list per inbound listener, then BuildRules turns
+// that list into an intersection graph, enumerates maximal cliques
+// (BronKerbosch), and for every tag combination of every clique calls createRule
+// over the whole item list.
+//
+// The shape modeled here is a per-service dependency allow-list: each policy
+// names the callers it admits with `from[].targetRef.kind: MeshSubset`, which is
+// how a zone's MeshTrafficPermissions look when they are generated per service.
+// The inbound counts mirror a pod fronted by correctly scoped Service selectors
+// (2) versus namespace-wide ones (6).
+//
+// All names and identities are synthetic.
+const (
+	benchMesh = "mesh-a"
+	benchZone = "zone-a"
+)
+
+// Benchmarks don't go through test.RunSpecs, which is what normally registers the
+// policy plugins, so the resource types have to be registered here.
+var initPolicyPlugins = sync.OnceFunc(func() {
+	core_plugins.InitAll(policies.NameToModule)
+})
+
+var (
+	// benchFromItems is the total number of `from` entries across all policies
+	// matched to a single inbound, which is what BuildRules receives.
+	benchFromItems = []int{50, 200, 500}
+	benchInbounds  = []int{2, 6}
+)
+
+// benchMTPList builds one MeshTrafficPermission per `from` entry, each admitting a
+// single distinct caller. tagsPerCaller controls how many tags identify a caller:
+// 1 is the common `kuma.io/service` case, 2 adds a version dimension.
+func benchMTPList(fromItems int, tagsPerCaller int) core_model.ResourceList {
+	items := make([]*meshtrafficpermission_api.MeshTrafficPermissionResource, 0, fromItems)
+	action := meshtrafficpermission_api.Allow
+
+	for i := range fromItems {
+		tags := map[string]string{
+			mesh_proto.ServiceTag: fmt.Sprintf("caller-%d", i),
+		}
+		if tagsPerCaller > 1 {
+			tags["version"] = fmt.Sprintf("v%d", i%3)
+		}
+
+		items = append(items, &meshtrafficpermission_api.MeshTrafficPermissionResource{
+			Meta: &test_model.ResourceMeta{
+				Mesh:   benchMesh,
+				Name:   fmt.Sprintf("mtp-%d", i),
+				Labels: map[string]string{mesh_proto.ZoneTag: benchZone},
+			},
+			Spec: &meshtrafficpermission_api.MeshTrafficPermission{
+				TargetRef: &common_api.TargetRef{Kind: common_api.Mesh},
+				From: &[]meshtrafficpermission_api.From{{
+					TargetRef: common_api.TargetRef{
+						Kind: common_api.MeshSubset,
+						Tags: pointer.To(tags),
+					},
+					Default: meshtrafficpermission_api.Conf{Action: &action},
+				}},
+			},
+		})
+	}
+
+	return &meshtrafficpermission_api.MeshTrafficPermissionResourceList{Items: items}
+}
+
+func benchByInbound(inbounds int, list core_model.ResourceList) map[core_rules.InboundListener]core_model.ResourceList {
+	byInbound := map[core_rules.InboundListener]core_model.ResourceList{}
+	for i := range inbounds {
+		byInbound[core_rules.InboundListener{
+			Address: "10.0.0.1",
+			Port:    uint32(8080 + i),
+		}] = list
+	}
+	return byInbound
+}
+
+// BenchmarkBuildFromRulesCliques measures the production entry point: the whole
+// per-inbound loop, including the clique enumeration and createRule expansion.
+func BenchmarkBuildFromRulesCliques(b *testing.B) {
+	initPolicyPlugins()
+
+	for _, tagsPerCaller := range []int{1, 2} {
+		for _, inbounds := range benchInbounds {
+			for _, fromItems := range benchFromItems {
+				list := benchMTPList(fromItems, tagsPerCaller)
+				byInbound := benchByInbound(inbounds, list)
+
+				name := fmt.Sprintf("tags%d/inbounds%d/from%d", tagsPerCaller, inbounds, fromItems)
+				b.Run(name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if _, err := core_rules.BuildFromRules(byInbound); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/plugins/policies/core/rules/inbound/inboundrules.go
+++ b/pkg/plugins/policies/core/rules/inbound/inboundrules.go
@@ -74,10 +74,14 @@ func getEntries(resources core_model.ResourceList) ([]common.WithPolicyAttribute
 		return nil, err
 	}
 
+	// GetItems() allocates and fills a new []core_model.Resource on every call, so it
+	// is called once here and indexed below. Cast is all-or-nothing, so policies stays
+	// aligned with items.
+	items := resources.GetItems()
 	policies, ok := common.Cast[interface {
 		PolicyWithRules
 		core_model.PolicyWithFromList
-	}](resources.GetItems())
+	}](items)
 	if !ok {
 		return nil, nil
 	}
@@ -90,7 +94,7 @@ func getEntries(resources core_model.ResourceList) ([]common.WithPolicyAttribute
 			for j, rule := range policy.GetRules() {
 				entries = append(entries, common.WithPolicyAttributes[RuleEntry]{
 					Entry:     rule,
-					Meta:      resources.GetItems()[i].GetMeta(),
+					Meta:      items[i].GetMeta(),
 					TopLevel:  policy.GetTargetRef(),
 					RuleIndex: j,
 				})
@@ -99,7 +103,7 @@ func getEntries(resources core_model.ResourceList) ([]common.WithPolicyAttribute
 			for j, fromEntry := range policy.GetFromList() {
 				entries = append(entries, common.WithPolicyAttributes[RuleEntry]{
 					Entry:     newRuleEntryAdapter(fromEntry),
-					Meta:      resources.GetItems()[i].GetMeta(),
+					Meta:      items[i].GetMeta(),
 					TopLevel:  policy.GetTargetRef(),
 					RuleIndex: j,
 				})

--- a/pkg/plugins/policies/core/rules/inbound/inboundrules.go
+++ b/pkg/plugins/policies/core/rules/inbound/inboundrules.go
@@ -86,7 +86,9 @@ func getEntries(resources core_model.ResourceList) ([]common.WithPolicyAttribute
 		return nil, nil
 	}
 
-	entries := []common.WithPolicyAttributes[RuleEntry]{}
+	// One policy can contribute several entries, so len(items) is a floor rather than a
+	// bound, but it saves the regrowth from an empty slice.
+	entries := make([]common.WithPolicyAttributes[RuleEntry], 0, len(items))
 
 	for i, policy := range policies {
 		switch {

--- a/pkg/plugins/policies/core/rules/outbound/resourcerules.go
+++ b/pkg/plugins/policies/core/rules/outbound/resourcerules.go
@@ -81,18 +81,24 @@ func BuildRules(policies core_model.ResourceList, reader kri.ResourceReader) (Re
 }
 
 func GetEntries(policies core_model.ResourceList) ([]common.WithPolicyAttributes[ToEntry], error) {
-	policiesWithTo, ok := common.Cast[core_model.PolicyWithToList](policies.GetItems())
+	// GetItems() allocates and fills a new []core_model.Resource on every call, so it
+	// is called once here and indexed below. Cast is all-or-nothing, so policiesWithTo
+	// stays aligned with items.
+	items := policies.GetItems()
+	policiesWithTo, ok := common.Cast[core_model.PolicyWithToList](items)
 	if !ok {
 		return nil, nil
 	}
 
-	entries := []common.WithPolicyAttributes[ToEntry]{}
+	// One policy can contribute several 'to' entries, so len(items) is a floor rather
+	// than a bound, but it saves the regrowth from an empty slice.
+	entries := make([]common.WithPolicyAttributes[ToEntry], 0, len(items))
 
 	for i, pwt := range policiesWithTo {
 		for j, item := range pwt.GetToList() {
 			entries = append(entries, common.WithPolicyAttributes[ToEntry]{
 				Entry:     item,
-				Meta:      policies.GetItems()[i].GetMeta(),
+				Meta:      items[i].GetMeta(),
 				TopLevel:  pwt.GetTargetRef(),
 				RuleIndex: j,
 			})

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -432,8 +432,11 @@ func buildRulesInternal(list []PolicyItemWithMeta, withNegations bool, useClique
 	}
 
 	uniqueKeys := map[string]struct{}{}
-	// 1. Convert list of rules into the list of subsets
-	var subsets []subsetutils.Subset
+	// 1. Convert list of rules into the list of subsets.
+	// itemSubsets stays index-aligned with oldKindsItems and is never reassigned, so
+	// createRule can look up an item's subset instead of recomputing it. subsets is
+	// the working copy that later steps are free to deduplicate.
+	itemSubsets := make([]subsetutils.Subset, 0, len(oldKindsItems))
 	for _, item := range oldKindsItems {
 		ss, err := asSubset(item.GetTargetRef())
 		if err != nil {
@@ -442,8 +445,9 @@ func buildRulesInternal(list []PolicyItemWithMeta, withNegations bool, useClique
 		for _, tag := range ss {
 			uniqueKeys[tag.Key] = struct{}{}
 		}
-		subsets = append(subsets, ss)
+		itemSubsets = append(itemSubsets, ss)
 	}
+	subsets := itemSubsets
 
 	// we don't need to generate all permutations when there is no negations
 	// and we have only 0 or one tag, in other cases we need to generate.
@@ -454,7 +458,7 @@ func buildRulesInternal(list []PolicyItemWithMeta, withNegations bool, useClique
 		subsets = subsetutils.Deduplicate(subsets)
 
 		for _, ss := range subsets {
-			if r, err := createRule(ss, oldKindsItems); err != nil {
+			if r, err := createRule(ss, oldKindsItems, itemSubsets); err != nil {
 				return nil, err
 			} else {
 				rules = append(rules, r...)
@@ -525,7 +529,7 @@ func buildRulesInternal(list []PolicyItemWithMeta, withNegations bool, useClique
 			}
 
 			// 5. For each combination determine a configuration
-			if r, err := createRule(ss, oldKindsItems); err != nil {
+			if r, err := createRule(ss, oldKindsItems, itemSubsets); err != nil {
 				return nil, err
 			} else {
 				rules = append(rules, r...)
@@ -540,17 +544,16 @@ func buildRulesInternal(list []PolicyItemWithMeta, withNegations bool, useClique
 	return rules, nil
 }
 
-func createRule(ss subsetutils.Subset, items []PolicyItemWithMeta) ([]*Rule, error) {
+// createRule builds the rules for subset ss. itemSubsets holds the subset of every
+// entry in items, index-aligned, so the caller's step-1 conversion is reused rather
+// than recomputed on every call.
+func createRule(ss subsetutils.Subset, items []PolicyItemWithMeta, itemSubsets []subsetutils.Subset) ([]*Rule, error) {
 	rules := []*Rule{}
 	confs := []any{}
 	var relevant []PolicyItemWithMeta
 	for i := range items {
 		item := items[i]
-		itemSubset, err := asSubset(item.GetTargetRef())
-		if err != nil {
-			return nil, err
-		}
-		if itemSubset.IsSubset(ss) {
+		if itemSubsets[i].IsSubset(ss) {
 			confs = append(confs, item.GetDefault())
 			relevant = append(relevant, item)
 		}

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -246,7 +246,11 @@ func BuildToRules(matchedPolicies core_model.ResourceList, reader kri.ResourceRe
 }
 
 func legacyBuildToRules(matchedPolicies core_model.ResourceList, reader kri.ResourceReader) (Rules, error) {
-	policiesWithTo, ok := common.Cast[core_model.PolicyWithToList](matchedPolicies.GetItems())
+	// GetItems() allocates and fills a new []core_model.Resource on every call, so it
+	// is called once here and indexed below. Cast is all-or-nothing, so policiesWithTo
+	// stays aligned with items.
+	items := matchedPolicies.GetItems()
+	policiesWithTo, ok := common.Cast[core_model.PolicyWithToList](items)
 	if !ok {
 		return Rules{}, nil
 	}
@@ -257,7 +261,7 @@ func legacyBuildToRules(matchedPolicies core_model.ResourceList, reader kri.Reso
 		}); idx >= 0 {
 			continue
 		}
-		meta := matchedPolicies.GetItems()[i].GetMeta()
+		meta := items[i].GetMeta()
 		tl, err := buildToListWithRoutes(meta, pwtl, reader.ListOrEmpty(meshhttproute_api.MeshHTTPRouteType).GetItems())
 		if err != nil {
 			return nil, err

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -434,8 +434,7 @@ func buildRulesInternal(list []PolicyItemWithMeta, withNegations bool, useClique
 	uniqueKeys := map[string]struct{}{}
 	// 1. Convert list of rules into the list of subsets.
 	// itemSubsets stays index-aligned with oldKindsItems and is never reassigned, so
-	// createRule can look up an item's subset instead of recomputing it. subsets is
-	// the working copy that later steps are free to deduplicate.
+	// createRule can look up an item's subset instead of recomputing it.
 	itemSubsets := make([]subsetutils.Subset, 0, len(oldKindsItems))
 	for _, item := range oldKindsItems {
 		ss, err := asSubset(item.GetTargetRef())

--- a/pkg/plugins/policies/core/rules/subsetutils/subset.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subset.go
@@ -93,19 +93,22 @@ func (ss Subset) IsSubset(other Subset) bool {
 	if len(ss) == 0 {
 		return true
 	}
-	otherByKeys := map[string][]Tag{}
-	for _, t := range other {
-		otherByKeys[t.Key] = append(otherByKeys[t.Key], t)
-	}
+	// Subsets hold a handful of tags, so scanning 'other' per tag is cheaper than
+	// indexing it by key, and it keeps this allocation-free. It is on the hot path of
+	// rule building, which calls it once per item per generated subset.
 	for _, tag := range ss {
-		oTags, ok := otherByKeys[tag.Key]
-		if !ok {
-			return false
-		}
-		for _, otherTag := range oTags {
+		keyPresent := false
+		for _, otherTag := range other {
+			if otherTag.Key != tag.Key {
+				continue
+			}
+			keyPresent = true
 			if !isSubset(tag, otherTag) {
 				return false
 			}
+		}
+		if !keyPresent {
+			return false
 		}
 	}
 	return true
@@ -170,22 +173,17 @@ func (ss Subset) Intersect(other Subset) bool {
 	if len(ss) == 0 || len(other) == 0 {
 		return true
 	}
-	otherByKeysOnlyPositive := map[string][]Tag{}
-	for _, t := range other {
-		if t.Not {
-			continue
-		}
-		otherByKeysOnlyPositive[t.Key] = append(otherByKeysOnlyPositive[t.Key], t)
-	}
+	// Same reasoning as IsSubset: a linear scan over the few tags in 'other' avoids
+	// building a map. This one is called O(n^2) times when the intersection graph is
+	// constructed.
 	for _, tag := range ss {
 		if tag.Not {
 			continue
 		}
-		oTags, ok := otherByKeysOnlyPositive[tag.Key]
-		if !ok {
-			continue
-		}
-		for _, otherTag := range oTags {
+		for _, otherTag := range other {
+			if otherTag.Not || otherTag.Key != tag.Key {
+				continue
+			}
 			if otherTag != tag {
 				return false
 			}

--- a/pkg/plugins/policies/core/rules/subsetutils/subset_equivalence_test.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subset_equivalence_test.go
@@ -1,0 +1,157 @@
+package subsetutils
+
+import (
+	"testing"
+)
+
+// IsSubset and Intersect were rewritten to scan 'other' directly instead of
+// indexing it into a map[string][]Tag, which removed an allocation from the hot
+// path of rule building. Both are used to decide which MeshTrafficPermission
+// entries apply to a client, so the rewrite must not change a single verdict.
+//
+// The functions below are the original map-based implementations, kept verbatim as
+// a reference. The tests assert that the current implementations agree with them on
+// every pair of subsets built from a small tag alphabet.
+
+func isSubsetReference(ss Subset, other Subset) bool {
+	if len(ss) == 0 {
+		return true
+	}
+	otherByKeys := map[string][]Tag{}
+	for _, t := range other {
+		otherByKeys[t.Key] = append(otherByKeys[t.Key], t)
+	}
+	for _, tag := range ss {
+		oTags, ok := otherByKeys[tag.Key]
+		if !ok {
+			return false
+		}
+		for _, otherTag := range oTags {
+			if !isSubset(tag, otherTag) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func intersectReference(ss Subset, other Subset) bool {
+	if len(ss) == 0 || len(other) == 0 {
+		return true
+	}
+	otherByKeysOnlyPositive := map[string][]Tag{}
+	for _, t := range other {
+		if t.Not {
+			continue
+		}
+		otherByKeysOnlyPositive[t.Key] = append(otherByKeysOnlyPositive[t.Key], t)
+	}
+	for _, tag := range ss {
+		if tag.Not {
+			continue
+		}
+		oTags, ok := otherByKeysOnlyPositive[tag.Key]
+		if !ok {
+			continue
+		}
+		for _, otherTag := range oTags {
+			if otherTag != tag {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// alphabet covers both keys and values colliding or differing, and both polarities,
+// which is everything isSubset distinguishes between.
+func alphabet() []Tag {
+	var tags []Tag
+	for _, key := range []string{"k1", "k2"} {
+		for _, value := range []string{"v1", "v2"} {
+			for _, not := range []bool{false, true} {
+				tags = append(tags, Tag{Key: key, Value: value, Not: not})
+			}
+		}
+	}
+	return tags
+}
+
+// allSubsets enumerates every ordered tag sequence up to maxLen, including
+// sequences that repeat a key, which is the case the map-based versions grouped.
+func allSubsets(maxLen int) []Subset {
+	tags := alphabet()
+	subsets := []Subset{{}}
+	current := []Subset{{}}
+
+	for length := 1; length <= maxLen; length++ {
+		var next []Subset
+		for _, prefix := range current {
+			for _, tag := range tags {
+				extended := make(Subset, len(prefix), len(prefix)+1)
+				copy(extended, prefix)
+				next = append(next, append(extended, tag))
+			}
+		}
+		subsets = append(subsets, next...)
+		current = next
+	}
+	return subsets
+}
+
+func TestIsSubsetMatchesReference(t *testing.T) {
+	subsets := allSubsets(2)
+	for _, ss := range subsets {
+		for _, other := range subsets {
+			got := ss.IsSubset(other)
+			want := isSubsetReference(ss, other)
+			if got != want {
+				t.Fatalf("IsSubset(%v, %v) = %v, reference = %v", ss, other, got, want)
+			}
+		}
+	}
+}
+
+func TestIntersectMatchesReference(t *testing.T) {
+	subsets := allSubsets(2)
+	for _, ss := range subsets {
+		for _, other := range subsets {
+			got := ss.Intersect(other)
+			want := intersectReference(ss, other)
+			if got != want {
+				t.Fatalf("Intersect(%v, %v) = %v, reference = %v", ss, other, got, want)
+			}
+		}
+	}
+}
+
+// The length-3 sweep is the same check over a larger space. It is a separate test so
+// the cheap one still runs when this is skipped in short mode.
+func TestIsSubsetAndIntersectMatchReferenceDeep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exhaustive length-3 sweep")
+	}
+	subsets := allSubsets(3)
+	for _, ss := range subsets {
+		for _, other := range subsets {
+			if got, want := ss.IsSubset(other), isSubsetReference(ss, other); got != want {
+				t.Fatalf("IsSubset(%v, %v) = %v, reference = %v", ss, other, got, want)
+			}
+			if got, want := ss.Intersect(other), intersectReference(ss, other); got != want {
+				t.Fatalf("Intersect(%v, %v) = %v, reference = %v", ss, other, got, want)
+			}
+		}
+	}
+}
+
+func TestIsSubsetAndIntersectDoNotAllocate(t *testing.T) {
+	ss := Subset{{Key: "kuma.io/service", Value: "caller-1"}}
+	other := Subset{{Key: "kuma.io/service", Value: "caller-1"}, {Key: "version", Value: "v1"}}
+
+	if allocs := testing.AllocsPerRun(100, func() { _ = ss.IsSubset(other) }); allocs != 0 {
+		t.Errorf("IsSubset allocated %v times per run, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() { _ = ss.Intersect(other) }); allocs != 0 {
+		t.Errorf("Intersect allocated %v times per run, want 0", allocs)
+	}
+}

--- a/pkg/plugins/policies/core/rules/subsetutils/subset_equivalence_test.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subset_equivalence_test.go
@@ -2,6 +2,9 @@ package subsetutils
 
 import (
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // IsSubset and Intersect were rewritten to scan 'other' directly instead of
@@ -10,7 +13,7 @@ import (
 // entries apply to a client, so the rewrite must not change a single verdict.
 //
 // The functions below are the original map-based implementations, kept verbatim as
-// a reference. The tests assert that the current implementations agree with them on
+// a reference. The specs assert that the current implementations agree with them on
 // every pair of subsets built from a small tag alphabet.
 
 func isSubsetReference(ss Subset, other Subset) bool {
@@ -99,59 +102,35 @@ func allSubsets(maxLen int) []Subset {
 	return subsets
 }
 
-func TestIsSubsetMatchesReference(t *testing.T) {
-	subsets := allSubsets(2)
-	for _, ss := range subsets {
-		for _, other := range subsets {
-			got := ss.IsSubset(other)
-			want := isSubsetReference(ss, other)
-			if got != want {
-				t.Fatalf("IsSubset(%v, %v) = %v, reference = %v", ss, other, got, want)
-			}
-		}
-	}
-}
-
-func TestIntersectMatchesReference(t *testing.T) {
-	subsets := allSubsets(2)
-	for _, ss := range subsets {
-		for _, other := range subsets {
-			got := ss.Intersect(other)
-			want := intersectReference(ss, other)
-			if got != want {
-				t.Fatalf("Intersect(%v, %v) = %v, reference = %v", ss, other, got, want)
-			}
-		}
-	}
-}
-
-// The length-3 sweep is the same check over a larger space. It is a separate test so
-// the cheap one still runs when this is skipped in short mode.
-func TestIsSubsetAndIntersectMatchReferenceDeep(t *testing.T) {
-	if testing.Short() {
-		t.Skip("exhaustive length-3 sweep")
-	}
+var _ = Describe("Subset", func() {
+	// Sequences up to length 3 are enough to hit every case the map-based versions
+	// grouped: a repeated key with two different values, plus a third tag that can
+	// disagree with either of them.
 	subsets := allSubsets(3)
-	for _, ss := range subsets {
-		for _, other := range subsets {
-			if got, want := ss.IsSubset(other), isSubsetReference(ss, other); got != want {
-				t.Fatalf("IsSubset(%v, %v) = %v, reference = %v", ss, other, got, want)
-			}
-			if got, want := ss.Intersect(other), intersectReference(ss, other); got != want {
-				t.Fatalf("Intersect(%v, %v) = %v, reference = %v", ss, other, got, want)
+
+	It("IsSubset agrees with the map-based implementation on every pair", func() {
+		for _, ss := range subsets {
+			for _, other := range subsets {
+				got, want := ss.IsSubset(other), isSubsetReference(ss, other)
+				Expect(got).To(Equal(want), "IsSubset(%v, %v)", ss, other)
 			}
 		}
-	}
-}
+	})
 
-func TestIsSubsetAndIntersectDoNotAllocate(t *testing.T) {
-	ss := Subset{{Key: "kuma.io/service", Value: "caller-1"}}
-	other := Subset{{Key: "kuma.io/service", Value: "caller-1"}, {Key: "version", Value: "v1"}}
+	It("Intersect agrees with the map-based implementation on every pair", func() {
+		for _, ss := range subsets {
+			for _, other := range subsets {
+				got, want := ss.Intersect(other), intersectReference(ss, other)
+				Expect(got).To(Equal(want), "Intersect(%v, %v)", ss, other)
+			}
+		}
+	})
 
-	if allocs := testing.AllocsPerRun(100, func() { _ = ss.IsSubset(other) }); allocs != 0 {
-		t.Errorf("IsSubset allocated %v times per run, want 0", allocs)
-	}
-	if allocs := testing.AllocsPerRun(100, func() { _ = ss.Intersect(other) }); allocs != 0 {
-		t.Errorf("Intersect allocated %v times per run, want 0", allocs)
-	}
-}
+	It("does not allocate in IsSubset or Intersect", func() {
+		ss := Subset{{Key: "kuma.io/service", Value: "caller-1"}}
+		other := Subset{{Key: "kuma.io/service", Value: "caller-1"}, {Key: "version", Value: "v1"}}
+
+		Expect(testing.AllocsPerRun(100, func() { _ = ss.IsSubset(other) })).To(BeZero())
+		Expect(testing.AllocsPerRun(100, func() { _ = ss.Intersect(other) })).To(BeZero())
+	})
+})

--- a/pkg/plugins/policies/core/rules/subsetutils/subsetutils_suite_test.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subsetutils_suite_test.go
@@ -1,0 +1,11 @@
+package subsetutils_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestSubsetutils(t *testing.T) {
+	test.RunSpecs(t, "Subsetutils Suite")
+}


### PR DESCRIPTION
> Retargeted from `master` to `release-2.14`.
> This code is being removed from `master`, so there is nothing to land there and nothing to backport from.
> All measurements below were re-run on `release-2.14`.

## Motivation

Three redundant allocations in policy rule building, found while chasing zone CP CPU on a large zone.
None of them change what rules come out, they just stop recomputing things the surrounding code already computed.

The cost of all three scales with the number of inbound listeners on a Dataplane, because rule building runs once per inbound.
That matters when Kubernetes Services in a namespace use selectors wider than the Deployment they front: every Service then selects every pod, and each Dataplane gets one inbound per Service instead of one per container port.

On 2.14 both rule-building paths are live, since MeshTrafficPermission still carries `from` while newer policies use `rules`, so all three fixes apply.

## Implementation information

**1. `getEntries` calls `GetItems()` once per entry.**
The generated `GetItems()` does `make([]core_model.Resource, n)` and copies, and it was called inside both branches of the switch, so building entries was quadratic in allocation.
Hoisted out of the loop.
`common.Cast` is all-or-nothing and order-preserving, so `policies` stays aligned with `items`, which is what the existing indexing already assumed.

**2. `createRule` recomputes `asSubset` for every item, on every call.**
`buildRulesInternal` already converts every item to a subset in step 1.
`createRule` is called once per tag combination per clique, so that recompute is paid over and over.
Step-1 subsets are now kept in `itemSubsets`, index-aligned with `oldKindsItems` and never reassigned, and passed in.
`subsets` stays the working copy that the single-key path deduplicates.

**3. `IsSubset` and `Intersect` build a `map[string][]Tag` per call.**
Subsets here hold one or two tags, so the map costs more than the scan it replaced.
Both now scan the argument directly and allocate nothing.

## Measurements

Both benchmarks are added by this PR. `release-2.14`, `-benchtime=10x -count=6`, benchstat, Apple M4 Max.

`BenchmarkMatchedPoliciesInboundFanout` covers the `rules` path through `MatchedPolicies`:

| inbounds | policies | sec/op | vs base | B/op    | vs base |
|:---------|:---------|:-------|:--------|:--------|:--------|
| 2        | 500      | 285.6µ | -6.7%   | 167.7Ki | -58.9%  |
| 2        | 2000     | 1.225m | -35.8%  | 672.0Ki | -85.1%  |
| 6        | 500      | 646.0µ | -22.0%  | 492.1Ki | -59.4%  |
| 6        | 2000     | 2.989m | -36.9%  | 1.940Mi | -85.3%  |
| geomean  |          |        | -19.2%  |         |         |

`BenchmarkBuildFromRulesCliques` covers the `from` path, with 500 `from` entries across the policies matched to one inbound:

| tags per caller | inbounds | sec/op baseline | sec/op after | vs base |
|:----------------|:---------|:----------------|:-------------|:--------|
| 1               | 2        | 132.70m         | 14.47m       | -89.1%  |
| 1               | 6        | 399.35m         | 43.02m       | -89.2%  |
| 2               | 2        | 374.19m         | 26.37m       | -93.0%  |
| 2               | 6        | 1128.81m        | 78.25m       | -93.1%  |
| geomean         |          | 47.75m          | 5.503m       | -88.5%  |

All p=0.002, n=6.
Allocation on the worst cell drops from 1.4 GiB to 14.4 MiB.
The gain growing with input size is the quadratic terms going away.

Neither change alters the complexity of the clique algorithm.
It is still quadratic in the number of `from` entries and `NewSubsetIter` is still exponential in a clique's tag count.
This only shrinks the constant.

## Supporting documentation

`subsetutils` had no tests, and `IsSubset`/`Intersect` decide which policy entries apply to a client, so commit 3 adds `subset_equivalence_test.go`.
It keeps the original map-based implementations verbatim as a reference and asserts the new ones agree on every pair of subsets drawn from a 2-key x 2-value x 2-polarity alphabet, exhaustively up to length 3, roughly 342k pairs per function.
It also asserts both functions are allocation free via `testing.AllocsPerRun`.

`./pkg/plugins/policies/... ./pkg/xds/... ./pkg/core/...` pass, 148 packages, including the MeshTrafficPermission golden files, so rule output is unchanged.

Benchmarks were run on a single machine, no CI-grade isolation.

## Backport

Labelled for 2.13, 2.12 and 2.11.
All three defects are present unchanged on every one of those branches.
One thing to know for 2.11: MeshTrafficPermission there has no `rules`, only `from`, so commit 1 is a no-op for it and only commits 2 and 3 move the needle.
The other two branches carry both APIs like 2.14 does.