### PR TITLE
refactor(rules): replace single-item rules with merged config

### DIFF
--- a/pkg/api-server/resource_inspect_endpoints.go
+++ b/pkg/api-server/resource_inspect_endpoints.go
@@ -305,13 +305,13 @@ type matchedPoliciesToResponse func([]core_xds.TypedMatchingPolicies, *restful.R
 func matchedPoliciesToProxyPolicy(matchedPolicies []core_xds.TypedMatchingPolicies, _ *restful.Request, _ *core_mesh.MeshResource, _ *core_mesh.DataplaneResource, _ xds_context.Resources) (any, error) {
 	conf := []api_common.PolicyConf{}
 	for _, matched := range matchedPolicies {
-		if len(matched.SingleItemRules.Rules) == 0 {
+		if matched.ProxyConf == nil {
 			continue
 		}
 		conf = append(conf, api_common.PolicyConf{
-			Conf:    matched.SingleItemRules.Rules[0].Conf,
+			Conf:    matched.ProxyConf.Conf,
 			Kind:    string(matched.Type),
-			Origins: policyOriginsToKRIOrigins(matched.Type, matched.SingleItemRules.Rules[0].Origin),
+			Origins: policyOriginsToKRIOrigins(matched.Type, matched.ProxyConf.Origin),
 		})
 	}
 	return api_common.PoliciesList{Policies: conf}, nil
@@ -553,14 +553,14 @@ func (r *resourceInspectHandler) rulesForResource() restful.RouteFunction {
 				}
 			}
 
-			if len(res.ToRules.Rules) == 0 && len(res.ToRules.ResourceRules) == 0 && len(res.FromRules.InboundRules) == 0 && len(res.SingleItemRules.Rules) == 0 {
+			if len(res.ToRules.Rules) == 0 && len(res.ToRules.ResourceRules) == 0 && len(res.FromRules.InboundRules) == 0 && res.ProxyConf == nil {
 				continue
 			}
 			var proxyRule *api_common.ProxyRule
-			if len(res.SingleItemRules.Rules) > 0 {
+			if res.ProxyConf != nil {
 				proxyRule = &api_common.ProxyRule{
-					Conf:   res.SingleItemRules.Rules[0].Conf,
-					Origin: oapi_helpers.ResourceMetaListToMetaList(res.Type, res.SingleItemRules.Rules[0].Origin),
+					Conf:   res.ProxyConf.Conf,
+					Origin: oapi_helpers.ResourceMetaListToMetaList(res.Type, res.ProxyConf.Origin),
 				}
 			}
 

--- a/pkg/core/xds/matched_policies.go
+++ b/pkg/core/xds/matched_policies.go
@@ -17,7 +17,7 @@ type TypedMatchingPolicies struct {
 	DataplanePolicies []core_model.Resource
 	FromRules         rules.FromRules
 	ToRules           rules.ToRules
-	SingleItemRules   rules.SingleItemRules
+	ProxyConf         *rules.ProxyConf
 	Warnings          []string
 }
 

--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -97,8 +97,8 @@ func (s *SnapshotGenerator) getMatchingDataplanes(ctx context.Context, meshesWit
 			if err != nil {
 				return nil, errors.Wrap(err, "error on matching dpp")
 			}
-			if len(matchedPolicies.SingleItemRules.Rules) == 1 {
-				conf := matchedPolicies.SingleItemRules.Rules[0].Conf.(v1alpha1.Conf)
+			if matchedPolicies.ProxyConf != nil {
+				conf := matchedPolicies.ProxyConf.Conf.(v1alpha1.Conf)
 				meshMetricConfToDataplanes[&conf] = dp
 			}
 		}

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -108,7 +108,7 @@ func MatchedPolicies(
 		warnings = append(warnings, fmt.Sprintf("couldn't create To rules: %s", err.Error()))
 	}
 
-	sr, err := core_rules.BuildSingleItemRules(dpPolicies.GetItems())
+	pc, err := core_rules.BuildProxyConf(dpPolicies.GetItems())
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("couldn't create top level rules: %s", err.Error()))
 	}
@@ -118,7 +118,7 @@ func MatchedPolicies(
 		DataplanePolicies: dpPolicies.GetItems(),
 		FromRules:         fr,
 		ToRules:           tr,
-		SingleItemRules:   sr,
+		ProxyConf:         pc,
 		Warnings:          warnings,
 	}
 	if mpOpts.Cache != nil {

--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -110,7 +110,7 @@ func MatchedPolicies(
 
 	pc, err := core_rules.BuildProxyConf(dpPolicies.GetItems())
 	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("couldn't create top level rules: %s", err.Error()))
+		warnings = append(warnings, fmt.Sprintf("couldn't create proxy-wide config: %s", err.Error()))
 	}
 
 	result := core_xds.TypedMatchingPolicies{

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -58,7 +58,8 @@ type ToRules struct {
 }
 
 // ProxyConf is the single merged configuration of a proxy-wide policy applying
-// to the whole proxy. A nil *ProxyConf means no policy of that type matched the proxy.
+// to the whole proxy. A nil *ProxyConf means either no policy of that type matched
+// the proxy, or the matched policy type doesn't support proxy-wide configuration.
 type ProxyConf struct {
 	Conf   any
 	Origin []core_model.ResourceMeta

--- a/pkg/plugins/policies/core/rules/rules.go
+++ b/pkg/plugins/policies/core/rules/rules.go
@@ -57,8 +57,11 @@ type ToRules struct {
 	ResourceRules outbound.ResourceRules
 }
 
-type SingleItemRules struct {
-	Rules Rules
+// ProxyConf is the single merged configuration of a proxy-wide policy applying
+// to the whole proxy. A nil *ProxyConf means no policy of that type matched the proxy.
+type ProxyConf struct {
+	Conf   any
+	Origin []core_model.ResourceMeta
 }
 
 // Deprecated: use common.WithPolicyAttributes instead
@@ -295,27 +298,32 @@ func BuildPolicyItemsWithMeta(items []core_model.PolicyItem, meta core_model.Res
 	return result
 }
 
-func BuildSingleItemRules(matchedPolicies []core_model.Resource) (SingleItemRules, error) {
-	items := []PolicyItemWithMeta{}
+func BuildProxyConf(matchedPolicies []core_model.Resource) (*ProxyConf, error) {
+	var confs []any
+	var origin []core_model.ResourceMeta
 	for _, mp := range matchedPolicies {
 		policyWithSingleItem, ok := mp.GetSpec().(core_model.PolicyWithSingleItem)
 		if !ok {
 			// policy doesn't support single item
-			return SingleItemRules{}, nil
+			return nil, nil
 		}
-		item := PolicyItemWithMeta{
-			PolicyItem:   policyWithSingleItem.GetPolicyItem(),
-			ResourceMeta: mp.GetMeta(),
-		}
-		items = append(items, item)
+		confs = append(confs, policyWithSingleItem.GetPolicyItem().GetDefault())
+		origin = append(origin, mp.GetMeta())
 	}
 
-	rules, err := BuildRules(items, false)
+	if len(confs) == 0 {
+		return nil, nil
+	}
+
+	merged, err := merge.Confs(confs)
 	if err != nil {
-		return SingleItemRules{}, err
+		return nil, err
+	}
+	if len(merged) == 0 {
+		return nil, nil
 	}
 
-	return SingleItemRules{Rules: rules}, nil
+	return &ProxyConf{Conf: merged[0], Origin: origin}, nil
 }
 
 // BuildRules creates a list of rules with negations sorted by the number of positive tags.

--- a/pkg/plugins/policies/core/rules/rules_test.go
+++ b/pkg/plugins/policies/core/rules/rules_test.go
@@ -549,7 +549,7 @@ var _ = Describe("Rules", func() {
 		DescribeTable("should build a rule-based view for list of single item policies",
 			func(inputFile string) {
 				buildRulesTestTemplate(inputFile, func(policies []core_model.Resource) (any, error) {
-					return core_rules.BuildSingleItemRules(policies)
+					return core_rules.BuildProxyConf(policies)
 				})
 			},
 			test.EntriesForFolder("rules/single"),

--- a/pkg/plugins/policies/core/rules/testdata/rules/single/06.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/single/06.golden.yaml
@@ -1,21 +1,18 @@
-Rules:
-- Conf:
-    backends:
-    - type: Zipkin
-      zipkin:
-        apiVersion: httpJson
-        sharedSpanContext: true
-        traceId128bit: false
-        url: http://jaeger-collector.mesh-observability:9411/api/v2/spans
-    tags:
-    - literal: core
-      name: team
-  Origin:
-  - creationTime: "0001-01-01T00:00:00Z"
-    kri: kri_mtr_mesh-1___mt-1_
-    mesh: mesh-1
-    modificationTime: "0001-01-01T00:00:00Z"
-    name: mt-1
-    type: MeshTrace
-  OriginByMatches: {}
-  Subset: []
+Conf:
+  backends:
+  - type: Zipkin
+    zipkin:
+      apiVersion: httpJson
+      sharedSpanContext: true
+      traceId128bit: false
+      url: http://jaeger-collector.mesh-observability:9411/api/v2/spans
+  tags:
+  - literal: core
+    name: team
+Origin:
+- creationTime: "0001-01-01T00:00:00Z"
+  kri: kri_mtr_mesh-1___mt-1_
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: mt-1
+  type: MeshTrace

--- a/pkg/plugins/policies/core/rules/testdata/rules/single/07.golden.yaml
+++ b/pkg/plugins/policies/core/rules/testdata/rules/single/07.golden.yaml
@@ -1,25 +1,22 @@
-Rules:
-- Conf:
-    backends:
-    - datadog:
-        splitService: false
-        url: http://ingest.datadoghq.eu:8126
-      type: Datadog
-    tags:
-    - literal: support
-      name: team
-  Origin:
-  - creationTime: "0001-01-01T00:00:00Z"
-    kri: kri_mtr_mesh-1___mt-1_
-    mesh: mesh-1
-    modificationTime: "0001-01-01T00:00:00Z"
-    name: mt-1
-    type: MeshTrace
-  - creationTime: "0001-01-01T00:00:00Z"
-    kri: kri_mtr_mesh-1___mt-2_
-    mesh: mesh-1
-    modificationTime: "0001-01-01T00:00:00Z"
-    name: mt-2
-    type: MeshTrace
-  OriginByMatches: {}
-  Subset: []
+Conf:
+  backends:
+  - datadog:
+      splitService: false
+      url: http://ingest.datadoghq.eu:8126
+    type: Datadog
+  tags:
+  - literal: support
+    name: team
+Origin:
+- creationTime: "0001-01-01T00:00:00Z"
+  kri: kri_mtr_mesh-1___mt-1_
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: mt-1
+  type: MeshTrace
+- creationTime: "0001-01-01T00:00:00Z"
+  kri: kri_mtr_mesh-1___mt-2_
+  mesh: mesh-1
+  modificationTime: "0001-01-01T00:00:00Z"
+  name: mt-2
+  type: MeshTrace

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -98,16 +98,15 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *core_xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshMetricType]
-	if !ok || len(policies.SingleItemRules.Rules) == 0 {
+	if !ok || policies.ProxyConf == nil {
 		return nil
 	}
 
-	rule := policies.SingleItemRules.Rules[0]
-	policyNames := make([]string, 0, len(rule.Origin))
-	for _, o := range rule.Origin {
+	policyNames := make([]string, 0, len(policies.ProxyConf.Origin))
+	for _, o := range policies.ProxyConf.Origin {
 		policyNames = append(policyNames, o.GetName())
 	}
-	conf := sanitizeConfForProxy(rule.Conf.(api.Conf), proxy, policyNames)
+	conf := sanitizeConfForProxy(policies.ProxyConf.Conf.(api.Conf), proxy, policyNames)
 
 	if len(pointer.Deref(conf.Backends)) == 0 {
 		return nil

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck // SA1019 Test file: tests backward compatibility with deprecated core_rules.Rule
 package v1alpha1_test
 
 import (
@@ -19,7 +18,6 @@ import (
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/plugin/v1alpha1"
 	k8s_metadata "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
@@ -127,26 +125,21 @@ var _ = Describe("MeshMetric", func() {
 						WithLabels(workloadLabels()),
 				).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Applications: &[]api.Application{
-										{
-											Name: pointer.To("test-app"),
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												Path: "/metrics",
-												Port: 5670,
-											},
-										},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Applications: &[]api.Application{
+								{
+									Name: pointer.To("test-app"),
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										Path: "/metrics",
+										Port: 5670,
 									},
 								},
 							},
@@ -165,28 +158,23 @@ var _ = Describe("MeshMetric", func() {
 				).
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Sidecar: &api.Sidecar{
-										IncludeUnused: pointer.To(false),
-									},
-									Applications: &[]api.Application{
-										{
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												Path: "/metrics",
-												Port: 5670,
-											},
-										},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Sidecar: &api.Sidecar{
+								IncludeUnused: pointer.To(false),
+							},
+							Applications: &[]api.Application{
+								{
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										Path: "/metrics",
+										Port: 5670,
 									},
 								},
 							},
@@ -205,37 +193,32 @@ var _ = Describe("MeshMetric", func() {
 				).
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Sidecar: &api.Sidecar{
-										IncludeUnused: pointer.To(false),
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Sidecar: &api.Sidecar{
+								IncludeUnused: pointer.To(false),
+							},
+							Applications: &[]api.Application{
+								{
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										ClientId: pointer.To("first-backend"),
+										Path:     "/metrics",
+										Port:     5670,
 									},
-									Applications: &[]api.Application{
-										{
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												ClientId: pointer.To("first-backend"),
-												Path:     "/metrics",
-												Port:     5670,
-											},
-										},
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												ClientId: pointer.To("second-backend"),
-												Path:     "/metrics",
-												Port:     5671,
-											},
-										},
+								},
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										ClientId: pointer.To("second-backend"),
+										Path:     "/metrics",
+										Port:     5671,
 									},
 								},
 							},
@@ -256,25 +239,20 @@ var _ = Describe("MeshMetric", func() {
 				).
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Applications: &[]api.Application{
-										{
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.OpenTelemetryBackendType,
-											OpenTelemetry: &api.OpenTelemetryBackend{
-												BackendRef:      otelBackendRef("otel-collector"),
-												RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
-											},
-										},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Applications: &[]api.Application{
+								{
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.OpenTelemetryBackendType,
+									OpenTelemetry: &api.OpenTelemetryBackend{
+										BackendRef:      otelBackendRef("otel-collector"),
+										RefreshInterval: &k8s.Duration{Duration: 10 * time.Second},
 									},
 								},
 							},
@@ -296,21 +274,16 @@ var _ = Describe("MeshMetric", func() {
 					MetricsKeyPath:  "/path/key",
 				}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												Path: "/metrics",
-												Port: 5670,
-												Tls: &api.PrometheusTls{
-													Mode: api.ProvidedTLS,
-												},
-											},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										Path: "/metrics",
+										Port: 5670,
+										Tls: &api.PrometheusTls{
+											Mode: api.ProvidedTLS,
 										},
 									},
 								},
@@ -334,42 +307,37 @@ var _ = Describe("MeshMetric", func() {
 				).
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Origin: []core_model.ResourceMeta{
-									&test_model.ResourceMeta{
-										Mesh: "default",
-										Name: "meshmetric1",
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Sidecar: &api.Sidecar{
+								IncludeUnused: pointer.To(false),
+							},
+							Applications: &[]api.Application{
+								{
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										Path: "/metrics",
+										Port: 5670,
 									},
 								},
-								Conf: api.Conf{
-									Sidecar: &api.Sidecar{
-										IncludeUnused: pointer.To(false),
-									},
-									Applications: &[]api.Application{
-										{
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												Path: "/metrics",
-												Port: 5670,
-											},
-										},
-										{
-											Type: api.OpenTelemetryBackendType,
-											OpenTelemetry: &api.OpenTelemetryBackend{
-												BackendRef: otelBackendRef("otel-collector"),
-											},
-										},
+								{
+									Type: api.OpenTelemetryBackendType,
+									OpenTelemetry: &api.OpenTelemetryBackend{
+										BackendRef: otelBackendRef("otel-collector"),
 									},
 								},
+							},
+						},
+						Origin: []core_model.ResourceMeta{
+							&test_model.ResourceMeta{
+								Mesh: "default",
+								Name: "meshmetric1",
 							},
 						},
 					}),
@@ -390,33 +358,28 @@ var _ = Describe("MeshMetric", func() {
 				).
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Sidecar: &api.Sidecar{
-										IncludeUnused: pointer.To(false),
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Sidecar: &api.Sidecar{
+								IncludeUnused: pointer.To(false),
+							},
+							Applications: &[]api.Application{
+								{
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.OpenTelemetryBackendType,
+									OpenTelemetry: &api.OpenTelemetryBackend{
+										BackendRef: otelBackendRef("otel-collector"),
 									},
-									Applications: &[]api.Application{
-										{
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.OpenTelemetryBackendType,
-											OpenTelemetry: &api.OpenTelemetryBackend{
-												BackendRef: otelBackendRef("otel-collector"),
-											},
-										},
-										{
-											Type: api.OpenTelemetryBackendType,
-											OpenTelemetry: &api.OpenTelemetryBackend{
-												BackendRef: otelBackendRef("second-collector"),
-											},
-										},
+								},
+								{
+									Type: api.OpenTelemetryBackendType,
+									OpenTelemetry: &api.OpenTelemetryBackend{
+										BackendRef: otelBackendRef("second-collector"),
 									},
 								},
 							},
@@ -432,25 +395,20 @@ var _ = Describe("MeshMetric", func() {
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithDataplane(zoneEgressOnlyDataplane()).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Applications: &[]api.Application{
-										{
-											Path: "/metrics",
-											Port: 8080,
-										},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												Path: "/metrics",
-												Port: 5670,
-											},
-										},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Applications: &[]api.Application{
+								{
+									Path: "/metrics",
+									Port: 8080,
+								},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										Path: "/metrics",
+										Port: 5670,
 									},
 								},
 							},
@@ -466,19 +424,14 @@ var _ = Describe("MeshMetric", func() {
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithDataplane(zoneIngressOnlyDataplane("zone-ingress-1")).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Backends: &[]api.Backend{
-										{
-											Type: api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{
-												Path: "/metrics",
-												Port: 5670,
-											},
-										},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Backends: &[]api.Backend{
+								{
+									Type: api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{
+										Path: "/metrics",
+										Port: 5670,
 									},
 								},
 							},
@@ -496,20 +449,15 @@ var _ = Describe("MeshMetric", func() {
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithDataplane(dp).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Applications: &[]api.Application{
-										{Name: pointer.To("my-app"), Path: "/metrics", Port: 8080},
-									},
-									Backends: &[]api.Backend{
-										{
-											Type:       api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{Path: "/metrics", Port: 5670},
-										},
-									},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Applications: &[]api.Application{
+								{Name: pointer.To("my-app"), Path: "/metrics", Port: 8080},
+							},
+							Backends: &[]api.Backend{
+								{
+									Type:       api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{Path: "/metrics", Port: 5670},
 								},
 							},
 						},
@@ -558,18 +506,13 @@ var _ = Describe("MeshMetric", func() {
 				WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
 				WithDataplane(zoneEgressOnlyDataplane()).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Applications: nil,
-									Backends: &[]api.Backend{
-										{
-											Type:       api.PrometheusBackendType,
-											Prometheus: &api.PrometheusBackend{Path: "/metrics", Port: 5670},
-										},
-									},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Applications: nil,
+							Backends: &[]api.Backend{
+								{
+									Type:       api.PrometheusBackendType,
+									Prometheus: &api.PrometheusBackend{Path: "/metrics", Port: 5670},
 								},
 							},
 						},
@@ -617,14 +560,9 @@ var _ = Describe("MeshMetric", func() {
 					},
 				}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshMetricType, core_rules.SingleItemRules{
-						Rules: []*core_rules.Rule{
-							{
-								Subset: []subsetutils.Tag{},
-								Conf: api.Conf{
-									Backends: backends,
-								},
-							},
+					WithProxyConfPolicy(api.MeshMetricType, &core_rules.ProxyConf{
+						Conf: api.Conf{
+							Backends: backends,
 						},
 					}),
 				).

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin.go
@@ -49,7 +49,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return nil
 	}
 	listeners := policies_xds.GatherListeners(rs)
-	if err := applyToOutboundPassthrough(ctx, rs, policies.SingleItemRules, listeners, proxy); err != nil {
+	if err := applyToOutboundPassthrough(ctx, rs, policies.ProxyConf, listeners, proxy); err != nil {
 		return err
 	}
 	return nil
@@ -58,15 +58,14 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 func applyToOutboundPassthrough(
 	_ xds_context.Context,
 	rs *core_xds.ResourceSet,
-	rules core_rules.SingleItemRules,
+	rules *core_rules.ProxyConf,
 	listeners policies_xds.Listeners,
 	proxy *core_xds.Proxy,
 ) error {
-	if len(rules.Rules) == 0 {
+	if rules == nil {
 		return nil
 	}
-	rawConf := rules.Rules[0].Conf
-	conf := rawConf.(api.Conf)
+	conf := rules.Conf.(api.Conf)
 
 	// todo: this should be handled by "base policy"
 	if pointer.Deref(conf.PassthroughMode) == "" {

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin_test.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck // SA1019 Test file: tests backward compatibility with deprecated core_rules.Rule
 package v1alpha1_test
 
 import (
@@ -12,7 +11,6 @@ import (
 	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
 	plugins_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshpassthrough/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1"
@@ -34,7 +32,7 @@ var _ = Describe("MeshPassthrough", func() {
 
 	type testCase struct {
 		resources       []*core_xds.Resource
-		singleItemRules core_rules.SingleItemRules
+		proxyConf       *core_rules.ProxyConf
 		listenersGolden string
 		clustersGolden  string
 	}
@@ -63,7 +61,7 @@ var _ = Describe("MeshPassthrough", func() {
 						),
 				).
 				WithPolicies(
-					xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshPassthroughType, given.singleItemRules),
+					xds_builders.MatchedPolicies().WithProxyConfPolicy(api.MeshPassthroughType, given.proxyConf),
 				).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
@@ -104,78 +102,73 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							PassthroughMode: pointer.To[api.PassthroughMode](api.PassthroughMode("Matched")),
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "api.example.com",
-									Port:     pointer.To[uint32](443),
-									Protocol: api.ProtocolType("tls"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "example.com",
-									Port:     pointer.To[uint32](443),
-									Protocol: api.ProtocolType("tls"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "*.example.com",
-									Port:     pointer.To[uint32](443),
-									Protocol: api.ProtocolType("tls"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "example.com",
-									Port:     pointer.To[uint32](8080),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "other.com",
-									Port:     pointer.To[uint32](8080),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("CIDR"),
-									Value:    "192.168.0.0/16",
-									Protocol: api.ProtocolType("http"),
-									Port:     pointer.To[uint32](8126),
-								},
-								{
-									Type:     api.MatchType("CIDR"),
-									Value:    "240.0.0.0/4",
-									Protocol: api.ProtocolType("http"),
-									Port:     pointer.To[uint32](8126),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "www.google.com",
-									Protocol: api.ProtocolType("http"),
-									Port:     pointer.To[uint32](80),
-								},
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "10.42.0.8",
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "b6e5:a45e:70ae:e77f:d24e:5023:375d:20a6",
-									Protocol: api.ProtocolType("tls"),
-								},
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "9942:9abf:d0e0:f2da:2290:333b:e590:f497",
-									Port:     pointer.To[uint32](9091),
-									Protocol: api.ProtocolType("tcp"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					PassthroughMode: pointer.To[api.PassthroughMode](api.PassthroughMode("Matched")),
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "api.example.com",
+							Port:     pointer.To[uint32](443),
+							Protocol: api.ProtocolType("tls"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "example.com",
+							Port:     pointer.To[uint32](443),
+							Protocol: api.ProtocolType("tls"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "*.example.com",
+							Port:     pointer.To[uint32](443),
+							Protocol: api.ProtocolType("tls"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "example.com",
+							Port:     pointer.To[uint32](8080),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "other.com",
+							Port:     pointer.To[uint32](8080),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("CIDR"),
+							Value:    "192.168.0.0/16",
+							Protocol: api.ProtocolType("http"),
+							Port:     pointer.To[uint32](8126),
+						},
+						{
+							Type:     api.MatchType("CIDR"),
+							Value:    "240.0.0.0/4",
+							Protocol: api.ProtocolType("http"),
+							Port:     pointer.To[uint32](8126),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "www.google.com",
+							Protocol: api.ProtocolType("http"),
+							Port:     pointer.To[uint32](80),
+						},
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "10.42.0.8",
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "b6e5:a45e:70ae:e77f:d24e:5023:375d:20a6",
+							Protocol: api.ProtocolType("tls"),
+						},
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "9942:9abf:d0e0:f2da:2290:333b:e590:f497",
+							Port:     pointer.To[uint32](9091),
+							Protocol: api.ProtocolType("tcp"),
 						},
 					},
 				},
@@ -208,19 +201,14 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "192.168.0.0",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("tcp"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "192.168.0.0",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("tcp"),
 						},
 					},
 				},
@@ -253,25 +241,20 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "api.example.com",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "192.168.0.0",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("tcp"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "api.example.com",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "192.168.0.0",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("tcp"),
 						},
 					},
 				},
@@ -304,30 +287,25 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("CIDR"),
-									Value:    "10.10.0.0/16",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("CIDR"),
-									Value:    "192.168.0.0/24",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "192.168.0.0",
-									Protocol: api.ProtocolType("http"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("CIDR"),
+							Value:    "10.10.0.0/16",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("CIDR"),
+							Value:    "192.168.0.0/24",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "192.168.0.0",
+							Protocol: api.ProtocolType("http"),
 						},
 					},
 				},
@@ -360,35 +338,30 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "example1.com",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "anotherexample.com",
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "example2.com",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "*.example.com",
-									Protocol: api.ProtocolType("http"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "example1.com",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "anotherexample.com",
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "example2.com",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "*.example.com",
+							Protocol: api.ProtocolType("http"),
 						},
 					},
 				},
@@ -421,24 +394,19 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "www.example.com",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "www.anotherexample.com",
-									Protocol: api.ProtocolType("http"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "www.example.com",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "www.anotherexample.com",
+							Protocol: api.ProtocolType("http"),
 						},
 					},
 				},
@@ -471,24 +439,19 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "www.gmail.com",
-									Port:     pointer.To[uint32](80),
-									Protocol: api.ProtocolType("http"),
-								},
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "10.42.0.8",
-									Protocol: api.ProtocolType("http"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "www.gmail.com",
+							Port:     pointer.To[uint32](80),
+							Protocol: api.ProtocolType("http"),
+						},
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "10.42.0.8",
+							Protocol: api.ProtocolType("http"),
 						},
 					},
 				},
@@ -521,25 +484,20 @@ var _ = Describe("MeshPassthrough", func() {
 						)).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("IP"),
-									Value:    "172.12.2.2",
-									Port:     pointer.To[uint32](3306),
-									Protocol: api.ProtocolType("mysql"),
-								},
-								{
-									Type:     api.MatchType("CIDR"),
-									Value:    "172.12.2.2/24",
-									Port:     pointer.To[uint32](3307),
-									Protocol: api.ProtocolType("mysql"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("IP"),
+							Value:    "172.12.2.2",
+							Port:     pointer.To[uint32](3306),
+							Protocol: api.ProtocolType("mysql"),
+						},
+						{
+							Type:     api.MatchType("CIDR"),
+							Value:    "172.12.2.2/24",
+							Port:     pointer.To[uint32](3307),
+							Protocol: api.ProtocolType("mysql"),
 						},
 					},
 				},
@@ -566,14 +524,9 @@ var _ = Describe("MeshPassthrough", func() {
 					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, outboundPassthroughIPv4Name).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							PassthroughMode: pointer.To[api.PassthroughMode](api.PassthroughMode("None")),
-						},
-					},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					PassthroughMode: pointer.To[api.PassthroughMode](api.PassthroughMode("None")),
 				},
 			},
 			listenersGolden: "disabled_on_policy.listeners.golden.yaml",
@@ -598,20 +551,15 @@ var _ = Describe("MeshPassthrough", func() {
 					Resource: clusters.NewClusterBuilder(envoy_common.APIV3, outboundPassthroughIPv4Name).MustBuild(),
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							PassthroughMode: pointer.To[api.PassthroughMode](api.PassthroughMode("All")),
-							AppendMatch: &[]api.Match{
-								{
-									Type:     api.MatchType("Domain"),
-									Value:    "api.example.com",
-									Port:     pointer.To[uint32](443),
-									Protocol: api.ProtocolType("tls"),
-								},
-							},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					PassthroughMode: pointer.To[api.PassthroughMode](api.PassthroughMode("All")),
+					AppendMatch: &[]api.Match{
+						{
+							Type:     api.MatchType("Domain"),
+							Value:    "api.example.com",
+							Port:     pointer.To[uint32](443),
+							Protocol: api.ProtocolType("tls"),
 						},
 					},
 				},

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin.go
@@ -7,7 +7,6 @@ import (
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/matchers"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshproxypatch/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
@@ -36,11 +35,10 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, _ xds_context.Context, proxy *co
 	if !ok {
 		return nil
 	}
-	if len(policies.SingleItemRules.Rules) == 0 {
+	if policies.ProxyConf == nil {
 		return nil
 	}
-	rule := policies.SingleItemRules.Rules.Compute(subsetutils.MeshElement())
-	conf := rule.Conf.(api.Conf)
+	conf := policies.ProxyConf.Conf.(api.Conf)
 	if err := ApplyMods(rs, pointer.Deref(conf.AppendModifications)); err != nil {
 		return err
 	}

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_test.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck // SA1019 Test file: tests backward compatibility with deprecated core_rules.Rule
 package v1alpha1_test
 
 import (
@@ -9,7 +8,6 @@ import (
 	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
 	policies_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshproxypatch/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1"
@@ -25,7 +23,7 @@ import (
 var _ = Describe("MeshProxyPatch", func() {
 	type testCase struct {
 		resources        []core_xds.Resource
-		rules            core_rules.SingleItemRules
+		rules            *core_rules.ProxyConf
 		expectedClusters []string
 	}
 
@@ -40,7 +38,7 @@ var _ = Describe("MeshProxyPatch", func() {
 			context := xds_samples.SampleContext()
 			proxy := xds_builders.Proxy().
 				WithDataplane(samples.DataplaneBackendBuilder()).
-				WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshProxyPatchType, given.rules)).
+				WithPolicies(xds_builders.MatchedPolicies().WithProxyConfPolicy(api.MeshProxyPatchType, given.rules)).
 				Build()
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
 
@@ -56,32 +54,27 @@ var _ = Describe("MeshProxyPatch", func() {
 						MustBuild(),
 				},
 			},
-			rules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: subsetutils.Subset{},
-						Conf: api.Conf{
-							AppendModifications: &[]api.Modification{
-								{
-									Cluster: &api.ClusterMod{
-										Operation: api.ModOpAdd,
-										Value: pointer.To(`
+			rules: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					AppendModifications: &[]api.Modification{
+						{
+							Cluster: &api.ClusterMod{
+								Operation: api.ModOpAdd,
+								Value: pointer.To(`
 name: new-cluster
 connectTimeout: 5s
 `),
-									},
+							},
+						},
+						{
+							Cluster: &api.ClusterMod{
+								Operation: api.ModOpPatch,
+								Match: &api.ClusterMatch{
+									Name: pointer.To("echo-http"),
 								},
-								{
-									Cluster: &api.ClusterMod{
-										Operation: api.ModOpPatch,
-										Match: &api.ClusterMatch{
-											Name: pointer.To("echo-http"),
-										},
-										Value: pointer.To(`
+								Value: pointer.To(`
 connectTimeout: 100s
 `),
-									},
-								},
 							},
 						},
 					},

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_zone_proxy_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/plugin_zone_proxy_test.go
@@ -154,7 +154,7 @@ func newMeshProxyPatch(name string, targetRef *common_api.TopLevelTargetRef, mod
 }
 
 // MeshProxyPatch on a zone proxy Dataplane flows through the same
-// SingleItemRules path as a regular Dataplane — the matcher (#16584)
+// ProxyConf path as a regular Dataplane — the matcher (#16584)
 // is what makes Dataplane-targeted policies reach the embedded zone
 // proxy listeners. MeshProxyPatch itself is proxy-wide; scoping to a
 // specific zone proxy DPP is done with computed labels on `targetRef`,

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -57,7 +57,7 @@ func (p plugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resource
 
 func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.Proxy) error {
 	policies, ok := proxy.Policies.Dynamic[api.MeshTraceType]
-	if !ok || len(policies.SingleItemRules.Rules) == 0 {
+	if !ok || policies.ProxyConf == nil {
 		return nil
 	}
 
@@ -68,14 +68,14 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 	if err := applyToZoneProxyListeners(ctx, policies, rs, proxy); err != nil {
 		return err
 	}
-	if err := applyToClusters(ctx, policies.SingleItemRules, rs, proxy); err != nil {
+	if err := applyToClusters(ctx, policies.ProxyConf, rs, proxy); err != nil {
 		return err
 	}
-	if err := applyToRealResources(ctx, policies.SingleItemRules, rs, proxy); err != nil {
+	if err := applyToRealResources(ctx, policies.ProxyConf, rs, proxy); err != nil {
 		return err
 	}
 	if proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) && proxy.OtelPipeBackends != nil {
-		addToOtelPipeBackends(ctx, policies.SingleItemRules, proxy)
+		addToOtelPipeBackends(ctx, policies.ProxyConf, proxy)
 	}
 
 	return nil
@@ -84,14 +84,14 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 func applyToInbounds(ctx xds_context.Context, policies xds.TypedMatchingPolicies, inboundListeners map[core_rules.InboundListener]*envoy_listener.Listener, proxy *xds.Proxy) error {
 	sectionNames := inboundSectionNames(proxy.Dataplane.Spec.GetNetworking())
 	for key, inboundListener := range inboundListeners {
-		listenerRules, err := buildListenerScopedSingleItemRules(policies, sectionNames[key])
+		listenerConf, err := buildListenerScopedProxyConf(policies, sectionNames[key])
 		if err != nil {
 			return err
 		}
-		if len(listenerRules.Rules) == 0 {
+		if listenerConf == nil {
 			continue
 		}
-		if err := configureListener(ctx, listenerRules, proxy, inboundListener, "", inboundListener.TrafficDirection); err != nil {
+		if err := configureListener(ctx, listenerConf, proxy, inboundListener, "", inboundListener.TrafficDirection); err != nil {
 			return err
 		}
 	}
@@ -135,30 +135,30 @@ func applyToZoneProxyListeners(ctx xds_context.Context, policies xds.TypedMatchi
 		if !ok {
 			continue
 		}
-		listenerRules, err := buildListenerScopedSingleItemRules(policies, l.GetSectionName())
+		listenerConf, err := buildListenerScopedProxyConf(policies, l.GetSectionName())
 		if err != nil {
 			return err
 		}
-		if len(listenerRules.Rules) == 0 {
+		if listenerConf == nil {
 			continue
 		}
 		// Zone-proxy listener TrafficDirection is INBOUND on the wire (Envoy receives
 		// from local sidecars), but a zone-egress span represents an outbound hop. Pass
 		// UNSPECIFIED so Datadog SplitService skips the misleading "_INBOUND" suffix.
-		if err := configureListener(ctx, listenerRules, proxy, listener, "", envoy_core.TrafficDirection_UNSPECIFIED); err != nil {
+		if err := configureListener(ctx, listenerConf, proxy, listener, "", envoy_core.TrafficDirection_UNSPECIFIED); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// buildListenerScopedSingleItemRules returns rules scoped to the given embedded listener.
+// buildListenerScopedProxyConf returns the merged conf scoped to the given embedded listener.
 // Policies with `kind: Dataplane` and a non-empty `sectionName` that does not match the
 // listener are excluded; everything else (including the matcher's proxy-wide rule when no
 // per-policy info is available) is preserved.
-func buildListenerScopedSingleItemRules(policies xds.TypedMatchingPolicies, sectionName string) (core_rules.SingleItemRules, error) {
+func buildListenerScopedProxyConf(policies xds.TypedMatchingPolicies, sectionName string) (*core_rules.ProxyConf, error) {
 	if len(policies.DataplanePolicies) == 0 {
-		return policies.SingleItemRules, nil
+		return policies.ProxyConf, nil
 	}
 	filtered := make([]core_model.Resource, 0, len(policies.DataplanePolicies))
 	for _, p := range policies.DataplanePolicies {
@@ -174,10 +174,10 @@ func buildListenerScopedSingleItemRules(policies xds.TypedMatchingPolicies, sect
 		}
 		filtered = append(filtered, p)
 	}
-	return core_rules.BuildSingleItemRules(filtered)
+	return core_rules.BuildProxyConf(filtered)
 }
 
-func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {
+func applyToRealResources(ctx xds_context.Context, rules *core_rules.ProxyConf, rs *xds.ResourceSet, proxy *xds.Proxy) error {
 	for uri, resType := range rs.IndexByOrigin(xds.NonMeshExternalService) {
 		service, port, found := meshroute.DestinationPortFromRef(ctx.Mesh, &resolve.RealResourceBackendRef{
 			Resource: uri,
@@ -199,7 +199,7 @@ func applyToRealResources(ctx xds_context.Context, rules core_rules.SingleItemRu
 	return nil
 }
 
-func configureListener(ctx xds_context.Context, rules core_rules.SingleItemRules, proxy *xds.Proxy, listener *envoy_listener.Listener, destination string, direction envoy_core.TrafficDirection) error {
+func configureListener(ctx xds_context.Context, rules *core_rules.ProxyConf, proxy *xds.Proxy, listener *envoy_listener.Listener, destination string, direction envoy_core.TrafficDirection) error {
 	serviceName := proxy.Dataplane.IdentifyingName()
 	// IdentifyingName falls back to "unknown" on a zone-proxy-only Dataplane (no service tag).
 	// Prefer the workload label (stable across pod restarts on K8s) and fall back to the
@@ -211,8 +211,7 @@ func configureListener(ctx xds_context.Context, rules core_rules.SingleItemRules
 			serviceName = proxy.Dataplane.GetMeta().GetName()
 		}
 	}
-	rawConf := rules.Rules[0].Conf
-	conf := rawConf.(api.Conf)
+	conf := rules.Conf.(api.Conf)
 
 	var workloadKRI string
 	if workloadName := proxy.Dataplane.GetMeta().GetLabels()[k8s_metadata.KumaWorkload]; workloadName != "" {
@@ -291,10 +290,8 @@ func shouldSkipUnresolvedOpenTelemetryBackend(
 	return hasOpenTelemetryBackend(conf)
 }
 
-func applyToClusters(ctx xds_context.Context, rules core_rules.SingleItemRules, rs *xds.ResourceSet, proxy *xds.Proxy) error {
-	rawConf := rules.Rules[0].Conf
-
-	conf := rawConf.(api.Conf)
+func applyToClusters(ctx xds_context.Context, rules *core_rules.ProxyConf, rs *xds.ResourceSet, proxy *xds.Proxy) error {
+	conf := rules.Conf.(api.Conf)
 
 	var backend api.Backend
 	if backends := pointer.Deref(conf.Backends); len(backends) == 0 {
@@ -399,8 +396,8 @@ func endpointForDatadog(cfg *api.DatadogBackend) *xds.Endpoint {
 	}
 }
 
-func addToOtelPipeBackends(ctx xds_context.Context, rules core_rules.SingleItemRules, proxy *xds.Proxy) {
-	conf := rules.Rules[0].Conf.(api.Conf)
+func addToOtelPipeBackends(ctx xds_context.Context, rules *core_rules.ProxyConf, proxy *xds.Proxy) {
+	conf := rules.Conf.(api.Conf)
 	if !hasOtelBackendRef(conf) {
 		return
 	}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck // SA1019 Test file: tests backward compatibility with deprecated core_rules.Rule
 package v1alpha1_test
 
 import (
@@ -23,7 +22,6 @@ import (
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	core_matchers "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/matchers"
 	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
 	plugins_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrace/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrace/plugin/v1alpha1"
@@ -66,13 +64,13 @@ func otelBackendRef(name string) *common_api.BackendResourceRef {
 
 var _ = Describe("MeshTrace", func() {
 	type testCase struct {
-		resources       []core_xds.Resource
-		singleItemRules core_rules.SingleItemRules
-		outbounds       xds_types.Outbounds
-		goldenFile      string
-		proxyLabels     map[string]string
-		zone            string
-		otelBackends    []*motb_api.MeshOpenTelemetryBackendResource
+		resources    []core_xds.Resource
+		proxyConf    *core_rules.ProxyConf
+		outbounds    xds_types.Outbounds
+		goldenFile   string
+		proxyLabels  map[string]string
+		zone         string
+		otelBackends []*motb_api.MeshOpenTelemetryBackendResource
 	}
 	backendMeshServiceIdentifier := kri.Identifier{
 		ResourceType: "MeshService",
@@ -144,7 +142,7 @@ var _ = Describe("MeshTrace", func() {
 			proxyBuilder := xds_builders.Proxy().
 				WithDataplane(dpBuilder).
 				WithOutbounds(given.outbounds).
-				WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, given.singleItemRules))
+				WithPolicies(xds_builders.MatchedPolicies().WithProxyConfPolicy(api.MeshTraceType, given.proxyConf))
 			if given.zone != "" {
 				proxyBuilder = proxyBuilder.WithZone(given.zone)
 			}
@@ -170,31 +168,26 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Tags: &[]api.Tag{
-								{Name: "app", Literal: pointer.To("backend")},
-								{Name: "app_code", Header: &api.HeaderTag{Name: "app_code"}},
-								{Name: "client_id", Header: &api.HeaderTag{Name: "client_id", Default: pointer.To("none")}},
-							},
-							Sampling: &api.Sampling{
-								Overall: pointer.To(intstr.FromInt(10)),
-								Client:  pointer.To(intstr.FromInt(20)),
-								Random:  pointer.To(intstr.FromInt(50)),
-							},
-							Backends: &[]api.Backend{{
-								Zipkin: &api.ZipkinBackend{
-									Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-									SharedSpanContext: true,
-									ApiVersion:        "httpProto",
-									TraceId128Bit:     true,
-								},
-							}},
-						},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Tags: &[]api.Tag{
+						{Name: "app", Literal: pointer.To("backend")},
+						{Name: "app_code", Header: &api.HeaderTag{Name: "app_code"}},
+						{Name: "client_id", Header: &api.HeaderTag{Name: "client_id", Default: pointer.To("none")}},
 					},
+					Sampling: &api.Sampling{
+						Overall: pointer.To(intstr.FromInt(10)),
+						Client:  pointer.To(intstr.FromInt(20)),
+						Random:  pointer.To(intstr.FromInt(50)),
+					},
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							ApiVersion:        "httpProto",
+							TraceId128Bit:     true,
+						},
+					}},
 				},
 			},
 			goldenFile: "inbound-outbound-zipkin",
@@ -208,28 +201,23 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Tags: &[]api.Tag{
-								{Name: "app", Literal: pointer.To("backend")},
-								{Name: "app_code", Header: &api.HeaderTag{Name: "app_code"}},
-								{Name: "client_id", Header: &api.HeaderTag{Name: "client_id", Default: pointer.To("none")}},
-							},
-							Sampling: &api.Sampling{
-								Overall: pointer.To(intstr.FromInt(10)),
-								Client:  pointer.To(intstr.FromInt(20)),
-								Random:  pointer.To(intstr.FromInt(50)),
-							},
-							Backends: &[]api.Backend{{
-								OpenTelemetry: &api.OpenTelemetryBackend{
-									BackendRef: otelBackendRef("otel-collector"),
-								},
-							}},
-						},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Tags: &[]api.Tag{
+						{Name: "app", Literal: pointer.To("backend")},
+						{Name: "app_code", Header: &api.HeaderTag{Name: "app_code"}},
+						{Name: "client_id", Header: &api.HeaderTag{Name: "client_id", Default: pointer.To("none")}},
 					},
+					Sampling: &api.Sampling{
+						Overall: pointer.To(intstr.FromInt(10)),
+						Client:  pointer.To(intstr.FromInt(20)),
+						Random:  pointer.To(intstr.FromInt(50)),
+					},
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: otelBackendRef("otel-collector"),
+						},
+					}},
 				},
 			},
 			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
@@ -246,18 +234,13 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								OpenTelemetry: &api.OpenTelemetryBackend{
-									BackendRef: otelBackendRef("otel-collector-ipv6"),
-								},
-							}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: otelBackendRef("otel-collector-ipv6"),
 						},
-					},
+					}},
 				},
 			},
 			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
@@ -274,22 +257,17 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Sampling: &api.Sampling{
-								Random: pointer.To(intstr.FromInt(50)),
-							},
-							Backends: &[]api.Backend{{
-								Datadog: &api.DatadogBackend{
-									Url:          "http://ingest.datadog.eu:8126",
-									SplitService: true,
-								},
-							}},
-						},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Sampling: &api.Sampling{
+						Random: pointer.To(intstr.FromInt(50)),
 					},
+					Backends: &[]api.Backend{{
+						Datadog: &api.DatadogBackend{
+							Url:          "http://ingest.datadog.eu:8126",
+							SplitService: true,
+						},
+					}},
 				},
 			},
 			goldenFile: "inbound-outbound-datadog",
@@ -303,20 +281,15 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								Zipkin: &api.ZipkinBackend{
-									Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-									SharedSpanContext: true,
-									TraceId128Bit:     true,
-								},
-							}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							TraceId128Bit:     true,
 						},
-					},
+					}},
 				},
 			},
 			goldenFile: "empty-sampling",
@@ -330,21 +303,16 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								Zipkin: &api.ZipkinBackend{
-									Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-									SharedSpanContext: true,
-									ApiVersion:        "httpProto",
-									TraceId128Bit:     true,
-								},
-							}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							ApiVersion:        "httpProto",
+							TraceId128Bit:     true,
 						},
-					},
+					}},
 				},
 			},
 			goldenFile: "inbound-outbound-zipkin-workload-identity",
@@ -364,24 +332,19 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Tags: &[]api.Tag{
-								{Name: "kuma.mesh", Literal: pointer.To("user-mesh")},
-							},
-							Backends: &[]api.Backend{{
-								Zipkin: &api.ZipkinBackend{
-									Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-									SharedSpanContext: true,
-									ApiVersion:        "httpProto",
-									TraceId128Bit:     true,
-								},
-							}},
-						},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Tags: &[]api.Tag{
+						{Name: "kuma.mesh", Literal: pointer.To("user-mesh")},
 					},
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							ApiVersion:        "httpProto",
+							TraceId128Bit:     true,
+						},
+					}},
 				},
 			},
 			goldenFile: "inbound-outbound-zipkin-user-tag-no-override",
@@ -401,14 +364,9 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{},
-						},
-					},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{},
 				},
 			},
 			goldenFile: "empty-backend-list",
@@ -447,16 +405,11 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			}).
-			WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								OpenTelemetry: &api.OpenTelemetryBackend{},
-							}},
-						},
-					},
+			WithPolicies(xds_builders.MatchedPolicies().WithProxyConfPolicy(api.MeshTraceType, &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{},
+					}},
 				},
 			})).
 			Build()
@@ -505,23 +458,18 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			}).
-			WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								OpenTelemetry: &api.OpenTelemetryBackend{
-									BackendRef: &common_api.BackendResourceRef{
-										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Labels: map[string]string{
-											"kuma.io/test": "non-existing",
-										},
-									},
+			WithPolicies(xds_builders.MatchedPolicies().WithProxyConfPolicy(api.MeshTraceType, &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: &common_api.BackendResourceRef{
+								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{
+									"kuma.io/test": "non-existing",
 								},
-							}},
+							},
 						},
-					},
+					}},
 				},
 			})).
 			Build()
@@ -596,23 +544,18 @@ var _ = Describe("MeshTrace", func() {
 					Resource: backendMeshServiceIdentifier,
 				},
 			}).
-			WithPolicies(xds_builders.MatchedPolicies().WithSingleItemPolicy(api.MeshTraceType, core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{
-					{
-						Subset: []subsetutils.Tag{},
-						Conf: api.Conf{
-							Backends: &[]api.Backend{{
-								OpenTelemetry: &api.OpenTelemetryBackend{
-									BackendRef: &common_api.BackendResourceRef{
-										Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
-										Labels: map[string]string{
-											"kuma.io/display-name": backendName,
-										},
-									},
+			WithPolicies(xds_builders.MatchedPolicies().WithProxyConfPolicy(api.MeshTraceType, &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: &common_api.BackendResourceRef{
+								Kind: common_api.BackendResourceMeshOpenTelemetryBackend,
+								Labels: map[string]string{
+									"kuma.io/display-name": backendName,
 								},
-							}},
+							},
 						},
-					},
+					}},
 				},
 			})).
 			Build()
@@ -757,11 +700,11 @@ func mixedInboundAndZoneEgressResources() []core_xds.Resource {
 
 var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 	type testCase struct {
-		dp              *builders.DataplaneBuilder
-		resources       []core_xds.Resource
-		singleItemRules core_rules.SingleItemRules
-		goldenFile      string
-		otelBackends    []*motb_api.MeshOpenTelemetryBackendResource
+		dp           *builders.DataplaneBuilder
+		resources    []core_xds.Resource
+		proxyConf    *core_rules.ProxyConf
+		goldenFile   string
+		otelBackends []*motb_api.MeshOpenTelemetryBackendResource
 	}
 	DescribeTable("should generate proper Envoy config",
 		func(given testCase) {
@@ -785,7 +728,7 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 				WithDataplane(given.dp).
 				WithMetadata(&core_xds.DataplaneMetadata{}).
 				WithPolicies(xds_builders.MatchedPolicies().
-					WithSingleItemPolicy(api.MeshTraceType, given.singleItemRules)).
+					WithProxyConfPolicy(api.MeshTraceType, given.proxyConf)).
 				WithZone("zone-1").
 				Build()
 
@@ -803,54 +746,45 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 		Entry("zone-egress-only zipkin", testCase{
 			dp:        zoneEgressOnlyDataplane(),
 			resources: []core_xds.Resource{zoneEgressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Zipkin: &api.ZipkinBackend{
-								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-								SharedSpanContext: true,
-								TraceId128Bit:     true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							TraceId128Bit:     true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-egress-only-zipkin",
 		}),
 		Entry("zone-egress-only datadog", testCase{
 			dp:        zoneEgressOnlyDataplane(),
 			resources: []core_xds.Resource{zoneEgressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Datadog: &api.DatadogBackend{
-								Url:          "http://ingest.datadog.eu:8126",
-								SplitService: true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Datadog: &api.DatadogBackend{
+							Url:          "http://ingest.datadog.eu:8126",
+							SplitService: true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-egress-only-datadog",
 		}),
 		Entry("zone-egress-only opentelemetry", testCase{
 			dp:        zoneEgressOnlyDataplane(),
 			resources: []core_xds.Resource{zoneEgressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							OpenTelemetry: &api.OpenTelemetryBackend{
-								BackendRef: otelBackendRef("otel-collector"),
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: otelBackendRef("otel-collector"),
+						},
+					}},
+				},
 			},
 			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
 				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
@@ -860,54 +794,45 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 		Entry("zone-ingress-only zipkin", testCase{
 			dp:        zoneIngressOnlyDataplane("zone-ingress-1"),
 			resources: []core_xds.Resource{zoneIngressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Zipkin: &api.ZipkinBackend{
-								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-								SharedSpanContext: true,
-								TraceId128Bit:     true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							TraceId128Bit:     true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-ingress-only-zipkin",
 		}),
 		Entry("zone-ingress-only datadog", testCase{
 			dp:        zoneIngressOnlyDataplane("zone-ingress-1"),
 			resources: []core_xds.Resource{zoneIngressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Datadog: &api.DatadogBackend{
-								Url:          "http://ingest.datadog.eu:8126",
-								SplitService: true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Datadog: &api.DatadogBackend{
+							Url:          "http://ingest.datadog.eu:8126",
+							SplitService: true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-ingress-only-datadog",
 		}),
 		Entry("zone-ingress-only opentelemetry", testCase{
 			dp:        zoneIngressOnlyDataplane("zone-ingress-1"),
 			resources: []core_xds.Resource{zoneIngressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							OpenTelemetry: &api.OpenTelemetryBackend{
-								BackendRef: otelBackendRef("otel-collector"),
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: otelBackendRef("otel-collector"),
+						},
+					}},
+				},
 			},
 			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
 				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
@@ -917,54 +842,45 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 		Entry("mixed inbound and zone egress zipkin", testCase{
 			dp:        mixedInboundAndZoneEgressDataplane(),
 			resources: mixedInboundAndZoneEgressResources(),
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Zipkin: &api.ZipkinBackend{
-								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-								SharedSpanContext: true,
-								TraceId128Bit:     true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							TraceId128Bit:     true,
+						},
+					}},
+				},
 			},
 			goldenFile: "mixed-inbound-and-zone-egress-zipkin",
 		}),
 		Entry("mixed inbound and zone egress datadog", testCase{
 			dp:        mixedInboundAndZoneEgressDataplane(),
 			resources: mixedInboundAndZoneEgressResources(),
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Datadog: &api.DatadogBackend{
-								Url:          "http://ingest.datadog.eu:8126",
-								SplitService: true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Datadog: &api.DatadogBackend{
+							Url:          "http://ingest.datadog.eu:8126",
+							SplitService: true,
+						},
+					}},
+				},
 			},
 			goldenFile: "mixed-inbound-and-zone-egress-datadog",
 		}),
 		Entry("mixed inbound and zone egress opentelemetry", testCase{
 			dp:        mixedInboundAndZoneEgressDataplane(),
 			resources: mixedInboundAndZoneEgressResources(),
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							OpenTelemetry: &api.OpenTelemetryBackend{
-								BackendRef: otelBackendRef("otel-collector"),
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						OpenTelemetry: &api.OpenTelemetryBackend{
+							BackendRef: otelBackendRef("otel-collector"),
+						},
+					}},
+				},
 			},
 			otelBackends: []*motb_api.MeshOpenTelemetryBackendResource{
 				otelBackendResource("otel-collector", "jaeger-collector.mesh-observability"),
@@ -977,19 +893,16 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 		Entry("zone-egress-only with missing xDS listener", testCase{
 			dp:        zoneEgressOnlyDataplane(),
 			resources: nil,
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Zipkin: &api.ZipkinBackend{
-								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-								SharedSpanContext: true,
-								TraceId128Bit:     true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							TraceId128Bit:     true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-egress-only-missing-listener",
 		}),
@@ -999,19 +912,16 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 		Entry("zone-egress-only zipkin without workload label", testCase{
 			dp:        zoneEgressOnlyDataplane(),
 			resources: []core_xds.Resource{zoneEgressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Zipkin: &api.ZipkinBackend{
-								Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
-								SharedSpanContext: true,
-								TraceId128Bit:     true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Zipkin: &api.ZipkinBackend{
+							Url:               "http://jaeger-collector.mesh-observability:9411/api/v2/spans",
+							SharedSpanContext: true,
+							TraceId128Bit:     true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-egress-only-zipkin",
 		}),
@@ -1025,18 +935,15 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 				k8s_metadata.KumaWorkload: "kuma-default-egress",
 			}),
 			resources: []core_xds.Resource{zoneEgressListenerResource()},
-			singleItemRules: core_rules.SingleItemRules{
-				Rules: []*core_rules.Rule{{
-					Subset: []subsetutils.Tag{},
-					Conf: api.Conf{
-						Backends: &[]api.Backend{{
-							Datadog: &api.DatadogBackend{
-								Url:          "http://datadog-collector.mesh-observability:8126",
-								SplitService: true,
-							},
-						}},
-					},
-				}},
+			proxyConf: &core_rules.ProxyConf{
+				Conf: api.Conf{
+					Backends: &[]api.Backend{{
+						Datadog: &api.DatadogBackend{
+							Url:          "http://datadog-collector.mesh-observability:8126",
+							SplitService: true,
+						},
+					}},
+				},
 			},
 			goldenFile: "zone-egress-only-datadog-workload-label",
 		}),
@@ -1046,7 +953,7 @@ var _ = Describe("MeshTrace on zone proxy Dataplane", func() {
 var _ = Describe("MeshTrace on mixed Dataplane with sectionName targetRef", func() {
 	// A MeshTrace policy that targets only the zone egress section name must apply tracing
 	// to that listener and leave the regular inbound untouched. Exercises the matcher path
-	// (not a hand-built SingleItemRules), so it catches the per-section filtering in Apply.
+	// (not a hand-built ProxyConf), so it catches the per-section filtering in Apply.
 	It("only configures the targeted zone listener", func() {
 		dpp := mixedInboundAndZoneEgressDataplane().Build()
 
@@ -1077,7 +984,7 @@ var _ = Describe("MeshTrace on mixed Dataplane with sectionName targetRef", func
 		matched, err := core_matchers.MatchedPolicies(api.MeshTraceType, dpp, meshResources)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(matched.DataplanePolicies).To(HaveLen(1), "matcher must include the MeshTrace policy")
-		Expect(matched.SingleItemRules.Rules).To(HaveLen(1), "matcher must produce a single-item rule")
+		Expect(matched.ProxyConf).ToNot(BeNil(), "matcher must produce a single-item rule")
 
 		rs := core_xds.NewResourceSet()
 		for _, res := range mixedInboundAndZoneEgressResources() {

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -984,7 +984,7 @@ var _ = Describe("MeshTrace on mixed Dataplane with sectionName targetRef", func
 		matched, err := core_matchers.MatchedPolicies(api.MeshTraceType, dpp, meshResources)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(matched.DataplanePolicies).To(HaveLen(1), "matcher must include the MeshTrace policy")
-		Expect(matched.ProxyConf).ToNot(BeNil(), "matcher must produce a single-item rule")
+		Expect(matched.ProxyConf).ToNot(BeNil(), "matcher must produce a merged proxy-wide config")
 
 		rs := core_xds.NewResourceSet()
 		for _, res := range mixedInboundAndZoneEgressResources() {

--- a/pkg/test/xds/builders/matchedpolicies_builder.go
+++ b/pkg/test/xds/builders/matchedpolicies_builder.go
@@ -43,6 +43,7 @@ func (mp *MatchedPoliciesBuilder) WithFromPolicy(resourceType core_model.Resourc
 
 func (mp *MatchedPoliciesBuilder) WithProxyConfPolicy(resourceType core_model.ResourceType, proxyConf *rules.ProxyConf) *MatchedPoliciesBuilder {
 	mp.res.Dynamic[resourceType] = xds.TypedMatchingPolicies{
+		Type:      resourceType,
 		ProxyConf: proxyConf,
 	}
 	return mp

--- a/pkg/test/xds/builders/matchedpolicies_builder.go
+++ b/pkg/test/xds/builders/matchedpolicies_builder.go
@@ -41,9 +41,9 @@ func (mp *MatchedPoliciesBuilder) WithFromPolicy(resourceType core_model.Resourc
 	return mp
 }
 
-func (mp *MatchedPoliciesBuilder) WithSingleItemPolicy(resourceType core_model.ResourceType, singleItemRules rules.SingleItemRules) *MatchedPoliciesBuilder {
+func (mp *MatchedPoliciesBuilder) WithProxyConfPolicy(resourceType core_model.ResourceType, proxyConf *rules.ProxyConf) *MatchedPoliciesBuilder {
 	mp.res.Dynamic[resourceType] = xds.TypedMatchingPolicies{
-		SingleItemRules: singleItemRules,
+		ProxyConf: proxyConf,
 	}
 	return mp
 }


### PR DESCRIPTION
## Motivation

MeshProxyPatch, MeshTrace, MeshMetric, and MeshPassthrough attach one configuration to the whole proxy but are currently expressed as a list of subset rules. This creates unnecessary indirection: every consumer either reads entry zero or queries the empty subset, and the list can never hold more than one entry.

This complexity forces the four plugins and inspect endpoints to carry subset vocabulary they don't use, keeping the subset engine alive for a case with no actual subsets.

## Implementation information

- Replaced single-entry rule lists with a merged configuration that is either present or absent
- The four proxy-wide policies now read the configuration directly without naming a subset or element
- Matching returns the merged configuration (or nothing when no policy matches)
- Inspect API returns the same configuration and origin for proxy-wide policies as before
- Golden files for all policy plugins remain unchanged

Closes https://github.com/kumahq/kuma/issues/17959

_Generated by Sybra harness_