### PR TITLE
test(e2e): wait for zone proxy rollout

### DIFF
--- a/test/e2e/helm/kuma_helm_deploy_multizone.go
+++ b/test/e2e/helm/kuma_helm_deploy_multizone.go
@@ -59,8 +59,11 @@ func ZoneWithHelmChartAndUniversalGlobal() {
 				// never gets an address on the k3d clusters the E2E tests run on.
 				WithHelmOpt("meshes[0].ingress.service.type", "NodePort"),
 			)).
-			Install(WaitNumPods(Config.KumaNamespace, 1, meshZoneIngressApp)).
-			Install(WaitPodsAvailable(Config.KumaNamespace, meshZoneIngressApp)).
+			// The chart deploys the zone proxy before the injector webhook
+			// exists, so the first pod comes up without a sidecar and a
+			// post-install hook restarts the Deployment. Waiting for that
+			// rollout is the only wait the pre-restart pod can't satisfy.
+			Install(WaitDeploymentRollout(Config.KumaNamespace, meshZoneIngressApp)).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(Parallel(
 				democlient.Install(democlient.WithNamespace(TestNamespace), democlient.WithMesh("default")),

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -97,10 +97,21 @@ func UpgradingZoneWithHelmChart() {
 					WithHelmOpt("meshes[0].ingress.service.type", "NodePort"),
 					WithoutHelmOpt("global.image.tag"),
 				)).
-				Install(WaitNumPods(Config.KumaNamespace, 1, meshZoneIngressApp)).
-				Install(WaitPodsAvailable(Config.KumaNamespace, meshZoneIngressApp)).
+				// The chart deploys the zone proxy before the injector webhook
+				// exists, so the first pod comes up without a sidecar and a
+				// post-install hook restarts the Deployment. Waiting for that
+				// rollout is the only wait the pre-restart pod can't satisfy.
+				Install(WaitDeploymentRollout(Config.KumaNamespace, meshZoneIngressApp)).
 				Setup(zoneK8s)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Only once the restarted pod is up does the ingress have a Dataplane,
+			// which the counts below include.
+			Eventually(func(g Gomega) {
+				dataplanes, err := zoneK8s.GetKumactlOptions().KumactlList("dataplanes", "default")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(dataplanes).To(ContainElement(ContainSubstring(meshZoneIngressApp)))
+			}, "60s", "1s").Should(Succeed(), "mesh zone ingress is not registered in the zone")
 
 			By("Sync policies from Global to Zone")
 			Expect(YamlUniversal(fmt.Sprintf(`
@@ -128,10 +139,13 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 
 			// The zone's own mesh zone ingress is a Dataplane too, so it counts
-			// alongside the test server.
-			Eventually(func(g Gomega) (int, error) {
-				return NumberOfResources(global, mesh.DataplaneResourceTypeDescriptor)
-			}, "60s", "1s").Should(Equal(2), "dpps should be synced to global")
+			// alongside the test server. List them instead of counting so a
+			// failure says which one is missing.
+			Eventually(func(g Gomega) {
+				dataplanes, err := global.GetKumactlOptions().KumactlList("dataplanes", "default")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(dataplanes).To(HaveLen(2))
+			}, "60s", "1s").Should(Succeed(), "dpps should be synced to global")
 
 			By("deploy a new universal zone with latest version")
 			err = NewClusterSetup().

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -366,6 +366,26 @@ func WaitNumPods(namespace string, num int, app string) InstallFunc {
 	}
 }
 
+// WaitDeploymentRollout waits until the Deployment's current generation is
+// rolled out. Unlike WaitNumPods and WaitPodsAvailable it cannot be satisfied by
+// pods of an older generation, so it's the one to use for Deployments the chart
+// restarts from a post-install hook.
+func WaitDeploymentRollout(namespace, name string) InstallFunc {
+	return func(c Cluster) error {
+		ck8s := c.(*K8sCluster)
+		timeout := time.Duration(ck8s.defaultRetries) * ck8s.defaultTimeout
+		out, err := k8s.RunKubectlAndGetOutputContextE(
+			c.GetTesting(), context.Background(),
+			c.GetKubectlOptions(namespace),
+			"rollout", "status", "deployment/"+name, "--timeout="+timeout.String(),
+		)
+		if err != nil {
+			return errors.Wrapf(err, "deployment %q did not roll out: %s", name, out)
+		}
+		return nil
+	}
+}
+
 func WaitPodsAvailable(namespace, app string) InstallFunc {
 	return WaitPodsAvailableWithLabel(namespace, "app", app)
 }


### PR DESCRIPTION
## Motivation

`Upgrade Zone with Helm chart / upgrade zone` fails on master with:

```
[FAILED] Timed out after 60.000s.
dpps should be synced to global
Expected
    <int>: 1
to equal
    <int>: 2
```

6 of the last 22 master runs I checked hit it, always the same assertion, on both the 2.14.2 and 2.14.3 entries. Two examples: https://github.com/kumahq/kuma/actions/runs/31400314410 and https://github.com/kumahq/kuma/actions/runs/31424643025.

The missing dataplane is the mesh zone ingress. Before #17713 the assertion was `Equal(1)` (test server only) and passed at 30s; that PR added the chart ingress to the count and the flake starts there. Bumping the timeout to 60s in #17965 did not fix it.

Root cause is in the waits, not the timeout. As `post-install-rollout-zoneproxy-job.yaml` says itself, the chart deploys the zone proxy before the injector webhook exists, so the first pod starts without a sidecar and a post-install hook does a `kubectl rollout restart` to replace it. `helm install` returns once the hook Job completes, i.e. with the rollout still in flight. Then:

* `WaitNumPods(ns, 1, app)` matches *exactly* one pod, so if the new ReplicaSet has not created its pod yet it returns on the pre-restart, sidecar-less pod
* `WaitPodsAvailable` lists pods at that instant and waits on that same pod, which is just `pause` and therefore immediately ready

A sidecar-less pod has no Dataplane, so the test installs the test server and starts its 60s `Eventually` while the ingress is still being replaced. That window has to cover pod scheduling, sidecar injection, Envoy readiness, Dataplane creation and the KDS sync, which does not fit on a loaded runner. Failing runs also show a slower install phase (56-64s vs 48-50s on passing ones).

## Implementation information

* new `WaitDeploymentRollout` framework helper: `kubectl rollout status` is generation aware, so the pre-restart pod cannot satisfy it
* use it in place of `WaitNumPods` + `WaitPodsAvailable` for the mesh zone ingress in both helm tests
* wait for the ingress Dataplane to be registered in the zone before the test server install, so a future failure separates "ingress never came up" from "KDS did not sync"
* the global check lists dataplanes and asserts the length instead of comparing a bare total, so the failure message names what is actually there

## Supporting documentation

Related: #17713, #17965.

> Changelog: skip