### PR TITLE
refactor(policy): unify the three copies of the namespace check

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -138,7 +138,7 @@ func DppSelectedByPolicy(
 	if !dppSelectedByZone(meta, dpp) {
 		return []core_rules.InboundListener{}, false, nil
 	}
-	if !dppSelectedByNamespace(meta, dpp) {
+	if !core_rules.PolicySelectsByNamespace(meta, dpp.GetMeta()) {
 		return []core_rules.InboundListener{}, false, nil
 	}
 	switch ref.Kind {
@@ -226,16 +226,6 @@ func isSelectedByLabels(dpp *core_mesh.DataplaneResource, ref common_api.TargetR
 	return true
 }
 
-func dppSelectedByNamespace(meta core_model.ResourceMeta, dpp *core_mesh.DataplaneResource) bool {
-	switch core_model.PolicyRole(meta) {
-	case mesh_proto.ConsumerPolicyRole, mesh_proto.WorkloadOwnerPolicyRole:
-		ns, ok := meta.GetLabels()[mesh_proto.KubeNamespaceTag]
-		return ok && ns == dpp.GetMeta().GetLabels()[mesh_proto.KubeNamespaceTag]
-	default:
-		return true
-	}
-}
-
 func dppSelectedByZone(policyMeta core_model.ResourceMeta, dpp *core_mesh.DataplaneResource) bool {
 	switch core_model.PolicyRole(policyMeta) {
 	case mesh_proto.ProducerPolicyRole:
@@ -279,27 +269,12 @@ func resolveMeshHTTPRouteRef(policyMeta core_model.ResourceMeta, ref common_api.
 		// (e.g. kuma.io/display-name) across namespaces. Namespaced
 		// policies must only expand routes from their own namespace,
 		// otherwise route-derived config leaks across namespaces.
-		if !policySelectsResourceByNamespace(policyMeta, item.GetMeta()) {
+		if !core_rules.PolicySelectsByNamespace(policyMeta, item.GetMeta()) {
 			continue
 		}
 		matches = append(matches, item.(*meshhttproute_api.MeshHTTPRouteResource))
 	}
 	return matches
-}
-
-// policySelectsResourceByNamespace reports whether a policy may reference a
-// resource living in the given namespace. Consumer and workload-owner policies
-// are namespaced, so they can only reference resources from their own
-// namespace; producer/system policies are namespace-agnostic. Mirrors the
-// equivalent check applied when building To rules.
-func policySelectsResourceByNamespace(policyMeta, resourceMeta core_model.ResourceMeta) bool {
-	switch core_model.PolicyRole(policyMeta) {
-	case mesh_proto.ConsumerPolicyRole, mesh_proto.WorkloadOwnerPolicyRole:
-		ns, ok := policyMeta.GetLabels()[mesh_proto.KubeNamespaceTag]
-		return ok && ns == resourceMeta.GetLabels()[mesh_proto.KubeNamespaceTag]
-	default:
-		return true
-	}
 }
 
 // allInboundListeners returns every inbound of the dataplane as an InboundListener

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -208,7 +208,7 @@ func buildToListWithRoutes(meta core_model.ResourceMeta, policyWithTo core_model
 			// (e.g. kuma.io/display-name) across namespaces. Namespaced
 			// policies must only expand routes from their own namespace,
 			// otherwise route-derived config leaks across namespaces.
-			if !policySelectsByNamespace(meta, route.GetMeta()) {
+			if !PolicySelectsByNamespace(meta, route.GetMeta()) {
 				continue
 			}
 			if r, ok := route.(*meshhttproute_api.MeshHTTPRouteResource); ok {
@@ -532,12 +532,11 @@ func asSubset(tr common_api.TargetRef) (subsetutils.Subset, error) {
 	}
 }
 
-// policySelectsByNamespace reports whether a policy may reference a resource
+// PolicySelectsByNamespace reports whether a policy may reference a resource
 // living in the given namespace. Consumer and workload-owner policies are
 // namespaced, so they can only reference resources from their own namespace;
-// producer/system policies are namespace-agnostic. This mirrors the dataplane
-// namespace scoping applied during matching.
-func policySelectsByNamespace(policyMeta, resourceMeta core_model.ResourceMeta) bool {
+// producer/system policies are namespace-agnostic.
+func PolicySelectsByNamespace(policyMeta, resourceMeta core_model.ResourceMeta) bool {
 	switch core_model.PolicyRole(policyMeta) {
 	case mesh_proto.ConsumerPolicyRole, mesh_proto.WorkloadOwnerPolicyRole:
 		ns, ok := policyMeta.GetLabels()[mesh_proto.KubeNamespaceTag]


### PR DESCRIPTION
## Motivation

Three functions implement the same namespace-scope check in different contexts: when deciding if a policy selects a dataplane, when resolving route references during matching, and when expanding routes for outbound rules. Duplicating this logic creates maintenance risk—a fix applied to one copy could leave the others wrong, silently allowing policies to leak across namespace boundaries.

## Implementation information

Consolidated the three namespace-scope checks into a single function used by all callers. Consumer and workload-owner policies continue to enforce namespace isolation, while producer and system policies maintain their existing cross-namespace behavior. No behavioral changes—golden files and unit tests remain unchanged.

Closes https://github.com/kumahq/kuma/issues/17958

_Generated by Sybra harness_