### PR TITLE
test(e2e): dump k8s manifests per namespace

### DIFF
--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -234,7 +234,9 @@ func debugKubeNamespace(cluster Cluster, namespace string) error {
 	} else {
 		Logf("Gateway API CRDs not installed in cluster %q", cluster.Name())
 	}
-	report.AddFileToReportEntry(path.Join(cluster.Name(), "k8s", "manifests.yaml"), out)
+	// Per namespace, like the events below: this function runs once for every
+	// namespace and a shared path would leave only the last one's manifests.
+	report.AddFileToReportEntry(path.Join(cluster.Name(), "k8s", namespace, "manifests.yaml"), out)
 
 	events, err := k8s.RunKubectlAndGetOutputContextE(cluster.GetTesting(), context.Background(), &kubeOptions, "get", "events", "--sort-by=.lastTimestamp", "-owide")
 	if err != nil {


### PR DESCRIPTION
## Motivation

`debugKubeNamespace` runs once per namespace, but every call wrote its dump to the same path:

```go
report.AddFileToReportEntry(path.Join(cluster.Name(), "k8s", "manifests.yaml"), out)
```

so only the last namespace survives in the debug artifact. Events right below it already use a per-namespace path, so this looks like an oversight rather than intent.

Concretely, on the helm upgrade suite `kuma-system` overwrites `helm-upgrade-ns`. Chasing a failure where a test-server Dataplane never reached global, the artifact from https://github.com/kumahq/kuma/actions/runs/31484536422 had the two ingress Dataplanes from `kuma-system` and nothing at all from the namespace the workload lives in, which is exactly the resource needed to tell what the zone had actually stored.

## Implementation information

* write to `k8s/<namespace>/manifests.yaml`, alongside that namespace events.txt

## Supporting documentation

Follow-up to #17976, same class of bug: a shared path in the debug dumper silently dropping the data you need.

> Changelog: skip