### PR TITLE
refactor(policy): drop no-op targetRef deprecation shims

### DIFF
--- a/pkg/plugins/policies/core/jsonpatch/validators/validator.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator.go
@@ -116,11 +116,3 @@ func validatePath(path *string, op string) validators.ValidationError {
 
 	return err
 }
-
-// TopLevelTargetRefDeprecations used to warn about MeshService, MeshServiceSubset,
-// MeshSubset, MeshGateway, and MeshHTTPRoute as top-level targetRef kinds. Those kinds
-// are now rejected outright by top-level targetRef validation, so there is nothing left
-// to deprecate for them.
-func TopLevelTargetRefDeprecations(_ *common_api.TopLevelTargetRef) []string {
-	return nil
-}

--- a/pkg/plugins/policies/core/jsonpatch/validators/validator_test.go
+++ b/pkg/plugins/policies/core/jsonpatch/validators/validator_test.go
@@ -317,15 +317,4 @@ var _ = Describe("JsonPatchBlock Validator", func() {
             `,
 		}),
 	)
-
-	DescribeTable("TopLevelTargetRefDeprecations",
-		func(targetRef *common_api.TopLevelTargetRef) {
-			Expect(jsonpatch_validators.TopLevelTargetRefDeprecations(targetRef)).To(BeEmpty())
-		},
-		Entry("nil targetRef", nil),
-		Entry("Mesh", &common_api.TopLevelTargetRef{Kind: common_api.Mesh}),
-		Entry("Dataplane", &common_api.TopLevelTargetRef{Kind: common_api.Dataplane}),
-		Entry("MeshHTTPRoute", &common_api.TopLevelTargetRef{Kind: common_api.MeshHTTPRoute}),
-		Entry("MeshService", &common_api.TopLevelTargetRef{Kind: common_api.MeshService}),
-	)
 })

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshAccessLogResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshCircuitBreakerResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshFaultInjectionResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshHealthCheckResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshHTTPRouteResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshLoadBalancingStrategyResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshMetricResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshProxyPatchResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/deprecated.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"fmt"
 
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
@@ -23,7 +22,7 @@ func (t *MeshRateLimitResource) Deprecations() []string {
 			}
 		}
 	}
-	return append(deprecations, validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)...)
+	return deprecations
 }
 
 func isStatusInvalid(local Local) bool {

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshRetryResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshTCPRouteResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshTimeoutResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/deprecated.go
@@ -1,7 +1,0 @@
-package v1alpha1
-
-import "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-
-func (t *MeshTLSResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshTraceResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/deprecated.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/deprecated.go
@@ -1,9 +1,0 @@
-package v1alpha1
-
-import (
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch/validators"
-)
-
-func (t *MeshTrafficPermissionResource) Deprecations() []string {
-	return validators.TopLevelTargetRefDeprecations(t.Spec.TargetRef)
-}

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/validator_test.go
@@ -257,26 +257,4 @@ violations:
 			}),
 		)
 	})
-
-	Describe("Deprecations()", func() {
-		It("does not report any 'from'-related deprecations", func() {
-			mtp := meshtrafficpermissions_proto.NewMeshTrafficPermissionResource()
-
-			err := core_model.FromYAML([]byte(`
-targetRef:
-  kind: Mesh
-rules:
-  - default:
-      allow:
-        - spiffeID:
-            type: Exact
-            value: spiffe://trust.domain/service
-`), &mtp.Spec)
-			Expect(err).ToNot(HaveOccurred())
-
-			deprecations := mtp.Deprecations()
-
-			Expect(deprecations).To(BeEmpty())
-		})
-	})
 })


### PR DESCRIPTION
## Motivation

The shared helper for targetRef deprecations now returns nothing—validation handles the cases it once warned about. Fourteen policies still call this empty helper, creating false positives when auditing which policies carry real deprecations.

## Implementation information

Removed deprecation files and helper calls from the fourteen policies with no-op shims. MeshRateLimit's real deprecation (warning when local HTTP rate-limit status is below 400) is preserved and continues to emit properly.

Closes https://github.com/kumahq/kuma/issues/17957

_Generated by Sybra harness_