### PR TITLE
fix(config): enforce RFC1123 compliance for zone names

### DIFF
--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -4,11 +4,12 @@ import (
 	"crypto/x509"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
-	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	k8s_validation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/kumahq/kuma/v3/pkg/config"
 	config_types "github.com/kumahq/kuma/v3/pkg/config/types"
@@ -84,11 +85,8 @@ func (r *ZoneConfig) Validate() error {
 	if r.Name == "" {
 		return errors.Errorf("Name is mandatory")
 	}
-	if !govalidator.IsDNSName(r.Name) {
-		return errors.Errorf("Zone name %s has to be a valid DNS name", r.Name)
-	}
-	if len(r.Name) > 63 {
-		return errors.New("Zone name cannot be longer than 63 characters")
+	if violations := k8s_validation.IsDNS1123Label(r.Name); len(violations) > 0 {
+		return errors.Errorf("Zone name %s has to be a valid RFC1123 DNS label: %s", r.Name, strings.Join(violations, ", "))
 	}
 	if r.GlobalAddress != "" {
 		u, err := url.Parse(r.GlobalAddress)

--- a/pkg/config/multizone/multicluster.go
+++ b/pkg/config/multizone/multicluster.go
@@ -86,7 +86,7 @@ func (r *ZoneConfig) Validate() error {
 		return errors.Errorf("Name is mandatory")
 	}
 	if violations := k8s_validation.IsDNS1123Label(r.Name); len(violations) > 0 {
-		return errors.Errorf("Zone name %s has to be a valid RFC1123 DNS label: %s", r.Name, strings.Join(violations, ", "))
+		return errors.Errorf("Zone name %q has to be a valid RFC1123 DNS label: %s", r.Name, strings.Join(violations, ", "))
 	}
 	if r.GlobalAddress != "" {
 		u, err := url.Parse(r.GlobalAddress)

--- a/pkg/config/multizone/multicluster_test.go
+++ b/pkg/config/multizone/multicluster_test.go
@@ -1,0 +1,40 @@
+package multizone
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZoneConfigValidateName(t *testing.T) {
+	cases := []struct {
+		name      string
+		zoneName  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "empty name", zoneName: "", wantErr: true, errSubstr: "Name is mandatory"},
+		{name: "valid lowercase name", zoneName: "zone-1", wantErr: false},
+		{name: "rejects uppercase letters", zoneName: "Zone-1", wantErr: true, errSubstr: "valid RFC1123 DNS label"},
+		{name: "rejects underscore", zoneName: "zone_1", wantErr: true, errSubstr: "valid RFC1123 DNS label"},
+		{name: "rejects name longer than 63 characters", zoneName: strings.Repeat("a", 64), wantErr: true, errSubstr: "valid RFC1123 DNS label"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := ZoneConfig{
+				Name: c.zoneName,
+			}
+			err := cfg.Validate()
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error for zone name %q", c.zoneName)
+				}
+				if !strings.Contains(err.Error(), c.errSubstr) {
+					t.Fatalf("expected error to contain %q, got %v", c.errSubstr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no validation error for zone name %q, got %v", c.zoneName, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Zone name validation was accepting uppercase letters, which violates RFC1123 compliance and causes KDS errors during multizone operations. Zone names must be lowercase-only per RFC1123.

## Implementation information

Updated zone name validation to enforce RFC1123 compliance by rejecting zone names containing uppercase letters, ensuring compatibility with KDS across multizone setups.

Closes https://github.com/kumahq/kuma/issues/12988

_Generated by Sybra harness_