### PR TITLE
chore(kds): remove FeatureOptionalTopLevelTargetRef and UsesSyntacticSugar

### DIFF
--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -94,10 +94,6 @@ func (x TargetRefKindSlice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 
 // TargetRef defines structure that allows attaching policy to various objects
 type TargetRef struct {
-	// This is needed to not sync policies with empty topLevelTarget ref to old zones that does not support it
-	// This can be removed in 2.11.x
-	UsesSyntacticSugar bool `json:"-"`
-
 	// Kind of the referenced resource
 	// +kubebuilder:validation:Enum=Mesh;MeshService;MeshExternalService;MeshMultiZoneService;MeshServiceSubset;MeshHTTPRoute;Dataplane
 	Kind TargetRefKind `json:"kind"`
@@ -125,10 +121,6 @@ const (
 // TopLevelTargetRef defines the structure of the top-level targetRef field,
 // used to attach a policy's default configuration to a Mesh or Dataplane.
 type TopLevelTargetRef struct {
-	// This is needed to not sync policies with empty topLevelTarget ref to old zones that does not support it
-	// This can be removed in 2.11.x
-	UsesSyntacticSugar bool `json:"-"`
-
 	// Kind of the referenced resource
 	// +kubebuilder:validation:Enum=Mesh;Dataplane
 	Kind TopLevelTargetRefKind `json:"kind"`
@@ -147,13 +139,12 @@ type TopLevelTargetRef struct {
 // default previously applied by generated GetTargetRef() helpers.
 func (t *TopLevelTargetRef) ToTargetRef() TargetRef {
 	if t == nil {
-		return TargetRef{Kind: Mesh, UsesSyntacticSugar: true}
+		return TargetRef{Kind: Mesh}
 	}
 	return TargetRef{
-		UsesSyntacticSugar: t.UsesSyntacticSugar,
-		Kind:               TargetRefKind(t.Kind),
-		Labels:             t.Labels,
-		SectionName:        t.SectionName,
+		Kind:        TargetRefKind(t.Kind),
+		Labels:      t.Labels,
+		SectionName: t.SectionName,
 	}
 }
 

--- a/pkg/kds/client/stream.go
+++ b/pkg/kds/client/stream.go
@@ -201,7 +201,6 @@ func (s *stream) DeltaDiscoveryRequest(resourceType core_model.ResourceType) err
 							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureHashSuffix}},
 							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureHostnameGeneratorMzSelector}},
 							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureProducerPolicyFlow}},
-							{Kind: &structpb.Value_StringValue{StringValue: kds.FeatureOptionalTopLevelTargetRef}},
 						},
 					}}},
 				},

--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -284,12 +284,6 @@ func GlobalProvidedFilter(rm manager.ResourceManager) kds_reconcile.ResourceFilt
 
 		switch {
 		case isGlobal && r.Descriptor().KDSFlags.Has(core_model.GlobalToZonesFlag):
-			if r.Descriptor().IsPluginOriginated && r.Descriptor().IsPolicy {
-				policy := r.GetSpec().(core_model.Policy)
-				if policy.GetTargetRef().UsesSyntacticSugar && !features.HasFeature(kds.FeatureOptionalTopLevelTargetRef) {
-					return false
-				}
-			}
 			return true
 		case !isGlobal && r.Descriptor().KDSFlags.Has(core_model.SyncedAcrossZonesFlag):
 			if r.Descriptor().IsPluginOriginated && r.Descriptor().IsPolicy {
@@ -297,9 +291,6 @@ func GlobalProvidedFilter(rm manager.ResourceManager) kds_reconcile.ResourceFilt
 					return false
 				}
 				policy := r.GetSpec().(core_model.Policy)
-				if policy.GetTargetRef().UsesSyntacticSugar && !features.HasFeature(kds.FeatureOptionalTopLevelTargetRef) {
-					return false
-				}
 				// if declared role is not 'producer' then no syncing
 				if core_model.PolicyRole(r.GetMeta()) != mesh_proto.ProducerPolicyRole {
 					return false

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Context", func() {
 				func(given testCase) {
 					ctx := stdcontext.Background()
 					// when
-					ok := predicate(ctx, clusterID, kds.Features{kds.FeatureOptionalTopLevelTargetRef: true}, given.resource)
+					ok := predicate(ctx, clusterID, kds.Features{}, given.resource)
 
 					// then
 					Expect(ok).To(BeTrue())

--- a/pkg/kds/features.go
+++ b/pkg/kds/features.go
@@ -37,8 +37,6 @@ const FeatureHostnameGeneratorMzSelector string = "hg-mz-selector"
 // FeatureProducerPolicyFlow means that the zone control plane supports the producer policy flow.
 const FeatureProducerPolicyFlow string = "producer-policy-flow"
 
-const FeatureOptionalTopLevelTargetRef string = "optional-top-level-target-ref"
-
 func ContextHasFeature(ctx context.Context, feature string) bool {
 	md, _ := metadata.FromIncomingContext(ctx)
 	features := md.Get(FeaturesMetadataKey)

--- a/pkg/test/resources/builders/targetref_builder.go
+++ b/pkg/test/resources/builders/targetref_builder.go
@@ -103,10 +103,9 @@ func ToTopLevelTargetRef(ref common_api.TargetRef) common_api.TopLevelTargetRef 
 		panic("unsupported top-level targetRef kind: " + string(ref.Kind))
 	}
 	return common_api.TopLevelTargetRef{
-		UsesSyntacticSugar: ref.UsesSyntacticSugar,
-		Kind:               kind,
-		Labels:             ref.Labels,
-		SectionName:        ref.SectionName,
+		Kind:        kind,
+		Labels:      ref.Labels,
+		SectionName: ref.SectionName,
 	}
 }
 


### PR DESCRIPTION
## Motivation

`FeatureOptionalTopLevelTargetRef` gates whether a zone CP receives policies with an omitted top-level `targetRef`. The feature shipped in Kuma 2.9.0, and the zone CP floor for 3.0 is 2.14 (kumahq/kuma#17962). Every zone CP a 3.0 global syncs with therefore always supports this feature, making the gates dead code.

## Implementation information

- Removed `TargetRef.UsesSyntacticSugar` and `TopLevelTargetRef.UsesSyntacticSugar` from `api/common/v1alpha1/targetref.go`
- Removed the two `FeatureOptionalTopLevelTargetRef` gates from `GlobalProvidedFilter` in `pkg/kds/context/context.go`; policies with an omitted top-level `targetRef` now sync unconditionally
- Removed `FeatureOptionalTopLevelTargetRef` constant and its advertisement in `pkg/kds/client/stream.go`
- Removed test builder field copy in `pkg/test/resources/builders/targetref_builder.go` and corresponding test case in `pkg/kds/context/context_test.go`
- `make generate && make check && make test` pass with no remaining references to the removed symbols

Closes https://github.com/kumahq/kuma/issues/18001

_Generated by Sybra harness_