### PR TITLE
test(gatewayapi): gate merges on core mesh conformance tests

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -68,6 +68,13 @@ jobs:
                 "parallelism": [4],
                 "cniNetworkPlugin": ["flannel"]
               },
+              "test_e2e_gatewayapi": {
+                "target": ["gatewayapi"],
+                "k8sVersion": ["${{ env.K8S_MAX_VERSION }}"],
+                "arch": ["amd64"],
+                "parallelism": [1],
+                "cniNetworkPlugin": ["flannel"]
+              },
               "test_e2e_env": {
                 "target": ["kubernetes", "universal", "multizone"],
                 "k8sVersion": ["kind", "kindIpv6", "${{ env.K8S_MAX_VERSION }}"],
@@ -108,6 +115,7 @@ jobs:
           # Expand parallelRunnerId into the matrix based on each suite's parallelism, then remove parallelism
           BASE_MATRIX_ALL=$(echo "$BASE_MATRIX_ALL" | jq '
             if .test_e2e and (.test_e2e | type == "object") then .test_e2e.parallelRunnerId = [range(.test_e2e.parallelism[0] // 1)] | del(.test_e2e.parallelism) else . end |
+            if .test_e2e_gatewayapi and (.test_e2e_gatewayapi | type == "object") then .test_e2e_gatewayapi.shards = [.test_e2e_gatewayapi.parallelism[0] // 1] | .test_e2e_gatewayapi.parallelRunnerId = [range(.test_e2e_gatewayapi.parallelism[0] // 1)] | del(.test_e2e_gatewayapi.parallelism) else . end |
             if .test_e2e_env and (.test_e2e_env | type == "object") then .test_e2e_env.shards = [.test_e2e_env.parallelism[0] // 1] | .test_e2e_env.parallelRunnerId = [range(.test_e2e_env.parallelism[0] // 1)] | del(.test_e2e_env.parallelism) else . end
           ')
 
@@ -126,6 +134,33 @@ jobs:
     strategy:
       max-parallel: ${{ github.event_name == 'pull_request' && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e }}
+      fail-fast: false
+    env:
+      CI_TOOLS_DIR: ${{ contains(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch], '-kong') && '/work/kuma/kuma/.ci_tools' || '/home/runner/work/kuma/kuma/.ci_tools' }}
+      MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
+      DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: ./.github/actions/run-e2e
+        with:
+          k8s_version: ${{ matrix.k8sVersion }}
+          cni_network_plugin: ${{ matrix.cniNetworkPlugin }}
+          arch: ${{ matrix.arch }}
+          target: ${{ matrix.target }}
+          parallel_runner_id: ${{ matrix.parallelRunnerId }}
+          shards: ${{ matrix.shards }}
+  test_e2e_gatewayapi:
+    needs: ["gen_e2e_matrix"]
+    name: "e2e (gatewayapi, ${{ matrix.k8sVersion }}, ${{ matrix.arch }})"
+    if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi
+    timeout-minutes: 60
+    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
+    strategy:
+      max-parallel: ${{ github.event_name == 'pull_request' && 12 || 5 }}
+      matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi }}
       fail-fast: false
     env:
       CI_TOOLS_DIR: ${{ contains(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch], '-kong') && '/work/kuma/kuma/.ci_tools' || '/home/runner/work/kuma/kuma/.ci_tools' }}

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -132,7 +132,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
     strategy:
-      max-parallel: ${{ github.event_name == 'pull_request' && 12 || 5 }}
+      max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e }}
       fail-fast: false
     env:
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
     strategy:
-      max-parallel: ${{ github.event_name == 'pull_request' && 12 || 5 }}
+      max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi }}
       fail-fast: false
     env:
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
     strategy:
-      max-parallel: ${{ github.event_name == 'pull_request' && 12 || 5 }}
+      max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env }}
       fail-fast: false
     env:


### PR DESCRIPTION
## Motivation

**Original title:** test(gatewayapi): gate merges on the core mesh conformance tests

## Problem

The Gateway API mesh conformance suite left the e2e matrix in July 2026 after failing on every master run, and GAMMA has had no automated coverage since. The suite also cannot pass in its current shape: it asks the Mesh for a meshServices mode the API no longer has, declares Gateway feature names where the mesh tests gate on the mesh equivalents, and creates no traffic permission for the conformance namespaces.

The recorded failure was a conformance backend Pod that never became ready. That happens while the suite applies its base manifests, before any per-test gating, so it blocks every mesh test no matter how few are declared.

## Expected outcome

- The suite creates its Mesh with no field the current API rejects or ignores
- Both conformance namespaces reach a ready state, and traffic between them succeeds under the identity and permission model that ships today
- The core mesh tests run and pass, and a pull request that breaks one fails before merge
- A test that is not yet expected to pass is skipped by name or left undeclared, never left failing
- The generated report names only features that a passing test actually covers

## Out of scope

The extended mesh features, which #17981 widens one at a time.

## ⚠️ Plan Critic Verdict: REFINE

The plan critic did not approve this plan as written — review the findings in the critique sidecar before approving.

## Implementation information

See commit history for test(gatewayapi): gate merges on core mesh conformance tests.

Closes https://github.com/kumahq/kuma/issues/17980

_Generated by Sybra harness_