### PR TITLE
chore(kds): drop dead v2 and error helpers

### DIFF
--- a/pkg/kds/mux/version.go
+++ b/pkg/kds/mux/version.go
@@ -1,19 +1,7 @@
 package mux
 
-import (
-	"context"
-
-	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_sd_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/metadata"
-)
-
 const (
 	KDSVersionHeaderKey = "kds-version"
-	KDSVersionV2        = "v2"
 	KDSVersionV3        = "v3"
 
 	// ZoneVersionHeaderKey marks the zone CP's KDS generation so the global CP
@@ -21,79 +9,3 @@ const (
 	ZoneVersionHeaderKey = "zone-version"
 	ZoneVersionV3        = "v3"
 )
-
-func KDSVersion(ctx context.Context) string {
-	md, found := metadata.FromIncomingContext(ctx)
-	if found {
-		version := md.Get(KDSVersionHeaderKey)
-		if len(version) == 1 {
-			return version[0]
-		}
-	}
-
-	md, found = metadata.FromOutgoingContext(ctx)
-	if found {
-		version := md.Get(KDSVersionHeaderKey)
-		if len(version) == 1 {
-			return version[0]
-		}
-	}
-
-	return KDSVersionV2
-}
-
-func UnsupportedKDSVersion(version string) error {
-	return errors.Errorf("invalid KDS version %s. Supported versions %s %s", version, KDSVersionV2, KDSVersionV3)
-}
-
-func DiscoveryRequestV2(request *envoy_sd_v3.DiscoveryRequest) *envoy_api_v2.DiscoveryRequest {
-	return &envoy_api_v2.DiscoveryRequest{
-		VersionInfo: request.VersionInfo,
-		Node: &envoy_core_v2.Node{
-			Id:       request.Node.Id,
-			Metadata: request.Node.Metadata,
-		},
-		ResourceNames: request.ResourceNames,
-		TypeUrl:       request.TypeUrl,
-		ResponseNonce: request.ResponseNonce,
-		ErrorDetail:   request.ErrorDetail,
-	}
-}
-
-func DiscoveryRequestV3(request *envoy_api_v2.DiscoveryRequest) *envoy_sd_v3.DiscoveryRequest {
-	return &envoy_sd_v3.DiscoveryRequest{
-		VersionInfo: request.VersionInfo,
-		Node: &envoy_core_v3.Node{
-			Id:       request.Node.Id,
-			Metadata: request.Node.Metadata,
-		},
-		ResourceNames: request.ResourceNames,
-		TypeUrl:       request.TypeUrl,
-		ResponseNonce: request.ResponseNonce,
-		ErrorDetail:   request.ErrorDetail,
-	}
-}
-
-func DiscoveryResponseV2(response *envoy_sd_v3.DiscoveryResponse) *envoy_api_v2.DiscoveryResponse {
-	return &envoy_api_v2.DiscoveryResponse{
-		VersionInfo: response.VersionInfo,
-		Resources:   response.Resources,
-		TypeUrl:     response.TypeUrl,
-		Nonce:       response.Nonce,
-		ControlPlane: &envoy_core_v2.ControlPlane{
-			Identifier: response.ControlPlane.Identifier,
-		},
-	}
-}
-
-func DiscoveryResponseV3(response *envoy_api_v2.DiscoveryResponse) *envoy_sd_v3.DiscoveryResponse {
-	return &envoy_sd_v3.DiscoveryResponse{
-		VersionInfo: response.VersionInfo,
-		Resources:   response.Resources,
-		TypeUrl:     response.TypeUrl,
-		Nonce:       response.Nonce,
-		ControlPlane: &envoy_core_v3.ControlPlane{
-			Identifier: response.ControlPlane.Identifier,
-		},
-	}
-}

--- a/pkg/kds/util/errors.go
+++ b/pkg/kds/util/errors.go
@@ -5,23 +5,12 @@ import (
 	"strings"
 )
 
-var (
-	ErrUserNack     = errors.New("user error")
-	ErrInternalNack = errors.New("internal error")
-)
+var ErrUserNack = errors.New("user error")
 
 func IsUserErrorMessage(message string) bool {
 	return strings.HasPrefix(message, ErrUserNack.Error())
 }
 
-func IsInternalErrorMessage(message string) bool {
-	return strings.HasPrefix(message, ErrInternalNack.Error())
-}
-
 func IsUserError(err error) bool {
 	return errors.Is(err, ErrUserNack)
-}
-
-func IsInternalError(err error) bool {
-	return errors.Is(err, ErrInternalNack)
 }

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"maps"
-	"strings"
 
 	envoy_sd "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -105,16 +104,6 @@ func AddSuffixToResourceKeyNames(rk []core_model.ResourceKey, suffix string) []c
 		rk[idx].Name = fmt.Sprintf("%s.%s", r.Name, suffix)
 	}
 	return rk
-}
-
-func ResourceNameHasAtLeastOneOfPrefixes(resName string, prefixes ...string) bool {
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(resName, prefix) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func toResources(resourceType core_model.ResourceType, krs []*mesh_proto.KumaResource) (core_model.ResourceList, error) {


### PR DESCRIPTION
> Changelog: skip

## Motivation

KDS still carried the v2 wire helpers from when the protocol version was negotiated per stream. Nothing negotiates any more — `mux/client.go` sends `KDSVersionV3` unconditionally — so `KDSVersion`, `UnsupportedKDSVersion` and the v2/v3 `DiscoveryRequest`/`DiscoveryResponse` converters are unreachable, and with them the last use of the go-control-plane v2 API in KDS. Two smaller strays turned up in the same sweep.

## Implementation information

`mux/version.go` keeps only the header keys and `KDSVersionV3`; `KDSVersionV2` went with the converters that referenced it.

`util/errors.go` loses `ErrInternalNack` and its `IsInternalError`/`IsInternalErrorMessage` predicates — nothing ever wrapped an error with it. The user-error side stays: `IsUserErrorMessage` drives NACK logging and `IsUserError` is asserted in the store sync tests.

`util/resource.go` loses `ResourceNameHasAtLeastOneOfPrefixes`.

Left alone deliberately: `pkg/kds/server/nack_backoff.go`. It is dead in the same sense, but its only reference is a commented-out callback in `components.go` and the `nackBackoff` parameter it feeds comes from user-facing config, so removing it is a product call rather than dead-code hygiene.

## Supporting documentation

Verified with `deadcode -filter github.com/kumahq/kuma ./...` before and after, and cross-checked that no downstream project references the removed symbols.