### PR TITLE
fix(k8s): reject mesh not matching ownerReference

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1763,6 +1763,14 @@ Move any per-inbound tags declared in hand-authored Universal `Dataplane` resour
 
 **Warning**: `networking.inbound[].tags` is silently dropped on deserialization, not rejected — the field is `reserved` in the proto and protos are unmarshalled with `AllowUnknownFields`, so it is simply ignored. Dataplanes still submitting it will upgrade without error, but any policy matching on those inbound tags stops matching, with nothing in the API to signal it.
 
+### A resource's `Mesh` ownerReference must match its mesh
+
+On Kubernetes, a mesh-scoped resource can no longer end up owned by one `Mesh` while belonging to another. The validating webhook now rejects any create or update where a `kuma.io` `ownerReference` of kind `Mesh` names a mesh different from the resource's own `kuma.io/mesh` label (or `mesh` field). This closes both ways such a mismatch could previously happen: editing `kuma.io/mesh` on an existing resource to move it between meshes in place, and hand-writing or hand-editing a `Mesh` ownerReference. Writes from the control plane, `generic-garbage-collector` and the storage version migrator are unaffected, so a `Dataplane` can still be moved between meshes as its Pod is rescheduled.
+
+**Action required**
+
+If a resource in your cluster already has a `Mesh` ownerReference that disagrees with its mesh, it must be deleted and re-applied in the correct mesh — the webhook rejects any further edit to it until then.
+
 ## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -149,7 +149,7 @@ type KubernetesRuntimeConfig struct {
 	// cache is turned off
 	MarshalingCacheExpirationTime config_types.Duration `json:"marshalingCacheExpirationTime" envconfig:"kuma_runtime_kubernetes_marshaling_cache_expiration_time"`
 	// List of names of Service Accounts that admission requests are allowed.
-	// This list is appended with Control Plane's Service Account and generic-garbage-collector
+	// This list is appended with Control Plane's Service Account, generic-garbage-collector, and storage-version-migrator-controller.
 	AllowedUsers []string `json:"allowedUsers,omitempty" envconfig:"kuma_runtime_kubernetes_allowed_users"`
 	// ControlPlaneServiceName defines service name of the Kuma control plane. It is used to point Kuma DP to proper URL.
 	ControlPlaneServiceName string `json:"controlPlaneServiceName,omitempty" envconfig:"kuma_runtime_kubernetes_control_plane_service_name"`

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -260,7 +260,8 @@ func addValidators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s
 	resourceAdmissionChecker := k8s_webhooks.ResourceAdmissionChecker{
 		AllowedUsers: append(
 			rt.Config().Runtime.Kubernetes.AllowedUsers,
-			"system:serviceaccount:kube-system:generic-garbage-collector",
+			k8s_webhooks.GenericGarbageCollectorUser,
+			k8s_webhooks.StorageVersionMigratorUser,
 		),
 		Mode:                         rt.Config().Mode,
 		FederatedZone:                rt.Config().IsFederatedZoneCP(),
@@ -359,7 +360,8 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 	resourceAdmissionChecker := k8s_webhooks.ResourceAdmissionChecker{
 		AllowedUsers: append(
 			rt.Config().Runtime.Kubernetes.AllowedUsers,
-			"system:serviceaccount:kube-system:generic-garbage-collector",
+			k8s_webhooks.GenericGarbageCollectorUser,
+			k8s_webhooks.StorageVersionMigratorUser,
 		),
 		Mode:                         rt.Config().Mode,
 		FederatedZone:                rt.Config().IsFederatedZoneCP(),

--- a/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
+++ b/pkg/plugins/runtime/k8s/webhooks/resourceadmissionchecker.go
@@ -26,6 +26,11 @@ type ResourceAdmissionChecker struct {
 	ZoneName                     string
 }
 
+const (
+	GenericGarbageCollectorUser = "system:serviceaccount:kube-system:generic-garbage-collector"
+	StorageVersionMigratorUser  = "system:serviceaccount:kube-system:storage-version-migrator-controller"
+)
+
 func (c *ResourceAdmissionChecker) IsOperationAllowed(userInfo authenticationv1.UserInfo, r core_model.Resource, ns string) admission.Response {
 	if c.isPrivilegedUser(c.AllowedUsers, userInfo) {
 		return admission.Allowed("")
@@ -74,8 +79,8 @@ func (c *ResourceAdmissionChecker) isResourceAllowed(r core_model.Resource, ns s
 func (c *ResourceAdmissionChecker) isPrivilegedUser(allowedUsers []string, userInfo authenticationv1.UserInfo) bool {
 	// Assume this means one of the following:
 	// - sync from another zone
-	// - GC cleanup resources due to OwnerRef. ("system:serviceaccount:kube-system:generic-garbage-collector")
-	// - storageversionmigratior
+	// - GC cleanup resources due to OwnerRef.
+	// - storage-version migration
 	// Not security; protecting user from self.
 	return slices.Contains(allowedUsers, userInfo.Username)
 }

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.federated.golden.yaml
@@ -1,0 +1,15 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  details:
+    causes:
+    - field: metadata.labels[kuma.io/origin]
+      message: cannot be empty
+      reason: FieldValueInvalid
+  message: Operation not allowed. Applying policies on Zone CP on a system namespace
+    requires 'kuma.io/origin' label to be set to 'zone'.
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.global.golden.yaml
@@ -1,0 +1,19 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: metadata.ownerReferences[0].name
+      message: must be the same as the mesh of the resource "default". A resource
+        cannot be moved between meshes, delete it and apply it again in the new mesh
+      reason: FieldValueInvalid
+    kind: MeshTimeout
+    name: backend-v3
+  message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
+    resource "default". A resource cannot be moved between meshes, delete it and apply
+    it again in the new mesh'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.global.golden.yaml
@@ -5,14 +5,15 @@ status:
   details:
     causes:
     - field: metadata.ownerReferences[0].name
-      message: must be the same as the mesh of the resource "default". A resource
-        cannot be moved between meshes, delete it and apply it again in the new mesh
+      message: must be the same as the mesh of the resource "default", got "other".
+        A resource cannot be moved between meshes, delete it and apply it again in
+        the new mesh
       reason: FieldValueInvalid
     kind: MeshTimeout
     name: backend-v3
   message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
-    resource "default". A resource cannot be moved between meshes, delete it and apply
-    it again in the new mesh'
+    resource "default", got "other". A resource cannot be moved between meshes, delete
+    it and apply it again in the new mesh'
   metadata: {}
   reason: Invalid
   status: Failure

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.input.yaml
@@ -1,0 +1,22 @@
+# user=cli-user,operation=CREATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: default
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: other
+      uid: 8a2c3d1e-0000-4000-8000-000000000002
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
@@ -1,0 +1,19 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: metadata.ownerReferences[0].name
+      message: must be the same as the mesh of the resource "default". A resource
+        cannot be moved between meshes, delete it and apply it again in the new mesh
+      reason: FieldValueInvalid
+    kind: MeshTimeout
+    name: backend-v3
+  message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
+    resource "default". A resource cannot be moved between meshes, delete it and apply
+    it again in the new mesh'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_create_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
@@ -5,14 +5,15 @@ status:
   details:
     causes:
     - field: metadata.ownerReferences[0].name
-      message: must be the same as the mesh of the resource "default". A resource
-        cannot be moved between meshes, delete it and apply it again in the new mesh
+      message: must be the same as the mesh of the resource "default", got "other".
+        A resource cannot be moved between meshes, delete it and apply it again in
+        the new mesh
       reason: FieldValueInvalid
     kind: MeshTimeout
     name: backend-v3
   message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
-    resource "default". A resource cannot be moved between meshes, delete it and apply
-    it again in the new mesh'
+    resource "default", got "other". A resource cannot be moved between meshes, delete
+    it and apply it again in the new mesh'
   metadata: {}
   reason: Invalid
   status: Failure

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.federated.golden.yaml
@@ -1,0 +1,15 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  details:
+    causes:
+    - field: metadata.labels[kuma.io/origin]
+      message: cannot be empty
+      reason: FieldValueInvalid
+  message: Operation not allowed. Applying policies on Zone CP on a system namespace
+    requires 'kuma.io/origin' label to be set to 'zone'.
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
@@ -1,0 +1,19 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: metadata.ownerReferences[0].name
+      message: must be the same as the mesh of the resource "other". A resource cannot
+        be moved between meshes, delete it and apply it again in the new mesh
+      reason: FieldValueInvalid
+    kind: MeshTimeout
+    name: backend-v3
+  message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
+    resource "other". A resource cannot be moved between meshes, delete it and apply
+    it again in the new mesh'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
@@ -5,14 +5,15 @@ status:
   details:
     causes:
     - field: metadata.ownerReferences[0].name
-      message: must be the same as the mesh of the resource "other". A resource cannot
-        be moved between meshes, delete it and apply it again in the new mesh
+      message: must be the same as the mesh of the resource "other", got "default".
+        A resource cannot be moved between meshes, delete it and apply it again in
+        the new mesh
       reason: FieldValueInvalid
     kind: MeshTimeout
     name: backend-v3
   message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
-    resource "other". A resource cannot be moved between meshes, delete it and apply
-    it again in the new mesh'
+    resource "other", got "default". A resource cannot be moved between meshes, delete
+    it and apply it again in the new mesh'
   metadata: {}
   reason: Invalid
   status: Failure

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.input.yaml
@@ -1,0 +1,44 @@
+# user=cli-user,operation=UPDATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: other
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000001
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: default
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000001
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
@@ -1,0 +1,19 @@
+Patches: null
+allowed: false
+status:
+  code: 422
+  details:
+    causes:
+    - field: metadata.ownerReferences[0].name
+      message: must be the same as the mesh of the resource "other". A resource cannot
+        be moved between meshes, delete it and apply it again in the new mesh
+      reason: FieldValueInvalid
+    kind: MeshTimeout
+    name: backend-v3
+  message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
+    resource "other". A resource cannot be moved between meshes, delete it and apply
+    it again in the new mesh'
+  metadata: {}
+  reason: Invalid
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
@@ -5,14 +5,15 @@ status:
   details:
     causes:
     - field: metadata.ownerReferences[0].name
-      message: must be the same as the mesh of the resource "other". A resource cannot
-        be moved between meshes, delete it and apply it again in the new mesh
+      message: must be the same as the mesh of the resource "other", got "default".
+        A resource cannot be moved between meshes, delete it and apply it again in
+        the new mesh
       reason: FieldValueInvalid
     kind: MeshTimeout
     name: backend-v3
   message: 'metadata.ownerReferences[0].name: must be the same as the mesh of the
-    resource "other". A resource cannot be moved between meshes, delete it and apply
-    it again in the new mesh'
+    resource "other", got "default". A resource cannot be moved between meshes, delete
+    it and apply it again in the new mesh'
   metadata: {}
   reason: Invalid
   status: Failure

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.federated.golden.yaml
@@ -1,0 +1,15 @@
+Patches: null
+allowed: false
+status:
+  code: 403
+  details:
+    causes:
+    - field: metadata.labels[kuma.io/origin]
+      message: cannot be empty
+      reason: FieldValueInvalid
+  message: Operation not allowed. Applying policies on Zone CP on a system namespace
+    requires 'kuma.io/origin' label to be set to 'zone'.
+  metadata: {}
+  reason: Forbidden
+  status: Failure
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.global.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.input.yaml
@@ -1,0 +1,44 @@
+# user=cli-user,operation=UPDATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: default
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000003
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 30s
+          streamIdleTimeout: 1h
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: default
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000003
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cli-user_update_mt-mesh-owner-ref.non-federated.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.federated.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.input.yaml
@@ -1,0 +1,44 @@
+# user=system:serviceaccount:kuma-system:kuma-control-plane,operation=UPDATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: other
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000004
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: default
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000004
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/cp-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.federated.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.global.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.input.yaml
@@ -1,0 +1,44 @@
+# user=system:serviceaccount:kube-system:storage-version-migrator-controller,operation=UPDATE,namespace=kuma-system
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: other
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000005
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshTimeout
+metadata:
+  name: backend-v3
+  labels:
+    kuma.io/mesh: default
+  ownerReferences:
+    - apiVersion: kuma.io/v1alpha1
+      kind: Mesh
+      name: default
+      uid: 8a2c3d1e-0000-4000-8000-000000000005
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        http:
+          requestTimeout: 19s
+          streamIdleTimeout: 1h

--- a/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/testdata/validation/migrator-user_update_mt-mesh-owner-ref-mismatch.non-federated.golden.yaml
@@ -1,0 +1,6 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+uid: "12345"

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -145,7 +145,8 @@ func (h *validatingHandler) validateMeshOwnerReference(obj k8s_model.KubernetesO
 		}
 		if ref.Name != obj.GetMesh() {
 			verr.AddViolationAt(path.Index(i).Field("name"), fmt.Sprintf(
-				"must be the same as the mesh of the resource %q. A resource cannot be moved between meshes, delete it and apply it again in the new mesh", obj.GetMesh()))
+				"must be the same as the mesh of the resource %q, got %q. A resource cannot be moved between meshes, delete it and apply it again in the new mesh", obj.GetMesh(), ref.Name,
+			))
 		}
 	}
 	return verr

--- a/pkg/plugins/runtime/k8s/webhooks/validation.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation.go
@@ -2,11 +2,13 @@ package webhooks
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
@@ -16,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/validator"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	k8s_common "github.com/kumahq/kuma/v3/pkg/plugins/common/k8s"
+	mesh_k8s "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/api/v1alpha1"
 	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
 	k8s_registry "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/registry"
 )
@@ -75,6 +78,12 @@ func (h *validatingHandler) Handle(_ context.Context, req admission.Request) adm
 			return convertValidationErrorOf(err, k8sObj, k8sObj.GetObjectMeta())
 		}
 
+		if !h.isPrivilegedUser(h.AllowedUsers, req.UserInfo) && coreRes.Descriptor().Scope == core_model.ScopeMesh {
+			if err := h.validateMeshOwnerReference(k8sObj); err.HasViolations() {
+				return convertValidationErrorOf(err, k8sObj, k8sObj.GetObjectMeta())
+			}
+		}
+
 		if err := validator.Validate(coreRes); err != nil {
 			if kumaErr, ok := err.(*validators.ValidationError); ok {
 				// we assume that coreRes.Validate() returns validation errors of the spec
@@ -121,6 +130,22 @@ func (h *validatingHandler) validateLabels(rm core_model.ResourceMeta) validator
 	if origin, ok := core_model.ResourceOrigin(rm); ok {
 		if err := origin.IsValid(); err != nil {
 			verr.AddViolationAt(labelsPath.Key(mesh_proto.ResourceOriginLabel), err.Error())
+		}
+	}
+	return verr
+}
+
+func (h *validatingHandler) validateMeshOwnerReference(obj k8s_model.KubernetesObject) validators.ValidationError {
+	var verr validators.ValidationError
+	path := validators.RootedAt("metadata").Field("ownerReferences")
+	for i, ref := range obj.GetObjectMeta().GetOwnerReferences() {
+		gv, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil || gv.Group != mesh_k8s.GroupVersion.Group || ref.Kind != string(core_mesh.MeshType) {
+			continue
+		}
+		if ref.Name != obj.GetMesh() {
+			verr.AddViolationAt(path.Index(i).Field("name"), fmt.Sprintf(
+				"must be the same as the mesh of the resource %q. A resource cannot be moved between meshes, delete it and apply it again in the new mesh", obj.GetMesh()))
 		}
 	}
 	return verr

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -72,7 +72,8 @@ var _ = Describe("Validating Webhook", func() {
 func newValidatingWebhook(mode core.CpMode, federatedZone bool) *kube_admission.Webhook {
 	checker := webhooks.ResourceAdmissionChecker{
 		AllowedUsers: []string{
-			"system:serviceaccount:kube-system:generic-garbage-collector",
+			webhooks.GenericGarbageCollectorUser,
+			webhooks.StorageVersionMigratorUser,
 			"system:serviceaccount:kuma-system:kuma-control-plane",
 		},
 		Mode:                         mode,


### PR DESCRIPTION
## Motivation

Prevent the mesh field from diverging from its ownerReference. A prior incident showed this mismatch was possible; validation prevents future inconsistency.

## Implementation information

Added validation to reject mesh values that don't match the Mesh ownerReference.

Closes https://github.com/kumahq/kuma/issues/6200

_Generated by Sybra harness_