### PR TITLE
test(framework): fail e2e suites on KDS NACKs

### DIFF
--- a/pkg/util/xds/stats_callbacks.go
+++ b/pkg/util/xds/stats_callbacks.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kumahq/kuma/v3/pkg/core"
+	kds_util "github.com/kumahq/kuma/v3/pkg/kds/util"
 )
 
 var statsLogger = core.Log.WithName("stats-callbacks")
@@ -337,10 +338,14 @@ func (s *statsCallbacks) maybeReportWindowDepletion(last lastSend) {
 	)
 }
 
+// classifyError separates NACKs the user caused from ones that point at a
+// control plane defect. KDS marks the former with kds_util.ErrUserNack: when a
+// resource the peer sends conflicts with one that already exists locally, the
+// CP skips it and NACKs on purpose (pkg/kds/store/sync.go), so the stream is
+// working as designed.
 func classifyError(err string) string {
-	if strings.Contains(err, failedCallingWebhook) {
+	if strings.Contains(err, failedCallingWebhook) || kds_util.IsUserErrorMessage(err) {
 		return userErrorType
-	} else {
-		return otherErrorType
 	}
+	return otherErrorType
 }

--- a/pkg/util/xds/stats_callbacks_test.go
+++ b/pkg/util/xds/stats_callbacks_test.go
@@ -131,6 +131,29 @@ var _ = Describe("Stats callbacks", func() {
 			Expect(test_metrics.FindMetric(metrics, "delta_xds_requests_received", "confirmation", "NACK", "type_url", resource.RouteType).GetCounter().GetValue()).To(Equal(1.0))
 		})
 
+		It("should track a user-caused NACK under its own error_type", func() {
+			// given a NACK the peer sent because the resource conflicts with one
+			// the user already created locally, which KDS skips on purpose
+			req := &envoy_discovery.DeltaDiscoveryRequest{
+				TypeUrl: resource.RouteType,
+				InitialResourceVersions: map[string]string{
+					"route-1": "123",
+				},
+				ResponseNonce: "1",
+				ErrorDetail: &status.Status{
+					Message: `user error
+resource already exists: type="Secret" name="global-and-zone-secret" mesh="sync"`,
+				},
+			}
+
+			// when
+			err := adaptedCallbacks.OnStreamDeltaRequest(streamId, req)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(test_metrics.FindMetric(metrics, "delta_xds_requests_received", "confirmation", "NACK", "error_type", "user", "type_url", resource.RouteType).GetCounter().GetValue()).To(Equal(1.0))
+		})
+
 		It("should track version", func() {
 			// when
 			version := "1.0.0"

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -53,8 +53,15 @@ func UpgradingZoneWithHelmChart() {
 	})
 
 	E2EAfterEach(func() {
-		ControlPlaneAssertions(global)
-		ControlPlaneAssertions(zoneK8s)
+		// A 2.14 zone sends Dataplanes whose VIP outbounds carry no
+		// backendRef, which this Global rejects on every resync until the
+		// zone is upgraded. Both ends count it: Global as the sync client
+		// that sends the NACK, the zone as the delta server that receives
+		// it. Fixed in 2.14.x, so both come off once a release carrying the
+		// fix is out and SupportedVersionEntriesAtLeast picks it up.
+		const vipOutboundNack = "2.14 zones send VIP outbounds without backendRef, fixed but not yet released"
+		ControlPlaneAssertions(global, KnownNack("kds_nack_total", vipOutboundNack))
+		ControlPlaneAssertions(zoneK8s, KnownNack("kds_delta_requests_received", vipOutboundNack))
 		ControlPlaneAssertions(zoneUniversal)
 		grp := sync.WaitGroup{}
 		grp.Add(3)

--- a/test/e2e/helm/kuma_helm_upgrade_multizone.go
+++ b/test/e2e/helm/kuma_helm_upgrade_multizone.go
@@ -27,6 +27,17 @@ import (
 // or upgraded here: Global-on-Kubernetes was removed (#17270), Global is always
 // Universal now, and the test framework has no mechanism to run an old Universal
 // kuma-cp binary, only old Helm charts/images for Kubernetes clusters.
+// vipOutboundNack is why this spec relaxes two things a 2.14 pre-upgrade zone
+// cannot satisfy: it sends Dataplanes whose VIP outbounds carry no backendRef,
+// which this Global rejects on every resync until the upgrade lands. Both ends
+// count the NACK - Global as the sync client that sends it, the zone as the
+// delta server that receives it - and the rejection also makes the test
+// server's Dataplane reach Global only if it wins a race with VIP computation.
+// Fixed in 2.14.x. Grep this identifier to revert every accommodation once a
+// release carrying the fix is out and SupportedVersionEntriesAtLeast picks it
+// up.
+const vipOutboundNack = "2.14 zones send VIP outbounds without backendRef, fixed but not yet released"
+
 func UpgradingZoneWithHelmChart() {
 	namespace := "helm-upgrade-ns"
 	var global, zoneK8s, zoneUniversal Cluster
@@ -53,13 +64,6 @@ func UpgradingZoneWithHelmChart() {
 	})
 
 	E2EAfterEach(func() {
-		// A 2.14 zone sends Dataplanes whose VIP outbounds carry no
-		// backendRef, which this Global rejects on every resync until the
-		// zone is upgraded. Both ends count it: Global as the sync client
-		// that sends the NACK, the zone as the delta server that receives
-		// it. Fixed in 2.14.x, so both come off once a release carrying the
-		// fix is out and SupportedVersionEntriesAtLeast picks it up.
-		const vipOutboundNack = "2.14 zones send VIP outbounds without backendRef, fixed but not yet released"
 		ControlPlaneAssertions(global, KnownNack("kds_nack_total", vipOutboundNack))
 		ControlPlaneAssertions(zoneK8s, KnownNack("kds_delta_requests_received", vipOutboundNack))
 		ControlPlaneAssertions(zoneUniversal)
@@ -134,11 +138,16 @@ spec:
 				Install(testserver.Install(testserver.WithNamespace(namespace))).Setup(zoneK8s)
 			Expect(err).ToNot(HaveOccurred())
 
-			// The zone's own mesh zone ingress is a Dataplane too, so it counts
-			// alongside the test server.
+			// Only the zone's own mesh zone ingress is asserted here. Whether
+			// the test server's Dataplane also makes it across is a race while
+			// the pre-upgrade zone is on 2.14: if KDS syncs it before the zone
+			// computes its VIP outbounds it lands, otherwise it is already
+			// invalid and Global rejects it (see vipOutboundNack). The count
+			// after the upgrade is asserted strictly below, which is what this
+			// spec is actually about.
 			Eventually(func(g Gomega) (int, error) {
 				return NumberOfResources(global, mesh.DataplaneResourceTypeDescriptor)
-			}, "60s", "1s").Should(Equal(2), "dpps should be synced to global")
+			}, "60s", "1s").Should(BeNumerically(">=", 1), "dpps should be synced to global")
 
 			By("deploy a new universal zone with latest version")
 			err = NewClusterSetup().

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -25,7 +25,30 @@ import (
 	"github.com/kumahq/kuma/v3/test/framework/utils"
 )
 
-func ControlPlaneAssertions(cluster Cluster) {
+// CPAssertionOpt relaxes one of the control plane assertions for a single
+// call site.
+type CPAssertionOpt func(*cpAssertionOpts)
+
+type cpAssertionOpts struct {
+	// knownNacks maps a NACK counter family to why it is exempt.
+	knownNacks map[string]string
+}
+
+// KnownNack exempts a NACK counter family on this cluster from the NACK
+// assertion. Use it only for a NACK a spec provokes on purpose, or a product
+// bug that is already fixed but not yet released, and say which in reason.
+// Everything else on the cluster stays asserted, including the other NACK
+// families.
+func KnownNack(family string, reason string) CPAssertionOpt {
+	return func(opts *cpAssertionOpts) {
+		if opts.knownNacks == nil {
+			opts.knownNacks = map[string]string{}
+		}
+		opts.knownNacks[family] = reason
+	}
+}
+
+func ControlPlaneAssertions(cluster Cluster, opts ...CPAssertionOpt) {
 	ginkgo.GinkgoHelper()
 	defer ginkgo.GinkgoRecover() // Ensures that Ginkgo can recover from any failures
 	logs := cluster.GetKumaCPLogs()
@@ -43,7 +66,7 @@ func ControlPlaneAssertions(cluster Cluster) {
 	default:
 		ginkgo.Fail("unknown cluster")
 	}
-	assertNoXdsNacks(cluster)
+	assertNoXdsNacks(cluster, opts...)
 	assertNoXdsChurn(cluster, logs)
 }
 
@@ -107,19 +130,28 @@ var nackCounters = []nackCounter{
 // assertNoXdsNacks scrapes the CP /metrics endpoint and fails if any xDS or
 // KDS request has been answered with a NACK. A non-zero counter means the CP
 // produced a config that Envoy or a peer control plane rejected.
-func assertNoXdsNacks(cluster Cluster) {
+func assertNoXdsNacks(cluster Cluster, opts ...CPAssertionOpt) {
 	ginkgo.GinkgoHelper()
+	options := cpAssertionOpts{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	for family, reason := range options.knownNacks {
+		Logf("[WARNING]: not asserting %s on CP %s: %s", family, cluster.Name(), reason)
+	}
+
 	raw, err := cluster.GetKuma().GetMetrics()
 	Expect(err).ToNot(HaveOccurred(), "failed to scrape metrics from CP %s", cluster.Name())
 
-	nacks, err := findNacks(raw)
+	nacks, err := findNacks(raw, options.knownNacks)
 	Expect(err).ToNot(HaveOccurred(), "failed to parse metrics from CP %s", cluster.Name())
 	Expect(nacks).To(BeEmpty(), "CP %s reported NACK(s): %s", cluster.Name(), strings.Join(nacks, ", "))
 }
 
 // findNacks returns one description per NACK counter that exceeds its
-// tolerance in a Prometheus text exposition.
-func findNacks(raw string) ([]string, error) {
+// tolerance in a Prometheus text exposition, skipping the families named in
+// knownNacks.
+func findNacks(raw string, knownNacks map[string]string) ([]string, error) {
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	families, err := parser.TextToMetricFamilies(strings.NewReader(raw))
 	if err != nil {
@@ -128,6 +160,9 @@ func findNacks(raw string) ([]string, error) {
 
 	var nacks []string
 	for _, counter := range nackCounters {
+		if _, known := knownNacks[counter.family]; known {
+			continue
+		}
 		family, ok := families[counter.family]
 		if !ok {
 			continue

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -60,38 +60,92 @@ func assertNoXdsChurn(cluster Cluster, logs map[string]string) {
 	}
 }
 
-// assertNoXdsNacks scrapes the CP /metrics endpoint and fails if any xDS
-// request has been answered with a NACK. A non-zero counter means the CP
-// produced a config that Envoy rejected.
+// nackCounter is a CP counter family that records a rejected config, the
+// label pair that marks a NACK series inside that family, and how many NACKs
+// are tolerated before the suite fails.
+type nackCounter struct {
+	family string
+	// label and value select the NACK series. Empty label means every
+	// series in the family is a NACK by construction.
+	label string
+	value string
+	// maxTolerated is the highest value that still passes.
+	maxTolerated float64
+}
+
+// nackCounters covers both the proxy-facing xDS servers and the KDS streams
+// between zone and global. The two sides are separate metric families because
+// they come from separate servers:
+//   - "xds"/"delta_xds" prefixes: pkg/xds/server/components.go, a NACK means
+//     Envoy rejected a config this CP generated.
+//   - "kds_delta" prefix: pkg/kds/server/components.go, a NACK means the peer
+//     CP rejected a resource this CP sent over KDS.
+//   - kds_nack_total: pkg/kds/mux/zone_sync.go, a NACK this CP sent back
+//     because a resource the peer sent failed validation. Every series is a
+//     NACK, and the family is absent until the first one.
+//
+// KDS tolerates nothing. A KDS NACK is not a transient eventual-consistency
+// blip that resolves itself: the sender keeps resending the same rejected
+// resource on every resync, so the stream never converges and the two CPs
+// disagree about state for as long as the resource exists. The proxy-facing
+// thresholds are left as they were.
+var nackCounters = []nackCounter{
+	{family: "xds_requests_received", label: "confirmation", value: "NACK", maxTolerated: 2},
+	{family: "delta_xds_requests_received", label: "confirmation", value: "NACK", maxTolerated: 2},
+	{family: "kds_delta_requests_received", label: "confirmation", value: "NACK", maxTolerated: 0},
+	{family: "kds_nack_total", maxTolerated: 0},
+}
+
+// assertNoXdsNacks scrapes the CP /metrics endpoint and fails if any xDS or
+// KDS request has been answered with a NACK. A non-zero counter means the CP
+// produced a config that Envoy or a peer control plane rejected.
 func assertNoXdsNacks(cluster Cluster) {
 	ginkgo.GinkgoHelper()
 	raw, err := cluster.GetKuma().GetMetrics()
 	Expect(err).ToNot(HaveOccurred(), "failed to scrape metrics from CP %s", cluster.Name())
 
+	nacks, err := findNacks(raw)
+	Expect(err).ToNot(HaveOccurred(), "failed to parse metrics from CP %s", cluster.Name())
+	Expect(nacks).To(BeEmpty(), "CP %s reported NACK(s): %s", cluster.Name(), strings.Join(nacks, ", "))
+}
+
+// findNacks returns one description per NACK counter that exceeds its
+// tolerance in a Prometheus text exposition.
+func findNacks(raw string) ([]string, error) {
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	families, err := parser.TextToMetricFamilies(strings.NewReader(raw))
-	Expect(err).ToNot(HaveOccurred(), "failed to parse metrics from CP %s", cluster.Name())
+	if err != nil {
+		return nil, err
+	}
 
-	for _, metricName := range []string{"xds_requests_received", "delta_xds_requests_received"} {
-		family, ok := families[metricName]
+	var nacks []string
+	for _, counter := range nackCounters {
+		family, ok := families[counter.family]
 		if !ok {
 			continue
 		}
 		for _, metric := range family.GetMetric() {
-			isNack := false
-			for _, label := range metric.GetLabel() {
-				if label.GetName() == "confirmation" && label.GetValue() == "NACK" {
-					isNack = true
-					break
-				}
-			}
-			if !isNack {
+			if counter.label != "" && !hasLabel(metric.GetLabel(), counter.label, counter.value) {
 				continue
 			}
-			Expect(metric.GetCounter().GetValue()).To(BeNumerically("<", 3),
-				"CP %s reported %s NACK(s) for labels %s", cluster.Name(), metricName, formatLabels(metric.GetLabel()))
+			value := metric.GetCounter().GetValue()
+			if value <= counter.maxTolerated {
+				continue
+			}
+			nacks = append(nacks, fmt.Sprintf("%s%s = %v (tolerated %v)",
+				counter.family, formatLabels(metric.GetLabel()), value, counter.maxTolerated))
 		}
 	}
+	return nacks, nil
+}
+
+func hasLabel(labels []*io_prometheus_client.LabelPair, name string, value string) bool {
+	for _, label := range labels {
+		if label.GetName() == name && label.GetValue() == value {
+			return true
+		}
+	}
+	return false
 }
 
 func formatLabels(labels []*io_prometheus_client.LabelPair) string {

--- a/test/framework/debug.go
+++ b/test/framework/debug.go
@@ -69,6 +69,9 @@ type nackCounter struct {
 	// series in the family is a NACK by construction.
 	label string
 	value string
+	// skipErrorType exempts series carrying this error_type. Used for
+	// "user", which marks a NACK the user caused rather than a CP defect.
+	skipErrorType string
 	// maxTolerated is the highest value that still passes.
 	maxTolerated float64
 }
@@ -89,10 +92,15 @@ type nackCounter struct {
 // resource on every resync, so the stream never converges and the two CPs
 // disagree about state for as long as the resource exists. The proxy-facing
 // thresholds are left as they were.
+//
+// The exception is error_type="user", which KDS sets when the peer sent a
+// resource that conflicts with one the user already created locally. The CP
+// skips it and NACKs on purpose (pkg/kds/store/sync.go), and
+// test/e2e_env/multizone/sync asserts exactly that, so it is not a defect.
 var nackCounters = []nackCounter{
 	{family: "xds_requests_received", label: "confirmation", value: "NACK", maxTolerated: 2},
 	{family: "delta_xds_requests_received", label: "confirmation", value: "NACK", maxTolerated: 2},
-	{family: "kds_delta_requests_received", label: "confirmation", value: "NACK", maxTolerated: 0},
+	{family: "kds_delta_requests_received", label: "confirmation", value: "NACK", skipErrorType: "user", maxTolerated: 0},
 	{family: "kds_nack_total", maxTolerated: 0},
 }
 
@@ -126,6 +134,9 @@ func findNacks(raw string) ([]string, error) {
 		}
 		for _, metric := range family.GetMetric() {
 			if counter.label != "" && !hasLabel(metric.GetLabel(), counter.label, counter.value) {
+				continue
+			}
+			if counter.skipErrorType != "" && hasLabel(metric.GetLabel(), "error_type", counter.skipErrorType) {
 				continue
 			}
 			value := metric.GetCounter().GetValue()

--- a/test/framework/debug_test.go
+++ b/test/framework/debug_test.go
@@ -5,10 +5,43 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("KnownNack", func() {
+	// The signature the helm upgrade suite exempts while the 2.14 fix waits
+	// on a release.
+	const metrics = `
+# HELP kds_nack_total Total KDS NACKs sent by zone and resource type.
+# TYPE kds_nack_total counter
+kds_nack_total{resource_type="Dataplane",zone="Global",zone_name="kuma-2"} 2
+# HELP kds_delta_requests_received Number of confirmations requests from a client
+# TYPE kds_delta_requests_received counter
+kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} 1
+`
+
+	exempt := func(opts ...CPAssertionOpt) map[string]string {
+		options := cpAssertionOpts{}
+		for _, opt := range opts {
+			opt(&options)
+		}
+		return options.knownNacks
+	}
+
+	It("should exempt only the named family", func() {
+		nacks, err := findNacks(metrics, exempt(KnownNack("kds_nack_total", "fixed, waiting on release")))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nacks).To(ConsistOf(`kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} = 1 (tolerated 0)`))
+	})
+
+	It("should report the family when it is not exempt", func() {
+		nacks, err := findNacks(metrics, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nacks).To(ContainElement(`kds_nack_total{resource_type="Dataplane",zone="Global",zone_name="kuma-2"} = 2 (tolerated 0)`))
+	})
+})
+
 var _ = Describe("findNacks", func() {
 	DescribeTable("should report NACK counters over their tolerance",
 		func(metrics string, expected []string) {
-			nacks, err := findNacks(metrics)
+			nacks, err := findNacks(metrics, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nacks).To(ConsistOf(expected))
 		},

--- a/test/framework/debug_test.go
+++ b/test/framework/debug_test.go
@@ -1,0 +1,50 @@
+package framework
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("findNacks", func() {
+	DescribeTable("should report NACK counters over their tolerance",
+		func(metrics string, expected []string) {
+			nacks, err := findNacks(metrics)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nacks).To(ConsistOf(expected))
+		},
+		Entry("no NACK series at all", `
+# HELP kds_delta_requests_received Number of confirmations requests from a client
+# TYPE kds_delta_requests_received counter
+kds_delta_requests_received{confirmation="ACK",error_type="no_error",type_url="Dataplane",zone="Global"} 12
+# HELP xds_requests_received Number of confirmations requests from a client
+# TYPE xds_requests_received counter
+xds_requests_received{confirmation="ACK",error_type="no_error",type_url="type.googleapis.com/envoy.config.cluster.v3.Cluster"} 4
+`, nil),
+		// A zone that keeps sending a resource this CP rejects, as in the
+		// helm upgrade suite where a 2.14 zone leaks VIP outbounds onto a
+		// Dataplane. kds_nack_total has no confirmation label.
+		Entry("KDS NACK sent by this CP", `
+# HELP kds_nack_total Total KDS NACKs sent by zone and resource type.
+# TYPE kds_nack_total counter
+kds_nack_total{resource_type="Dataplane",zone="Global",zone_name="kuma-2"} 1
+`, []string{`kds_nack_total{resource_type="Dataplane",zone="Global",zone_name="kuma-2"} = 1 (tolerated 0)`}),
+		Entry("KDS NACK received from the peer CP", `
+# HELP kds_delta_requests_received Number of confirmations requests from a client
+# TYPE kds_delta_requests_received counter
+kds_delta_requests_received{confirmation="ACK",error_type="no_error",type_url="Mesh",zone="Global"} 3
+kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} 1
+`, []string{`kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} = 1 (tolerated 0)`}),
+		// Proxy-facing xDS keeps its existing tolerance: an Envoy NACK can
+		// resolve itself on the next config push.
+		Entry("proxy xDS NACKs within tolerance", `
+# HELP xds_requests_received Number of confirmations requests from a client
+# TYPE xds_requests_received counter
+xds_requests_received{confirmation="NACK",error_type="other",type_url="type.googleapis.com/envoy.config.listener.v3.Listener"} 2
+`, nil),
+		Entry("proxy xDS NACKs over tolerance", `
+# HELP xds_requests_received Number of confirmations requests from a client
+# TYPE xds_requests_received counter
+xds_requests_received{confirmation="NACK",error_type="other",type_url="type.googleapis.com/envoy.config.listener.v3.Listener"} 3
+`, []string{`xds_requests_received{confirmation="NACK",error_type="other",type_url="type.googleapis.com/envoy.config.listener.v3.Listener"} = 3 (tolerated 2)`}),
+	)
+})

--- a/test/framework/debug_test.go
+++ b/test/framework/debug_test.go
@@ -34,6 +34,20 @@ kds_nack_total{resource_type="Dataplane",zone="Global",zone_name="kuma-2"} 1
 kds_delta_requests_received{confirmation="ACK",error_type="no_error",type_url="Mesh",zone="Global"} 3
 kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} 1
 `, []string{`kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} = 1 (tolerated 0)`}),
+		// A Secret the user created on both global and the zone: the zone
+		// declines to overwrite its own copy and NACKs on purpose, which
+		// test/e2e_env/multizone/sync asserts.
+		Entry("user-caused KDS NACK is not a defect", `
+# HELP kds_delta_requests_received Number of confirmations requests from a client
+# TYPE kds_delta_requests_received counter
+kds_delta_requests_received{confirmation="NACK",error_type="user",type_url="Secret",zone="Global"} 1
+`, nil),
+		Entry("user-caused NACK does not mask a real one on the same family", `
+# HELP kds_delta_requests_received Number of confirmations requests from a client
+# TYPE kds_delta_requests_received counter
+kds_delta_requests_received{confirmation="NACK",error_type="user",type_url="Secret",zone="Global"} 1
+kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} 1
+`, []string{`kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Mesh",zone="Global"} = 1 (tolerated 0)`}),
 		// Proxy-facing xDS keeps its existing tolerance: an Envoy NACK can
 		// resolve itself on the next config push.
 		Entry("proxy xDS NACKs within tolerance", `


### PR DESCRIPTION
## Motivation

The e2e NACK guard never failed a suite whose KDS stream was NACKing permanently.

`assertNoXdsNacks` scraped only `xds_requests_received` and `delta_xds_requests_received`.
Those are the dataplane-facing families registered by `pkg/xds/server/components.go` with `dsType = "xds"`.
KDS NACKs are counted elsewhere, so a zone-to-global stream could NACK on every tick for the whole spec and the suite still went green.

That is not hypothetical.
In the helm upgrade suite a 2.14 zone leaks VIP outbounds onto a Dataplane it sends over KDS, and the 3.x global rejects it with `networking.outbound[N].backendRef: must be defined`.
The global logs `received resource is invalid, sending NACK` every ~12s from `kds-delta-client`, and the run passes.
A passing run leaves no trace of this: `DumpOnSuccess` is false by default so CP logs are never dumped, and the ginkgo report says nothing about NACKs.
The metric guard is the only signal that can survive a green run.

## Implementation information

Both KDS directions were already instrumented, so the guard just had to read them.

- `kds_nack_total{zone_name,resource_type}` - `pkg/kds/mux/zone_sync.go` wires `Callbacks.OnNACK`, incremented when this CP rejects a resource the peer sent.
- `kds_delta_requests_received{type_url,confirmation,error_type}` - `pkg/kds/server/components.go` builds stats callbacks with `dsType = "kds_delta"`, so the delta server records the peer rejecting what this CP sent.

The guard's hardcoded family list becomes a table with a per-family tolerance.
`kds_nack_total` has no `confirmation` label because every series in it is a NACK by construction, hence the optional label selector.
The matching loop moved into a pure `findNacks` so it can be unit tested, and the assertion now reports every offending series in one message instead of failing on the first.

### Thresholds

KDS tolerates nothing, proxy-facing xDS keeps its existing tolerance of 2.
A KDS NACK does not resolve itself the way an Envoy NACK can - the sender resends the same rejected resource on every resync, so the stream never converges and the two CPs disagree about state for as long as the resource exists.
The number is not arbitrary either way.
The upgrade suite's loop reads `kds_nack_total = 2` at teardown, so reusing the existing threshold of 3 would have missed this bug entirely.
In the other direction, the same-version `kuma_helm_deploy_multizone` suite exercises a full zone/global sync and produces no KDS NACK at all, so the observed transient count is 0.

I also considered sampling the counter twice and failing only if it is still increasing, which would separate a permanent loop from a transient blip more precisely.
It does not work here: the zone gets upgraded to 3.x mid-spec, the loop stops, and the counter is non-zero but static by `E2EAfterEach`.
The check has to be cumulative.

### User-caused NACKs

The first CI run surfaced one KDS NACK that is not a defect.
`test/e2e_env/multizone/sync/sync.go:188` creates a Secret named `global-and-zone-secret` on both a zone and global, then asserts the zone's copy is not overridden.
The zone enforces that by skipping the conflicting resource and NACKing with `kds_util.ErrUserNack` (`pkg/kds/store/sync.go:286-288`), so the NACK is the mechanism that makes the spec pass.
All 230 multizone specs passed; only the teardown assertion failed, on `kds_delta_requests_received{confirmation="NACK",error_type="other",type_url="Secret"} = 1`.

KDS already distinguishes this class of NACK via the `ErrUserNack` sentinel, but the metric did not carry it: `classifyError` only mapped `failed calling webhook` to `error_type="user"`.
It now also classifies `ErrUserNack`-prefixed messages as user errors, and the guard exempts that `error_type` on the KDS family.
CP-caused NACKs stay at 0.
The zone-to-global direction is unaffected because `GlobalSyncCallback` never sets `SkipConflictResource`, so no intentional conflict can reach `kds_nack_total`.

A numeric tolerance was the alternative and it is too fragile here.
The conflict NACK is one-shot per stream, not fixed at 1 - a zone reconnect re-pushes the Secret and NACKs again - so any small threshold is one reconnect away from flaking, and it would blunt the whole global-to-zone direction.

### The helm upgrade spec

The spec upgrades a 2.14 zone, so it provokes the very bug this guard exists to catch, and that bug is fixed but not yet released.
`KnownNack` drops one counter family on one cluster and logs why, leaving every other assertion on that CP live.
Both ends of the stream count the NACK - Global in `kds_nack_total` as the sync client that sends it, the zone in `kds_delta_requests_received` as the delta server that receives it - so the spec exempts both.
Both exemptions come off once a 2.14.x carrying the fix is published and `SupportedVersionEntriesAtLeast` picks it up.

The same bug also made the spec racy on its own, independently of the guard.
If KDS syncs the Dataplane to Global before the zone computes its VIP outbounds it lands valid and only later updates are rejected; if the VIPs come first the initial sync is already invalid and `dpps should be synced to global` timed out at 1 instead of 2.
Two local runs on identical product code went both ways.
So the pre-upgrade count now asserts only that the zone's own mesh zone ingress crossed, which is what that step is there to show.
The post-upgrade count stays strict at 3, so an upgraded zone that cannot sync a Dataplane still fails - the accommodation costs coverage only in the window where the product is known broken.

All three accommodations share one anchor, the package-level `vipOutboundNack`.
Grep that identifier to revert them together; deleting the const makes the compiler point at whatever is left.

`delta_xds` is registered nowhere outside tests, so `delta_xds_requests_received` never exists on a real CP.
I left the entry alone as out of scope.

## Supporting documentation

Verified with `make test/e2e E2E_PKG_LIST=./test/e2e/helm/...`: `SuiteSucceeded: true`, 4 of 4 specs passed, with both exemptions logged.

```
[WARNING]: not asserting kds_nack_total on CP kuma-1: 2.14 zones send VIP outbounds without backendRef, fixed but not yet released
[WARNING]: not asserting kds_delta_requests_received on CP kuma-2: ...
```

Before the exemptions, the same suite failed on the guard, which is the guard doing its job:

```
[FAILED] CP kuma-1 reported NACK(s):
    kds_nack_total{resource_type="Dataplane",zone="Global",zone_name="kuma-2"} = 2 (tolerated 0)
```

Full CI on the previous push: 14 of 16 e2e jobs green, including all four multizone jobs that the user-error classification fixed.

> Changelog: skip