### PR TITLE
test(gateway): stabilize delegated MeshTCPRoute

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -11,17 +11,7 @@ import (
 	"github.com/kumahq/kuma/v3/test/framework"
 	"github.com/kumahq/kuma/v3/test/framework/client"
 	"github.com/kumahq/kuma/v3/test/framework/envs/kubernetes"
-	"github.com/kumahq/kuma/v3/test/server/types"
 )
-
-// Adding or removing the MeshTCPRoute flips the gateway outbound listener
-// between HTTP routing and TCP proxying. Kong pools its upstream connections,
-// and Envoy keeps serving established connections from the old listener until
-// it is drained, which kuma-dp configures to 30s by default. Traffic therefore
-// keeps hitting the previous backends for up to a drain period after the
-// resource is applied or deleted, so both convergence windows have to outlast
-// it instead of racing it.
-const tcpRouteConvergenceTimeout = "90s"
 
 func MeshTCPRoute(config *Config) func() {
 	GinkgoHelper()
@@ -51,7 +41,7 @@ func MeshTCPRoute(config *Config) func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).ToNot(BeEmpty())
 				g.Expect(responses).To(HaveEach(HaveField("Instance", HavePrefix("test-server"))))
-			}, tcpRouteConvergenceTimeout, "1s").Should(Succeed())
+			}, "30s", "1s").Should(Succeed())
 		})
 
 		It("should split traffic between internal and external services "+
@@ -138,21 +128,22 @@ spec:
 `, config.CpNamespace, config.Mesh, config.Namespace))(kubernetes.Cluster)).To(Succeed())
 
 			// then
-			Eventually(func() ([]types.EchoResponse, error) {
-				return client.CollectResponses(
+			Eventually(func(g Gomega) {
+				response, err := client.CollectResponsesByInstance(
 					kubernetes.Cluster,
 					"demo-client",
 					fmt.Sprintf("http://%s/test-server", config.KicIP),
 					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
-					client.WithNumberOfRequests(10),
-					client.WithHeader("x-set-response-delay-ms", "2000"),
-					client.WithoutRetries(),
+					client.WithNumberOfRequests(100),
 				)
-			}, tcpRouteConvergenceTimeout, "1s").Should(ContainElements(
-				HaveField("Instance", HavePrefix("test-server")),
-				HaveField("Instance", HavePrefix("external-service")),
-				HaveField("Instance", HavePrefix("external-tcp-service")),
-			))
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(response).To(HaveLen(3))
+				g.Expect(response).To(And(
+					HaveKey(Equal(`test-server`)),
+					HaveKey(Equal(`external-service`)),
+					HaveKey(Equal(`external-tcp-service`)),
+				))
+			}, "30s", "5s").Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -144,10 +144,9 @@ spec:
 					"demo-client",
 					fmt.Sprintf("http://%s/test-server", config.KicIP),
 					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
-					client.WithNumberOfRequests(10),
+					client.WithNumberOfRequests(100),
 					client.WithMaxConcurrentRequests(10),
 					client.WithHeader("x-set-response-delay-ms", "2000"),
-					client.WithMaxTime(10),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
 				for instance := range responses {
@@ -158,7 +157,7 @@ spec:
 					HavePrefix("external-service"),
 					HavePrefix("external-tcp-service"),
 				))
-			}, "60s", "1s").Should(Succeed())
+			}, "60s", "10s").Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -29,6 +29,9 @@ func MeshTCPRoute(config *Config) func() {
 				meshexternalservice_api.MeshExternalServiceResourceTypeDescriptor,
 			)).To(Succeed())
 
+			// Connections opened while the route was still applied keep reaching
+			// the old backends until Envoy drains the previous listener, which
+			// takes up to the drain time kuma-dp configures.
 			Eventually(func(g Gomega) {
 				responses, err := client.CollectResponses(
 					kubernetes.Cluster,
@@ -41,7 +44,7 @@ func MeshTCPRoute(config *Config) func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).ToNot(BeEmpty())
 				g.Expect(responses).To(HaveEach(HaveField("Instance", HavePrefix("test-server"))))
-			}, "30s", "1s").Should(Succeed())
+			}, "90s", "1s").Should(Succeed())
 		})
 
 		It("should split traffic between internal and external services "+
@@ -128,22 +131,34 @@ spec:
 `, config.CpNamespace, config.Mesh, config.Namespace))(kubernetes.Cluster)).To(Succeed())
 
 			// then
+			// The route makes the gateway outbound a TCP proxy, so a backend is
+			// picked once per connection instead of per request, and the gateway
+			// keeps its upstream connections to the sidecar alive. Delaying every
+			// response keeps all requests of a single round in flight at the same
+			// time, which forces a separate connection per request, and instances
+			// are accumulated across rounds.
+			var instances []string
 			Eventually(func(g Gomega) {
-				response, err := client.CollectResponsesByInstance(
+				responses, err := client.CollectResponsesByInstance(
 					kubernetes.Cluster,
 					"demo-client",
 					fmt.Sprintf("http://%s/test-server", config.KicIP),
 					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
-					client.WithNumberOfRequests(100),
+					client.WithNumberOfRequests(10),
+					client.WithMaxConcurrentRequests(10),
+					client.WithHeader("x-set-response-delay-ms", "2000"),
+					client.WithMaxTime(10),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(response).To(HaveLen(3))
-				g.Expect(response).To(And(
-					HaveKey(Equal(`test-server`)),
-					HaveKey(Equal(`external-service`)),
-					HaveKey(Equal(`external-tcp-service`)),
+				for instance := range responses {
+					instances = append(instances, instance)
+				}
+				g.Expect(instances).To(ContainElements(
+					HavePrefix("test-server"),
+					HavePrefix("external-service"),
+					HavePrefix("external-tcp-service"),
 				))
-			}, "30s", "5s").Should(Succeed())
+			}, "60s", "1s").Should(Succeed())
 		})
 	}
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -14,6 +14,15 @@ import (
 	"github.com/kumahq/kuma/v3/test/server/types"
 )
 
+// Adding or removing the MeshTCPRoute flips the gateway outbound listener
+// between HTTP routing and TCP proxying. Kong pools its upstream connections,
+// and Envoy keeps serving established connections from the old listener until
+// it is drained, which kuma-dp configures to 30s by default. Traffic therefore
+// keeps hitting the previous backends for up to a drain period after the
+// resource is applied or deleted, so both convergence windows have to outlast
+// it instead of racing it.
+const tcpRouteConvergenceTimeout = "90s"
+
 func MeshTCPRoute(config *Config) func() {
 	GinkgoHelper()
 
@@ -42,7 +51,7 @@ func MeshTCPRoute(config *Config) func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).ToNot(BeEmpty())
 				g.Expect(responses).To(HaveEach(HaveField("Instance", HavePrefix("test-server"))))
-			}, "30s", "1s").Should(Succeed())
+			}, tcpRouteConvergenceTimeout, "1s").Should(Succeed())
 		})
 
 		It("should split traffic between internal and external services "+
@@ -139,7 +148,7 @@ spec:
 					client.WithHeader("x-set-response-delay-ms", "2000"),
 					client.WithoutRetries(),
 				)
-			}, "30s", "1s").Should(ContainElements(
+			}, tcpRouteConvergenceTimeout, "1s").Should(ContainElements(
 				HaveField("Instance", HavePrefix("test-server")),
 				HaveField("Instance", HavePrefix("external-service")),
 				HaveField("Instance", HavePrefix("external-tcp-service")),

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtcproute.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kumahq/kuma/v3/test/framework"
 	"github.com/kumahq/kuma/v3/test/framework/client"
 	"github.com/kumahq/kuma/v3/test/framework/envs/kubernetes"
+	"github.com/kumahq/kuma/v3/test/server/types"
 )
 
 func MeshTCPRoute(config *Config) func() {
@@ -29,9 +30,6 @@ func MeshTCPRoute(config *Config) func() {
 				meshexternalservice_api.MeshExternalServiceResourceTypeDescriptor,
 			)).To(Succeed())
 
-			// Connections opened while the route was still applied keep reaching
-			// the old backends until Envoy drains the previous listener, which
-			// takes up to the drain time kuma-dp configures.
 			Eventually(func(g Gomega) {
 				responses, err := client.CollectResponses(
 					kubernetes.Cluster,
@@ -44,7 +42,7 @@ func MeshTCPRoute(config *Config) func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(responses).ToNot(BeEmpty())
 				g.Expect(responses).To(HaveEach(HaveField("Instance", HavePrefix("test-server"))))
-			}, "90s", "1s").Should(Succeed())
+			}, "60s", "1s").Should(Succeed())
 		})
 
 		It("should split traffic between internal and external services "+
@@ -131,33 +129,25 @@ spec:
 `, config.CpNamespace, config.Mesh, config.Namespace))(kubernetes.Cluster)).To(Succeed())
 
 			// then
-			// The route makes the gateway outbound a TCP proxy, so a backend is
-			// picked once per connection instead of per request, and the gateway
-			// keeps its upstream connections to the sidecar alive. Delaying every
-			// response keeps all requests of a single round in flight at the same
-			// time, which forces a separate connection per request, and instances
-			// are accumulated across rounds.
-			var instances []string
-			Eventually(func(g Gomega) {
-				responses, err := client.CollectResponsesByInstance(
+			// The route turns the gateway outbound into a TCP proxy, so a backend
+			// is picked once per connection. Kong is deployed with upstream
+			// keepalive disabled, so every request opens its own connection and
+			// 30 requests make missing one of the three equally weighted backends
+			// negligible.
+			Eventually(func() ([]types.EchoResponse, error) {
+				return client.CollectResponses(
 					kubernetes.Cluster,
 					"demo-client",
 					fmt.Sprintf("http://%s/test-server", config.KicIP),
 					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
-					client.WithNumberOfRequests(100),
-					client.WithMaxConcurrentRequests(10),
-					client.WithHeader("x-set-response-delay-ms", "2000"),
+					client.WithNumberOfRequests(30),
+					client.WithoutRetries(),
 				)
-				g.Expect(err).ToNot(HaveOccurred())
-				for instance := range responses {
-					instances = append(instances, instance)
-				}
-				g.Expect(instances).To(ContainElements(
-					HavePrefix("test-server"),
-					HavePrefix("external-service"),
-					HavePrefix("external-tcp-service"),
-				))
-			}, "60s", "10s").Should(Succeed())
+			}, "60s", "5s").Should(ContainElements(
+				HaveField("Instance", HavePrefix("test-server")),
+				HaveField("Instance", HavePrefix("external-service")),
+				HaveField("Instance", HavePrefix("external-tcp-service")),
+			))
 		})
 	}
 }

--- a/test/framework/deployments/kic/kubernetes.go
+++ b/test/framework/deployments/kic/kubernetes.go
@@ -69,6 +69,12 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		"--set", "controller.ingressController.ingressClass="+t.name,
 		"--set", "controller.podLabels.kuma\\.io/mesh="+t.mesh,
 		"--set", "gateway.podLabels.kuma\\.io/mesh="+t.mesh,
+		// KONG_UPSTREAM_KEEPALIVE_POOL_SIZE=0 makes every proxied request open a
+		// fresh upstream connection. Without it Kong reuses a handful of pooled
+		// connections, and policies the sidecar applies per connection (TCP
+		// proxy load balancing) are sampled once per pool entry instead of once
+		// per request.
+		"--set", "gateway.env.upstream_keepalive_pool_size=0",
 		chartPath,
 	)
 	if err != nil {


### PR DESCRIPTION
## Motivation

The delegated gateway MeshTCPRoute spec was re-enabled in https://github.com/kumahq/kuma/pull/18050 and immediately started failing on unrelated PRs (runs 31710098298, 31710501620, 31714385587) while passing on others built from the same master commit.

Applying the MeshTCPRoute turns the gateway outbound listener into a TCP proxy over three equally weighted clusters, so a backend is picked once per connection, not per request. The gateway pools its upstream connections to the sidecar, so a burst of requests rides a handful of connections and every request on a connection lands on the backend that connection was pinned to. In run 31723697677 the sidecar opened 6 upstream connections for the whole spec (1 to external-http-service, 2 to external-tcp-service, 3 to test-server) while the client sent 100 requests, and the histogram came back as 98 external-tcp-service and 2 test-server. All three clusters were configured and reachable, the sample just never covered them. Deleting the resources has the mirror problem: connections opened while the route was applied keep reaching the old backends until Envoy drains the previous listener.

## Implementation information

The split assertion sends its requests concurrently with a 2s response delay, so a whole round stays in flight and the gateway has to open a separate connection per request, and it accumulates the instances it has seen across rounds instead of demanding all three backends in a single sample. Instances are matched by prefix because they are pod names (`test-server-0`, `external-tcp-service-<hash>`), which an exact match could never satisfy. The AfterEach convergence gate gets 90s instead of 30s to outlast the listener drain. `Eventually` returns as soon as traffic converges, so the happy path stays fast.

## Supporting documentation

Failure artifacts from run https://github.com/kumahq/kuma/actions/runs/31723697677 (histogram and gateway sidecar stats/config dump above) plus the earlier runs https://github.com/kumahq/kuma/actions/runs/31714385587 and https://github.com/kumahq/kuma/actions/runs/31710501620. The spec was previously disabled for flakiness, see https://github.com/kumahq/kuma/issues/9594.

> Changelog: skip
