### PR TITLE
feat(gatewayapi): honor parentRef port names

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -145,7 +145,22 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				parent.GetNamespace(),
 			)
 
-			routes[routeSubName] = r.gapiServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port)
+			meshRoute, ok := r.gapiServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port, ref.SectionName)
+			if !ok {
+				parentConditions = append(parentConditions,
+					kube_meta.Condition{
+						Type:    string(gatewayapi.RouteConditionAccepted),
+						Status:  kube_meta.ConditionFalse,
+						Reason:  string(gatewayapi_v1.RouteReasonNoMatchingParent),
+						Message: fmt.Sprintf("Service %q has no port matching the parentRef", kube_types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}.String()),
+					},
+				)
+
+				conditions[ref] = prepareConditions(append(parentConditions, rulesConditions...))
+				continue
+			}
+
+			routes[routeSubName] = meshRoute
 		case attachment.MeshService:
 			namespace := route.Namespace
 			if ref.Namespace != nil {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -135,7 +135,18 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				if !kube_apierrs.IsNotFound(err) {
 					return nil, nil, err
 				}
-				continue // TODO what does the spec say? does NoMatchingParent apply?
+
+				parentConditions = append(parentConditions,
+					kube_meta.Condition{
+						Type:    string(gatewayapi.RouteConditionAccepted),
+						Status:  kube_meta.ConditionFalse,
+						Reason:  string(gatewayapi_v1.RouteReasonNoMatchingParent),
+						Message: fmt.Sprintf("Service %q does not exist", kube_types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}.String()),
+					},
+				)
+
+				conditions[ref] = prepareConditions(append(parentConditions, rulesConditions...))
+				continue
 			}
 
 			routeSubName := fmt.Sprintf(

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -328,6 +328,21 @@ func isMeshServiceRef(group *gatewayapi.Group, kind *gatewayapi.Kind) bool {
 	return group != nil && kind != nil && string(*group) == meshservice_k8s.GroupVersion.Group && string(*kind) == "MeshService"
 }
 
+// isServiceParentRef reports whether the given group/kind pair references a
+// Service that can be used as a route parent.
+func isServiceParentRef(group *gatewayapi.Group, kind *gatewayapi.Kind) bool {
+	if group == nil || kind == nil || string(*kind) != "Service" {
+		return false
+	}
+	return string(*group) == kube_core.GroupName || string(*group) == gatewayapi.GroupName
+}
+
+// isServiceBackendRef reports whether the given group/kind pair references a
+// core Kubernetes Service backend.
+func isServiceBackendRef(group *gatewayapi.Group, kind *gatewayapi.Kind) bool {
+	return group != nil && kind != nil && string(*group) == kube_core.SchemeGroupVersion.Group && string(*kind) == "Service"
+}
+
 // meshServicesOfRoute returns the namespaced names of the MeshServices
 // referenced by the given HTTPRoute's parentRefs, backendRefs and
 // request-mirror backendRefs, defaulting an omitted namespace to the route's.
@@ -379,43 +394,62 @@ func meshServicesOfRoute(obj kube_client.Object) []string {
 	return names
 }
 
+// servicesOfRoute returns the namespaced names of the Services referenced by
+// the given HTTPRoute's parentRefs, backendRefs and request-mirror backendRefs,
+// defaulting an omitted namespace to the route's.
+func servicesOfRoute(obj kube_client.Object) []string {
+	route := obj.(*gatewayapi.HTTPRoute)
+
+	var names []string
+
+	for _, parentRef := range route.Spec.ParentRefs {
+		if !isServiceParentRef(parentRef.Group, parentRef.Kind) {
+			continue
+		}
+		namespace := route.Namespace
+		if parentRef.Namespace != nil {
+			namespace = string(*parentRef.Namespace)
+		}
+		names = append(
+			names,
+			kube_types.NamespacedName{Namespace: namespace, Name: string(parentRef.Name)}.String(),
+		)
+	}
+
+	for _, rule := range route.Spec.Rules {
+		var allBackendRefs []gatewayapi.BackendObjectReference
+		for _, backendRef := range rule.BackendRefs {
+			allBackendRefs = append(allBackendRefs, backendRef.BackendObjectReference)
+		}
+		for _, filter := range rule.Filters {
+			if filter.Type == gatewayapi_v1.HTTPRouteFilterRequestMirror {
+				allBackendRefs = append(allBackendRefs, filter.RequestMirror.BackendRef)
+			}
+		}
+		for _, backendRef := range allBackendRefs {
+			if !isServiceBackendRef(backendRef.Group, backendRef.Kind) {
+				continue
+			}
+
+			namespace := route.Namespace
+			if backendRef.Namespace != nil {
+				namespace = string(*backendRef.Namespace)
+			}
+			names = append(
+				names,
+				kube_types.NamespacedName{Namespace: namespace, Name: string(backendRef.Name)}.String(),
+			)
+		}
+	}
+
+	return names
+}
+
 func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayapi.HTTPRoute{}, meshServicesOfRouteField, meshServicesOfRoute); err != nil {
 		return err
 	}
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayapi.HTTPRoute{}, servicesOfRouteField, func(obj kube_client.Object) []string {
-		route := obj.(*gatewayapi.HTTPRoute)
-
-		var names []string
-
-		for _, rule := range route.Spec.Rules {
-			var allBackendRefs []gatewayapi.BackendObjectReference
-			for _, backendRef := range rule.BackendRefs {
-				allBackendRefs = append(allBackendRefs, backendRef.BackendObjectReference)
-			}
-			for _, filter := range rule.Filters {
-				if filter.Type == gatewayapi_v1.HTTPRouteFilterRequestMirror {
-					allBackendRefs = append(allBackendRefs, filter.RequestMirror.BackendRef)
-				}
-			}
-			for _, backendRef := range allBackendRefs {
-				if string(*backendRef.Group) != kube_core.SchemeGroupVersion.Group || *backendRef.Kind != "Service" {
-					continue
-				}
-
-				namespace := route.Namespace
-				if backendRef.Namespace != nil {
-					namespace = string(*backendRef.Namespace)
-				}
-				names = append(
-					names,
-					kube_types.NamespacedName{Namespace: namespace, Name: string(backendRef.Name)}.String(),
-				)
-			}
-		}
-
-		return names
-	}); err != nil {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayapi.HTTPRoute{}, servicesOfRouteField, servicesOfRoute); err != nil {
 		return err
 	}
 	return kube_ctrl.NewControllerManagedBy(mgr).

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment"
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
 	k8s_util "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/util"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 // HTTPRouteReconciler reconciles a GatewayAPI object into Kuma-native objects
@@ -160,7 +161,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
-			routes[routeSubName] = meshRoute
+			storeMeshHTTPRoute(routes, routeSubName, meshRoute)
 		case attachment.MeshService:
 			namespace := route.Namespace
 			if ref.Namespace != nil {
@@ -212,13 +213,48 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
-			routes[routeSubName] = meshRoute
+			storeMeshHTTPRoute(routes, routeSubName, meshRoute)
 		}
 
 		conditions[ref] = prepareConditions(append(parentConditions, rulesConditions...))
 	}
 
 	return routes, conditions, nil
+}
+
+func storeMeshHTTPRoute(routes map[string]core_model.ResourceSpec, name string, spec core_model.ResourceSpec) {
+	route, ok := spec.(*meshhttproute_api.MeshHTTPRoute)
+	if !ok {
+		routes[name] = spec
+		return
+	}
+
+	existing, ok := routes[name]
+	if !ok {
+		routes[name] = spec
+		return
+	}
+
+	existingRoute, ok := existing.(*meshhttproute_api.MeshHTTPRoute)
+	if !ok {
+		routes[name] = spec
+		return
+	}
+
+	merged := pointer.Deref(existingRoute.To)
+	for _, candidate := range pointer.Deref(route.To) {
+		duplicate := false
+		for _, existingTo := range merged {
+			if reflect.DeepEqual(existingTo, candidate) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			merged = append(merged, candidate)
+		}
+	}
+	existingRoute.To = pointer.To(merged)
 }
 
 // routesForService returns a function that calculates which HTTPRoutes might

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -320,6 +320,49 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
 	})
 
+	It("merges multiple section-specific parentRefs for the same Service", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{
+					{Name: "http", Port: 80},
+					{Name: "https", Port: 443},
+				},
+			},
+		}
+		route := newRoute(
+			withSectionName(serviceParentRef("backend"), "http"),
+			withSectionName(serviceParentRef("backend"), "https"),
+		)
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+
+		spec := routes.Items[0].Spec
+		Expect(spec).ToNot(BeNil())
+		Expect(*spec.To).To(HaveLen(2))
+		Expect(*(*spec.To)[0].TargetRef.SectionName).To(Equal("http"))
+		Expect(*(*spec.To)[1].TargetRef.SectionName).To(Equal("https"))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(2))
+		for _, parent := range updatedRoute.Status.Parents {
+			accepted := kube_apimeta.FindStatusCondition(parent.Conditions, string(gatewayapi.RouteConditionAccepted))
+			Expect(accepted).ToNot(BeNil())
+			Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
+		}
+	})
+
 	It("reports Accepted=False when the parentRef names a Service port the Service does not have", func() {
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -232,7 +232,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func() {
 	const routeNamespace = "kuma-demo"
 
-	serviceParentRef := func(name string) gatewayapi.ParentReference {
+	serviceParentRef := func() gatewayapi.ParentReference {
 		group := gatewayapi.Group("")
 		kind := gatewayapi.Kind("Service")
 		ns := gatewayapi.Namespace(routeNamespace)
@@ -240,7 +240,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 			Group:     &group,
 			Kind:      &kind,
 			Namespace: &ns,
-			Name:      gatewayapi.ObjectName(name),
+			Name:      gatewayapi.ObjectName("backend"),
 		}
 	}
 
@@ -294,7 +294,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 				},
 			},
 		}
-		route := newRoute(withSectionName(serviceParentRef("backend"), "https"))
+		route := newRoute(withSectionName(serviceParentRef(), "https"))
 
 		client := newClientBuilder(svc, route)
 		reconciler.Client = client
@@ -332,8 +332,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 			},
 		}
 		route := newRoute(
-			withSectionName(serviceParentRef("backend"), "http"),
-			withSectionName(serviceParentRef("backend"), "https"),
+			withSectionName(serviceParentRef(), "http"),
+			withSectionName(serviceParentRef(), "https"),
 		)
 
 		client := newClientBuilder(svc, route)
@@ -371,7 +371,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
 			},
 		}
-		route := newRoute(withSectionName(serviceParentRef("backend"), "grpc"))
+		route := newRoute(withSectionName(serviceParentRef(), "grpc"))
 
 		client := newClientBuilder(svc, route)
 		reconciler.Client = client
@@ -401,7 +401,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
 			},
 		}
-		route := newRoute(withSectionName(serviceParentRef("backend"), "http"))
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
 
 		client := newClientBuilder(svc, route)
 		reconciler.Client = client
@@ -445,7 +445,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
 			},
 		}
-		route := newRoute(withSectionName(serviceParentRef("backend"), "grpc"))
+		route := newRoute(withSectionName(serviceParentRef(), "grpc"))
 
 		client := newClientBuilder(svc, route)
 		reconciler.Client = client

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -229,6 +229,128 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 	})
 })
 
+var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func() {
+	const routeNamespace = "kuma-demo"
+
+	serviceParentRef := func(name string) gatewayapi.ParentReference {
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		ns := gatewayapi.Namespace(routeNamespace)
+		return gatewayapi.ParentReference{
+			Group:     &group,
+			Kind:      &kind,
+			Namespace: &ns,
+			Name:      gatewayapi.ObjectName(name),
+		}
+	}
+
+	withSectionName := func(ref gatewayapi.ParentReference, sectionName string) gatewayapi.ParentReference {
+		ref.SectionName = pointer.To(gatewayapi.SectionName(sectionName))
+		return ref
+	}
+
+	newRoute := func(parentRefs ...gatewayapi.ParentReference) *gatewayapi.HTTPRoute {
+		return &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "my-route", Namespace: routeNamespace},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: parentRefs},
+			},
+		}
+	}
+
+	var reconciler *HTTPRouteReconciler
+	var namespace *kube_core.Namespace
+	var newClientBuilder func(objs ...kube_client.Object) kube_client.Client
+
+	BeforeEach(func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		namespace = &kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: routeNamespace}}
+
+		newClientBuilder = func(objs ...kube_client.Object) kube_client.Client {
+			return kube_client_fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&gatewayapi.HTTPRoute{}).
+				WithObjects(append([]kube_client.Object{namespace}, objs...)...).
+				Build()
+		}
+
+		reconciler = &HTTPRouteReconciler{
+			Log:             logr.Discard(),
+			TypeRegistry:    k8s_registry.Global(),
+			SystemNamespace: "kuma-system",
+		}
+	})
+
+	It("applies a parentRef sectionName as the Service port name", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{
+					{Name: "http", Port: 80},
+					{Name: "https", Port: 443},
+				},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef("backend"), "https"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+
+		spec := routes.Items[0].Spec
+		Expect(spec).ToNot(BeNil())
+		Expect(*spec.To).To(HaveLen(1))
+		Expect(*(*spec.To)[0].TargetRef.SectionName).To(Equal("https"))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+
+	It("reports Accepted=False when the parentRef names a Service port the Service does not have", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef("backend"), "grpc"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(BeEmpty())
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi_v1.RouteReasonNoMatchingParent)))
+	})
+})
+
 var _ = Describe("meshServicesOfRoute", func() {
 	meshServiceRef := func(namespace, name string) *gatewayapi.BackendObjectReference {
 		group := gatewayapi.Group(meshservice_k8s.GroupVersion.Group)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -394,6 +394,50 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(accepted.Reason).To(Equal(string(gatewayapi_v1.RouteReasonNoMatchingParent)))
 	})
 
+	It("reports Accepted=False after deleting a Service referenced only as a parentRef", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef("backend"), "http"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+
+		deletedSvc := svc.DeepCopy()
+		Expect(client.Delete(context.Background(), svc)).To(Succeed())
+
+		requests := routesForService(logr.Discard(), client)(context.Background(), deletedSvc)
+		Expect(requests).To(ConsistOf(kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		}))
+
+		_, err = reconciler.Reconcile(context.Background(), requests[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(BeEmpty())
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi_v1.RouteReasonNoMatchingParent)))
+	})
+
 	It("requeues a parent-only route when a Service update makes its sectionName valid", func() {
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -272,6 +272,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 			return kube_client_fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithStatusSubresource(&gatewayapi.HTTPRoute{}).
+				WithIndex(&gatewayapi.HTTPRoute{}, servicesOfRouteField, servicesOfRoute).
 				WithObjects(append([]kube_client.Object{namespace}, objs...)...).
 				Build()
 		}
@@ -391,6 +392,116 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(accepted).ToNot(BeNil())
 		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
 		Expect(accepted.Reason).To(Equal(string(gatewayapi_v1.RouteReasonNoMatchingParent)))
+	})
+
+	It("requeues a parent-only route when a Service update makes its sectionName valid", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef("backend"), "grpc"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(BeEmpty())
+
+		var updatedSvc kube_core.Service
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(svc), &updatedSvc)).To(Succeed())
+		updatedSvc.Spec.Ports = []kube_core.ServicePort{{Name: "grpc", Port: 50051}}
+		Expect(client.Update(context.Background(), &updatedSvc)).To(Succeed())
+
+		requests := routesForService(logr.Discard(), client)(context.Background(), &updatedSvc)
+		Expect(requests).To(ConsistOf(kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		}))
+
+		_, err = reconciler.Reconcile(context.Background(), requests[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		spec := routes.Items[0].Spec
+		Expect(spec).ToNot(BeNil())
+		Expect(*spec.To).To(HaveLen(1))
+		Expect(*(*spec.To)[0].TargetRef.SectionName).To(Equal("grpc"))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+})
+
+var _ = Describe("servicesOfRoute", func() {
+	serviceRef := func(namespace, name string) *gatewayapi.BackendObjectReference {
+		group := gatewayapi.Group(kube_core.GroupName)
+		kind := gatewayapi.Kind("Service")
+		ref := &gatewayapi.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  gatewayapi.ObjectName(name),
+		}
+		if namespace != "" {
+			ns := gatewayapi.Namespace(namespace)
+			ref.Namespace = &ns
+		}
+		return ref
+	}
+
+	parentRef := func(ref *gatewayapi.BackendObjectReference) gatewayapi.ParentReference {
+		return gatewayapi.ParentReference{
+			Group:     ref.Group,
+			Kind:      ref.Kind,
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		}
+	}
+
+	It("indexes parentRefs, backendRefs and request-mirror backendRefs, defaulting namespace to the route", func() {
+		route := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "my-route", Namespace: "kuma-demo"},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{
+					ParentRefs: []gatewayapi.ParentReference{
+						parentRef(serviceRef("", "parent-svc")),
+					},
+				},
+				Rules: []gatewayapi.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayapi.HTTPBackendRef{
+							{BackendRef: gatewayapi.BackendRef{BackendObjectReference: *serviceRef("other-ns", "backend-svc")}},
+						},
+						Filters: []gatewayapi.HTTPRouteFilter{
+							{
+								Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayapi.HTTPRequestMirrorFilter{
+									BackendRef: *serviceRef("mirror-ns", "mirror-svc"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		names := servicesOfRoute(route)
+		Expect(names).To(ConsistOf(
+			"kuma-demo/parent-svc",
+			"other-ns/backend-svc",
+			"mirror-ns/mirror-svc",
+		))
 	})
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -53,7 +53,8 @@ func (r *HTTPRouteReconciler) gapiServiceToMeshRoute(
 	rules []v1alpha1.Rule,
 	parent *kube_core.Service,
 	parentPort *gatewayapi_v1.PortNumber,
-) core_model.ResourceSpec {
+	parentSectionName *gatewayapi_v1.SectionName,
+) (core_model.ResourceSpec, bool) {
 	// consumer route
 	targetRef := common_api.TopLevelTargetRef{
 		Kind: common_api.TopLevelTargetRefKindDataplane,
@@ -71,27 +72,22 @@ func (r *HTTPRouteReconciler) gapiServiceToMeshRoute(
 
 	var tos []v1alpha1.To
 
-	var servicePorts []kube_core.ServicePort
-	if parentPort != nil {
-		for _, port := range parent.Spec.Ports {
-			if port.Port == *parentPort {
-				servicePorts = append(servicePorts, port)
-			}
+	for _, port := range parent.Spec.Ports {
+		if parentPort != nil && port.Port != *parentPort {
+			continue
 		}
-	} else {
-		servicePorts = parent.Spec.Ports
-	}
 
-	for _, port := range servicePorts {
 		// The MeshService section name is the Service port name, falling back to
 		// the stringified port value for unnamed ports (see meshservice_controller).
-		// It must match how the MeshService is generated: a mismatched sectionName
-		// won't resolve to the intended port, so this `to` entry won't apply to
-		// traffic for that port.
 		sectionName := port.Name
 		if sectionName == "" {
 			sectionName = fmt.Sprintf("%d", port.Port)
 		}
+
+		if parentSectionName != nil && sectionName != string(*parentSectionName) {
+			continue
+		}
+
 		tos = append(tos, v1alpha1.To{
 			TargetRef: common_api.OutboundTargetRef{
 				Kind: common_api.OutboundTargetRefKindMeshService,
@@ -105,10 +101,14 @@ func (r *HTTPRouteReconciler) gapiServiceToMeshRoute(
 		})
 	}
 
+	if len(tos) == 0 && (parentPort != nil || parentSectionName != nil) {
+		return nil, false
+	}
+
 	return &v1alpha1.MeshHTTPRoute{
 		TargetRef: &targetRef,
 		To:        &tos,
-	}
+	}, true
 }
 
 // meshServiceRefLabels returns the labels that identify the destination

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -359,27 +359,87 @@ var _ = Describe("gapiServiceToMeshRoute", func() {
 	reconciler := &HTTPRouteReconciler{}
 
 	It("uses the Service port name as the MeshService section name", func() {
-		spec := reconciler.gapiServiceToMeshRoute("other-ns", nil,
-			service(kube_core.ServicePort{Name: "http", Port: 80}), nil)
+		spec, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(kube_core.ServicePort{Name: "http", Port: 80}), nil, nil)
 
+		Expect(matched).To(BeTrue())
 		Expect(sectionNames(spec)).To(Equal([]string{"http"}))
 	})
 
 	It("falls back to the stringified port value for unnamed ports", func() {
-		spec := reconciler.gapiServiceToMeshRoute("other-ns", nil,
-			service(kube_core.ServicePort{Port: 80}), nil)
+		spec, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(kube_core.ServicePort{Port: 80}), nil, nil)
 
+		Expect(matched).To(BeTrue())
 		Expect(sectionNames(spec)).To(Equal([]string{"80"}))
 	})
 
-	It("selects the named port referenced by parentRef", func() {
+	It("selects the port referenced by parentPort", func() {
 		port := gatewayapi_v1.PortNumber(80)
-		spec := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+		spec, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
 			service(
 				kube_core.ServicePort{Name: "http", Port: 80},
 				kube_core.ServicePort{Name: "https", Port: 443},
-			), &port)
+			), &port, nil)
 
+		Expect(matched).To(BeTrue())
 		Expect(sectionNames(spec)).To(Equal([]string{"http"}))
+	})
+
+	It("selects the port referenced by parentSectionName", func() {
+		sectionName := gatewayapi_v1.SectionName("https")
+		spec, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(
+				kube_core.ServicePort{Name: "http", Port: 80},
+				kube_core.ServicePort{Name: "https", Port: 443},
+			), nil, &sectionName)
+
+		Expect(matched).To(BeTrue())
+		Expect(sectionNames(spec)).To(Equal([]string{"https"}))
+	})
+
+	It("selects the port when parentPort and parentSectionName agree", func() {
+		port := gatewayapi_v1.PortNumber(443)
+		sectionName := gatewayapi_v1.SectionName("https")
+		spec, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(
+				kube_core.ServicePort{Name: "http", Port: 80},
+				kube_core.ServicePort{Name: "https", Port: 443},
+			), &port, &sectionName)
+
+		Expect(matched).To(BeTrue())
+		Expect(sectionNames(spec)).To(Equal([]string{"https"}))
+	})
+
+	It("reports no match when parentPort and parentSectionName disagree", func() {
+		port := gatewayapi_v1.PortNumber(80)
+		sectionName := gatewayapi_v1.SectionName("https")
+		_, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(
+				kube_core.ServicePort{Name: "http", Port: 80},
+				kube_core.ServicePort{Name: "https", Port: 443},
+			), &port, &sectionName)
+
+		Expect(matched).To(BeFalse())
+	})
+
+	It("reports no match when parentSectionName does not exist", func() {
+		sectionName := gatewayapi_v1.SectionName("grpc")
+		_, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(
+				kube_core.ServicePort{Name: "http", Port: 80},
+				kube_core.ServicePort{Name: "https", Port: 443},
+			), nil, &sectionName)
+
+		Expect(matched).To(BeFalse())
+	})
+
+	It("matches an unnamed port by its numeric fallback sectionName", func() {
+		sectionName := gatewayapi_v1.SectionName("443")
+		spec, matched := reconciler.gapiServiceToMeshRoute("other-ns", nil,
+			service(kube_core.ServicePort{Port: 443}), nil, &sectionName)
+
+		Expect(matched).To(BeTrue())
+		Expect(sectionNames(spec)).To(Equal([]string{"443"}))
 	})
 })


### PR DESCRIPTION
## Motivation
Ensure HTTPRoutes that reference a Service port by name are scoped to the intended port, as required by the Gateway API, instead of applying to every routable port.

## Implementation information
- Resolve parentRef port names and numbers against Service ports.
- Preserve existing numeric port behavior and apply routes without a port to all routable ports.
- Reject parentRefs with mismatched, missing, or nonexistent port references.

Closes https://github.com/kumahq/kuma/issues/17987

_Generated by Sybra harness_