### PR TITLE
test(e2e): dump debug reports per suite

### DIFF
--- a/test/framework/report/report.go
+++ b/test/framework/report/report.go
@@ -102,19 +102,25 @@ func persistFile(name, srcPath string) {
 	}
 }
 
+// SuiteDir is the directory a suite dumps into: a subdirectory of BaseDir named
+// after the suite. Every suite of a job shares BaseDir, so without the extra
+// level the suite that finishes last wipes the debug data of the suite that
+// actually failed.
+func SuiteDir(suiteDescription string) string {
+	name := files.ToValidUnixFilename(suiteDescription)
+	if name == "" {
+		name = "suite"
+	}
+	return path.Join(BaseDir, name)
+}
+
 // DumpReport dumps the report to the disk.
 func DumpReport(report ginkgo.Report) {
 	ginkgo.GinkgoHelper()
-	basePath := BaseDir
-	if files.FileExists(basePath) {
-		tmpDir := path.Join(os.TempDir(), fmt.Sprintf("kuma-%04d", ginkgo.GinkgoRandomSeed()))
-		logf("Report already exists in %q, moving to tmpDir: %q", basePath, tmpDir)
-		if err := os.Rename(BaseDir, tmpDir); err != nil {
-			logf("[WARNING]: failed to move %q to %q deleting it! %v", basePath, tmpDir, err)
-			if err := os.RemoveAll(basePath); err != nil {
-				logf("[WARNING]: failed to remove %q %v", basePath, err)
-			}
-		}
+	basePath := SuiteDir(report.SuiteDescription)
+	// Only this suite's own directory is cleaned, so re-runs don't mix results.
+	if err := os.RemoveAll(basePath); err != nil {
+		logf("[WARNING]: failed to remove %q %v", basePath, err)
 	}
 	logf("saving report to %q DumpOnSuccess: %v", basePath, DumpOnSuccess)
 	writeEntry := func(path string, data string) {

--- a/test/framework/report/report_test.go
+++ b/test/framework/report/report_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 )
 
 // TestAddFileToReportEntryOutsideGinkgo runs outside a Ginkgo spec (no
@@ -27,5 +30,41 @@ func TestAddFileToReportEntryOutsideGinkgo(t *testing.T) {
 	}
 	if string(got) != "boom" {
 		t.Fatalf("unexpected report content: got %q, want %q", got, "boom")
+	}
+}
+
+// TestDumpReportKeepsOtherSuites covers the case of a job running several suites
+// against the same BaseDir: the suites that run after the failing one used to
+// move its whole directory away, so the failure was uploaded with no debug data.
+func TestDumpReportKeepsOtherSuites(t *testing.T) {
+	baseDir := filepath.Join(t.TempDir(), "results")
+	oldBase, oldDumpOnSuccess := BaseDir, DumpOnSuccess
+	BaseDir, DumpOnSuccess = baseDir, false
+	t.Cleanup(func() { BaseDir, DumpOnSuccess = oldBase, oldDumpOnSuccess })
+
+	failed := func(suite string) ginkgo.Report {
+		return ginkgo.Report{
+			SuiteDescription: suite,
+			SpecReports: []types.SpecReport{{
+				LeafNodeType:               types.NodeTypeIt,
+				LeafNodeText:               "spec",
+				State:                      types.SpecStateFailed,
+				CapturedGinkgoWriterOutput: suite + " output",
+			}},
+		}
+	}
+
+	DumpReport(failed("E2E Helm Suite"))
+	// A later suite in the same job must not touch the helm suite's dump.
+	DumpReport(failed("E2E CNI Suite"))
+
+	for _, suite := range []string{"E2E_Helm_Suite", "E2E_CNI_Suite"} {
+		got, err := os.ReadFile(filepath.Join(baseDir, suite, "spec", "combined.log"))
+		if err != nil {
+			t.Fatalf("expected report for suite %s: %v", suite, err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("expected non-empty report for suite %s", suite)
+		}
 	}
 }


### PR DESCRIPTION
## Motivation

E2E failures on master are being uploaded with no debug data at all.

`build/reports/e2e-debug` is shared by every suite of an e2e job, and `DumpReport` moved the whole directory into the system temp dir whenever it already existed.
The helm suite runs first, fails, and dumps its CP logs / `kumactl export` / dataplane inspects.
Then the transparent proxy, cni, webhooks and federation suites run, pass, and each one moves the previous dump away without writing anything of their own.
The `e2e-debug-*` artifact ends up empty, so it is not even uploaded (`if-no-files-found: ignore`).

Visible in the logs as `Report already exists in "...e2e-debug", moving to tmpDir: ...`.

Concretely: https://github.com/kumahq/kuma/actions/runs/31400314410 has a failing helm upgrade spec and no `e2e-debug` artifact, which makes that flake impossible to diagnose from CI.

## Implementation information

* dump into `<dump dir>/<suite name>/` instead of straight into the dump dir
* clean only that suite subdirectory before writing, so re-runs still do not mix results and other suites are left alone

Artifact layout changes from `e2e-debug/<spec>/...` to `e2e-debug/<suite>/<spec>/...`.

## Supporting documentation

Found while investigating the `dpps should be synced to global` flake in the helm upgrade test.

> Changelog: skip