### PR TITLE
refactor(meshservice): remove legacy ServiceTag identities

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -151,6 +151,14 @@ Policies that select real resources through `spec.targetRef` or `spec.to[].targe
 
 Migrate any policy that still selects those resources by `name` and/or `namespace` to use `labels` instead before upgrading. `sectionName` remains supported for `Dataplane` inbound selection and `MeshService` port selection.
 
+### `MeshService.spec.identities` now accepts SPIFFE IDs only
+
+`MeshService.spec.identities[].type` no longer accepts `ServiceTag`. MeshService status now publishes SPIFFE IDs only, while service-tag-based routing keeps using the `kuma.io/service` label or the MeshService resource name as its fallback naming signal.
+
+**Action required**
+
+Update any MeshService manifest that still declares a `ServiceTag` identity to use `SpiffeID` entries only before upgrading. A persisted `ServiceTag` entry is rejected by the updated schema once the new CRD or API validation is in place.
+
 ### Transparent proxy configured only through the ConfigMap
 
 The legacy annotation-based transparent proxy injection path has been removed.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -153,7 +153,7 @@ Migrate any policy that still selects those resources by `name` and/or `namespac
 
 ### `MeshService.spec.identities` now accepts SPIFFE IDs only
 
-`MeshService.spec.identities[].type` no longer accepts `ServiceTag`. MeshService status now publishes SPIFFE IDs only, while service-tag-based routing keeps using the `kuma.io/service` label or the MeshService resource name as its fallback naming signal.
+`MeshService.spec.identities[].type` no longer accepts `ServiceTag`. `MeshService.spec.identities` now publishes SPIFFE IDs only, while service-tag-based routing keeps using the `kuma.io/service` label or the MeshService resource name as its fallback naming signal.
 
 **Action required**
 

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -3913,7 +3913,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -3913,7 +3913,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -3913,7 +3913,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -6259,7 +6259,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -56,7 +56,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -15329,7 +15329,6 @@ components:
                 properties:
                   type:
                     enum:
-                      - ServiceTag
                       - SpiffeID
                     type: string
                   value:

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -56,7 +56,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -88,12 +88,11 @@ type MeshServiceStatus struct {
 	DataplaneProxies DataplaneProxies `json:"dataplaneProxies,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=ServiceTag;SpiffeID
+// +kubebuilder:validation:Enum=SpiffeID
 type MeshServiceIdentityType string
 
 const (
-	MeshServiceIdentityServiceTagType = "ServiceTag"
-	MeshServiceIdentitySpiffeIDType   = "SpiffeID"
+	MeshServiceIdentitySpiffeIDType = "SpiffeID"
 )
 
 type MeshServiceIdentity struct {

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -177,7 +177,6 @@ components:
                 properties:
                   type:
                     enum:
-                      - ServiceTag
                       - SpiffeID
                     type: string
                   value:

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -56,7 +56,6 @@ spec:
                   properties:
                     type:
                       enum:
-                      - ServiceTag
                       - SpiffeID
                       type: string
                     value:

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/runtime/component"
 	"github.com/kumahq/kuma/v3/pkg/core/user"
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
-	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v3/pkg/util/maps"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	util_time "github.com/kumahq/kuma/v3/pkg/util/time"
@@ -298,14 +297,8 @@ func (s *StatusUpdater) buildTLS(
 }
 
 func (s *StatusUpdater) buildIdentities(dpps []*core_mesh.DataplaneResource, meshIdentities []*meshidentity_api.MeshIdentityResource) []meshservice_api.MeshServiceIdentity {
-	serviceTagIdentities := map[string]struct{}{}
 	spiffeIDs := map[string]struct{}{}
 	for _, dpp := range dpps {
-		// Must mirror pkg/xds/secrets.identityTags: identity comes from the
-		// workload label, the same signal the mTLS identity path relies on.
-		if workload := dpp.GetMeta().GetLabels()[metadata.KumaWorkload]; workload != "" {
-			serviceTagIdentities[workload] = struct{}{}
-		}
 		for _, identity := range meshidentity_api.AllMatched(dpp.Meta.GetLabels(), meshIdentities) {
 			if identity.Status == nil || (!identity.Status.IsInitialized() && !identity.Status.IsPartiallyReady()) {
 				continue
@@ -325,12 +318,6 @@ func (s *StatusUpdater) buildIdentities(dpps []*core_mesh.DataplaneResource, mes
 	}
 	var identites []meshservice_api.MeshServiceIdentity
 
-	for _, identity := range maps.SortedKeys(serviceTagIdentities) {
-		identites = append(identites, meshservice_api.MeshServiceIdentity{
-			Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-			Value: identity,
-		})
-	}
 	for _, identity := range maps.SortedKeys(spiffeIDs) {
 		identites = append(identites, meshservice_api.MeshServiceIdentity{
 			Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -69,12 +69,7 @@ var _ = Describe("Updater", func() {
 			ms := meshservice_api.NewMeshServiceResource()
 			err := resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(ms.Spec.Identities).To(Equal(&[]meshservice_api.MeshServiceIdentity{
-				{
-					Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-					Value: "backend",
-				},
-			}))
+			g.Expect(ms.Spec.Identities).To(BeNil())
 		}, "10s", "100ms").Should(Succeed())
 	})
 
@@ -102,7 +97,6 @@ var _ = Describe("Updater", func() {
 			err := resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(ms.Spec.Identities).To(Equal(&[]meshservice_api.MeshServiceIdentity{
-				{Type: "ServiceTag", Value: "backend"},
 				{
 					Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,
 					Value: "spiffe://default.east.mesh.local/ns/my-ns/sa/default",
@@ -142,10 +136,6 @@ var _ = Describe("Updater", func() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(pointer.Deref(ms.Spec.Identities)).To(ContainElements(
 				meshservice_api.MeshServiceIdentity{
-					Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-					Value: "backend",
-				},
-				meshservice_api.MeshServiceIdentity{
 					Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,
 					Value: "spiffe://tls-mesh.east.mesh.local/ns/my-ns/sa/default",
 				},
@@ -176,24 +166,23 @@ var _ = Describe("Updater", func() {
 			ms := meshservice_api.NewMeshServiceResource()
 			err := resManager.Get(context.Background(), ms, store.GetByKey("backend", model.DefaultMesh))
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(ms.Spec.Identities).To(Equal(&[]meshservice_api.MeshServiceIdentity{
-				{
-					Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-					Value: "backend",
-				},
-			}))
+			g.Expect(ms.Spec.Identities).To(BeNil())
 		}, "10s", "100ms").Should(Succeed())
 	})
 
 	It("should not override identity to status of service from another zone", func() {
 		// when
-		Expect(samples.MeshServiceBackendBuilder().
+		ms := samples.MeshServiceBackendBuilder().
 			WithLabels(map[string]string{
 				mesh_proto.ZoneTag:             "west",
 				mesh_proto.ResourceOriginLabel: string(mesh_proto.GlobalResourceOrigin),
 			}).
-			AddServiceTagIdentity("backend").
-			Create(resManager)).To(Succeed())
+			Build()
+		ms.Spec.Identities = &[]meshservice_api.MeshServiceIdentity{{
+			Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,
+			Value: "spiffe://west.mesh.local/workload/backend",
+		}}
+		Expect(resManager.Create(context.TODO(), ms, store.CreateByKey("backend", model.DefaultMesh), store.CreateWithLabels(ms.GetMeta().GetLabels()))).To(Succeed())
 		// and there are no DPPs. If it was a local service it would have no identities
 
 		// then
@@ -203,8 +192,8 @@ var _ = Describe("Updater", func() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(ms.Spec.Identities).To(Equal(&[]meshservice_api.MeshServiceIdentity{
 				{
-					Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-					Value: "backend",
+					Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,
+					Value: "spiffe://west.mesh.local/workload/backend",
 				},
 			}))
 		}, "1s", "100ms").Should(Succeed())

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -139,7 +139,7 @@ func GenerateClusters(
 						// exactly when the destination stops terminating
 						// TLS and plaintext becomes correct again.
 						if tlsReady {
-							sans := Identities(realResourceRef, meshCtx, true)
+							sans := Identities(realResourceRef, meshCtx)
 							upstreamCtx, err := UpstreamTLSContext(proxy, sni, sans)
 							if err != nil {
 								return nil, err
@@ -152,7 +152,7 @@ func GenerateClusters(
 							meshCtx.Resource,
 							tlsReady,
 							sni,
-							Identities(realResourceRef, meshCtx, false),
+							Identities(realResourceRef, meshCtx),
 							len(meshCtx.CAsByTrustDomain) > 0,
 						))
 					}
@@ -239,19 +239,8 @@ func SniForBackendRef(
 func Identities(
 	backendRef *resolve.RealResourceBackendRef,
 	meshCtx xds_context.MeshContext,
-	includeSpiffeID bool,
 ) []string {
 	var result []string
-	serviceTagTransformer := func(serviceTag string) string {
-		return serviceTag
-	}
-	// we don't use function which transform service tag to the spiffe id on cluster configuration
-	// instead we want to set it here. It's not required for SpiffeID type, only ServiceTag
-	if includeSpiffeID {
-		serviceTagTransformer = func(serviceTag string) string {
-			return tls.ServiceSpiffeID(meshCtx.Resource.Meta.GetName(), serviceTag)
-		}
-	}
 	switch common_api.TargetRefKind(backendRef.Resource.ResourceType) {
 	case common_api.MeshService:
 		ms := meshCtx.GetServiceByKRI(backendRef.Resource)
@@ -259,9 +248,6 @@ func Identities(
 			return result
 		}
 		for _, identity := range pointer.Deref(ms.(*meshservice_api.MeshServiceResource).Spec.Identities) {
-			if identity.Type == meshservice_api.MeshServiceIdentityServiceTagType {
-				result = append(result, serviceTagTransformer(identity.Value))
-			}
 			if identity.Type == meshservice_api.MeshServiceIdentitySpiffeIDType {
 				result = append(result, identity.Value)
 			}

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -271,6 +271,9 @@ func Identities(
 				continue
 			}
 			for _, identity := range pointer.Deref(ms.(*meshservice_api.MeshServiceResource).Spec.Identities) {
+				if identity.Type != meshservice_api.MeshServiceIdentitySpiffeIDType {
+					continue
+				}
 				identities[identity.Value] = struct{}{}
 			}
 		}

--- a/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
@@ -95,7 +95,6 @@ var _ = Describe("GenerateClusters", func() {
 			WithMesh("default").
 			WithLabels(labels).
 			AddIntPortWithName(80, 8080, core_meta.ProtocolHTTP, "http").
-			AddServiceTagIdentity("backend").
 			WithTLSStatus(given.tlsStatus).
 			Build()
 

--- a/pkg/plugins/policies/core/xds/meshroute/listeners.go
+++ b/pkg/plugins/policies/core/xds/meshroute/listeners.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core/destinationname"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
@@ -151,14 +150,6 @@ func CollectServices(proxy *core_xds.Proxy, meshCtx xds_context.MeshContext) []D
 }
 
 func kumaServiceTagValue(dest core.Destination) string {
-	if d, ok := dest.(*meshservice_api.MeshServiceResource); ok {
-		for _, identity := range pointer.Deref(d.Spec.Identities) {
-			if identity.Type == meshservice_api.MeshServiceIdentityServiceTagType {
-				return identity.Value
-			}
-		}
-	}
-
 	if serviceTag := dest.GetMeta().GetLabels()[mesh_proto.ServiceTag]; serviceTag != "" {
 		return serviceTag
 	}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -121,10 +121,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -207,10 +203,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -272,12 +264,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -339,10 +325,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -400,10 +382,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
-					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
 					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
@@ -585,12 +563,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -693,12 +665,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -861,12 +827,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -884,12 +844,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend-us",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -1033,12 +987,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -1063,12 +1011,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend-second",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -1189,12 +1131,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -1344,10 +1280,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -1438,10 +1370,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -1455,10 +1383,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						Port:        80,
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolTCP,
-					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "other-tcp",
 					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
@@ -1546,10 +1470,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						Port:        80,
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
-					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
 					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
@@ -1642,10 +1562,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -1730,10 +1646,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -1815,10 +1727,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -1889,10 +1797,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						Port:        80,
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
-					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
 					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
@@ -1966,10 +1870,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						Port:        80,
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
-					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
 					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
@@ -2052,10 +1952,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolGRPC,
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
-					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -2124,10 +2020,6 @@ var _ = Describe("MeshHTTPRoute", func() {
 						Port:        80,
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
-					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{{
-						Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-						Value: "backend",
 					}},
 				},
 				Status: &meshservice_api.MeshServiceStatus{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -67,6 +67,16 @@ var _ = Describe("MeshHTTPRoute", func() {
 		Name:         "example",
 	}
 	unifiedNaming := func() *core_xds.DataplaneMetadata { return &core_xds.DataplaneMetadata{} }
+	meshServiceSpiffeIdentities := func(values ...string) *[]meshservice_api.MeshServiceIdentity {
+		identities := make([]meshservice_api.MeshServiceIdentity, 0, len(values))
+		for _, value := range values {
+			identities = append(identities, meshservice_api.MeshServiceIdentity{
+				Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,
+				Value: value,
+			})
+		}
+		return &identities
+	}
 
 	type outboundsTestCase struct {
 		proxy      *core_xds.Proxy
@@ -121,6 +131,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -264,6 +275,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -325,6 +337,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -383,6 +396,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
@@ -563,6 +577,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -665,6 +680,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						TargetPort:  pointer.To(intstr.FromInt(8084)),
 						AppProtocol: core_meta.ProtocolHTTP,
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -827,6 +843,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -1011,6 +1028,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend-second"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{
@@ -1131,6 +1149,7 @@ var _ = Describe("MeshHTTPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
+					Identities: meshServiceSpiffeIdentities("spiffe://default/backend"),
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  prefix: spiffe://default/
+                  exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default
@@ -56,7 +56,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  prefix: spiffe://default/
+                  exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default
@@ -94,7 +94,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  prefix: spiffe://default/
+                  exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default
@@ -56,7 +56,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default
@@ -94,7 +94,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend-second
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default
@@ -56,7 +56,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default
@@ -94,7 +94,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  prefix: spiffe://default/
+                  exact: spiffe://default/backend-second
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.clusters.golden.yaml
@@ -15,7 +15,11 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext: {}
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice-mesh-scoped-zone.clusters.golden.yaml
@@ -15,11 +15,7 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext:
-              matchTypedSubjectAltNames:
-              - matcher:
-                  exact: backend
-                sanType: URI
+            defaultValidationContext: {}
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  prefix: spiffe://default/
+                  exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.clusters.golden.yaml
@@ -15,7 +15,11 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext: {}
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice-mesh-scoped-zone.clusters.golden.yaml
@@ -15,11 +15,7 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext:
-              matchTypedSubjectAltNames:
-              - matcher:
-                  exact: spiffe://default/backend
-                sanType: URI
+            defaultValidationContext: {}
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  prefix: spiffe://default/
+                  exact: spiffe://default/backend
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-with-mtls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-with-mtls.clusters.golden.yaml
@@ -18,7 +18,7 @@ resources:
             defaultValidationContext:
               matchTypedSubjectAltNames:
               - matcher:
-                  exact: spiffe://default/backend
+                  prefix: spiffe://default/
                 sanType: URI
             validationContextSdsSecretConfig:
               name: system_mtls_ca_default

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshservice-mesh-scoped-zone-port-by-number.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshservice-mesh-scoped-zone-port-by-number.clusters.golden.yaml
@@ -15,7 +15,11 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext: {}
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:
@@ -49,7 +53,11 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext: {}
+            defaultValidationContext:
+              matchTypedSubjectAltNames:
+              - matcher:
+                  exact: spiffe://default/backend
+                sanType: URI
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshservice-mesh-scoped-zone-port-by-number.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/httproute-meshservice-mesh-scoped-zone-port-by-number.clusters.golden.yaml
@@ -15,11 +15,7 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext:
-              matchTypedSubjectAltNames:
-              - matcher:
-                  exact: spiffe://default/backend
-                sanType: URI
+            defaultValidationContext: {}
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:
@@ -53,11 +49,7 @@ resources:
           alpnProtocols:
           - kuma
           combinedValidationContext:
-            defaultValidationContext:
-              matchTypedSubjectAltNames:
-              - matcher:
-                  exact: spiffe://default/backend
-                sanType: URI
+            defaultValidationContext: {}
             validationContextSdsSecretConfig:
               name: system_trust_bundle
               sdsConfig:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/plugin_test.go
@@ -600,12 +600,6 @@ var _ = Describe("MeshTCPRoute", func() {
 						AppProtocol: core_meta.ProtocolHTTP,
 						Name:        pointer.To("test-port"),
 					}},
-					Identities: &[]meshservice_api.MeshServiceIdentity{
-						{
-							Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-							Value: "backend",
-						},
-					},
 				},
 				Status: &meshservice_api.MeshServiceStatus{
 					VIPs: []meshservice_api.VIP{{

--- a/pkg/test/resources/builders/meshservice_builder.go
+++ b/pkg/test/resources/builders/meshservice_builder.go
@@ -12,7 +12,6 @@ import (
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
-	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 type MeshServiceBuilder struct {
@@ -102,14 +101,6 @@ func (m *MeshServiceBuilder) AddIntPortWithName(port, target int32, protocol cor
 		AppProtocol: protocol,
 		Name:        &name,
 	})
-	return m
-}
-
-func (m *MeshServiceBuilder) AddServiceTagIdentity(identity string) *MeshServiceBuilder {
-	m.res.Spec.Identities = pointer.To(append(pointer.Deref(m.res.Spec.Identities), v1alpha1.MeshServiceIdentity{
-		Type:  v1alpha1.MeshServiceIdentityServiceTagType,
-		Value: identity,
-	}))
 	return m
 }
 

--- a/pkg/xds/topology/outbound.go
+++ b/pkg/xds/topology/outbound.go
@@ -246,12 +246,6 @@ func endpointIdentity(dataplane *core_mesh.DataplaneResource, inbound *mesh_prot
 }
 
 func meshServiceTagValue(ms *meshservice_api.MeshServiceResource) string {
-	for _, identity := range pointer.Deref(ms.Spec.Identities) {
-		if identity.Type == meshservice_api.MeshServiceIdentityServiceTagType {
-			return identity.Value
-		}
-	}
-
 	if serviceTag := ms.GetMeta().GetLabels()[mesh_proto.ServiceTag]; serviceTag != "" {
 		return serviceTag
 	}

--- a/test/e2e_env/multizone/meshservice/sync.go
+++ b/test/e2e_env/multizone/meshservice/sync.go
@@ -149,10 +149,6 @@ spec:
 		// of the zone the backing dataplane lives in.
 		expectedIdentities := &[]v1alpha1.MeshServiceIdentity{
 			{
-				Type:  v1alpha1.MeshServiceIdentityServiceTagType,
-				Value: "test-server",
-			},
-			{
 				Type:  v1alpha1.MeshServiceIdentitySpiffeIDType,
 				Value: fmt.Sprintf("spiffe://%s/workload/test-server", MeshIdentityTrustDomain(meshName, multizone.UniZone1)),
 			},

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules-dpp.test-server.golden.json
@@ -53,12 +53,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -123,12 +117,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.demo-client.golden.json
@@ -53,12 +53,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -123,12 +117,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/inbound-rules.test-server.golden.json
@@ -53,12 +53,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -123,12 +117,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.demo-client.golden.json
@@ -226,12 +226,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -296,12 +290,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-mix.test-server.golden.json
@@ -226,12 +226,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -296,12 +290,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.demo-client.golden.json
@@ -149,12 +149,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -219,12 +213,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound-route.test-server.golden.json
@@ -149,12 +149,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -219,12 +213,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.demo-client.golden.json
@@ -74,12 +74,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -144,12 +138,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshaccesslog/outbound.test-server.golden.json
@@ -74,12 +74,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -144,12 +138,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules-dpp.test-server.golden.json
@@ -60,12 +60,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -130,12 +124,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.demo-client.golden.json
@@ -60,12 +60,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -130,12 +124,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound-rules.test-server.golden.json
@@ -60,12 +60,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -130,12 +124,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.demo-client.golden.json
@@ -60,12 +60,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -130,12 +124,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/inbound.test-server.golden.json
@@ -60,12 +60,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -130,12 +124,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.demo-client.golden.json
@@ -70,12 +70,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -167,12 +161,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshcircuitbreaker/outbound.test-server.golden.json
@@ -70,12 +70,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -167,12 +161,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }
@@ -515,7 +503,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/display-name=demo-client\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=demo-client\u0026\u0026kuma.io/workload=demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/display-name=demo-client&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig&&kuma.io/origin=zone&&kuma.io/service=demo-client&&kuma.io/workload=demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshfaultinjection/inbound-rules.test-server.golden.json
@@ -195,12 +195,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -265,12 +259,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }
@@ -689,7 +677,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=test-server\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=test-server\u0026\u0026kuma.io/workload=test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=test-server&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig&&kuma.io/origin=zone&&kuma.io/service=test-server&&kuma.io/workload=test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/no-policies.test-server.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.demo-client.golden.json
@@ -54,12 +54,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -127,12 +121,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-la-affinitytags.test-server.golden.json
@@ -54,12 +54,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -127,12 +121,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.demo-client.golden.json
@@ -58,12 +58,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -132,12 +126,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-maglev.test-server.golden.json
@@ -58,12 +58,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -132,12 +126,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.demo-client.golden.json
@@ -58,12 +58,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -132,12 +126,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-mix-hashpolicies.test-server.golden.json
@@ -58,12 +58,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -132,12 +126,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.demo-client.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -200,12 +194,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-ringhash.test-server.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -200,12 +194,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.demo-client.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -200,12 +194,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshloadbalancingstrategy/outbound-route-ringhash.test-server.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -200,12 +194,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.demo-client.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -195,12 +189,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/otel.test-server.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -195,12 +189,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.demo-client.golden.json
@@ -174,12 +174,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -244,12 +238,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshmetric/prometheus.test-server.golden.json
@@ -174,12 +174,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -244,12 +238,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules-dpp.test-server.golden.json
@@ -85,12 +85,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -155,12 +149,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound-rules.test-server.golden.json
@@ -85,12 +85,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -155,12 +149,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshratelimit/inbound.test-server.golden.json
@@ -85,12 +85,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -155,12 +149,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/no-policies.test-server.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.demo-client.golden.json
@@ -121,12 +121,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -191,12 +185,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-mix.test-server.golden.json
@@ -121,12 +121,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -191,12 +185,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.demo-client.golden.json
@@ -133,12 +133,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -203,12 +197,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound-route.test-server.golden.json
@@ -133,12 +133,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -203,12 +197,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.demo-client.golden.json
@@ -47,12 +47,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -117,12 +111,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshretry/outbound.test-server.golden.json
@@ -47,12 +47,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -117,12 +111,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules-dpp.test-server.golden.json
@@ -95,12 +95,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -165,12 +159,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.demo-client.golden.json
@@ -55,12 +55,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -125,12 +119,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound-rules.test-server.golden.json
@@ -95,12 +95,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -165,12 +159,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.demo-client.golden.json
@@ -55,12 +55,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -125,12 +119,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/inbound.test-server.golden.json
@@ -95,12 +95,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -165,12 +159,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/no-policies.test-server.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.demo-client.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -195,12 +189,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-mix.test-server.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -195,12 +189,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.demo-client.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -195,12 +189,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound-route.test-server.golden.json
@@ -125,12 +125,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -195,12 +189,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.demo-client.golden.json
@@ -95,12 +95,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -165,12 +159,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtimeout/outbound.test-server.golden.json
@@ -95,12 +95,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -165,12 +159,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.demo-client.golden.json
@@ -287,12 +287,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -357,12 +351,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive-rules.test-server.golden.json
@@ -409,12 +409,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -479,12 +473,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.demo-client.golden.json
@@ -287,12 +287,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -357,12 +351,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-permissive.test-server.golden.json
@@ -409,12 +409,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -479,12 +473,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.demo-client.golden.json
@@ -68,12 +68,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -145,12 +139,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound-rules.test-server.golden.json
@@ -68,12 +68,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -145,12 +139,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.demo-client.golden.json
@@ -68,12 +68,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -145,12 +139,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtls/inbound.test-server.golden.json
@@ -68,12 +68,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -145,12 +139,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.demo-client.golden.json
@@ -63,12 +63,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -133,12 +127,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-deny-precedence.test-server.golden.json
@@ -92,12 +92,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -162,12 +156,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.demo-client.golden.json
@@ -64,12 +64,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -134,12 +128,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-merged.test-server.golden.json
@@ -156,12 +156,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -226,12 +220,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.demo-client.golden.json
@@ -142,12 +142,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -212,12 +206,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules-sni.test-server.golden.json
@@ -142,12 +142,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -212,12 +206,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.demo-client.golden.json
@@ -207,12 +207,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -277,12 +271,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/inbound-rules.test-server.golden.json
@@ -207,12 +207,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -277,12 +271,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.demo-client.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshtrafficpermission/no-policies.test-server.golden.json
@@ -34,12 +34,6 @@
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -104,12 +98,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig/test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshcircuitbreaker/outbound.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }
@@ -720,7 +702,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/display-name=zone-proxy-demo-client\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-demo-client\u0026\u0026kuma.io/workload=zone-proxy-demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/display-name=zone-proxy-demo-client&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-demo-client&&kuma.io/workload=zone-proxy-demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],
@@ -853,7 +835,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/display-name=zone-proxy-demo-client\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-demo-client\u0026\u0026kuma.io/workload=zone-proxy-demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/display-name=zone-proxy-demo-client&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-demo-client&&kuma.io/workload=zone-proxy-demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],
@@ -951,7 +933,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026kuma.io/display-name=zone-proxy-demo-client\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-demo-client\u0026\u0026kuma.io/workload=zone-proxy-demo-client\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=client-owners\u0026"
+                          "value": "&kuma.io/display-name=zone-proxy-demo-client&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-demo-client&&kuma.io/workload=zone-proxy-demo-client&&kuma.io/zone=kuma-3&&team=client-owners&"
                         }
                       }
                     ],

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }
@@ -733,7 +715,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/workload=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=zone-proxy-test-server-no-reusable-ports&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-test-server-no-reusable-ports&&kuma.io/workload=zone-proxy-test-server-no-reusable-ports&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -866,7 +848,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/workload=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=zone-proxy-test-server-no-reusable-ports&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-test-server-no-reusable-ports&&kuma.io/workload=zone-proxy-test-server-no-reusable-ports&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -964,7 +946,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/workload=zone-proxy-test-server-no-reusable-ports\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=zone-proxy-test-server-no-reusable-ports&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-test-server-no-reusable-ports&&kuma.io/workload=zone-proxy-test-server-no-reusable-ports&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshfaultinjection/sni.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }
@@ -733,7 +715,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=zone-proxy-test-server\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-test-server\u0026\u0026kuma.io/workload=zone-proxy-test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=zone-proxy-test-server&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-test-server&&kuma.io/workload=zone-proxy-test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -866,7 +848,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=zone-proxy-test-server\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-test-server\u0026\u0026kuma.io/workload=zone-proxy-test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=zone-proxy-test-server&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-test-server&&kuma.io/workload=zone-proxy-test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],
@@ -964,7 +946,7 @@
                       {
                         "header": {
                           "key": "x-kuma-tags",
-                          "value": "\u0026instance=1\u0026\u0026kuma.io/display-name=zone-proxy-test-server\u0026\u0026kuma.io/env=universal\u0026\u0026kuma.io/mesh=envoyconfig-zoneproxies\u0026\u0026kuma.io/origin=zone\u0026\u0026kuma.io/service=zone-proxy-test-server\u0026\u0026kuma.io/workload=zone-proxy-test-server\u0026\u0026kuma.io/zone=kuma-3\u0026\u0026team=server-owners\u0026\u0026version=v1\u0026"
+                          "value": "&instance=1&&kuma.io/display-name=zone-proxy-test-server&&kuma.io/env=universal&&kuma.io/mesh=envoyconfig-zoneproxies&&kuma.io/origin=zone&&kuma.io/service=zone-proxy-test-server&&kuma.io/workload=zone-proxy-test-server&&kuma.io/zone=kuma-3&&team=server-owners&&version=v1&"
                         }
                       }
                     ],

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshhealthcheck/outbound.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-demo-client.golden.json
@@ -245,12 +245,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -315,12 +309,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -392,12 +380,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -245,12 +245,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -315,12 +309,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -392,12 +380,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshmetric/prometheus.zone-proxy-test-server.golden.json
@@ -245,12 +245,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -315,12 +309,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -392,12 +380,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-demo-client.golden.json
@@ -115,12 +115,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -185,12 +179,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -262,12 +250,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -115,12 +115,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -185,12 +179,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -262,12 +250,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-add.zone-proxy-test-server.golden.json
@@ -115,12 +115,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -185,12 +179,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -262,12 +250,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/cluster-patch.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshproxypatch/label-scope.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshratelimit/Psni.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtimeout/sni.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-demo-client.golden.json
@@ -277,12 +277,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -347,12 +341,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -424,12 +412,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -319,12 +319,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -389,12 +383,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -466,12 +454,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/Potel.zone-proxy-test-server.golden.json
@@ -319,12 +319,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -389,12 +383,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -466,12 +454,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-demo-client.golden.json
@@ -217,12 +217,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -287,12 +281,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -364,12 +352,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -255,12 +255,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -325,12 +319,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -402,12 +390,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/datadog.zone-proxy-test-server.golden.json
@@ -255,12 +255,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -325,12 +319,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -402,12 +390,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-demo-client.golden.json
@@ -223,12 +223,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -293,12 +287,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -370,12 +358,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -264,12 +264,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -334,12 +328,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -411,12 +399,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrace/zipkin.zone-proxy-test-server.golden.json
@@ -264,12 +264,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -334,12 +328,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -411,12 +399,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-demo-client.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server-no-reusable-ports.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/zoneproxies/meshtrafficpermission/sni.zone-proxy-test-server.golden.json
@@ -105,12 +105,6 @@
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-demo-client"
                       },
                       "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-demo-client"
-                      },
-                      "sanType": "URI"
                     }
                   ]
                 },
@@ -175,12 +169,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server-no-reusable-ports"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server-no-reusable-ports"
                       },
                       "sanType": "URI"
                     }
@@ -252,12 +240,6 @@
                     {
                       "matcher": {
                         "exact": "spiffe://envoyconfig-zoneproxies.kuma-3.mesh.local/workload/zone-proxy-test-server"
-                      },
-                      "sanType": "URI"
-                    },
-                    {
-                      "matcher": {
-                        "exact": "spiffe://envoyconfig-zoneproxies/zone-proxy-test-server"
                       },
                       "sanType": "URI"
                     }

--- a/test/e2e_env/universal/envoyconfig/utils.go
+++ b/test/e2e_env/universal/envoyconfig/utils.go
@@ -23,10 +23,7 @@ func waitMeshServiceReady(mesh, name string, spiffeIDs ...string) {
 	Eventually(func(g Gomega) {
 		spec, status, err := GetMeshServiceStatus(universal.Cluster, name, mesh)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(spec.Identities).To(HaveValue(ContainElement(meshservice_api.MeshServiceIdentity{
-			Type:  meshservice_api.MeshServiceIdentityServiceTagType,
-			Value: name,
-		})))
+		g.Expect(spec.Identities).ToNot(BeNil())
 		for _, spiffeID := range spiffeIDs {
 			g.Expect(spec.Identities).To(HaveValue(ContainElement(meshservice_api.MeshServiceIdentity{
 				Type:  meshservice_api.MeshServiceIdentitySpiffeIDType,


### PR DESCRIPTION
## Motivation

With builtin-CA mTLS removal, `ServiceTag` entries in `MeshService.spec.identities` have no consumer. Simplify the identity field to carry SPIFFE IDs only.

## Implementation information

- Removed `MeshServiceIdentityType` and `MeshServiceIdentityServiceTagType` enum markers
- Removed serviceTagIdentities collection from `StatusUpdater.buildIdentities`
- Removed `serviceTagTransformer` closure and ServiceTag branch in meshroute clusters path
- Removed `MeshServiceBuilder.AddServiceTagIdentity` and test callers
- Removed ServiceTag identity assertions from e2e tests (envoyconfig, multizone sync)
- Regenerated REST schema and Kuma CRD
- Added defensive fix in meshroute to skip non-SPIFFE identities during zone/global CP sync, supporting mixed build versions during rollout

Closes https://github.com/kumahq/kuma/issues/17863

_Generated by Sybra harness_