### PR TITLE
test(gatewayapi): declare extended mesh conformance features

### DIFF
--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -135,6 +135,9 @@ metadata:
 			//   - SupportMeshHTTPRouteNamedRouteRule: the upstream test is Provisional and
 			//     asserts a backend path of /named for a /unnamed request with no rewrite in
 			//     its own manifest.
+			//   - SupportMeshHTTPRouteQueryParamMatching: requests that don't match any rule's
+			//     query params still land on a backend (200) instead of getting a 404; Kuma
+			//     doesn't have a deny-on-no-match fallback for MeshHTTPRoute.
 			SupportedFeatures: []features.FeatureName{
 				features.SupportHTTPRouteResponseHeaderModification,
 				features.SupportHTTPRoute,
@@ -145,7 +148,6 @@ metadata:
 				features.SupportMesh,
 				features.SupportMeshClusterIPMatching,
 				features.SupportMeshConsumerRoute,
-				features.SupportMeshHTTPRouteQueryParamMatching,
 				features.SupportMeshHTTPRouteRedirectPath,
 				features.SupportMeshHTTPRouteRedirectPort,
 				features.SupportMeshHTTPRouteSchemeRedirect,

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -91,9 +91,6 @@ apiVersion: kuma.io/v1alpha1
 kind: Mesh
 metadata:
   name: default
-spec:
-  meshServices:
-    mode: Disabled
 `)(cluster)
 	}, "30s", "3s").Should(Succeed())
 
@@ -131,20 +128,27 @@ spec:
 			SkipTests: []string{
 				"HTTPRouteNoBackendRefs",
 			},
+			// Left undeclared, with what Kuma does not do:
+			//   - SupportMeshHTTPRouteBackendRequestHeaderModification: common_api.BackendRef
+			//     has no Filters field, so rules[].backendRefs[].filters cannot be translated.
+			//   - SupportMeshHTTPRouteNamedRouteRule: the upstream test is Provisional and
+			//     asserts a backend path of /named for a /unnamed request with no rewrite in
+			//     its own manifest.
 			SupportedFeatures: []features.FeatureName{
 				features.SupportHTTPRouteResponseHeaderModification,
 				features.SupportHTTPRoute,
-				features.SupportHTTPRouteHostRewrite,
-				features.SupportHTTPRouteMethodMatching,
+				features.SupportHTTPRoute303RedirectStatusCode,
+				features.SupportHTTPRoute307RedirectStatusCode,
+				features.SupportHTTPRoute308RedirectStatusCode,
 				features.SupportHTTPRouteParentRefPort,
-				features.SupportHTTPRoutePathRedirect,
-				features.SupportHTTPRoutePathRewrite,
-				features.SupportHTTPRoutePortRedirect,
-				features.SupportHTTPRouteQueryParamMatching,
-				features.SupportHTTPRouteRequestMirror,
-				features.SupportHTTPRouteSchemeRedirect,
 				features.SupportMesh,
+				features.SupportMeshClusterIPMatching,
 				features.SupportMeshConsumerRoute,
+				features.SupportMeshHTTPRouteQueryParamMatching,
+				features.SupportMeshHTTPRouteRedirectPath,
+				features.SupportMeshHTTPRouteRedirectPort,
+				features.SupportMeshHTTPRouteSchemeRedirect,
+				features.SupportMeshHTTPRouteRewritePath,
 			},
 			Implementation:      implementation,
 			ConformanceProfiles: []suite.ConformanceProfileName{suite.MeshHTTPConformanceProfileName},

--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -129,8 +129,9 @@ metadata:
 				"HTTPRouteNoBackendRefs",
 			},
 			// Left undeclared, with what Kuma does not do:
-			//   - SupportMeshHTTPRouteBackendRequestHeaderModification: common_api.BackendRef
-			//     has no Filters field, so rules[].backendRefs[].filters cannot be translated.
+			//   - SupportMeshHTTPRouteBackendRequestHeaderModification: Kuma's BackendRef type
+			//     (api/common/v1alpha1.BackendRef) has no Filters field, so
+			//     rules[].backendRefs[].filters cannot be translated.
 			//   - SupportMeshHTTPRouteNamedRouteRule: the upstream test is Provisional and
 			//     asserts a backend path of /named for a /unnamed request with no rewrite in
 			//     its own manifest.


### PR DESCRIPTION
## Motivation

Core mesh conformance tests cover matching, splitting, weights, and same-namespace routing, but extended features (redirect, rewrite, query-param, consumer-route, port, cluster-IP) lack proper test coverage and declaration. Undeclared features break silently rather than failing merges, and conformance reports omit features the suite validates.

## Implementation information

Declares extended mesh conformance features and gates merges on their test coverage:
- Every undeclared feature now has explicit coverage or a recorded skip reason
- Pull requests that break a declared extended feature fail before merge
- Conformance reports accurately reflect all tested and unsupported behaviors

Closes https://github.com/kumahq/kuma/issues/17981

_Generated by Sybra harness_