### PR TITLE
test(gateway): enable delegated MeshTCPRoute spec

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -195,6 +195,7 @@ spec:
 		"MeshProxyPatch":            delegated.MeshProxyPatch(&config),
 		"MeshHealthCheck":           delegated.MeshHealthCheck(&config),
 		"MeshRetry":                 delegated.MeshRetry(&config),
+		"MeshTCPRoute":              delegated.MeshTCPRoute(&config),
 		"MeshHTTPRoute":             delegated.MeshHTTPRoute(&config),
 		"MeshHTTPRouteMeshService":  delegated.MeshHTTPRouteMeshService(&config),
 		"MeshTimeout":               delegated.MeshTimeout(&config),

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -29,6 +29,20 @@ func MeshTCPRoute(config *Config) func() {
 				v1alpha1.MeshTCPRouteResourceTypeDescriptor,
 				meshexternalservice_api.MeshExternalServiceResourceTypeDescriptor,
 			)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				responses, err := client.CollectResponses(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+					client.WithNumberOfRequests(10),
+					client.WithoutRetries(),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(responses).ToNot(BeEmpty())
+				g.Expect(responses).To(HaveEach(HaveField("Instance", HavePrefix("test-server"))))
+			}, "30s", "1s").Should(Succeed())
 		})
 
 		It("should split traffic between internal and external services "+

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -93,18 +93,26 @@ spec:
       kind: MeshService
       labels:
         kuma.io/display-name: test-server
+        k8s.kuma.io/namespace: %[3]s
     rules: 
     - default:
         backendRefs:
         - kind: MeshService
-          name: test-server_%[2]s_svc_80
-        - kind: MeshExternalService
-          name: external-http-service-mtcprd
+          labels:
+            kuma.io/display-name: test-server
+            k8s.kuma.io/namespace: %[3]s
           port: 80
         - kind: MeshExternalService
-          name: external-tcp-service-mtcprd
+          labels:
+            kuma.io/display-name: external-http-service-mtcprd
+            k8s.kuma.io/namespace: %[1]s
           port: 80
-`, config.CpNamespace, config.Mesh))(kubernetes.Cluster)).To(Succeed())
+        - kind: MeshExternalService
+          labels:
+            kuma.io/display-name: external-tcp-service-mtcprd
+            k8s.kuma.io/namespace: %[1]s
+          port: 80
+`, config.CpNamespace, config.Mesh, config.Namespace))(kubernetes.Cluster)).To(Succeed())
 
 			// then
 			Eventually(func() ([]types.EchoResponse, error) {


### PR DESCRIPTION
## Motivation

The delegated gateway test suite contains a MeshTCPRoute spec that has not run since September 2024. With no disable markers or comments, it appears as active coverage to anyone scanning the directory, yet refactoring continues without any CI verification. As 3.0 removed the built-in gateway and the delegated gateway is now the only supported gateway mode, TCP routing requires end-to-end testing.

## Implementation information

Enable the MeshTCPRoute spec in the delegated gateway test suite to run in CI. This provides verification that:
- TCP traffic entering through a delegated gateway routes to the correct backend
- Changing the route definition affects traffic routing as expected
- TCP routing coverage is explicit and maintained in CI

Closes https://github.com/kumahq/kuma/issues/18021

_Generated by Sybra harness_