### PR TITLE
fix(gatewayapi): require ReferenceGrant for cross-namespace backendRefs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -275,6 +275,25 @@ This covers every `MeshHTTPRoute`, not only the ones the Gateway API translation
 
 None, as long as every `backendRefs` entry names a resource that exists. Check the routes that reference a resource from another zone or another namespace before upgrading: those are the ones whose masked misconfiguration becomes visible traffic loss.
 
+### Gateway API cross-namespace `backendRefs` now require a `ReferenceGrant`
+
+The Gateway API `HTTPRoute` translation now enforces `ReferenceGrant` for any
+backend reference that points across namespaces, for both core `Service`
+backends and Kuma `MeshService` backends. A cross-namespace backend without a
+matching grant is no longer programmed into the generated `MeshHTTPRoute`; the
+route reports `ResolvedRefs=False` with reason `RefNotPermitted` instead.
+
+To evaluate those grants, the control plane ClusterRole now includes `get`,
+`list`, and `watch` on `gateway.networking.k8s.io/referencegrants`.
+
+**Action required**
+
+Create a `ReferenceGrant` in the backend namespace for every cross-namespace
+`HTTPRoute` backend that should remain valid after upgrading. If you manage
+RBAC outside Helm (for example via GitOps or manual manifests), also add
+`get`, `list`, and `watch` on `referencegrants` in the
+`gateway.networking.k8s.io` API group to the control plane ClusterRole.
+
 ### `MeshService.spec.identities` now accepts SPIFFE IDs only
 
 `MeshService.spec.identities[].type` no longer accepts `ServiceTag`. `MeshService.spec.identities` now publishes SPIFFE IDs only, while service-tag-based routing keeps using the `kuma.io/service` label or the MeshService resource name as its fallback naming signal.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -190,6 +190,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -8107,6 +8107,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -8107,6 +8107,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.skip-crds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.skip-crds.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -8107,6 +8107,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -190,6 +190,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -190,6 +190,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -158,6 +158,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -144,6 +144,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -190,6 +190,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -143,6 +143,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
@@ -162,6 +162,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
@@ -162,6 +162,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
@@ -162,6 +162,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -184,6 +184,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
@@ -174,6 +174,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
@@ -162,6 +162,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
@@ -162,6 +162,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -140,6 +140,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/deployments/charts/kuma/templates/cp-rbac.yaml
+++ b/deployments/charts/kuma/templates/cp-rbac.yaml
@@ -67,6 +67,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/docs/generated/raw/rbac.yaml
+++ b/docs/generated/raw/rbac.yaml
@@ -43,6 +43,7 @@ rules:
       - gateway.networking.k8s.io
     resources:
       - httproutes
+      - referencegrants
     verbs:
       - get
       - list

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -411,7 +411,8 @@ func routesForMeshService(l logr.Logger, client kube_client.Client) kube_handler
 }
 
 // routesForReferenceGrant returns the routes that may change validity when a
-// grant in the target namespace is added, updated, or deleted.
+// grant in the target namespace is added, updated, or deleted. Update events
+// run this mapper for both the old and new grant objects.
 func routesForReferenceGrant(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
 	l = l.WithName("referencegrant-to-routes-mapper")
 
@@ -467,12 +468,6 @@ func isServiceParentRef(group *gatewayapi.Group, kind *gatewayapi.Kind) bool {
 		return false
 	}
 	return string(*group) == kube_core.GroupName || string(*group) == gatewayapi.GroupName
-}
-
-// isServiceBackendRef reports whether the given group/kind pair references a
-// core Kubernetes Service backend.
-func isServiceBackendRef(group *gatewayapi.Group, kind *gatewayapi.Kind) bool {
-	return group != nil && kind != nil && string(*group) == kube_core.SchemeGroupVersion.Group && string(*kind) == "Service"
 }
 
 // meshServicesOfRoute returns the namespaced names of the MeshServices

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -40,6 +41,87 @@ type HTTPRouteReconciler struct {
 	SystemNamespace string
 	ResourceManager manager.ResourceManager
 	Zone            string
+}
+
+type backendObjectReferenceDetails struct {
+	Namespace string
+	Group     string
+	Kind      string
+	Name      string
+	Ref       gatewayapi.BackendObjectReference
+}
+
+func backendObjectReferenceInfo(routeNamespace string, ref gatewayapi.BackendObjectReference) (backendObjectReferenceDetails, bool) {
+	namespace := routeNamespace
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+
+	group := ""
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+
+	kind := "Service"
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+
+	switch {
+	case group == kube_core.SchemeGroupVersion.Group && kind == "Service":
+		return backendObjectReferenceDetails{
+			Namespace: namespace,
+			Group:     group,
+			Kind:      kind,
+			Name:      string(ref.Name),
+			Ref:       ref,
+		}, true
+	case group == meshservice_k8s.GroupVersion.Group && kind == "MeshService":
+		return backendObjectReferenceDetails{
+			Namespace: namespace,
+			Group:     group,
+			Kind:      kind,
+			Name:      string(ref.Name),
+			Ref:       ref,
+		}, true
+	default:
+		return backendObjectReferenceDetails{}, false
+	}
+}
+
+func backendObjectReferencesOfRoute(route *gatewayapi.HTTPRoute) []gatewayapi.BackendObjectReference {
+	var refs []gatewayapi.BackendObjectReference
+
+	for _, rule := range route.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			refs = append(refs, backendRef.BackendObjectReference)
+		}
+		for _, filter := range rule.Filters {
+			if filter.Type == gatewayapi_v1.HTTPRouteFilterRequestMirror {
+				refs = append(refs, filter.RequestMirror.BackendRef)
+			}
+		}
+	}
+
+	return refs
+}
+
+func backendObjectReferenceMatchesGrant(grant *gatewayapi.ReferenceGrant, routeNamespace string, backendRef backendObjectReferenceDetails) bool {
+	fromMatches := slices.ContainsFunc(grant.Spec.From, func(from gatewayapi.ReferenceGrantFrom) bool {
+		return string(from.Group) == gatewayapi.GroupVersion.Group &&
+			string(from.Kind) == "HTTPRoute" &&
+			string(from.Namespace) == routeNamespace
+	})
+	if !fromMatches {
+		return false
+	}
+
+	return slices.ContainsFunc(grant.Spec.To, func(to gatewayapi.ReferenceGrantTo) bool {
+		if string(to.Group) != backendRef.Group || string(to.Kind) != backendRef.Kind {
+			return false
+		}
+		return to.Name == nil || string(*to.Name) == backendRef.Name
+	})
 }
 
 // Reconcile handles transforming a gateway-api HTTPRoute into a Kuma
@@ -328,6 +410,45 @@ func routesForMeshService(l logr.Logger, client kube_client.Client) kube_handler
 	}
 }
 
+// routesForReferenceGrant returns the routes that may change validity when a
+// grant in the target namespace is added, updated, or deleted.
+func routesForReferenceGrant(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
+	l = l.WithName("referencegrant-to-routes-mapper")
+
+	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
+		grant, ok := obj.(*gatewayapi.ReferenceGrant)
+		if !ok {
+			l.Error(nil, "unexpected error converting object to ReferenceGrant", "typ", reflect.TypeOf(obj))
+			return nil
+		}
+
+		var routes gatewayapi.HTTPRouteList
+		if err := client.List(ctx, &routes); err != nil {
+			l.Error(err, "unexpected error listing HTTPRoutes")
+			return nil
+		}
+
+		var requests []kube_reconcile.Request
+		for i := range routes.Items {
+			route := &routes.Items[i]
+			for _, backendRef := range backendObjectReferencesOfRoute(route) {
+				details, ok := backendObjectReferenceInfo(route.Namespace, backendRef)
+				if !ok || details.Namespace != grant.Namespace || details.Namespace == route.Namespace {
+					continue
+				}
+				if backendObjectReferenceMatchesGrant(grant, route.Namespace, details) {
+					requests = append(requests, kube_reconcile.Request{
+						NamespacedName: kube_client.ObjectKeyFromObject(route),
+					})
+					break
+				}
+			}
+		}
+
+		return requests
+	}
+}
+
 const (
 	servicesOfRouteField     = ".metadata.services"
 	meshServicesOfRouteField = ".metadata.meshservices"
@@ -376,30 +497,15 @@ func meshServicesOfRoute(obj kube_client.Object) []string {
 		)
 	}
 
-	for _, rule := range route.Spec.Rules {
-		var allBackendRefs []gatewayapi.BackendObjectReference
-		for _, backendRef := range rule.BackendRefs {
-			allBackendRefs = append(allBackendRefs, backendRef.BackendObjectReference)
+	for _, backendRef := range backendObjectReferencesOfRoute(route) {
+		details, ok := backendObjectReferenceInfo(route.Namespace, backendRef)
+		if !ok || details.Kind != "MeshService" {
+			continue
 		}
-		for _, filter := range rule.Filters {
-			if filter.Type == gatewayapi_v1.HTTPRouteFilterRequestMirror {
-				allBackendRefs = append(allBackendRefs, filter.RequestMirror.BackendRef)
-			}
-		}
-		for _, backendRef := range allBackendRefs {
-			if !isMeshServiceRef(backendRef.Group, backendRef.Kind) {
-				continue
-			}
-
-			namespace := route.Namespace
-			if backendRef.Namespace != nil {
-				namespace = string(*backendRef.Namespace)
-			}
-			names = append(
-				names,
-				kube_types.NamespacedName{Namespace: namespace, Name: string(backendRef.Name)}.String(),
-			)
-		}
+		names = append(
+			names,
+			kube_types.NamespacedName{Namespace: details.Namespace, Name: details.Name}.String(),
+		)
 	}
 
 	return names
@@ -427,30 +533,15 @@ func servicesOfRoute(obj kube_client.Object) []string {
 		)
 	}
 
-	for _, rule := range route.Spec.Rules {
-		var allBackendRefs []gatewayapi.BackendObjectReference
-		for _, backendRef := range rule.BackendRefs {
-			allBackendRefs = append(allBackendRefs, backendRef.BackendObjectReference)
+	for _, backendRef := range backendObjectReferencesOfRoute(route) {
+		details, ok := backendObjectReferenceInfo(route.Namespace, backendRef)
+		if !ok || details.Kind != "Service" {
+			continue
 		}
-		for _, filter := range rule.Filters {
-			if filter.Type == gatewayapi_v1.HTTPRouteFilterRequestMirror {
-				allBackendRefs = append(allBackendRefs, filter.RequestMirror.BackendRef)
-			}
-		}
-		for _, backendRef := range allBackendRefs {
-			if !isServiceBackendRef(backendRef.Group, backendRef.Kind) {
-				continue
-			}
-
-			namespace := route.Namespace
-			if backendRef.Namespace != nil {
-				namespace = string(*backendRef.Namespace)
-			}
-			names = append(
-				names,
-				kube_types.NamespacedName{Namespace: namespace, Name: string(backendRef.Name)}.String(),
-			)
-		}
+		names = append(
+			names,
+			kube_types.NamespacedName{Namespace: details.Namespace, Name: details.Name}.String(),
+		)
 	}
 
 	return names
@@ -473,6 +564,10 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr kube_ctrl.Manager) error {
 		Watches(
 			&meshservice_k8s.MeshService{},
 			kube_handler.EnqueueRequestsFromMapFunc(routesForMeshService(r.Log, r.Client)),
+		).
+		Watches(
+			&gatewayapi.ReferenceGrant{},
+			kube_handler.EnqueueRequestsFromMapFunc(routesForReferenceGrant(r.Log, r.Client)),
 		).
 		Complete(r)
 }

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -15,6 +15,8 @@ import (
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	meshservice_k8s "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/k8s/v1alpha1"
 	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
@@ -485,6 +487,282 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
 		Expect(accepted).ToNot(BeNil())
 		Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+})
+
+var _ = Describe("HTTPRouteReconciler.Reconcile with cross-namespace backendRefs", func() {
+	serviceBackendRef := func(namespace, name string, port gatewayapi.PortNumber) gatewayapi.HTTPBackendRef {
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		ns := gatewayapi.Namespace(namespace)
+		weight := int32(1)
+		return gatewayapi.HTTPBackendRef{
+			BackendRef: gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Group:     &group,
+					Kind:      &kind,
+					Namespace: &ns,
+					Name:      gatewayapi.ObjectName(name),
+					Port:      &port,
+				},
+				Weight: &weight,
+			},
+		}
+	}
+
+	referenceGrant := func(grantNamespace, routeNamespace, targetName string) *gatewayapi.ReferenceGrant {
+		return &gatewayapi.ReferenceGrant{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "allow-route", Namespace: grantNamespace},
+			Spec: gatewayapi.ReferenceGrantSpec{
+				From: []gatewayapi.ReferenceGrantFrom{{
+					Group:     gatewayapi.Group(gatewayapi.GroupVersion.Group),
+					Kind:      gatewayapi.Kind("HTTPRoute"),
+					Namespace: gatewayapi.Namespace(routeNamespace),
+				}},
+				To: []gatewayapi.ReferenceGrantTo{{
+					Group: gatewayapi.Group(""),
+					Kind:  gatewayapi.Kind("Service"),
+					Name:  pointer.To(gatewayapi.ObjectName(targetName)),
+				}},
+			},
+		}
+	}
+
+	parentRef := func(namespace, name string) gatewayapi.ParentReference {
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		ns := gatewayapi.Namespace(namespace)
+		return gatewayapi.ParentReference{
+			Group:     &group,
+			Kind:      &kind,
+			Namespace: &ns,
+			Name:      gatewayapi.ObjectName(name),
+		}
+	}
+
+	newRoute := func() *gatewayapi.HTTPRoute {
+		return &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "my-route", Namespace: "route-ns"},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{
+					ParentRefs: []gatewayapi.ParentReference{parentRef("route-ns", "frontend")},
+				},
+				Rules: []gatewayapi.HTTPRouteRule{{
+					BackendRefs: []gatewayapi.HTTPBackendRef{
+						serviceBackendRef("backend-ns", "backend", 8080),
+					},
+				}},
+			},
+		}
+	}
+
+	var reconciler *HTTPRouteReconciler
+	var newClientBuilder func(objs ...kube_client.Object) kube_client.Client
+
+	BeforeEach(func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		newClientBuilder = func(objs ...kube_client.Object) kube_client.Client {
+			base := []kube_client.Object{
+				&kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "route-ns"}},
+				&kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "backend-ns"}},
+			}
+			return kube_client_fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&gatewayapi.HTTPRoute{}).
+				WithIndex(&gatewayapi.HTTPRoute{}, servicesOfRouteField, servicesOfRoute).
+				WithIndex(&gatewayapi.HTTPRoute{}, meshServicesOfRouteField, meshServicesOfRoute).
+				WithObjects(append(base, objs...)...).
+				Build()
+		}
+
+		reconciler = &HTTPRouteReconciler{
+			Log:             logr.Discard(),
+			TypeRegistry:    k8s_registry.Global(),
+			SystemNamespace: "kuma-system",
+		}
+	})
+
+	It("reports RefNotPermitted and keeps an unresolved backend targetRef when no ReferenceGrant exists", func() {
+		frontend := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "frontend", Namespace: "route-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		backend := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "backend-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+		route := newRoute()
+
+		client := newClientBuilder(frontend, backend, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		backendRefs := *(*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs
+		Expect(backendRefs).To(HaveLen(1))
+		Expect(backendRefs[0].TargetRef).To(Equal(common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Labels: pointer.To(map[string]string{
+				mesh_proto.DisplayName:      "backend",
+				mesh_proto.KubeNamespaceTag: "backend-ns",
+			}),
+		}))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		resolvedRefs := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(resolvedRefs.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
+		Expect(resolvedRefs.Message).To(ContainSubstring("backend-ns/backend"))
+	})
+
+	It("requeues and allows the route after grant creation, then denies it again after grant deletion", func() {
+		frontend := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "frontend", Namespace: "route-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		backend := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "backend-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+		route := newRoute()
+
+		client := newClientBuilder(frontend, backend, route)
+		reconciler.Client = client
+
+		req := kube_ctrl.Request{NamespacedName: kube_client.ObjectKeyFromObject(route)}
+		_, err := reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		grant := referenceGrant("backend-ns", "route-ns", "backend")
+		Expect(client.Create(context.Background(), grant)).To(Succeed())
+
+		requests := routesForReferenceGrant(logr.Discard(), client)(context.Background(), grant)
+		Expect(requests).To(ConsistOf(req))
+
+		_, err = reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		backendRefs := *(*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs
+		Expect(backendRefs).To(HaveLen(1))
+		Expect(backendRefs[0].TargetRef.SectionName).To(Equal(pointer.To("http")))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		resolvedRefs := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionTrue))
+
+		deletedGrant := grant.DeepCopy()
+		Expect(client.Delete(context.Background(), grant)).To(Succeed())
+		requests = routesForReferenceGrant(logr.Discard(), client)(context.Background(), deletedGrant)
+		Expect(requests).To(ConsistOf(req))
+
+		_, err = reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		resolvedRefs = kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(resolvedRefs.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
+	})
+})
+
+var _ = Describe("routesForReferenceGrant", func() {
+	serviceBackendRef := func(namespace, name string) gatewayapi.HTTPBackendRef {
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		ns := gatewayapi.Namespace(namespace)
+		port := gatewayapi.PortNumber(80)
+		weight := int32(1)
+		return gatewayapi.HTTPBackendRef{
+			BackendRef: gatewayapi.BackendRef{
+				BackendObjectReference: gatewayapi.BackendObjectReference{
+					Group:     &group,
+					Kind:      &kind,
+					Namespace: &ns,
+					Name:      gatewayapi.ObjectName(name),
+					Port:      &port,
+				},
+				Weight: &weight,
+			},
+		}
+	}
+
+	It("requeues only routes matched by the grant source and destination rules", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		matchingRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "matching", Namespace: "route-ns"},
+			Spec: gatewayapi.HTTPRouteSpec{
+				Rules: []gatewayapi.HTTPRouteRule{{
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend-ns", "backend")},
+				}},
+			},
+		}
+		sameNamespaceRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "same-ns", Namespace: "backend-ns"},
+			Spec: gatewayapi.HTTPRouteSpec{
+				Rules: []gatewayapi.HTTPRouteRule{{
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend-ns", "backend")},
+				}},
+			},
+		}
+		wrongBackendRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "wrong-backend", Namespace: "route-ns"},
+			Spec: gatewayapi.HTTPRouteSpec{
+				Rules: []gatewayapi.HTTPRouteRule{{
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend-ns", "other-backend")},
+				}},
+			},
+		}
+		grant := &gatewayapi.ReferenceGrant{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "allow-route", Namespace: "backend-ns"},
+			Spec: gatewayapi.ReferenceGrantSpec{
+				From: []gatewayapi.ReferenceGrantFrom{{
+					Group:     gatewayapi.Group(gatewayapi.GroupVersion.Group),
+					Kind:      gatewayapi.Kind("HTTPRoute"),
+					Namespace: gatewayapi.Namespace("route-ns"),
+				}},
+				To: []gatewayapi.ReferenceGrantTo{{
+					Group: gatewayapi.Group(""),
+					Kind:  gatewayapi.Kind("Service"),
+					Name:  pointer.To(gatewayapi.ObjectName("backend")),
+				}},
+			},
+		}
+
+		client := kube_client_fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(matchingRoute, sameNamespaceRoute, wrongBackendRoute).
+			Build()
+
+		requests := routesForReferenceGrant(logr.Discard(), client)(context.Background(), grant)
+		Expect(requests).To(ConsistOf(kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(matchingRoute),
+		}))
 	})
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -15,8 +15,6 @@ import (
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
-	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	meshservice_k8s "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/k8s/v1alpha1"
 	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
@@ -584,7 +582,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with cross-namespace backendRefs
 		}
 	})
 
-	It("reports RefNotPermitted and keeps an unresolved backend targetRef when no ReferenceGrant exists", func() {
+	It("reports RefNotPermitted and omits the denied backend targetRef when no ReferenceGrant exists", func() {
 		frontend := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "frontend", Namespace: "route-ns"},
 			Spec: kube_core.ServiceSpec{
@@ -610,15 +608,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with cross-namespace backendRefs
 		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(HaveLen(1))
-		backendRefs := *(*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs
-		Expect(backendRefs).To(HaveLen(1))
-		Expect(backendRefs[0].TargetRef).To(Equal(common_api.TargetRef{
-			Kind: common_api.MeshService,
-			Labels: pointer.To(map[string]string{
-				mesh_proto.DisplayName:      "backend",
-				mesh_proto.KubeNamespaceTag: "backend-ns",
-			}),
-		}))
+		backendRefs := pointer.Deref((*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs)
+		Expect(backendRefs).To(BeEmpty())
 
 		var updatedRoute gatewayapi.HTTPRoute
 		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
@@ -663,7 +654,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with cross-namespace backendRefs
 		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(HaveLen(1))
-		backendRefs := *(*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs
+		backendRefs := pointer.Deref((*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs)
 		Expect(backendRefs).To(HaveLen(1))
 		Expect(backendRefs[0].TargetRef.SectionName).To(Equal(pointer.To("http")))
 
@@ -680,6 +671,12 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with cross-namespace backendRefs
 
 		_, err = reconciler.Reconcile(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
+
+		routes = &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		backendRefs = pointer.Deref((*routes.Items[0].Spec.To)[0].Rules[0].Default.BackendRefs)
+		Expect(backendRefs).To(BeEmpty())
 
 		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
 		resolvedRefs = kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -9,9 +9,13 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	kube_event "sigs.k8s.io/controller-runtime/pkg/event"
+	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
+	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -687,10 +691,10 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with cross-namespace backendRefs
 })
 
 var _ = Describe("routesForReferenceGrant", func() {
-	serviceBackendRef := func(namespace, name string) gatewayapi.HTTPBackendRef {
+	serviceBackendRef := func(name string) gatewayapi.HTTPBackendRef {
 		group := gatewayapi.Group("")
 		kind := gatewayapi.Kind("Service")
-		ns := gatewayapi.Namespace(namespace)
+		ns := gatewayapi.Namespace("backend-ns")
 		port := gatewayapi.PortNumber(80)
 		weight := int32(1)
 		return gatewayapi.HTTPBackendRef{
@@ -715,7 +719,7 @@ var _ = Describe("routesForReferenceGrant", func() {
 			ObjectMeta: kube_meta.ObjectMeta{Name: "matching", Namespace: "route-ns"},
 			Spec: gatewayapi.HTTPRouteSpec{
 				Rules: []gatewayapi.HTTPRouteRule{{
-					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend-ns", "backend")},
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend")},
 				}},
 			},
 		}
@@ -723,7 +727,7 @@ var _ = Describe("routesForReferenceGrant", func() {
 			ObjectMeta: kube_meta.ObjectMeta{Name: "same-ns", Namespace: "backend-ns"},
 			Spec: gatewayapi.HTTPRouteSpec{
 				Rules: []gatewayapi.HTTPRouteRule{{
-					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend-ns", "backend")},
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend")},
 				}},
 			},
 		}
@@ -731,7 +735,7 @@ var _ = Describe("routesForReferenceGrant", func() {
 			ObjectMeta: kube_meta.ObjectMeta{Name: "wrong-backend", Namespace: "route-ns"},
 			Spec: gatewayapi.HTTPRouteSpec{
 				Rules: []gatewayapi.HTTPRouteRule{{
-					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend-ns", "other-backend")},
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("other-backend")},
 				}},
 			},
 		}
@@ -760,6 +764,63 @@ var _ = Describe("routesForReferenceGrant", func() {
 		Expect(requests).To(ConsistOf(kube_ctrl.Request{
 			NamespacedName: kube_client.ObjectKeyFromObject(matchingRoute),
 		}))
+	})
+
+	It("requeues routes matched by the previous grant spec when an update revokes access", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		matchingRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "matching", Namespace: "route-ns"},
+			Spec: gatewayapi.HTTPRouteSpec{
+				Rules: []gatewayapi.HTTPRouteRule{{
+					BackendRefs: []gatewayapi.HTTPBackendRef{serviceBackendRef("backend")},
+				}},
+			},
+		}
+		oldGrant := &gatewayapi.ReferenceGrant{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "allow-route", Namespace: "backend-ns"},
+			Spec: gatewayapi.ReferenceGrantSpec{
+				From: []gatewayapi.ReferenceGrantFrom{{
+					Group:     gatewayapi.Group(gatewayapi.GroupVersion.Group),
+					Kind:      gatewayapi.Kind("HTTPRoute"),
+					Namespace: gatewayapi.Namespace("route-ns"),
+				}},
+				To: []gatewayapi.ReferenceGrantTo{{
+					Group: gatewayapi.Group(""),
+					Kind:  gatewayapi.Kind("Service"),
+					Name:  pointer.To(gatewayapi.ObjectName("backend")),
+				}},
+			},
+		}
+		updatedGrant := oldGrant.DeepCopy()
+		updatedGrant.Spec.From = []gatewayapi.ReferenceGrantFrom{{
+			Group:     gatewayapi.Group(gatewayapi.GroupVersion.Group),
+			Kind:      gatewayapi.Kind("HTTPRoute"),
+			Namespace: gatewayapi.Namespace("other-route-ns"),
+		}}
+
+		client := kube_client_fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(matchingRoute).
+			Build()
+
+		queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[kube_reconcile.Request]())
+		DeferCleanup(queue.ShutDown)
+
+		kube_handler.EnqueueRequestsFromMapFunc(routesForReferenceGrant(logr.Discard(), client)).Update(
+			context.Background(),
+			kube_event.UpdateEvent{ObjectOld: oldGrant, ObjectNew: updatedGrant},
+			queue,
+		)
+
+		Expect(queue.Len()).To(Equal(1))
+		req, shutdown := queue.Get()
+		Expect(shutdown).To(BeFalse())
+		Expect(req).To(Equal(kube_reconcile.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(matchingRoute),
+		}))
+		queue.Done(req)
 	})
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -11,6 +11,7 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_schema "k8s.io/apimachinery/pkg/runtime/schema"
 	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -457,7 +458,7 @@ type ResolvedRefsConditionFalse struct {
 func (c *ResolvedRefsConditionFalse) AddIfFalseAndNotPresent(conditions *[]kube_meta.Condition) {
 	if c != nil && kube_apimeta.FindStatusCondition(*conditions, string(gatewayapi.RouteConditionResolvedRefs)) == nil {
 		condition := kube_meta.Condition{
-			Type:    string(gatewayapi.RouteReasonResolvedRefs),
+			Type:    string(gatewayapi.RouteConditionResolvedRefs),
 			Status:  kube_meta.ConditionFalse,
 			Reason:  c.Reason,
 			Message: c.Message,
@@ -469,12 +470,12 @@ func (c *ResolvedRefsConditionFalse) AddIfFalseAndNotPresent(conditions *[]kube_
 func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 	ctx context.Context, objectNamespace string, ref gatewayapi.BackendObjectReference,
 ) (common_api.TargetRef, *ResolvedRefsConditionFalse, error) {
-	gk := kube_schema.GroupKind{Kind: string(*ref.Kind), Group: string(*ref.Group)}
-	// the backendRef's namespace, falling back to the route's namespace when unset
+	details, ok := backendObjectReferenceInfo(objectNamespace, ref)
 	refNamespace := objectNamespace
-	if ref.Namespace != nil {
-		refNamespace = string(*ref.Namespace)
+	if ok {
+		refNamespace = details.Namespace
 	}
+
 	unresolvedTargetRef := common_api.TargetRef{
 		Kind: common_api.MeshService,
 		Labels: &map[string]string{
@@ -482,9 +483,42 @@ func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 			mesh_proto.KubeNamespaceTag: refNamespace,
 		},
 	}
-	namespacedName := kube_types.NamespacedName{Namespace: refNamespace, Name: string(ref.Name)}
+	if !ok {
+		return unresolvedTargetRef,
+			&ResolvedRefsConditionFalse{
+				Reason:  string(gatewayapi.RouteReasonInvalidKind),
+				Message: "backend reference must be Service or MeshService",
+			},
+			nil
+	}
+
+	namespacedName := kube_types.NamespacedName{Namespace: details.Namespace, Name: details.Name}
+	gk := kube_schema.GroupKind{Kind: details.Kind, Group: details.Group}
+
+	if details.Namespace != objectNamespace {
+		allowed, err := r.referenceGrantAllowsBackendRef(ctx, objectNamespace, details)
+		if err != nil {
+			return common_api.TargetRef{}, nil, err
+		}
+		if !allowed {
+			return unresolvedTargetRef,
+				&ResolvedRefsConditionFalse{
+					Reason:  string(gatewayapi.RouteReasonRefNotPermitted),
+					Message: fmt.Sprintf("backend reference to %s %q is not permitted by any ReferenceGrant", gk.String(), namespacedName.String()),
+				},
+				nil
+		}
+	}
 
 	if gk.Kind == "Service" && gk.Group == "" {
+		if ref.Port == nil {
+			return unresolvedTargetRef,
+				&ResolvedRefsConditionFalse{
+					Reason:  string(gatewayapi.RouteReasonInvalidKind),
+					Message: "backend reference to Service must include a port",
+				},
+				nil
+		}
 		// References to Services are required by GAPI to include a port
 		port := *ref.Port
 
@@ -570,10 +604,24 @@ func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 		}, nil, nil
 	}
 
-	return unresolvedTargetRef,
-		&ResolvedRefsConditionFalse{
-			Reason:  string(gatewayapi.RouteReasonInvalidKind),
-			Message: "backend reference must be Service or MeshService",
-		},
-		nil
+	return unresolvedTargetRef, nil, nil
+}
+
+func (r *HTTPRouteReconciler) referenceGrantAllowsBackendRef(
+	ctx context.Context,
+	routeNamespace string,
+	backendRef backendObjectReferenceDetails,
+) (bool, error) {
+	var grants gatewayapi.ReferenceGrantList
+	if err := r.List(ctx, &grants, kube_client.InNamespace(backendRef.Namespace)); err != nil {
+		return false, err
+	}
+
+	for i := range grants.Items {
+		if backendObjectReferenceMatchesGrant(&grants.Items[i], routeNamespace, backendRef) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -240,6 +240,9 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 		}
 
 		refCondition.AddIfFalseAndNotPresent(&conditions)
+		if refCondition.preventsBackendTarget() {
+			continue
+		}
 
 		backendRefs = append(backendRefs, common_api.BackendRef{
 			TargetRef: ref,
@@ -467,6 +470,10 @@ func (c *ResolvedRefsConditionFalse) AddIfFalseAndNotPresent(conditions *[]kube_
 	}
 }
 
+func (c *ResolvedRefsConditionFalse) preventsBackendTarget() bool {
+	return c != nil && c.Reason == string(gatewayapi.RouteReasonRefNotPermitted)
+}
+
 func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 	ctx context.Context, objectNamespace string, ref gatewayapi.BackendObjectReference,
 ) (common_api.TargetRef, *ResolvedRefsConditionFalse, error) {
@@ -501,7 +508,7 @@ func (r *HTTPRouteReconciler) uncheckedGapiToKumaRef(
 			return common_api.TargetRef{}, nil, err
 		}
 		if !allowed {
-			return unresolvedTargetRef,
+			return common_api.TargetRef{},
 				&ResolvedRefsConditionFalse{
 					Reason:  string(gatewayapi.RouteReasonRefNotPermitted),
 					Message: fmt.Sprintf("backend reference to %s %q is not permitted by any ReferenceGrant", gk.String(), namespacedName.String()),

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -21,6 +21,50 @@ import (
 )
 
 var _ = Describe("uncheckedGapiToKumaRef", func() {
+	serviceRef := func(namespace, name string, port gatewayapi.PortNumber) gatewayapi.BackendObjectReference {
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		ref := gatewayapi.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  gatewayapi.ObjectName(name),
+			Port:  &port,
+		}
+		if namespace != "" {
+			ns := gatewayapi.Namespace(namespace)
+			ref.Namespace = &ns
+		}
+		return ref
+	}
+
+	referenceGrant := func(grantNamespace, routeNamespace, targetKind, targetName string) *gatewayapi.ReferenceGrant {
+		from := gatewayapi.ReferenceGrantFrom{
+			Group:     gatewayapi.Group(gatewayapi.GroupVersion.Group),
+			Kind:      gatewayapi.Kind("HTTPRoute"),
+			Namespace: gatewayapi.Namespace(routeNamespace),
+		}
+		to := gatewayapi.ReferenceGrantTo{
+			Group: gatewayapi.Group(""),
+			Kind:  gatewayapi.Kind(targetKind),
+		}
+		if targetKind == "MeshService" {
+			to.Group = gatewayapi.Group(meshservice_k8s.GroupVersion.Group)
+		}
+		if targetName != "" {
+			to.Name = pointer.To(gatewayapi.ObjectName(targetName))
+		}
+		return &gatewayapi.ReferenceGrant{
+			ObjectMeta: kube_meta.ObjectMeta{
+				Name:      "allow-route",
+				Namespace: grantNamespace,
+			},
+			Spec: gatewayapi.ReferenceGrantSpec{
+				From: []gatewayapi.ReferenceGrantFrom{from},
+				To:   []gatewayapi.ReferenceGrantTo{to},
+			},
+		}
+	}
+
 	It("should convert a Service backendRef to a MeshService targetRef without tags", func() {
 		scheme, err := bootstrap_k8s.NewScheme()
 		Expect(err).ToNot(HaveOccurred())
@@ -37,17 +81,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Zone:   "zone-1",
 		}
 
-		group := gatewayapi.Group("")
-		kind := gatewayapi.Kind("Service")
-		namespace := gatewayapi.Namespace("kuma-demo")
-		port := gatewayapi.PortNumber(80)
-		ref := gatewayapi.BackendObjectReference{
-			Group:     &group,
-			Kind:      &kind,
-			Name:      "backend",
-			Namespace: &namespace,
-			Port:      &port,
-		}
+		ref := serviceRef("kuma-demo", "backend", 80)
 
 		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "kuma-demo", ref)
 
@@ -172,6 +206,110 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 		Expect(targetRef.Kind).To(Equal(common_api.MeshService))
 	})
 
+	It("should deny a cross-namespace Service backendRef without a matching ReferenceGrant", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "backend-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Port: 80}},
+			},
+		}
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build(),
+		}
+
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend", 80))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
+		Expect(condition.Message).To(ContainSubstring("backend-ns/backend"))
+		Expect(targetRef).To(Equal(common_api.TargetRef{
+			Kind: common_api.MeshService,
+			Labels: pointer.To(map[string]string{
+				mesh_proto.DisplayName:      "backend",
+				mesh_proto.KubeNamespaceTag: "backend-ns",
+			}),
+		}))
+	})
+
+	It("should allow a cross-namespace Service backendRef when an exact-name ReferenceGrant matches", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "backend-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		grant := referenceGrant("backend-ns", "route-ns", "Service", "backend")
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc, grant).Build(),
+		}
+
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend", 80))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(condition).To(BeNil())
+		Expect(targetRef.SectionName).To(Equal(pointer.To("http")))
+	})
+
+	It("should allow a cross-namespace MeshService backendRef when a wildcard-name ReferenceGrant matches", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		ms := &meshservice_k8s.MeshService{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "backend-ns"},
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		grant := referenceGrant("backend-ns", "route-ns", "MeshService", "")
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(ms, grant).Build(),
+		}
+
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", func() gatewayapi.BackendObjectReference {
+			ref := meshServiceRef(pointer.To(gatewayapi.PortNumber(80)))
+			ns := gatewayapi.Namespace("backend-ns")
+			ref.Namespace = &ns
+			return ref
+		}())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(condition).To(BeNil())
+		Expect(targetRef.SectionName).To(Equal(pointer.To("http")))
+	})
+
+	It("should deny a cross-namespace Service backendRef when the ReferenceGrant targets a different backend name", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "backend-ns"},
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Port: 80}},
+			},
+		}
+		grant := referenceGrant("backend-ns", "route-ns", "Service", "other-backend")
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc, grant).Build(),
+		}
+
+		_, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend", 80))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
+	})
+
 	It("should return a valid unresolved MeshService targetRef when the backend Service is missing", func() {
 		scheme, err := bootstrap_k8s.NewScheme()
 		Expect(err).ToNot(HaveOccurred())
@@ -181,17 +319,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Zone:   "zone-1",
 		}
 
-		group := gatewayapi.Group("")
-		kind := gatewayapi.Kind("Service")
-		namespace := gatewayapi.Namespace("kuma-demo")
-		port := gatewayapi.PortNumber(80)
-		ref := gatewayapi.BackendObjectReference{
-			Group:     &group,
-			Kind:      &kind,
-			Name:      "missing-backend",
-			Namespace: &namespace,
-			Port:      &port,
-		}
+		ref := serviceRef("kuma-demo", "missing-backend", 80)
 
 		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "kuma-demo", ref)
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 var _ = Describe("uncheckedGapiToKumaRef", func() {
-	serviceRef := func(namespace, name string, port gatewayapi.PortNumber) gatewayapi.BackendObjectReference {
+	serviceRef := func(namespace, name string) gatewayapi.BackendObjectReference {
 		group := gatewayapi.Group("")
 		kind := gatewayapi.Kind("Service")
+		port := gatewayapi.PortNumber(80)
 		ref := gatewayapi.BackendObjectReference{
 			Group: &group,
 			Kind:  &kind,
@@ -81,7 +82,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Zone:   "zone-1",
 		}
 
-		ref := serviceRef("kuma-demo", "backend", 80)
+		ref := serviceRef("kuma-demo", "backend")
 
 		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "kuma-demo", ref)
 
@@ -221,7 +222,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build(),
 		}
 
-		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend", 80))
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend"))
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(condition).ToNot(BeNil())
@@ -246,7 +247,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc, grant).Build(),
 		}
 
-		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend", 80))
+		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend"))
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(condition).To(BeNil())
@@ -297,7 +298,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(svc, grant).Build(),
 		}
 
-		_, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend", 80))
+		_, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "route-ns", serviceRef("backend-ns", "backend"))
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(condition).ToNot(BeNil())
@@ -313,7 +314,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 			Zone:   "zone-1",
 		}
 
-		ref := serviceRef("kuma-demo", "missing-backend", 80)
+		ref := serviceRef("kuma-demo", "missing-backend")
 
 		targetRef, condition, err := reconciler.uncheckedGapiToKumaRef(context.Background(), "kuma-demo", ref)
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -227,13 +227,7 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
 		Expect(condition.Message).To(ContainSubstring("backend-ns/backend"))
-		Expect(targetRef).To(Equal(common_api.TargetRef{
-			Kind: common_api.MeshService,
-			Labels: pointer.To(map[string]string{
-				mesh_proto.DisplayName:      "backend",
-				mesh_proto.KubeNamespaceTag: "backend-ns",
-			}),
-		}))
+		Expect(targetRef).To(BeZero())
 	})
 
 	It("should allow a cross-namespace Service backendRef when an exact-name ReferenceGrant matches", func() {

--- a/pkg/plugins/runtime/k8s/plugin_gateway.go
+++ b/pkg/plugins/runtime/k8s/plugin_gateway.go
@@ -22,7 +22,8 @@ import (
 )
 
 var requiredGatewayCRDs = map[string]string{
-	"HTTPRoute": gatewayCRDNameWithGroupKindAndVersion("HTTPRoute"),
+	"HTTPRoute":      gatewayCRDNameWithGroupKindAndVersion("HTTPRoute"),
+	"ReferenceGrant": gatewayCRDNameWithGroupKindAndVersion("ReferenceGrant"),
 }
 
 func gatewayCRDNameWithGroupKindAndVersion(name string) string {


### PR DESCRIPTION
## Motivation

Gateway API requires a ReferenceGrant in the target namespace before a cross-namespace backendRef takes effect. This gives the destination Service owner control over who can route mesh traffic to it. Kuma was not enforcing this requirement, allowing any namespace to route to any Service in the cluster without permission.

## Implementation information

- Cross-namespace backendRefs without a matching ReferenceGrant now receive no traffic and return 500
- HTTPRoute reports ResolvedRefs false with RefNotPermitted reason for unpermitted references
- Creating a ReferenceGrant enables the route to function; deleting it revokes access immediately
- BackendRefs within the route's own namespace continue to work without a grant

Closes https://github.com/kumahq/kuma/issues/18014

_Generated by Sybra harness_