### PR TITLE
ci(github): avoid shell template injection

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -142,9 +142,13 @@ jobs:
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
       - id: image_meta
+        env:
+          REGISTRY: ${{ inputs.REGISTRY }}
+          IMAGE_NAME: ${{ matrix.image }}
+          VERSION_NAME: ${{ inputs.VERSION_NAME }}
         run: |
-          echo "Extracting image meta for ${{ matrix.image }}"
-          echo "image=${{ inputs.REGISTRY }}/${{ matrix.image }}:${{ inputs.VERSION_NAME }}" >> "$GITHUB_OUTPUT"
+          echo "Extracting image meta for $IMAGE_NAME"
+          printf 'image=%s/%s:%s\n' "$REGISTRY" "$IMAGE_NAME" "$VERSION_NAME" >> "$GITHUB_OUTPUT"
       - run: |
           make images/${{ matrix.image }}
       - run: |

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -78,13 +78,15 @@ jobs:
             .test_e2e = false
             | .test_e2e_env.include = []
             | .test_e2e_env.exclude += [{"arch": "arm64"}, {"k8sVersion": "kindIpv6"}, {"k8sVersion": "${{ env.K8S_MIN_VERSION}}"}]
+          FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
+          SKIP_E2E_TESTS: ${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG }}
         run: |-
-          BASE_MATRIX_ALL='${{ env.BASE_MATRIX }}'
-          if [[ "${{ inputs.FULL_MATRIX }}" != "true" ]]; then
-            BASE_MATRIX_ALL=$(echo "$BASE_MATRIX_ALL" | jq -r '${{ env.OVERRIDE_JQ_CMD }}')
+          BASE_MATRIX_ALL="$BASE_MATRIX"
+          if [[ "$FULL_MATRIX" != "true" ]]; then
+            BASE_MATRIX_ALL=$(echo "$BASE_MATRIX_ALL" | jq -r "$OVERRIDE_JQ_CMD")
           fi
           # Skip e2e tests if the PR has the label "ci/skip-e2e-test" or "ci/skip-test"
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-test') || contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG }}" == "true" ]]; then
+          if [[ "$SKIP_E2E_TESTS" == "true" ]]; then
             BASE_MATRIX_ALL='{}'
           fi
 

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -35,8 +35,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: ${{ runner.debug == '1' }}
+          INPUT_PR: ${{ inputs.PR }}
         run: |
           [[ "${GH_DEBUG}" == "true" ]] && set -x
+
+          if [[ ! "$INPUT_PR" =~ ^[0-9]+$ ]]; then
+            echo "PR input must be a numeric pull request number"
+            exit 1
+          fi
 
           function get_change_log() {
             awk '
@@ -60,8 +66,8 @@ jobs:
             ' <<< "$1"
           }
           
-          PR_INFO_JSON=$(gh pr view ${{ inputs.PR }} --json 'number,title,mergedAt,state,mergeCommit,baseRefName' || echo '{}')
-          PR_INFO_BODY=$(gh pr view ${{ inputs.PR }} --json 'body' -q '.body' || echo '')
+          PR_INFO_JSON=$(gh pr view "$INPUT_PR" --json 'number,title,mergedAt,state,mergeCommit,baseRefName' || echo '{}')
+          PR_INFO_BODY=$(gh pr view "$INPUT_PR" --json 'body' -q '.body' || echo '')
           
           TITLE=$(echo -n "$PR_INFO_JSON" | jq -r '.title //empty')
           CHANGE_LOG=$(get_change_log "$PR_INFO_BODY")
@@ -79,9 +85,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - name: ensure-pr-merged
+        env:
+          PR_NUMBER: ${{ inputs.PR }}
+          PR_STATE: ${{ steps.get-pr-info.outputs.pr_state }}
         run: |
-          if [[ "${{ steps.get-pr-info.outputs.pr_state }}" != "MERGED" ]]; then
-            echo "PR #${{ inputs.PR }} is not merged, current state: '$PR_STATE'"
+          if [[ "$PR_STATE" != "MERGED" ]]; then
+            echo "PR #$PR_NUMBER is not merged, current state: '$PR_STATE'"
             exit 1
           fi
   active-branches:


### PR DESCRIPTION
## Motivation

Three `run:` blocks on this branch build shell commands by interpolating values the caller supplies, so the shell sees them as code rather than as data. Master fixed this in #15808; this branch never got it.

- `backport.yaml` passes the PR number straight into `gh pr view`.
- `_test.yaml` builds the test matrix from `${{ env.BASE_MATRIX }}`, `${{ inputs.FULL_MATRIX }}` and a `contains()` over the PR's labels.
- `_build_publish.yaml` assembles the image reference from `inputs.REGISTRY`, `matrix.image` and `inputs.VERSION_NAME`.

## Implementation

Every one of those values now arrives through `env:` and is read as a quoted shell variable.

- `backport.yaml`: the PR number arrives as `INPUT_PR`, is checked against `^[0-9]+$` before anything uses it, and is quoted at both `gh pr view` call sites. `ensure-pr-merged` takes its state and number from `env` as well, which also fixes its error message — `$PR_STATE` was never set, so it always reported an empty state.
- `_test.yaml`: `BASE_MATRIX`, `FULL_MATRIX` and a new `SKIP_E2E_TESTS` replace the inline expressions.
- `_build_publish.yaml`: `REGISTRY`, `IMAGE_NAME` and `VERSION_NAME`, with the step output built by `printf` from quoted arguments.

`make images/${{ matrix.image }}` is left as it is, matching master — that value comes from a fixed list in the workflow.

## Notes

The cherry-pick of #15808 does not apply here; all three files have moved on since. The same change is made by hand, and the result is the same three files with the same +25/-10 shape as upstream.

Verified with `actionlint`: no new findings, and one unquoted-variable warning fewer than before (`echo $BASE_MATRIX_ALL` is now quoted).
