### PR TITLE
ci(build-publish): derive image binary from make

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -181,18 +181,19 @@ jobs:
           skip_cis_scan: false
         # TODO in the future we may want to have prerelease images and use `regctl image copy` to move them to their final location
       # Gates the push, not the build: a wrong version must never reach the registry.
-      # kuma-cni has no version subcommand (a CNI plugin binary, not a CLI), so
-      # there's nothing to assert for it.
+      # `docker/info/binary` returns empty for images that ship no versioned CLI
+      # (kuma-cni is a plugin binary), and lets distributions that rename images
+      # map their own names without patching this workflow.
       - name: Assert built binary reports tag version
-        if: ${{ github.ref_type == 'tag' && matrix.image != 'kuma-cni' }}
+        if: ${{ github.ref_type == 'tag' }}
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          case "${{ matrix.image }}" in
-            kuma-init) binary=kumactl ;;
-            kuma-universal) binary=kuma-cp ;;
-            *) binary="${{ matrix.image }}" ;;
-          esac
+          binary=$(make -s docker/info/binary/${{ matrix.image }})
+          if [ -z "${binary}" ]; then
+            echo "${{ matrix.image }} ships no versioned CLI, nothing to assert"
+            exit 0
+          fi
           for arch in $(make -s docker/info/enabled-arches); do
             make check/binary-version \
               BINARY_PATH="build/artifacts-linux-${arch}/${binary}/${binary}" \

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -150,6 +150,24 @@ docker/info/registry: ## Output the Docker registry
 docker/info/enabled-arches: ## Output the arches `images/<name>` builds for
 	@echo $(ENABLED_GOARCHES)
 
+# Maps an image name to the binary whose `version` output must match the image tag.
+# Empty means the image ships no versioned CLI (kuma-cni is a plugin binary, not a
+# CLI) and callers skip the assert. Keep in sync with the `image/<name>/<arch>`
+# prerequisites above - this is what CI uses to gate the push on a tag.
+image_binary = $(patsubst kuma-init,kumactl,$(patsubst kuma-universal,kuma-cp,$(filter-out kuma-cni,$(1))))
+
+# Distributions that rename images (e.g. a `ubi-` prefix) override this to reuse
+# `image_binary` with the upstream name, the same way RESOLVE_CONTAINER_TEST_FILE
+# is overridden for container structure tests.
+RESOLVE_IMAGE_BINARY ?= $(call image_binary,$(1))
+
+define IMAGE_INFO_TARGETS_BY_IMAGE
+.PHONY: docker/info/binary/$(1)
+docker/info/binary/$(1): ## Output the binary whose `version` must match the image tag ('' if the image ships none)
+	@echo $$(call RESOLVE_IMAGE_BINARY,$(1))
+endef
+$(foreach image,$(IMAGES_RELEASE) $(IMAGES_TEST),$(eval $(call IMAGE_INFO_TARGETS_BY_IMAGE,$(image))))
+
 # The awk command is ok because we're passing a list of container image names which won't contain ' ' or '"'
 # This outputs something like: ["docker.io/kumahq/kuma-cp:0.0.0-preview.vlocal-build","docker.io/kumahq/kuma-dp:0.0.0-preview.vlocal-build","docker.io/kumahq/kumactl:0.0.0-preview.vlocal-build","docker.io/kumahq/kuma-init:0.0.0-preview.vlocal-build","docker.io/kumahq/kuma-cni:0.0.0-preview.vlocal-build"]
 .PHONY: manifests/json/release


### PR DESCRIPTION
## Motivation

The tag-version assert in `build-images` re-derives the image -> binary mapping in a shell `case`, duplicating what the `image/<name>/<arch>` prerequisites in `mk/docker.mk` already say, with an identity fallback for anything unrecognised:

```sh
case "${{ matrix.image }}" in
  kuma-init) binary=kumactl ;;
  kuma-universal) binary=kuma-cp ;;
  *) binary="${{ matrix.image }}" ;;
esac
```

That fallback silently breaks any distribution whose image names differ. kong-mesh builds `ubi-*` variants, so `ubi-kumactl` looked for `build/artifacts-linux-amd64/ubi-kumactl/ubi-kumactl` rather than `build/artifacts-linux-amd64/kumactl/kumactl` - the binary inside keeps the unprefixed name. All five of its ubi images failed the assert on the 2.14.3 tag push and none of them got published.

Since the step is gated on `github.ref_type == tag`, branch CI never runs it, so this only surfaces during a release.

## Implementation information

Move the mapping into `mk/docker.mk` behind `docker/info/binary/<image>` and have the workflow ask make for it, next to the existing `make -s docker/info/enabled-arches` call.

An empty answer means the image ships no versioned CLI, so `kuma-cni` no longer needs its own clause in the `if:` - the skip became data rather than a second place to update.

Distributions that rename images override `RESOLVE_IMAGE_BINARY` to reuse `image_binary` with the upstream name, the same way `RESOLVE_CONTAINER_TEST_FILE` is already overridden for container structure tests. Downstream then needs one line and no patch to this workflow.

Verified locally:

```text
kuma-cp          -> [kuma-cp]
kuma-dp          -> [kuma-dp]
kumactl          -> [kumactl]
kuma-init        -> [kumactl]
kuma-cni         -> []
kuma-universal   -> [kuma-cp]
```

and with a simulated downstream override (`RESOLVE_IMAGE_BINARY=$(call image_binary,$(subst ubi-,,$(1)))`):

```text
ubi-kuma-cp      -> [kuma-cp]
ubi-kumactl      -> [kumactl]
ubi-kuma-init    -> [kumactl]
ubi-kuma-cni     -> []
```

`actionlint` is clean.

### Alternatives discarded

Stripping a `ubi-` prefix in the workflow - puts a downstream naming concept in kuma.

Asserting the version inside the image rather than on the host artifact, which needs no mapping at all and validates what actually ships. `test/container-structure/kumactl.yaml` already runs `kumactl version`, it just does not assert the value, and container-structure-test does not interpolate env into config files, so the expected version would have to be templated in. Worth doing separately.

## Supporting documentation

Mapping was introduced in https://github.com/kumahq/kuma/pull/17445

Downstream failure this fixes: https://github.com/Kong/kong-mesh/actions/runs/31378161958/job/93423911164

Labelled `backport` - `release-2.11` through `release-2.14` all carry the `case` statement.

> Changelog: skip