### PR TITLE
ci(backport): read branch input from env

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -100,18 +100,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: ${{ runner.debug == '1' }}
+          INPUT_BRANCHES: ${{ inputs.branches }}
+          REPOSITORY: ${{ github.repository }}
+          PR_BASE_REF: ${{ steps.get-pr-info.outputs.pr_base_ref }}
         run: |
           if [[ "${{ runner.debug }}" == "1" ]]; then
             set -x
           fi
           
           # target_branches
-          if [[ "${{ inputs.branches }}" != "" ]]; then
-            TARGET_BRANCHES=$(echo "[\"${{ inputs.branches }}\"]" | sed 's/ //g' | sed 's/,/","/g')
+          if [[ -n "$INPUT_BRANCHES" ]]; then
+            TARGET_BRANCHES=$(echo "[\"$INPUT_BRANCHES\"]" | sed 's/ //g' | sed 's/,/","/g')
             echo "branches=${TARGET_BRANCHES}" >> $GITHUB_OUTPUT
           else
             # The head -1 is because GITHUB_OUTPUT is easier to work with single line output
-            TARGET_BRANCHES=$(gh api /repos/${{ github.repository }}/contents/${{ env.BRANCH_FILE_PATH }} --jq '.content | @base64d' | jq  -cM '.[:index("${{ steps.get-pr-info.outputs.pr_base_ref }}")]')
+            TARGET_BRANCHES=$(gh api "/repos/${REPOSITORY}/contents/${BRANCH_FILE_PATH}" --jq '.content | @base64d' | jq -cM --arg base "$PR_BASE_REF" '.[:index($base)]')
             echo "branches=${TARGET_BRANCHES}" >> $GITHUB_OUTPUT
           fi
   open-prs:


### PR DESCRIPTION
## Motivation

The `generate-matrix` step in `backport.yaml` builds its shell from three values it does not control: `inputs.branches`, `github.repository`, and the base ref taken from the PR. All three are interpolated directly into the `run:` block, so the shell parses them as code rather than reading them as data.

`master`, `release-2.14` and `release-2.13` do not need this. Matrix generation moved out of the `run:` block there and passes `branches` through `with:`. Only 2.12 and 2.11 still build it inline.

The `inputs.PR` half of this same step was handled in #18114 and #18115. This finishes the job for the values those left behind.

## Implementation

The three values arrive through `env:` as `INPUT_BRANCHES`, `REPOSITORY` and `PR_BASE_REF`, and are quoted where used.

The base ref goes to `jq` through `--arg base` rather than being spliced into the jq program text, so it cannot alter the filter either. That was the one spot where quoting alone would not have been enough.

`runner.debug` is left inline. It is a runner context boolean, not caller input, and leaving it matches what these branches already do.

## Verification

`actionlint` gives the same 84 lines of output before and after, differing only in line numbers.

## Downstream

kong-mesh mirrors this file as `kuma-backport.yaml` and Aikido reports the same finding there on 2.12 and 2.11. Fixing it here means `upgrade-kuma` carries it down, rather than the same patch being applied twice and then overwritten on the next sync.
