### PR TITLE
refactor(api): remove dead from-targetRef descriptor flags

### DIFF
--- a/pkg/api-server/mappers/resource_type_description.go
+++ b/pkg/api-server/mappers/resource_type_description.go
@@ -27,10 +27,10 @@ func MapResourceTypeDescription(defs []model.ResourceTypeDescriptor, readOnly bo
 		if def.IsPolicy {
 			td.Policy = &api_common.PolicyDescription{
 				HasToTargetRef:    def.HasToTargetRef,
-				HasFromTargetRef:  def.HasFromTargetRef,
+				HasFromTargetRef:  false,
 				HasRulesTargetRef: def.HasRulesTargetRef,
 				IsTargetRef:       def.IsTargetRefBased,
-				IsFromAsRules:     def.IsFromAsRules,
+				IsFromAsRules:     false,
 			}
 		}
 		response.Resources = append(response.Resources, td)

--- a/pkg/api-server/mappers/resource_type_description_test.go
+++ b/pkg/api-server/mappers/resource_type_description_test.go
@@ -18,7 +18,6 @@ func TestMapResourceTypeDescriptionPreservesRulesTargetRefPolicies(t *testing.T)
 			IsPolicy:          true,
 			IsTargetRefBased:  true,
 			HasToTargetRef:    true,
-			HasFromTargetRef:  false,
 			HasRulesTargetRef: true,
 		},
 	}, false, false)
@@ -26,6 +25,7 @@ func TestMapResourceTypeDescriptionPreservesRulesTargetRefPolicies(t *testing.T)
 	require.Len(t, response.Resources, 1)
 	require.NotNil(t, response.Resources[0].Policy)
 	require.False(t, response.Resources[0].Policy.HasFromTargetRef)
+	require.False(t, response.Resources[0].Policy.IsFromAsRules)
 	require.True(t, response.Resources[0].Policy.HasRulesTargetRef)
 	require.True(t, response.Resources[0].Policy.HasToTargetRef)
 }

--- a/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/donothingresource/api/v1alpha1/zz_generated.resource.go
@@ -194,11 +194,9 @@ var DoNothingResourceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "dnr",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var HostnameGeneratorResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: true,
 	ShortName:                    "hg",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/zz_generated.resource.go
@@ -209,11 +209,9 @@ var MeshExternalServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
 	ShortName:                    "extsvc",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var MeshIdentityResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
 	ShortName:                    "mid",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/zz_generated.resource.go
@@ -209,11 +209,9 @@ var MeshMultiZoneServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mzsvc",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var MeshOpenTelemetryBackendResourceTypeDescriptor = model.ResourceTypeDescripto
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
 	ShortName:                    "motb",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/zz_generated.resource.go
@@ -209,11 +209,9 @@ var MeshServiceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "msvc",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshtrust/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshtrust/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var MeshTrustResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: true,
 	ShortName:                    "mtrust",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshZoneAddressResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mza",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/apis/workload/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var WorkloadResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             false,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "wl",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/core/resources/model/resource.go
+++ b/pkg/core/resources/model/resource.go
@@ -225,9 +225,6 @@ type ResourceTypeDescriptor struct {
 	IsTargetRefBased bool
 	// HasToTargetRef indicates that the policy can be applied to outbound traffic
 	HasToTargetRef bool
-	// HasFromTargetRef is retained for REST compatibility with older clients and
-	// is no longer set by policy generators.
-	HasFromTargetRef bool
 	// HasRulesTargetRef indicates that the policy can be applied to inbound traffic
 	HasRulesTargetRef bool
 	// HasStatus indicates that the policy has a status field
@@ -254,9 +251,6 @@ type ResourceTypeDescriptor struct {
 	AllowedOnSystemNamespaceOnly bool
 	// ShortName a name that is used in kubectl or in the envoy configuration
 	ShortName string
-	// IsFromAsRules is retained for REST compatibility with older clients and is
-	// no longer set by policy generators.
-	IsFromAsRules bool
 	// Order defines the execution order of the associated plugin relative to others. It's used only when IsPluginOriginated is true.
 	// Lower values run first. Used by PolicyPlugins() to return a sorted list.
 	Order int

--- a/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/donothingpolicy/api/v1alpha1/zz_generated.resource.go
@@ -194,11 +194,9 @@ var DoNothingPolicyResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "dnp",
-	IsFromAsRules:                false,
 	Order:                        0,
 }

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var MeshAccessLogResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mal",
-	IsFromAsRules:                false,
 	Order:                        600,
 }

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshCircuitBreakerResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mcb",
-	IsFromAsRules:                false,
 	Order:                        1300,
 }

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshFaultInjectionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mfi",
-	IsFromAsRules:                false,
 	Order:                        800,
 }

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshHealthCheckResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mhc",
-	IsFromAsRules:                false,
 	Order:                        1200,
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshHTTPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mhttpr",
-	IsFromAsRules:                false,
 	Order:                        100,
 }

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshLoadBalancingStrategyResourceTypeDescriptor = model.ResourceTypeDescript
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mlbs",
-	IsFromAsRules:                false,
 	Order:                        400,
 }

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var MeshMetricResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mm",
-	IsFromAsRules:                false,
 	Order:                        1500,
 }

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshPassthroughResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mp",
-	IsFromAsRules:                false,
 	Order:                        500,
 }

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshProxyPatchResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mpp",
-	IsFromAsRules:                false,
 	Order:                        9999,
 }

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshRateLimitResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mrl",
-	IsFromAsRules:                false,
 	Order:                        900,
 }

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshRetryResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mr",
-	IsFromAsRules:                false,
 	Order:                        1400,
 }

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshTCPRouteResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mtcpr",
-	IsFromAsRules:                false,
 	Order:                        200,
 }

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshTimeoutResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               true,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mt",
-	IsFromAsRules:                false,
 	Order:                        1000,
 }

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshTLSResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mtls",
-	IsFromAsRules:                false,
 	Order:                        300,
 }

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/zz_generated.resource.go
@@ -206,11 +206,9 @@ var MeshTraceResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            false,
 	HasStatus:                    true,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mtr",
-	IsFromAsRules:                false,
 	Order:                        700,
 }

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/zz_generated.resource.go
@@ -195,11 +195,9 @@ var MeshTrafficPermissionResourceTypeDescriptor = model.ResourceTypeDescriptor{
 	AffectsPolicyMatching:        true,
 	IsTargetRefBased:             true,
 	HasToTargetRef:               false,
-	HasFromTargetRef:             false,
 	HasRulesTargetRef:            true,
 	HasStatus:                    false,
 	AllowedOnSystemNamespaceOnly: false,
 	ShortName:                    "mtp",
-	IsFromAsRules:                false,
 	Order:                        1100,
 }

--- a/tools/policy-gen/generator/cmd/core_resource.go
+++ b/tools/policy-gen/generator/cmd/core_resource.go
@@ -277,12 +277,10 @@ var {{.Name}}ResourceTypeDescriptor = model.ResourceTypeDescriptor{
 		AffectsPolicyMatching: true,
 		IsTargetRefBased: {{.IsPolicy}},
 		HasToTargetRef: {{.HasTo}},
-		HasFromTargetRef: false,
         HasRulesTargetRef: {{.HasRules}},
 		HasStatus: {{.HasStatus}},
 		AllowedOnSystemNamespaceOnly: {{.AllowedOnSystemNamespaceOnly}},
 		ShortName: "{{.ShortName}}",
-		IsFromAsRules: false,
 		Order: {{.Order}},
 	}
 `))


### PR DESCRIPTION
## Motivation

The resource descriptor carries two flags describing from-style targetRef support that are hardcoded to false by policy generators and kept only for REST compatibility with older clients. Since these flags are never branched on by consumers, they represent dead code that can be safely removed to simplify the codebase and reduce maintenance burden.

## Implementation information

Removed the two from-targetRef support flags from the resource descriptor:
- Policy generators no longer set or reference these flags
- REST responses for 3.0 clients remain unchanged
- Resource schema remains unchanged for all fields consumers read
- `make generate` produces no diffs after regeneration
- Unit test suite passes

Closes https://github.com/kumahq/kuma/issues/17961

_Generated by Sybra harness_