### PR TITLE
refactor(xds)!: derive SNI from service resource names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -43,6 +43,8 @@ Drop `--scope ingress`/`--scope egress` from any script calling `kumactl generat
 
 A client proxy without a workload identity no longer gets a cluster for a `MeshExternalService`. It previously got one that addressed the zone egress by the legacy `zone-egress` service SNI, but such traffic could never be served: a zone egress only generates its egress listener when it has a workload identity, and that listener matches filter chains on the KRI SNI only, so the legacy SNI matched nothing.
 
+The same SNI change makes the upgrade one-way across zones: once a zone is upgraded, its client proxies send real-resource traffic to zone proxies by the KRI-derived SNI. A zone that is still on the previous version cannot terminate that traffic because its zone proxy listeners still match the legacy hashed SNI only. In practice, an upgraded zone cannot send `MeshService`, `MeshExternalService`, or `MeshMultiZoneService` traffic to a previous-version zone until that destination zone is upgraded too.
+
 **Action required**
 
 Create a `MeshIdentity` that matches the client proxies in any mesh that uses `MeshExternalService`. Without one, only the cluster is dropped — the outbound listener and its endpoints are still generated, so requests now fail locally in the client's Envoy with a 503 (`cluster_not_found`) instead of being reset by the zone egress. Keeping the listener is deliberate: removing it would let the request fall through to the transparent proxy passthrough and reach the external service directly, bypassing the egress.

--- a/docs/madr/decisions/101-sni-format-improvements.md
+++ b/docs/madr/decisions/101-sni-format-improvements.md
@@ -178,12 +178,16 @@ Keep the existing SNI format unchanged:
 <format-version><hash>.<resource-name>.<port>.<mesh-name>.<resource-type>
 ```
 
-The existing `SNIForResource` function already accepts an `additionalData map[string]string` parameter
-that gets mixed into the FNV hash:
+At the time this alternative was evaluated, the `pkg/xds/envoy/tls` package exposed an
+`SNIForResource` helper with an `additionalData map[string]string` parameter that got mixed
+into the FNV hash:
 
 ```go
 func SNIForResource(resName string, meshName string, resType model.ResourceType, port int32, additionalData map[string]string) string
 ```
+
+That helper has since been removed in favor of the KRI-based helpers in `pkg/core/resources/sni`,
+so this option is documented here only as a rejected historical alternative.
 
 Today, all callers pass `nil` for `additionalData`.
 The fix is to systematically pass `zone` and `namespace` (when present) in this map.
@@ -317,4 +321,3 @@ Related MADRs:
 - [MADR 055](055-sni.md) - Original SNI format for MeshService, MeshExternalService
 - [MADR 065](065-sni-in-the-resource.md) - SNI stored in resource definition
 - [MADR 070](070-resource-identifier.md) - Resource Identifier (KRI) format
-

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -105,21 +105,9 @@ func GenerateClusters(
 						tlsReady = !isLocalMeshService || ms.Status.TLS.Status == meshservice_api.TLSReady
 						protocol = port.GetProtocol()
 					}
-					// Every zone is reachable through a mesh-scoped zone proxy, which
-					// matches the KRI SNI, so a proxy with WorkloadIdentity always uses it.
-					kriSNI := proxy.WorkloadIdentity != nil
-					var sni string
-					if kriSNI {
-						var ok bool
-						sni, ok = SNIForRealResource(realResourceRef, port)
-						if !ok {
-							continue
-						}
-					} else {
-						sni, ok = SNIForRealResource(realResourceRef, port)
-						if !ok {
-							continue
-						}
+					sni, ok := SNIForRealResource(realResourceRef, port)
+					if !ok {
+						continue
 					}
 					// ClientSideMultiIdentitiesMTLS validate MTLS enabled on the mesh
 					if proxy.WorkloadIdentity != nil {

--- a/pkg/plugins/policies/core/xds/meshroute/clusters.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters.go
@@ -12,7 +12,6 @@ import (
 	core_resources "github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	meshmultizoneservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
-	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_sni "github.com/kumahq/kuma/v3/pkg/core/resources/sni"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	bldrs_common "github.com/kumahq/kuma/v3/pkg/envoy/builders/common"
@@ -26,7 +25,6 @@ import (
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/v3/pkg/xds/envoy/clusters"
 	envoy_tags "github.com/kumahq/kuma/v3/pkg/xds/envoy/tags"
-	"github.com/kumahq/kuma/v3/pkg/xds/envoy/tls"
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/metadata"
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/system_names"
 )
@@ -61,14 +59,10 @@ func GenerateClusters(
 				if proxy.WorkloadIdentity == nil {
 					continue
 				}
-				// The destination advertises its SNI from the resolved port
-				// name, so normalize a numeric backend-ref section (named port
-				// targeted by number) to the port name before deriving the KRI SNI.
-				kriID := kri.WithSectionName(realResourceRef.Resource, port.GetName())
-				if errs := core_sni.ValidateKRI(kriID); len(errs) > 0 {
+				sni, ok := SNIForRealResource(realResourceRef, port)
+				if !ok {
 					continue
 				}
-				sni := core_sni.FromKRI(kriID)
 				// we only want to route when are mesh-scoped zone egresses
 				if len(meshCtx.ZoneEgresses) == 0 {
 					continue
@@ -116,17 +110,16 @@ func GenerateClusters(
 					kriSNI := proxy.WorkloadIdentity != nil
 					var sni string
 					if kriSNI {
-						// The destination advertises its SNI from the resolved
-						// port name, so normalize a numeric backend-ref section
-						// (named port targeted by number) to the port name
-						// before deriving the KRI SNI.
-						kriID := kri.WithSectionName(realResourceRef.Resource, port.GetName())
-						if errs := core_sni.ValidateKRI(kriID); len(errs) > 0 {
+						var ok bool
+						sni, ok = SNIForRealResource(realResourceRef, port)
+						if !ok {
 							continue
 						}
-						sni = core_sni.FromKRI(kriID)
 					} else {
-						sni = SniForBackendRef(realResourceRef, dest, port, systemNamespace)
+						sni, ok = SNIForRealResource(realResourceRef, port)
+						if !ok {
+							continue
+						}
 					}
 					// ClientSideMultiIdentitiesMTLS validate MTLS enabled on the mesh
 					if proxy.WorkloadIdentity != nil {
@@ -222,18 +215,17 @@ func UpstreamTLSContext(proxy *core_xds.Proxy, sni string, sans []string) (*envo
 		Build()
 }
 
-func SniForBackendRef(
+func SNIForRealResource(
 	backendRef *resolve.RealResourceBackendRef,
-	dest core_resources.Destination,
 	port core_resources.Port,
-	systemNamespace string,
-) string {
-	name := core_model.GetDisplayName(dest.GetMeta())
-	if backendRef.Resource.ResourceType == meshservice_api.MeshServiceType {
-		name = dest.(*meshservice_api.MeshServiceResource).SNIName(systemNamespace)
+) (string, bool) {
+	// The destination advertises SNI from the resolved port name, so numeric
+	// backend-ref sections must be normalized before deriving the KRI SNI.
+	kriID := kri.WithSectionName(backendRef.Resource, port.GetName())
+	if errs := core_sni.ValidateKRI(kriID); len(errs) > 0 {
+		return "", false
 	}
-
-	return tls.SNIForResource(name, dest.GetMeta().GetMesh(), dest.Descriptor().Name, port.GetValue(), nil)
+	return core_sni.FromKRI(kriID), true
 }
 
 func Identities(

--- a/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
+++ b/pkg/plugins/policies/core/xds/meshroute/clusters_test.go
@@ -26,8 +26,8 @@ import (
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
 )
 
-var _ = Describe("SniForBackendRef", func() {
-	DescribeTable("returns SNI built from resolved port",
+var _ = Describe("SNIForRealResource", func() {
+	DescribeTable("returns KRI SNI built from the resolved port name",
 		func(sectionName string) {
 			ms := builders.MeshService().
 				WithName("backend").
@@ -41,32 +41,29 @@ var _ = Describe("SniForBackendRef", func() {
 			id := kri.WithSectionName(kri.From(ms), sectionName)
 			ref := &resolve.RealResourceBackendRef{Resource: id}
 
-			sni := meshroute.SniForBackendRef(ref, ms, port, "")
+			sni, ok := meshroute.SNIForRealResource(ref, port)
 
-			Expect(sni).NotTo(BeEmpty())
-			Expect(sni).To(ContainSubstring(".8080."))
+			Expect(ok).To(BeTrue())
+			Expect(sni).To(Equal("sni.msvc.default.backend.http"))
 		},
 		Entry("by port name", "http"),
 		Entry("by port value", "8080"),
 	)
 
-	It("uses SNIName for MeshService destination", func() {
+	It("skips invalid destination KRI SNI", func() {
 		ms := builders.MeshService().
 			WithName("backend").
 			WithMesh("default").
-			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "http").
+			AddIntPortWithName(8080, 8080, core_meta.ProtocolHTTP, "HTTP").
 			Build()
 
-		port, ok := ms.FindPortByName("http")
+		port, ok := ms.FindPortByName("HTTP")
 		Expect(ok).To(BeTrue())
 
-		id := kri.WithSectionName(kri.From(ms), "http")
-		id.ResourceType = meshservice_api.MeshServiceType
-		ref := &resolve.RealResourceBackendRef{Resource: id}
+		ref := &resolve.RealResourceBackendRef{Resource: kri.WithSectionName(kri.From(ms), "HTTP")}
 
-		sni := meshroute.SniForBackendRef(ref, ms, port, "kuma-system")
-
-		Expect(sni).To(ContainSubstring(ms.SNIName("kuma-system")))
+		_, valid := meshroute.SNIForRealResource(ref, port)
+		Expect(valid).To(BeFalse())
 	})
 })
 
@@ -188,6 +185,7 @@ var _ = Describe("GenerateClusters", func() {
 			zoneOrigin:     true,
 			permissiveMTLS: true,
 			expectMTLS:     true,
+			expectedSNI:    "sni.msvc.default.zone-1.backend.http",
 		}),
 	)
 
@@ -254,5 +252,54 @@ var _ = Describe("GenerateClusters", func() {
 		upstreamCtx := &envoy_tls.UpstreamTlsContext{}
 		Expect(util_proto.UnmarshalAnyTo(cluster.TransportSocket.GetTypedConfig(), upstreamCtx)).To(Succeed())
 		Expect(upstreamCtx.Sni).To(Equal("sni.extsvc.default.external-backend.9000"))
+	})
+
+	It("uses KRI SNI for MeshMultiZoneService without WorkloadIdentity", func() {
+		mzms := builders.MeshMultiZoneService().
+			WithName("backend").
+			WithMesh("default").
+			WithServiceLabelSelector(map[string]string{"app": "backend"}).
+			AddIntPortWithName(8080, core_meta.ProtocolHTTP, "http").
+			Build()
+
+		meshCtx := xds_context.MeshContext{
+			Resource: builders.Mesh().WithBuiltinMTLSBackend("ca-1").WithEnabledMTLSBackend("ca-1").WithPermissiveMTLSBackends().Build(),
+			BaseMeshContext: &xds_context.BaseMeshContext{
+				DestinationIndex: xds_context.NewDestinationIndex([]core_model.Resource{mzms}),
+			},
+			ServicesInformation: map[string]*xds_context.ServiceInformation{},
+		}
+
+		backendRef := resolve.NewResolvedBackendRef(&resolve.RealResourceBackendRef{
+			Resource: kri.WithSectionName(kri.From(mzms), "8080"),
+			Weight:   100,
+		})
+		services := envoy_common.NewServicesAccumulator(map[string]bool{"backend": true})
+		services.AddBackendRef(backendRef, policies_xds.NewClusterBuilder().WithService("backend").Build())
+
+		rs, err := meshroute.GenerateClusters(
+			xds_builders.Proxy().
+				WithSecretsTracker(envoy_common.NewSecretsTracker(core_model.DefaultMesh, nil)).
+				WithDataplane(builders.Dataplane().
+					WithName("web-01").
+					WithAddress("192.168.0.2").
+					WithInboundOfTags(mesh_proto.ServiceTag, "web", mesh_proto.ProtocolTag, "http")).
+				Build(),
+			meshCtx,
+			services.Services(),
+			"",
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		clusters := rs.Resources(envoy_resource.ClusterType)
+		Expect(clusters).To(HaveLen(1))
+		cluster, ok := clusters["backend"].Resource.(*envoy_cluster.Cluster)
+		Expect(ok).To(BeTrue())
+		Expect(cluster.TransportSocket).ToNot(BeNil())
+
+		upstreamCtx := &envoy_tls.UpstreamTlsContext{}
+		Expect(util_proto.UnmarshalAnyTo(cluster.TransportSocket.GetTypedConfig(), upstreamCtx)).To(Succeed())
+		Expect(upstreamCtx.Sni).To(Equal("sni.mzsvc.default.backend.http"))
+		Expect(cluster.TransportSocketMatches).To(BeEmpty())
 	})
 })

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-and-mzms-labels.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -68,7 +68,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -106,7 +106,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.mzms
+        sni: sni.mzsvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/basic-real-meshservice-labels.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: acf231f64f40a7325.backend-second.80.default.ms
+        sni: sni.msvc.default.backend-second.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -68,7 +68,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -106,7 +106,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshmultizoneservice.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a6844c35bc637ba96.multi-backend.80.default.mzms
+        sni: sni.mzsvc.default.multi-backend.80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-meshservice.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-with-mtls.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/default-route-with-mtls.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror-real-resources.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/request-mirror-real-resources.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a4e00178bd7b60937.payments-mes-mirror.9090.default.mes
+        sni: sni.extsvc.default.payments-mes-mirror.9090
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -68,7 +68,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -106,7 +106,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.test-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -144,7 +144,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: aad4a090772bd8489.payments-mirror.80.default.ms
+        sni: sni.msvc.default.payments-mirror.80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -182,7 +182,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a2df35fadf2df7e35.payments-mz-mirror.80.default.mzms
+        sni: sni.mzsvc.default.payments-mz-mirror.80
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/default-meshexternalservice.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.tcp-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
+++ b/pkg/plugins/policies/meshtcproute/plugin/v1alpha1/testdata/tcproute-meshexternalservice.clusters.golden.yaml
@@ -30,7 +30,7 @@ resources:
             sdsConfig:
               ads: {}
               resourceApiVersion: V3
-        sni: a601e0c00295a9fbe.backend.80.default.ms
+        sni: sni.msvc.default.backend.tcp-port
     type: EDS
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/xds/envoy/tls/sni.go
+++ b/pkg/xds/envoy/tls/sni.go
@@ -2,17 +2,11 @@ package tls
 
 import (
 	"fmt"
-	"hash/fnv"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
-	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	meshmzservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
-	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
-	"github.com/kumahq/kuma/v3/pkg/util/maps"
 	envoy_tags "github.com/kumahq/kuma/v3/pkg/xds/envoy/tags"
 )
 
@@ -40,41 +34,4 @@ func TagsFromSNI(sni string) (envoy_tags.Tags, error) {
 	}
 	tags[mesh_proto.ServiceTag] = parts[0]
 	return tags, nil
-}
-
-const (
-	sniFormatVersion = "a"
-	dnsLabelLimit    = 63
-)
-
-func SNIForResource(resName string, meshName string, resType model.ResourceType, port int32, additionalData map[string]string) string {
-	var mapStrings []string
-	for _, key := range maps.SortedKeys(additionalData) {
-		mapStrings = append(mapStrings, fmt.Sprintf("%s=%s", key, additionalData[key]))
-	}
-
-	hash := fnv.New64a()
-	_, _ = fmt.Fprintf(hash, "%s;%s;%v", resName, meshName, strings.Join(mapStrings, ",")) // fnv64a does not return error
-	hashBytes := hash.Sum(nil)
-
-	if len(resName) > dnsLabelLimit-1 {
-		resName = resName[:dnsLabelLimit-1] + "x"
-	}
-	if len(meshName) > dnsLabelLimit-1 {
-		meshName = meshName[:dnsLabelLimit-1] + "x"
-	}
-
-	resTypeAbbrv := ""
-	switch resType {
-	case meshservice_api.MeshServiceType:
-		resTypeAbbrv = "ms"
-	case meshexternalservice_api.MeshExternalServiceType:
-		resTypeAbbrv = "mes"
-	case meshmzservice_api.MeshMultiZoneServiceType:
-		resTypeAbbrv = "mzms"
-	default:
-		panic("resource type not supported for SNI")
-	}
-
-	return fmt.Sprintf("%s%x.%s.%d.%s.%s", sniFormatVersion, hashBytes, resName, port, meshName, resTypeAbbrv)
 }

--- a/pkg/xds/envoy/tls/sni_test.go
+++ b/pkg/xds/envoy/tls/sni_test.go
@@ -1,16 +1,9 @@
 package tls_test
 
 import (
-	"fmt"
-
-	"github.com/asaskevich/govalidator"
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	meshmzservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1"
-	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
-	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	envoy_tags "github.com/kumahq/kuma/v3/pkg/xds/envoy/tags"
 	"github.com/kumahq/kuma/v3/pkg/xds/envoy/tls"
 )
@@ -93,86 +86,4 @@ var _ = Describe("SNI", func() {
 		Entry("broken tags", "backend{", "invalid format of tags, pairs should be separated by , and key should be separated from value by ="),
 		Entry("to many separators", "backend{mesh=default{mesh", "cannot parse tags from sni: backend{mesh=default{mesh"),
 	)
-
-	type testCase struct {
-		resName        string
-		meshName       string
-		resType        model.ResourceType
-		port           int32
-		additionalData map[string]string
-		expected       string
-	}
-	DescribeTable("should convert SNI for resource",
-		func(given testCase) {
-			sni := tls.SNIForResource(
-				given.resName,
-				given.meshName,
-				given.resType,
-				given.port,
-				given.additionalData,
-			)
-
-			Expect(sni).To(Equal(given.expected))
-			Expect(govalidator.IsDNSName(sni)).To(BeTrue())
-		},
-		Entry("simple", testCase{
-			resName:        "backend",
-			meshName:       "demo",
-			resType:        meshservice_api.MeshServiceType,
-			port:           8080,
-			additionalData: nil,
-			expected:       "ae10a8071b8a8eeb8.backend.8080.demo.ms",
-		}),
-		Entry("simple subset", testCase{
-			resName:  "backend",
-			meshName: "demo",
-			resType:  meshservice_api.MeshServiceType,
-			port:     8080,
-			additionalData: map[string]string{
-				"x": "a",
-			},
-			expected: "a333a125865a97632.backend.8080.demo.ms",
-		}),
-		Entry("going over limit", testCase{
-			resName:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-qwe",
-			meshName: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-qwe",
-			resType:  meshservice_api.MeshServiceType,
-			port:     8080,
-			additionalData: map[string]string{
-				"x": "a",
-			},
-			expected: "a5b91d8a08567bf09.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaax.8080.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbx.ms",
-		}),
-		Entry("mesh multizone service", testCase{
-			resName:        "backend",
-			meshName:       "demo",
-			resType:        meshmzservice_api.MeshMultiZoneServiceType,
-			port:           8080,
-			additionalData: nil,
-			expected:       "ae10a8071b8a8eeb8.backend.8080.demo.mzms",
-		}),
-	)
-
-	It("SNI hash does not easily collide of the same services with different tags", func() {
-		snis := map[string]struct{}{}
-		for i := range 100_000 {
-			sni := tls.SNIForResource("backend", "demo", meshservice_api.MeshServiceType, 8080, map[string]string{
-				"version": fmt.Sprintf("%d", i),
-			})
-			_, ok := snis[sni]
-			Expect(ok).To(BeFalse())
-			snis[sni] = struct{}{}
-		}
-	})
-
-	It("SNI hash does not easily collide of the services with very long names", func() {
-		snis := map[string]struct{}{}
-		serviceName := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		for range 100_000 {
-			sni := tls.SNIForResource(serviceName+uuid.New().String(), "demo", meshservice_api.MeshServiceType, 8080, nil)
-			_, ok := snis[sni]
-			Expect(ok).To(BeFalse())
-			snis[sni] = struct{}{}
-		}
-	})
 })


### PR DESCRIPTION
## Motivation

Kuma previously encoded SNI in two formats: via the `kuma.io/service` tag and from real service resources. This ambiguity prevented receiving zones from determining which format produced a given SNI value. By deriving SNI exclusively from real service resources—keyed on resource name, mesh, port, and type—we ensure every SNI identifies an actual service and eliminate the fallback to tag-derived values. This makes SNI generation deterministic and improves cross-zone routing reliability.

## Implementation information

- Refactored meshroute SNI derivation to exclusively use real service resources
- Removed fallback SNI generation from `kuma.io/service` tags; destinations without a corresponding real service resource now produce no SNI
- Updated SNI test golden files to reflect the new SNI derivation logic
- Added UPGRADE.md note documenting that zones on the previous version cannot terminate traffic from upgraded zones due to the one-way SNI format change

Closes https://github.com/kumahq/kuma/issues/17917

_Generated by Sybra harness_