### PR TITLE
docs(CLAUDE): add front matter to recent MADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,20 @@ Default (no labels) is correct for most code PRs. Reach for `skip-*` only to sav
 
 ## Architecture
 
+### Architecture decisions (MADRs)
+
+`docs/madr/decisions/` is the map of why the current design looks the way it does — one decision per file, newest MADRs carrying YAML front matter (`title`, `status`, `date`, `tags`, `summary`, `related`).
+
+There is no maintained index — the front matter IS the map. When building context for a non-trivial change, scan it first and open only the MADRs whose summary or tags match the area you're touching; filenames are descriptive slugs, so older MADRs without front matter are findable by name:
+
+```bash
+rg -N '^(status|tags|summary):' docs/madr/decisions/  # the whole map
+rg -l 'zone-egress' docs/madr/decisions/              # narrow by tag or slug
+./docs/madr/list.sh                                   # same, one line per MADR (human view)
+```
+
+A MADR is the design rationale, not the current state — check the code before trusting it, and mind `status: superseded` and the `related` chain (later MADRs often revise earlier ones). Follow `related` when a MADR you read builds on another.
+
 ### Components
 
 - `kuma-cp`: control plane, serves xDS configs to data planes, manages mTLS certs, coordinates zones

--- a/docs/madr/README.md
+++ b/docs/madr/README.md
@@ -4,12 +4,18 @@ This is mostly built on: https://github.com/adr/madr
 
 To start a MADR see: [000-template.md](./decisions/000-template.md).
 
+## Front matter
+
+Newer MADRs start with YAML front matter (`title`, `status`, `date`, `tags`, `summary`, `related`) — see [000-template.md](./decisions/000-template.md).
+It exists so the MADR set can be scanned as a map without opening every file. When both front matter and the `* Status:` bullet are present, front matter wins.
+
 ## Listing MADRs
 
-Use the `list.sh` script to list and filter MADRs:
+Use the `list.sh` script to list and filter MADRs. Output is `<file> [<status>] <summary> #tag #tag`:
 
 ```bash
-./docs/madr/list.sh                    # list all MADRs
-./docs/madr/list.sh | grep accepted    # list only accepted MADRs 
-./docs/madr/list.sh | grep -v accepted # list only not accepted MADRs
+./docs/madr/list.sh                      # list all MADRs
+./docs/madr/list.sh | grep '\[accepted\]' # list only accepted MADRs
+./docs/madr/list.sh | grep -v accepted   # list only not accepted MADRs
+./docs/madr/list.sh | grep '#zone-egress' # list MADRs tagged zone-egress
 ```

--- a/docs/madr/README.md
+++ b/docs/madr/README.md
@@ -14,8 +14,8 @@ It exists so the MADR set can be scanned as a map without opening every file. Wh
 Use the `list.sh` script to list and filter MADRs. Output is `<file> [<status>] <summary> #tag #tag`:
 
 ```bash
-./docs/madr/list.sh                      # list all MADRs
-./docs/madr/list.sh | grep '\[accepted\]' # list only accepted MADRs
-./docs/madr/list.sh | grep -v accepted   # list only not accepted MADRs
-./docs/madr/list.sh | grep '#zone-egress' # list MADRs tagged zone-egress
+./docs/madr/list.sh                          # list all MADRs
+./docs/madr/list.sh | grep '\[accepted\]'    # list only accepted MADRs
+./docs/madr/list.sh | grep -v '\[accepted\]' # list only not accepted MADRs
+./docs/madr/list.sh | grep '#zone-egress'    # list MADRs tagged zone-egress
 ```

--- a/docs/madr/decisions/000-template.md
+++ b/docs/madr/decisions/000-template.md
@@ -1,3 +1,12 @@
+---
+title: {same as the H1 below}
+status: {rejected | accepted | superseded}
+date: {YYYY-MM-DD, when the MADR was written}
+tags: [{3-8 lowercase keywords: components, resources, policies, areas this touches}]
+summary: {one sentence: the problem and the decided solution, so a reader can tell from `list.sh` whether this MADR is relevant}
+related: [{file stems of MADRs this builds on or supersedes, e.g. 095-mesh-scoped-zone-ingress-egress}]
+---
+
 # {short title of solved problem and solution}
 
 * Status: {rejected | accepted} <!-- recommended to have the status as accepted proactively and then to change it if needed -->

--- a/docs/madr/decisions/000-template.md
+++ b/docs/madr/decisions/000-template.md
@@ -4,7 +4,7 @@ status: {rejected | accepted | superseded}
 date: {YYYY-MM-DD, when the MADR was written}
 tags: [{3-8 lowercase keywords: components, resources, policies, areas this touches}]
 summary: {one sentence: the problem and the decided solution, so a reader can tell from `list.sh` whether this MADR is relevant}
-related: [{file stems of MADRs this builds on or supersedes, e.g. 095-mesh-scoped-zone-ingress-egress}]
+related: [{file stems, oldest first, of every MADR this builds on, supersedes or is revised by — the earlier ones it derives from as well as the later ones, e.g. 070-resource-identifier, 095-mesh-scoped-zone-ingress-egress}]
 ---
 
 # {short title of solved problem and solution}

--- a/docs/madr/decisions/090-zone-egress-identity.md
+++ b/docs/madr/decisions/090-zone-egress-identity.md
@@ -2,7 +2,7 @@
 title: Zone Egress Identity
 status: accepted
 date: 2025-10-29
-tags: [zone-egress, identity, mtls, meshidentity, spire, meshexternalservice]
+tags: [zone-egress, identity, mtls, spire, meshexternalservice, sni]
 summary: A global ZoneEgress serves many meshes and therefore ends up with multiple mTLS identities, breaking the trust model; captures the requirements for giving zone egress a single workload identity.
 related: [094-zone-proxy-deployment-model, 095-mesh-scoped-zone-ingress-egress]
 ---

--- a/docs/madr/decisions/090-zone-egress-identity.md
+++ b/docs/madr/decisions/090-zone-egress-identity.md
@@ -1,3 +1,12 @@
+---
+title: Zone Egress Identity
+status: accepted
+date: 2025-10-29
+tags: [zone-egress, identity, mtls, meshidentity, spire, meshexternalservice]
+summary: A global ZoneEgress serves many meshes and therefore ends up with multiple mTLS identities, breaking the trust model; captures the requirements for giving zone egress a single workload identity.
+related: [094-zone-proxy-deployment-model, 095-mesh-scoped-zone-ingress-egress]
+---
+
 # Zone Egress Identity
 
 * Status: accepted

--- a/docs/madr/decisions/091-migrate-to-v2-module-path.md
+++ b/docs/madr/decisions/091-migrate-to-v2-module-path.md
@@ -1,3 +1,12 @@
+---
+title: Migrate Go Module Path to `/v2` for Semantic Import Versioning
+status: accepted
+date: 2025-11-06
+tags: [go-modules, versioning, release, breaking-change]
+summary: Adds the `/v2` suffix to the Go module path across all active branches so consumers get semantic versions instead of pseudo-versions; ships in patch releases alongside the `v`-prefixed tag change.
+related: [104-rethink-releasing-pipeline]
+---
+
 # Migrate Go Module Path to `/v2` for Semantic Import Versioning
 
 * Status: accepted

--- a/docs/madr/decisions/092-workload-identifier.md
+++ b/docs/madr/decisions/092-workload-identifier.md
@@ -1,3 +1,12 @@
+---
+title: Workload Identifier
+status: accepted
+date: 2025-11-14
+tags: [workload, identity, dataplane, labels]
+summary: Introduces the Workload identifier that groups data planes into one logical unit; the design itself lives in an external Google Doc, this file is only a pointer.
+related: [103-universal-meshservice-generation]
+---
+
 # Workload Identifier
 
 * Status: accepted

--- a/docs/madr/decisions/093-disallow-multiple-meshes-per-k8s-ns.md
+++ b/docs/madr/decisions/093-disallow-multiple-meshes-per-k8s-ns.md
@@ -1,3 +1,12 @@
+---
+title: Disallow Multiple Meshes per Kubernetes Namespace
+status: superseded
+date: 2025-11-21
+tags: [kubernetes, mesh, workload, namespace]
+summary: Blocked multiple meshes in one Kubernetes namespace behind a runtime flag to avoid Workload name collisions; superseded by MADR 099, which allows them again and handles collisions in the controller.
+related: [099-allow-multiple-meshes-per-k8s-ns, 094-zone-proxy-deployment-model, 092-workload-identifier]
+---
+
 # Disallow Multiple Meshes per Kubernetes Namespace
 
 * Status: superseded by [MADR 099](099-allow-multiple-meshes-per-k8s-ns.md)

--- a/docs/madr/decisions/094-zone-proxy-deployment-model.md
+++ b/docs/madr/decisions/094-zone-proxy-deployment-model.md
@@ -1,3 +1,12 @@
+---
+title: Zone Proxy Deployment Model
+status: accepted
+date: 2026-02-18
+tags: [zone-proxy, zone-ingress, zone-egress, helm, kubernetes, multizone, deployment]
+summary: Defines how mesh-scoped zone proxies are deployed via Helm — a per-mesh `meshes` list, empty by default (explicit opt-in), per-mesh Services in kuma-system, additive migration next to the legacy `ingress`/`egress` keys.
+related: [090-zone-egress-identity, 095-mesh-scoped-zone-ingress-egress, 097-zone-proxy-sidecar-deployment, 098-zone-proxy-deployment-topology, 099-allow-multiple-meshes-per-k8s-ns]
+---
+
 # Zone Proxy Deployment Model
 
 * Status: accepted

--- a/docs/madr/decisions/094-zone-proxy-deployment-model.md
+++ b/docs/madr/decisions/094-zone-proxy-deployment-model.md
@@ -4,7 +4,7 @@ status: accepted
 date: 2026-02-18
 tags: [zone-proxy, zone-ingress, zone-egress, helm, kubernetes, multizone, deployment]
 summary: Defines how mesh-scoped zone proxies are deployed via Helm — a per-mesh `meshes` list, empty by default (explicit opt-in), per-mesh Services in kuma-system, additive migration next to the legacy `ingress`/`egress` keys.
-related: [090-zone-egress-identity, 095-mesh-scoped-zone-ingress-egress, 097-zone-proxy-sidecar-deployment, 098-zone-proxy-deployment-topology, 099-allow-multiple-meshes-per-k8s-ns]
+related: [090-zone-egress-identity, 093-disallow-multiple-meshes-per-k8s-ns, 095-mesh-scoped-zone-ingress-egress, 097-zone-proxy-sidecar-deployment, 098-zone-proxy-deployment-topology, 099-allow-multiple-meshes-per-k8s-ns]
 ---
 
 # Zone Proxy Deployment Model

--- a/docs/madr/decisions/095-mesh-opentelemetry-backend.md
+++ b/docs/madr/decisions/095-mesh-opentelemetry-backend.md
@@ -1,3 +1,12 @@
+---
+title: Shared telemetry backend resource for observability policies
+status: accepted
+date: 2026-03-16
+tags: [observability, otel, meshmetric, meshtrace, meshaccesslog, policy, api]
+summary: Introduces the mesh-scoped `MeshOpenTelemetryBackend` resource so MeshMetric, MeshTrace and MeshAccessLog reference one collector via `backendRef` instead of each duplicating the endpoint; inline `endpoint` is deprecated and removed in 3.0.
+related: [100-otel-env-bootstrap-runtime, 096-observability-dashboards]
+---
+
 # Shared telemetry backend resource for observability policies
 
 - Status: accepted

--- a/docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md
+++ b/docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md
@@ -4,7 +4,7 @@ status: accepted
 date: 2026-03-03
 tags: [zone-proxy, zone-ingress, zone-egress, dataplane, api, multizone, identity]
 summary: Replaces the global-scoped ZoneIngress/ZoneEgress resources with mesh-scoped Dataplanes carrying `listeners`, so zone proxies get a mesh identity and can be targeted by mesh-scoped policies.
-related: [090-zone-egress-identity, 094-zone-proxy-deployment-model, 096-ingress-address-sync, 100-zone-egress-endpoint-storage, 102-zone-proxy-listener-computed-labels, 103-policy-matching-mesh-scoped-zone-proxy]
+related: [089-naming-envoy-resources-and-stats-from-multiple-kuma-policies, 090-zone-egress-identity, 094-zone-proxy-deployment-model, 096-ingress-address-sync, 100-zone-egress-endpoint-storage, 102-zone-proxy-listener-computed-labels, 103-policy-matching-mesh-scoped-zone-proxy]
 ---
 
 # Mesh Scoped Zone Ingress and Zone Egress

--- a/docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md
+++ b/docs/madr/decisions/095-mesh-scoped-zone-ingress-egress.md
@@ -1,3 +1,12 @@
+---
+title: Mesh Scoped Zone Ingress and Zone Egress
+status: accepted
+date: 2026-03-03
+tags: [zone-proxy, zone-ingress, zone-egress, dataplane, api, multizone, identity]
+summary: Replaces the global-scoped ZoneIngress/ZoneEgress resources with mesh-scoped Dataplanes carrying `listeners`, so zone proxies get a mesh identity and can be targeted by mesh-scoped policies.
+related: [090-zone-egress-identity, 094-zone-proxy-deployment-model, 096-ingress-address-sync, 100-zone-egress-endpoint-storage, 102-zone-proxy-listener-computed-labels, 103-policy-matching-mesh-scoped-zone-proxy]
+---
+
 # Mesh Scoped Zone Ingress and Zone Egress
 
 * Status: accepted

--- a/docs/madr/decisions/096-ingress-address-sync.md
+++ b/docs/madr/decisions/096-ingress-address-sync.md
@@ -1,3 +1,12 @@
+---
+title: Syncing Zone Ingress Address Across Zones
+status: accepted
+date: 2026-03-04
+tags: [zone-ingress, kds, multizone, dataplane, api]
+summary: Dataplanes are not synced across zones, so the zone ingress `advertisedAddress`/`advertisedPort` moves into a new mesh-scoped `MeshZoneAddress` resource synced zone-to-global and back.
+related: [095-mesh-scoped-zone-ingress-egress, 100-zone-egress-endpoint-storage]
+---
+
 # Syncing Zone Ingress Address Across Zones
 
 * Status: accepted

--- a/docs/madr/decisions/096-observability-dashboards.md
+++ b/docs/madr/decisions/096-observability-dashboards.md
@@ -1,3 +1,12 @@
+---
+title: Observability dashboards redesign
+status: accepted
+date: 2026-02-26
+tags: [observability, grafana, dashboards, metrics, kumactl]
+summary: `kumactl install observability` is dropped in 3.0; five rebuilt Grafana dashboards ship as raw JSON under `dashboards/grafana/` in the release tarball for import into an existing Grafana.
+related: [095-mesh-opentelemetry-backend]
+---
+
 # Observability dashboards redesign
 
 * Status: accepted

--- a/docs/madr/decisions/097-zone-proxy-sidecar-deployment.md
+++ b/docs/madr/decisions/097-zone-proxy-sidecar-deployment.md
@@ -4,7 +4,7 @@ status: accepted
 date: 2026-03-12
 tags: [zone-proxy, kubernetes, sidecar-injection, helm, deployment]
 summary: Zone proxies stop being standalone Deployments — a pause container becomes the main container and `kuma-dp` is injected as a sidecar, so Helm upgrades no longer restart zone proxies.
-related: [094-zone-proxy-deployment-model, 095-mesh-scoped-zone-ingress-egress, 098-zone-proxy-deployment-topology]
+related: [094-zone-proxy-deployment-model, 095-mesh-scoped-zone-ingress-egress, 096-ingress-address-sync, 098-zone-proxy-deployment-topology]
 ---
 
 # Zone Proxy Deployment as a Regular Sidecar

--- a/docs/madr/decisions/097-zone-proxy-sidecar-deployment.md
+++ b/docs/madr/decisions/097-zone-proxy-sidecar-deployment.md
@@ -1,3 +1,12 @@
+---
+title: Zone Proxy Deployment as a Regular Sidecar
+status: accepted
+date: 2026-03-12
+tags: [zone-proxy, kubernetes, sidecar-injection, helm, deployment]
+summary: Zone proxies stop being standalone Deployments — a pause container becomes the main container and `kuma-dp` is injected as a sidecar, so Helm upgrades no longer restart zone proxies.
+related: [094-zone-proxy-deployment-model, 095-mesh-scoped-zone-ingress-egress, 098-zone-proxy-deployment-topology]
+---
+
 # Zone Proxy Deployment as a Regular Sidecar
 
 * Status: accepted

--- a/docs/madr/decisions/098-zone-proxy-deployment-topology.md
+++ b/docs/madr/decisions/098-zone-proxy-deployment-topology.md
@@ -1,3 +1,12 @@
+---
+title: Zone Proxy Deployment Topology
+status: accepted
+date: 2026-03-11
+tags: [zone-proxy, zone-ingress, zone-egress, helm, deployment, multizone]
+summary: Separate ingress and egress Deployments stay the recommended default for independent scaling and failure isolation; `combinedProxies` is an opt-in single-Deployment topology for dev and resource-constrained zones.
+related: [094-zone-proxy-deployment-model, 095-mesh-scoped-zone-ingress-egress, 097-zone-proxy-sidecar-deployment]
+---
+
 # Zone Proxy Deployment Topology
 
 * Status: accepted

--- a/docs/madr/decisions/099-allow-multiple-meshes-per-k8s-ns.md
+++ b/docs/madr/decisions/099-allow-multiple-meshes-per-k8s-ns.md
@@ -1,3 +1,12 @@
+---
+title: Allow Multiple Meshes per Kubernetes Namespace
+status: accepted
+date: 2026-03-05
+tags: [kubernetes, mesh, workload, namespace, zone-proxy]
+summary: Reverts MADR 093 so mesh-scoped zone proxies for several meshes can live in kuma-system; Workload name collisions surface as controller errors and the `disallowMultipleMeshesPerNamespace` flag is removed.
+related: [093-disallow-multiple-meshes-per-k8s-ns, 094-zone-proxy-deployment-model, 092-workload-identifier]
+---
+
 # Allow Multiple Meshes per Kubernetes Namespace
 
 * Status: accepted

--- a/docs/madr/decisions/100-otel-env-bootstrap-runtime.md
+++ b/docs/madr/decisions/100-otel-env-bootstrap-runtime.md
@@ -1,3 +1,12 @@
+---
+title: OTEL env-var bootstrap and runtime resolution
+status: accepted
+date: 2026-03-16
+tags: [observability, otel, kuma-dp, bootstrap, meshmetric, meshtrace, meshaccesslog]
+summary: Lets Kuma reuse `OTEL_EXPORTER_OTLP_*` env vars already present on the proxy — kuma-dp reports a non-secret inventory at bootstrap, the CP returns a typed runtime plan with env policy, and secrets never leave the data plane.
+related: [095-mesh-opentelemetry-backend]
+---
+
 # OTEL env-var bootstrap and runtime resolution
 
 * Status: accepted

--- a/docs/madr/decisions/100-zone-egress-endpoint-storage.md
+++ b/docs/madr/decisions/100-zone-egress-endpoint-storage.md
@@ -3,7 +3,7 @@ title: Zone Egress Address Storage for Endpoint Generation
 status: accepted
 date: 2026-03-12
 tags: [zone-egress, meshexternalservice, xds, endpoints, dataplane]
-summary: Endpoint generation for MeshExternalService reads the egress address straight from live Dataplanes with a ZoneEgress listener, merged with legacy ZoneEgress resources, instead of storing it in a new resource.
+summary: Endpoint generation for MeshExternalService reads the egress address straight from live Dataplanes with a ZoneEgress listener, merged with legacy ZoneEgress resources, instead of mirroring it into `MeshExternalService` status.
 related: [095-mesh-scoped-zone-ingress-egress, 096-ingress-address-sync]
 ---
 

--- a/docs/madr/decisions/100-zone-egress-endpoint-storage.md
+++ b/docs/madr/decisions/100-zone-egress-endpoint-storage.md
@@ -1,3 +1,12 @@
+---
+title: Zone Egress Address Storage for Endpoint Generation
+status: accepted
+date: 2026-03-12
+tags: [zone-egress, meshexternalservice, xds, endpoints, dataplane]
+summary: Endpoint generation for MeshExternalService reads the egress address straight from live Dataplanes with a ZoneEgress listener, merged with legacy ZoneEgress resources, instead of storing it in a new resource.
+related: [095-mesh-scoped-zone-ingress-egress, 096-ingress-address-sync]
+---
+
 # Zone Egress Address Storage for Endpoint Generation
 
 * Status: accepted

--- a/docs/madr/decisions/101-sni-format-improvements.md
+++ b/docs/madr/decisions/101-sni-format-improvements.md
@@ -1,3 +1,12 @@
+---
+title: SNI Format Improvements
+status: accepted
+date: 2026-04-22
+tags: [sni, kri, naming, multizone, zone-proxy, meshexternalservice, tls]
+summary: Replaces the hashed SNI format from MADR 055 with a zone-aware format derived from KRI, so an observed SNI converts back to a KRI without a lookup table and global/local resources stop colliding.
+related: [102-zone-proxy-listener-computed-labels, 103-policy-matching-mesh-scoped-zone-proxy, 105-source-listener-tags-from-labels]
+---
+
 # SNI Format Improvements
 
 - Status: accepted

--- a/docs/madr/decisions/101-sni-format-improvements.md
+++ b/docs/madr/decisions/101-sni-format-improvements.md
@@ -2,9 +2,9 @@
 title: SNI Format Improvements
 status: accepted
 date: 2026-04-22
-tags: [sni, kri, naming, multizone, zone-proxy, meshexternalservice, tls]
+tags: [sni, kri, naming, multizone, zone-proxy, meshexternalservice]
 summary: Replaces the hashed SNI format from MADR 055 with a zone-aware format derived from KRI, so an observed SNI converts back to a KRI without a lookup table and global/local resources stop colliding.
-related: [102-zone-proxy-listener-computed-labels, 103-policy-matching-mesh-scoped-zone-proxy, 105-source-listener-tags-from-labels]
+related: [055-sni, 065-sni-in-the-resource, 070-resource-identifier, 102-zone-proxy-listener-computed-labels, 103-policy-matching-mesh-scoped-zone-proxy, 105-source-listener-tags-from-labels]
 ---
 
 # SNI Format Improvements

--- a/docs/madr/decisions/102-zone-proxy-listener-computed-labels.md
+++ b/docs/madr/decisions/102-zone-proxy-listener-computed-labels.md
@@ -1,3 +1,12 @@
+---
+title: Standardize Computed Labels for Mesh-Scoped Zone Proxy Listeners
+status: accepted
+date: 2026-04-28
+tags: [zone-proxy, labels, policy-matching, dataplane, inspect-api]
+summary: Adds auto-computed `kuma.io/listener-zoneingress` and `kuma.io/listener-zoneegress` Dataplane labels so policies, Inspect API and GUI can select all zone ingress or egress proxies without parsing listeners.
+related: [095-mesh-scoped-zone-ingress-egress, 103-policy-matching-mesh-scoped-zone-proxy]
+---
+
 # Standardize Computed Labels for Mesh-Scoped Zone Proxy Listeners
 
 * Status: accepted

--- a/docs/madr/decisions/103-policy-matching-mesh-scoped-zone-proxy.md
+++ b/docs/madr/decisions/103-policy-matching-mesh-scoped-zone-proxy.md
@@ -1,3 +1,12 @@
+---
+title: Policy Matching on MeshScoped Zone Proxy
+status: accepted
+date: 2026-05-12
+tags: [policy-matching, zone-proxy, zone-egress, meshtrafficpermission, sni, targetref, dataplane]
+summary: Zone proxy Dataplanes are targeted with the standard `targetRef.kind: Dataplane`; zone egress is deny-all by default and MeshTrafficPermission gains an `sni` match, while policies without `matches[]` select destinations through `spec.to[]`.
+related: [095-mesh-scoped-zone-ingress-egress, 101-sni-format-improvements, 102-zone-proxy-listener-computed-labels]
+---
+
 # Policy Matching on MeshScoped Zone Proxy
 
 * Status: accepted

--- a/docs/madr/decisions/103-universal-meshservice-generation.md
+++ b/docs/madr/decisions/103-universal-meshservice-generation.md
@@ -1,3 +1,12 @@
+---
+title: Auto-generated MeshService on Universal post-inbound-tag removal
+status: accepted
+date: 2026-05-25
+tags: [universal, meshservice, workload, dataplane, inbound-tags, migration]
+summary: After inbound tags go away, the CP generates one MeshService per `kuma.io/workload` value on Universal; blue/green, aggregation and port carve-out setups author MeshService by hand instead.
+related: [092-workload-identifier, 105-source-listener-tags-from-labels]
+---
+
 # Auto-generated MeshService on Universal post-inbound-tag removal
 
 * Status: accepted

--- a/docs/madr/decisions/104-rethink-releasing-pipeline.md
+++ b/docs/madr/decisions/104-rethink-releasing-pipeline.md
@@ -1,3 +1,12 @@
+---
+title: Rethink the releasing pipeline to release faster
+status: accepted
+date: 2026-07-10
+tags: [release, ci, github-actions, supply-chain]
+summary: A tag re-runs the full e2e matrix that already passed on the identical release-branch SHA; skipping unit and e2e on tags, guarding on a green published SHA, cuts release runs from ~100-220m to ~20-30m.
+related: [091-migrate-to-v2-module-path]
+---
+
 # Rethink the releasing pipeline to release faster
 
 - Status: accepted

--- a/docs/madr/decisions/105-source-listener-tags-from-labels.md
+++ b/docs/madr/decisions/105-source-listener-tags-from-labels.md
@@ -1,3 +1,12 @@
+---
+title: Source Envoy listener tags from resource labels
+status: accepted
+date: 2026-07-23
+tags: [meshproxypatch, xds, listeners, labels, kri, meshservice, inbound-tags]
+summary: `listenerTags` matching silently stops working once identity moves off tags, so every otherwise-empty `io.kuma.tags` gets a synthesized `kuma.io/unified-name` — the destination KRI outbound, `self_inbound_dp_<port>` inbound.
+related: [101-sni-format-improvements, 103-universal-meshservice-generation]
+---
+
 # Source Envoy listener tags from resource labels
 
 * Status: accepted

--- a/docs/madr/list.sh
+++ b/docs/madr/list.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# List MADRs with their status.
+# List MADRs with their status, summary and tags.
+#
+# Output format:
+#   <file> [<status>] <summary> #tag #tag
 #
 # Usage:
 #   ./list.sh                              # list all MADRs
 #   ./list.sh | grep '\[accepted\]'        # example: filter by status using grep
+#   ./list.sh | grep '#zone-egress'        # example: filter by tag using grep
 
 set -euo pipefail
 
@@ -16,9 +20,27 @@ for file in "${DECISIONS_DIR}"/*.md; do
     continue
   fi
 
-  # Extract status value, strip markdown bold and HTML comments
-  status=$(awk 'tolower($0) ~ /^[*-] status:/ {sub(/.*: */, ""); gsub(/\*|<.*/, ""); sub(/ *$/, ""); print tolower($0); exit}' "$file")
-  status="${status:-unknown}"
+  awk -v name="$name" '
+    # front matter: everything between the first pair of --- lines
+    NR == 1 && $0 == "---" { fm = 1; next }
+    fm && $0 == "---" { fm = 0; next }
+    fm && /^status:/ { status = tolower(value()) }
+    fm && /^summary:/ { summary = value() }
+    fm && /^tags:/ { tags = value(); gsub(/[\[\]]/, "", tags) }
 
-  printf "%-80s [%s]\n" "$name" "$status"
+    # fall back to the "* Status: ..." bullet for MADRs without front matter
+    !fm && !status && tolower($0) ~ /^[*-] status:/ {
+      status = tolower(value()); gsub(/\*|<.*/, "", status); sub(/ *$/, "", status)
+    }
+
+    function value(  v) { v = $0; sub(/^[^:]*: */, "", v); return v }
+
+    END {
+      line = sprintf("%-72s [%s]", name, status ? status : "unknown")
+      if (summary) line = line " " summary
+      n = split(tags, t, / *, */)
+      for (i = 1; i <= n; i++) if (t[i]) line = line " #" t[i]
+      print line
+    }
+  ' "$file"
 done


### PR DESCRIPTION
> Changelog: skip

## Motivation

Finding the MADR relevant to a change means opening files one by one — the filename is the only signal, and 106 decisions is past the point where that scales. There is no summary of what a MADR decided or what area it touches short of reading it.

## Implementation information

The last 20 MADRs (090-105) get YAML front matter: `title`, `status`, `date`, `tags`, `summary`, `related`. Dates come from each file's first commit; `related` uses file stems rather than numbers because 095, 096, 100 and 103 each exist twice. `000-template.md` carries the block so new MADRs land on the map without a separate index to update, and `list.sh` now renders `summary` and `#tags`, falling back to the `* Status:` bullet for the 85 older MADRs.

`CLAUDE.md` gains a section pointing agents at the front matter when building context for a non-trivial change — scan it, open only what matches the area, treat a MADR as rationale rather than current state, and follow `related`/`superseded`.

Status is currently duplicated between the front matter and the `* Status:` bullet in the body; `list.sh` and the README both treat front matter as authoritative. Dropping the bullet from those 20 files is a follow-up if reviewers prefer a single source.

## Supporting documentation

- [docs/madr/README.md](docs/madr/README.md)
- [000-template.md](docs/madr/decisions/000-template.md)
