### PR TITLE
test(e2e): restore MeshRetry MeshHTTPRoute coverage

### DIFF
--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -264,10 +264,6 @@ type: MeshHTTPRoute
 mesh: %s
 name: http-route-1
 spec:
-  targetRef:
-    kind: MeshService
-    labels:
-      kuma.io/display-name: demo-client
   to:
     - targetRef:
         kind: MeshService

--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -226,7 +226,7 @@ spec:
 		}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
 	})
 
-	It("should retry on HTTP connection failure applied on MeshHTTPRoute", func() {
+	It("should retry on HTTP 5xx responses applied on MeshHTTPRoute", func() {
 		meshFaultInjection := fmt.Sprintf(`
 type: MeshFaultInjection
 mesh: "%s"

--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -226,7 +226,7 @@ spec:
 		}, "1m", "1s", MustPassRepeatedly(5)).Should(Succeed())
 	})
 
-	XIt("should retry on HTTP connection failure applied on MeshHTTPRoute", func() {
+	It("should retry on HTTP connection failure applied on MeshHTTPRoute", func() {
 		meshFaultInjection := fmt.Sprintf(`
 type: MeshFaultInjection
 mesh: "%s"
@@ -248,13 +248,11 @@ type: MeshRetry
 mesh: "%s"
 name: meshretry-policy
 spec:
-  targetRef:
-    kind: MeshHTTPRoute
-    labels:
-      kuma.io/display-name: http-route-1
   to:
     - targetRef:
-        kind: Mesh
+        kind: MeshHTTPRoute
+        labels:
+          kuma.io/display-name: http-route-1
       default:
         http:
           numRetries: 5
@@ -283,7 +281,9 @@ spec:
           default:
             backendRefs:
               - kind: MeshService
-                name: test-server
+                labels:
+                  kuma.io/display-name: test-server
+                port: 80
                 weight: 100`, meshName)
 
 		Expect(universal.Cluster.Install(YamlUniversal(meshHttpRoute))).To(Succeed())

--- a/test/e2e_env/universal/meshretry/http.go
+++ b/test/e2e_env/universal/meshretry/http.go
@@ -233,7 +233,7 @@ mesh: "%s"
 name: mesh-fault-injecton
 spec:
   targetRef:
-    kind: MeshService
+    kind: Dataplane
     labels:
       kuma.io/display-name: test-server
   rules:


### PR DESCRIPTION
## Motivation

The universal MeshRetry spec that proves retries apply to traffic on a MeshHTTPRoute has been disabled since July 2026. The original spec used a top-level `targetRef` of kind MeshHTTPRoute, but 3.0 removed this targeting mode, causing the control plane to reject the policy. Currently, no other e2e test validates that MeshRetry functions correctly with MeshHTTPRoute routing.

## Implementation information

Restored the MeshRetry e2e spec using the new supported form:
- Attaches the policy to Mesh or Dataplane instead of directly to MeshHTTPRoute
- Names the target route under the `to` field, following the pattern used by MeshAccessLog and MeshLoadBalancingStrategy
- Validates that the control plane accepts the policy
- Confirms the spec runs in CI without pending markers and that retries successfully absorb failures from a server returning half-failure responses

Closes https://github.com/kumahq/kuma/issues/18019

_Generated by Sybra harness_