### PR TITLE
fix(gatewayapi): fail closed when a backendRef does not resolve

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -227,6 +227,16 @@ Policies that select real resources through `spec.targetRef` or `spec.to[].targe
 
 Migrate any policy that still selects those resources by `name` and/or `namespace` to use `labels` instead before upgrading. `sectionName` remains supported for `Dataplane` inbound selection and `MeshService` port selection.
 
+### A `MeshHTTPRoute` rule whose backendRefs all fail to resolve answers 500
+
+A rule that declares `backendRefs` and resolves none of them no longer falls back to the destination service. The rule now serves `500` to every request it matches, which is what the Gateway API requires of an invalid backendRef. A rule that resolves at least one of its backendRefs keeps routing to those backends, and a rule with a `RequestRedirect` filter still redirects.
+
+This covers every `MeshHTTPRoute`, not only the ones the Gateway API translation generates. A route pointing at a resource that does not exist yet — a `MeshService` that KDS has not synced to the zone, for example — fails its matching requests instead of sending them to the destination service, until the reference resolves.
+
+**Action required**
+
+None, as long as every `backendRefs` entry names a resource that exists. Check the routes that reference a resource from another zone or another namespace before upgrading: those are the ones whose masked misconfiguration becomes visible traffic loss.
+
 ### `MeshService.spec.identities` now accepts SPIFFE IDs only
 
 `MeshService.spec.identities[].type` no longer accepts `ServiceTag`. `MeshService.spec.identities` now publishes SPIFFE IDs only, while service-tag-based routing keeps using the `kuma.io/service` label or the MeshService resource name as its fallback naming signal.

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
@@ -96,11 +96,12 @@ func CompareMatch(a Match, b Match) int {
 }
 
 type Route struct {
-	Name        string
-	Origin      kri.Identifier
-	Match       Match
-	Filters     []Filter
-	BackendRefs []resolve.ResolvedBackendRef
+	Name                  string
+	Origin                kri.Identifier
+	Match                 Match
+	Filters               []Filter
+	BackendRefs           []resolve.ResolvedBackendRef
+	UnresolvedBackendRefs bool
 	// MirrorBackendRefs contains resolved backendRefs of RequestMirror filters,
 	// keyed by the index of the filter in Filters.
 	MirrorBackendRefs map[int]resolve.ResolvedBackendRef

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
@@ -96,12 +96,14 @@ func CompareMatch(a Match, b Match) int {
 }
 
 type Route struct {
-	Name                  string
-	Origin                kri.Identifier
-	Match                 Match
-	Filters               []Filter
-	BackendRefs           []resolve.ResolvedBackendRef
-	UnresolvedBackendRefs bool
+	Name        string
+	Origin      kri.Identifier
+	Match       Match
+	Filters     []Filter
+	BackendRefs []resolve.ResolvedBackendRef
+	// AllBackendRefsUnresolved is true when the rule declares backendRefs and
+	// none of them resolve, which is the case the Gateway API answers with 500.
+	AllBackendRefsUnresolved bool
 	// MirrorBackendRefs contains resolved backendRefs of RequestMirror filters,
 	// keyed by the index of the filter in Filters.
 	MirrorBackendRefs map[int]resolve.ResolvedBackendRef

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation.go
@@ -13,7 +13,6 @@ import (
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
-	"github.com/kumahq/kuma/v3/pkg/xds/generator/gateway/metadata"
 )
 
 func (r *MeshHTTPRouteResource) validate() error {
@@ -343,8 +342,7 @@ func validateBackendRefs(
 					common_api.MeshExternalService,
 					common_api.MeshMultiZoneService,
 				},
-				AllowedInvalidNames: []string{metadata.UnresolvedBackendServiceTag},
-				IsBackendRef:        true,
+				IsBackendRef: true,
 			}),
 		)
 		errs.AddErrorAt(

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -262,10 +262,13 @@ func prepareRoutes(
 
 		for _, match := range rule.Matches {
 			var refs []resolve.ResolvedBackendRef
+			hasUnresolvedBackendRefs := false
 
 			for _, br := range backendRefs {
 				if rbr, ok := resolve.BackendRef(originID, br, meshCtx.ResolveResourceIdentifier); ok {
 					refs = append(refs, rbr)
+				} else {
+					hasUnresolvedBackendRefs = true
 				}
 			}
 
@@ -277,7 +280,7 @@ func prepareRoutes(
 					Match:                 match,
 					Filters:               filters,
 					BackendRefs:           refs,
-					UnresolvedBackendRefs: hasExplicitBackendRefs && len(refs) == 0,
+					UnresolvedBackendRefs: hasExplicitBackendRefs && hasUnresolvedBackendRefs,
 					MirrorBackendRefs:     mirrorRefs,
 				},
 			)

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -106,12 +106,9 @@ func generateFromService(
 	var routes []xds.OutboundRoute
 
 	for _, route := range prepareRoutes(rules, svc, meshCtx) {
-		var split []envoy_common.Split
-		if !route.UnresolvedBackendRefs {
-			split = meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx)
-			if len(split) == 0 {
-				continue
-			}
+		split := meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx)
+		if len(split) == 0 && !route.AllBackendRefsUnresolved {
+			continue
 		}
 		// mirrored requests go to a cluster of their own, it has no weight so
 		// keep the split only to know which cluster was created for the mirror
@@ -132,12 +129,12 @@ func generateFromService(
 			mirrorSplits[i] = mirrorSplit[0]
 		}
 		routes = append(routes, xds.OutboundRoute{
-			Name:                  route.Name,
-			Match:                 route.Match,
-			Filters:               route.Filters,
-			UnresolvedBackendRefs: route.UnresolvedBackendRefs,
-			MirrorSplits:          mirrorSplits,
-			Split:                 split,
+			Name:                     route.Name,
+			Match:                    route.Match,
+			Filters:                  route.Filters,
+			AllBackendRefsUnresolved: route.AllBackendRefsUnresolved,
+			MirrorSplits:             mirrorSplits,
+			Split:                    split,
 		})
 	}
 
@@ -262,26 +259,23 @@ func prepareRoutes(
 
 		for _, match := range rule.Matches {
 			var refs []resolve.ResolvedBackendRef
-			hasUnresolvedBackendRefs := false
 
 			for _, br := range backendRefs {
 				if rbr, ok := resolve.BackendRef(originID, br, meshCtx.ResolveResourceIdentifier); ok {
 					refs = append(refs, rbr)
-				} else {
-					hasUnresolvedBackendRefs = true
 				}
 			}
 
 			routes = append(
 				routes,
 				api.Route{
-					Name:                  routeName,
-					Origin:                originID,
-					Match:                 match,
-					Filters:               filters,
-					BackendRefs:           refs,
-					UnresolvedBackendRefs: hasExplicitBackendRefs && hasUnresolvedBackendRefs,
-					MirrorBackendRefs:     mirrorRefs,
+					Name:                     routeName,
+					Origin:                   originID,
+					Match:                    match,
+					Filters:                  filters,
+					BackendRefs:              refs,
+					AllBackendRefsUnresolved: hasExplicitBackendRefs && len(refs) == 0,
+					MirrorBackendRefs:        mirrorRefs,
 				},
 			)
 		}
@@ -320,7 +314,7 @@ func prepareRoutes(
 			route.Match.Path = pointer.To(catchAllPathMatch)
 		}
 
-		if len(route.BackendRefs) == 0 && !route.UnresolvedBackendRefs {
+		if len(route.BackendRefs) == 0 && !route.AllBackendRefsUnresolved {
 			route.BackendRefs = []resolve.ResolvedBackendRef{
 				*svc.DefaultBackendRef(),
 			}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -106,9 +106,12 @@ func generateFromService(
 	var routes []xds.OutboundRoute
 
 	for _, route := range prepareRoutes(rules, svc, meshCtx) {
-		split := meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx)
-		if len(split) == 0 {
-			continue
+		var split []envoy_common.Split
+		if !route.UnresolvedBackendRefs {
+			split = meshroute_xds.MakeHTTPSplit(clusterCache, servicesAcc, route.BackendRefs, meshCtx)
+			if len(split) == 0 {
+				continue
+			}
 		}
 		// mirrored requests go to a cluster of their own, it has no weight so
 		// keep the split only to know which cluster was created for the mirror
@@ -129,11 +132,12 @@ func generateFromService(
 			mirrorSplits[i] = mirrorSplit[0]
 		}
 		routes = append(routes, xds.OutboundRoute{
-			Name:         route.Name,
-			Match:        route.Match,
-			Filters:      route.Filters,
-			MirrorSplits: mirrorSplits,
-			Split:        split,
+			Name:                  route.Name,
+			Match:                 route.Match,
+			Filters:               route.Filters,
+			UnresolvedBackendRefs: route.UnresolvedBackendRefs,
+			MirrorSplits:          mirrorSplits,
+			Split:                 split,
 		})
 	}
 
@@ -234,6 +238,7 @@ func prepareRoutes(
 	for _, rule := range apiRules {
 		filters := pointer.Deref(rule.Default.Filters)
 		backendRefs := pointer.Deref(rule.Default.BackendRefs)
+		hasExplicitBackendRefs := len(backendRefs) > 0
 		matchesHash := api.HashMatches(rule.Matches)
 		routeName := string(matchesHash)
 		origin := originByMatches[matchesHash]
@@ -267,12 +272,13 @@ func prepareRoutes(
 			routes = append(
 				routes,
 				api.Route{
-					Name:              routeName,
-					Origin:            originID,
-					Match:             match,
-					Filters:           filters,
-					BackendRefs:       refs,
-					MirrorBackendRefs: mirrorRefs,
+					Name:                  routeName,
+					Origin:                originID,
+					Match:                 match,
+					Filters:               filters,
+					BackendRefs:           refs,
+					UnresolvedBackendRefs: hasExplicitBackendRefs && len(refs) == 0,
+					MirrorBackendRefs:     mirrorRefs,
 				},
 			)
 		}
@@ -311,7 +317,7 @@ func prepareRoutes(
 			route.Match.Path = pointer.To(catchAllPathMatch)
 		}
 
-		if len(route.BackendRefs) == 0 {
+		if len(route.BackendRefs) == 0 && !route.UnresolvedBackendRefs {
 			route.BackendRefs = []resolve.ResolvedBackendRef{
 				*svc.DefaultBackendRef(),
 			}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -127,4 +127,86 @@ var _ = Describe("prepareRoutes", func() {
 		Entry("policy in team-a", "team-a"),
 		Entry("policy in team-b", "team-b"),
 	)
+
+	It("should fail closed when any explicit backendRef does not resolve", func() {
+		backend := builders.MeshService().
+			WithName("backend").
+			WithMesh(core_model.DefaultMesh).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			Build()
+		payments := builders.MeshService().
+			WithName("payments-hash").
+			WithMesh(core_model.DefaultMesh).
+			WithLabels(map[string]string{
+				mesh_proto.DisplayName:      "payments",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			}).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			Build()
+
+		meshCtx := xds_builders.Context().
+			WithMeshLocalResources([]core_model.Resource{backend, payments}).
+			Build().
+			Mesh
+
+		matches := []api.Match{{
+			Path: &api.PathMatch{Type: api.PathPrefix, Value: "/split"},
+		}}
+		policyMeta := &test_model.ResourceMeta{
+			Name: "web-route",
+			Mesh: core_model.DefaultMesh,
+			Labels: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			},
+		}
+		toRules := core_rules.ToRules{
+			ResourceRules: outbound.ResourceRules{
+				kri.From(backend): {
+					Resource: backend.GetMeta(),
+					Conf: []any{api.PolicyDefault{
+						Rules: []api.Rule{{
+							Matches: matches,
+							Default: api.RuleConf{
+								BackendRefs: &[]common_api.BackendRef{
+									{
+										TargetRef: builders.TargetRefMeshService("payments", "kuma-demo", ""),
+										Port:      pointer.To(uint32(8080)),
+									},
+									{
+										TargetRef: builders.TargetRefMeshService("missing-backend", "kuma-demo", ""),
+										Port:      pointer.To(uint32(8080)),
+									},
+								},
+							},
+						}},
+					}},
+					OriginByMatches: map[common_api.MatchesHash]common.Origin{
+						api.HashMatches(matches): {Resource: policyMeta},
+					},
+				},
+			},
+		}
+		svc := meshroute_xds.DestinationService{
+			Outbound: &xds_types.Outbound{
+				Resource: kri.WithSectionName(kri.From(backend), "8080"),
+				Port:     8080,
+			},
+			Protocol: core_meta.ProtocolHTTP,
+		}
+
+		routes := prepareRoutes(toRules, svc, meshCtx)
+
+		var matched *api.Route
+		for i := range routes {
+			if routes[i].Match.Path != nil && routes[i].Match.Path.Value == "/split" {
+				matched = &routes[i]
+				break
+			}
+		}
+		Expect(matched).ToNot(BeNil())
+		Expect(matched.UnresolvedBackendRefs).To(BeTrue())
+		Expect(matched.BackendRefs).To(HaveLen(1))
+		Expect(matched.BackendRefs[0].ReferencesRealResource()).To(BeTrue())
+		Expect(matched.BackendRefs[0].Resource()).To(Equal(kri.WithSectionName(kri.From(payments), "8080")))
+	})
 })

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -128,7 +128,7 @@ var _ = Describe("prepareRoutes", func() {
 		Entry("policy in team-b", "team-b"),
 	)
 
-	It("should fail closed when any explicit backendRef does not resolve", func() {
+	DescribeTable("should fail closed only when no explicit backendRef resolves", func(refNames []string, expectedAllUnresolved bool, expectedResolved []string) {
 		backend := builders.MeshService().
 			WithName("backend").
 			WithMesh(core_model.DefaultMesh).
@@ -159,6 +159,13 @@ var _ = Describe("prepareRoutes", func() {
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 			},
 		}
+		var backendRefs []common_api.BackendRef
+		for _, name := range refNames {
+			backendRefs = append(backendRefs, common_api.BackendRef{
+				TargetRef: builders.TargetRefMeshService(name, "kuma-demo", ""),
+				Port:      pointer.To(uint32(8080)),
+			})
+		}
 		toRules := core_rules.ToRules{
 			ResourceRules: outbound.ResourceRules{
 				kri.From(backend): {
@@ -167,16 +174,7 @@ var _ = Describe("prepareRoutes", func() {
 						Rules: []api.Rule{{
 							Matches: matches,
 							Default: api.RuleConf{
-								BackendRefs: &[]common_api.BackendRef{
-									{
-										TargetRef: builders.TargetRefMeshService("payments", "kuma-demo", ""),
-										Port:      pointer.To(uint32(8080)),
-									},
-									{
-										TargetRef: builders.TargetRefMeshService("missing-backend", "kuma-demo", ""),
-										Port:      pointer.To(uint32(8080)),
-									},
-								},
+								BackendRefs: &backendRefs,
 							},
 						}},
 					}},
@@ -204,9 +202,14 @@ var _ = Describe("prepareRoutes", func() {
 			}
 		}
 		Expect(matched).ToNot(BeNil())
-		Expect(matched.UnresolvedBackendRefs).To(BeTrue())
-		Expect(matched.BackendRefs).To(HaveLen(1))
-		Expect(matched.BackendRefs[0].ReferencesRealResource()).To(BeTrue())
-		Expect(matched.BackendRefs[0].Resource()).To(Equal(kri.WithSectionName(kri.From(payments), "8080")))
-	})
+		Expect(matched.AllBackendRefsUnresolved).To(Equal(expectedAllUnresolved))
+		Expect(matched.BackendRefs).To(HaveLen(len(expectedResolved)))
+		for i, name := range expectedResolved {
+			Expect(matched.BackendRefs[i].ReferencesRealResource()).To(BeTrue())
+			Expect(matched.BackendRefs[i].Resource().Name).To(Equal(name))
+		}
+	},
+		Entry("a resolving backendRef keeps its traffic", []string{"payments", "missing-backend"}, false, []string{"payments"}),
+		Entry("no resolving backendRef fails closed", []string{"missing-backend", "other-missing"}, true, nil),
+	)
 })

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
@@ -28,18 +28,20 @@ resources:
               - '*'
               name: kri_msvc_default___backend_80
               routes:
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: ""
+                  status: 503
+                match:
                   path: /v2
                 name: kri_mhttpr_default___test-origin_rule_0
-                route:
-                  cluster: kri_msvc_default___backend_80
-                  timeout: 0s
-              - match:
+              - directResponse:
+                  body:
+                    inlineString: ""
+                  status: 503
+                match:
                   prefix: /v2/
                 name: kri_mhttpr_default___test-origin_rule_0
-                route:
-                  cluster: kri_msvc_default___backend_80
-                  timeout: 0s
               - match:
                   path: /v1
                 name: kri_mhttpr_default___test-origin_rule_0

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
@@ -31,14 +31,14 @@ resources:
               - directResponse:
                   body:
                     inlineString: ""
-                  status: 503
+                  status: 500
                 match:
                   path: /v2
                 name: kri_mhttpr_default___test-origin_rule_0
               - directResponse:
                   body:
                     inlineString: ""
-                  status: 503
+                  status: 500
                 match:
                   prefix: /v2/
                 name: kri_mhttpr_default___test-origin_rule_0

--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -12,10 +12,12 @@ import (
 )
 
 type OutboundRoute struct {
-	Name                  string
-	Match                 api.Match
-	Filters               []api.Filter
-	UnresolvedBackendRefs bool
+	Name    string
+	Match   api.Match
+	Filters []api.Filter
+	// AllBackendRefsUnresolved is true when the rule declares backendRefs and
+	// none of them resolve, which is the case the Gateway API answers with 500.
+	AllBackendRefsUnresolved bool
 	// MirrorSplits contains splits of the clusters created for RequestMirror
 	// filters, keyed by the index of the filter in Filters
 	MirrorSplits map[int]envoy_common.Split
@@ -36,12 +38,12 @@ func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.Filt
 	for _, route := range c.Routes {
 		route := envoy_virtual_hosts.AddVirtualHostConfigurer(
 			&RoutesConfigurer{
-				Name:         route.Name,
-				Match:        route.Match,
-				Filters:      route.Filters,
-				Unresolved:   route.UnresolvedBackendRefs,
-				MirrorSplits: route.MirrorSplits,
-				Split:        route.Split,
+				Name:                     route.Name,
+				Match:                    route.Match,
+				Filters:                  route.Filters,
+				AllBackendRefsUnresolved: route.AllBackendRefsUnresolved,
+				MirrorSplits:             route.MirrorSplits,
+				Split:                    route.Split,
 			})
 		virtualHostBuilder = virtualHostBuilder.Configure(route)
 	}

--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -12,9 +12,10 @@ import (
 )
 
 type OutboundRoute struct {
-	Name    string
-	Match   api.Match
-	Filters []api.Filter
+	Name                  string
+	Match                 api.Match
+	Filters               []api.Filter
+	UnresolvedBackendRefs bool
 	// MirrorSplits contains splits of the clusters created for RequestMirror
 	// filters, keyed by the index of the filter in Filters
 	MirrorSplits map[int]envoy_common.Split
@@ -38,6 +39,7 @@ func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.Filt
 				Name:         route.Name,
 				Match:        route.Match,
 				Filters:      route.Filters,
+				Unresolved:   route.UnresolvedBackendRefs,
 				MirrorSplits: route.MirrorSplits,
 				Split:        route.Split,
 			})

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -15,12 +15,12 @@ import (
 )
 
 type RoutesConfigurer struct {
-	Name         string
-	Match        api.Match
-	Filters      []api.Filter
-	Unresolved   bool
-	MirrorSplits map[int]envoy_common.Split
-	Split        []envoy_common.Split
+	Name                     string
+	Match                    api.Match
+	Filters                  []api.Filter
+	AllBackendRefsUnresolved bool
+	MirrorSplits             map[int]envoy_common.Split
+	Split                    []envoy_common.Split
 }
 
 func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error {
@@ -54,8 +54,10 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error 
 			}
 		}
 
-		if c.Unresolved {
-			rb.Configure(envoy_routes.RouteActionDirectResponse(503, ""))
+		// A rule whose backendRefs all fail to resolve answers 500, unless a
+		// filter already terminates the request without an upstream.
+		if c.AllBackendRefsUnresolved && !hasTerminalFilter(c.Filters) {
+			rb.Configure(envoy_routes.RouteActionDirectResponse(500, ""))
 		}
 
 		r, err := rb.Build()
@@ -67,6 +69,17 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error 
 	}
 
 	return nil
+}
+
+// hasTerminalFilter reports whether a filter sets the route action itself, so
+// the route serves a response without reaching any backend.
+func hasTerminalFilter(filters []api.Filter) bool {
+	for _, filter := range filters {
+		if filter.Type == api.RequestRedirectType {
+			return true
+		}
+	}
+	return false
 }
 
 type routeMatch struct {

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -18,6 +18,7 @@ type RoutesConfigurer struct {
 	Name         string
 	Match        api.Match
 	Filters      []api.Filter
+	Unresolved   bool
 	MirrorSplits map[int]envoy_common.Split
 	Split        []envoy_common.Split
 }
@@ -51,6 +52,10 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error 
 			case api.RequestMirrorType:
 				rb.Configure(filters.NewRequestMirror(*filter.RequestMirror, c.MirrorSplits[i]))
 			}
+		}
+
+		if c.Unresolved {
+			rb.Configure(envoy_routes.RouteActionDirectResponse(503, ""))
 		}
 
 		r, err := rb.Build()

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -388,7 +388,7 @@ func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 	unresolvedTargetRef := common_api.TargetRef{
 		Kind: common_api.MeshService,
 		Labels: &map[string]string{
-			mesh_proto.DisplayName: metadata.UnresolvedBackendServiceTag,
+			mesh_proto.DisplayName: metadata.UnresolvedBackendServiceName,
 		},
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -19,7 +19,6 @@ import (
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
-	"github.com/kumahq/kuma/v3/pkg/xds/generator/gateway/metadata"
 )
 
 func (r *HTTPRouteReconciler) gapiToMeshRules(
@@ -385,18 +384,18 @@ func (c *ResolvedRefsConditionFalse) AddIfFalseAndNotPresent(conditions *[]kube_
 func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 	ctx context.Context, objectNamespace string, ref gatewayapi.BackendObjectReference,
 ) (common_api.TargetRef, *ResolvedRefsConditionFalse, error) {
-	unresolvedTargetRef := common_api.TargetRef{
-		Kind: common_api.MeshService,
-		Labels: &map[string]string{
-			mesh_proto.DisplayName: metadata.UnresolvedBackendServiceName,
-		},
-	}
-
 	gk := kube_schema.GroupKind{Kind: string(*ref.Kind), Group: string(*ref.Group)}
 	// the backendRef's namespace, falling back to the route's namespace when unset
 	refNamespace := objectNamespace
 	if ref.Namespace != nil {
 		refNamespace = string(*ref.Namespace)
+	}
+	unresolvedTargetRef := common_api.TargetRef{
+		Kind: common_api.MeshService,
+		Labels: &map[string]string{
+			mesh_proto.DisplayName:      string(ref.Name),
+			mesh_proto.KubeNamespaceTag: refNamespace,
+		},
 	}
 	namespacedName := kube_types.NamespacedName{Namespace: refNamespace, Name: string(ref.Name)}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -16,7 +16,6 @@ import (
 	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
-	"github.com/kumahq/kuma/v3/pkg/xds/generator/gateway/metadata"
 )
 
 var _ = Describe("uncheckedGapiToKumaRef", func() {
@@ -90,7 +89,8 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 		Expect(targetRef).To(Equal(common_api.TargetRef{
 			Kind: common_api.MeshService,
 			Labels: pointer.To(map[string]string{
-				mesh_proto.DisplayName: metadata.UnresolvedBackendServiceName,
+				mesh_proto.DisplayName:      "missing-backend",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
 			}),
 		}))
 	})

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -16,6 +16,7 @@ import (
 	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+	"github.com/kumahq/kuma/v3/pkg/xds/generator/gateway/metadata"
 )
 
 var _ = Describe("uncheckedGapiToKumaRef", func() {
@@ -58,6 +59,39 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 			}),
 			SectionName: pointer.To("80"),
+		}))
+	})
+
+	It("should return a valid unresolved MeshService targetRef when the backend Service is missing", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Zone:   "zone-1",
+		}
+
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		namespace := gatewayapi.Namespace("kuma-demo")
+		port := gatewayapi.PortNumber(80)
+		ref := gatewayapi.BackendObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      "missing-backend",
+			Namespace: &namespace,
+			Port:      &port,
+		}
+
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "kuma-demo", ref)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(condition).ToNot(BeNil())
+		Expect(targetRef).To(Equal(common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Labels: pointer.To(map[string]string{
+				mesh_proto.DisplayName: metadata.UnresolvedBackendServiceName,
+			}),
 		}))
 	})
 })

--- a/pkg/xds/generator/gateway/metadata/metadata.go
+++ b/pkg/xds/generator/gateway/metadata/metadata.go
@@ -3,6 +3,5 @@ package metadata
 const (
 	// PluginName is the key used to store gateway listener info on
 	// proxy.RuntimeExtensions.
-	PluginName                   = "gateway"
-	UnresolvedBackendServiceName = "unresolved-backend"
+	PluginName = "gateway"
 )

--- a/pkg/xds/generator/gateway/metadata/metadata.go
+++ b/pkg/xds/generator/gateway/metadata/metadata.go
@@ -3,6 +3,6 @@ package metadata
 const (
 	// PluginName is the key used to store gateway listener info on
 	// proxy.RuntimeExtensions.
-	PluginName                  = "gateway"
-	UnresolvedBackendServiceTag = "kuma.io/unresolved-backend"
+	PluginName                   = "gateway"
+	UnresolvedBackendServiceName = "unresolved-backend"
 )


### PR DESCRIPTION
## Motivation

When an HTTPRoute names a backendRef that Kuma cannot resolve, the translation uses a placeholder service name left over from the tag era. This placeholder never resolves, causing the rule to produce no cluster and the entire route to be dropped. Traffic then reaches the destination as though the HTTPRoute did not exist, masking the configuration error and producing the opposite of the intended behavior.

## Implementation information

- Fail with an error response when a request matches a rule whose backendRef does not resolve, instead of silently dropping the route
- Ensure traffic never falls through to unrouted destinations because of an unresolvable backendRef
- Preserve rules in the same HTTPRoute whose backendRefs do resolve
- Report HTTPRoute ResolvedRefs status as false with the specific failure reason
- Remove placeholder service names from translation and validation logic

Closes https://github.com/kumahq/kuma/issues/17982

_Generated by Sybra harness_