### PR TITLE
chore(deps): bump distroless base images

### DIFF
--- a/tools/releases/dockerfiles/base-root.Dockerfile
+++ b/tools/releases/dockerfiles/base-root.Dockerfile
@@ -1,5 +1,5 @@
 # use only when root is really needed
-FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:1321f45efc120268506fa83b0b6ac8e9086c1048e7c95253c41de79eb3e1f8b0
+FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:94b009dc8031fbdcb3038ba6452fbdb267ddb8cf2512538c1a9e556ef3cf9568
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/base.Dockerfile
+++ b/tools/releases/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:ef708361af252a61d6d9bf32c6605f530971c9da3c22b1a403fbddc1a6d12ee6
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:73a38455a118dc5dcd63ff83469b3b2de6b64e4747ee79e758c6c80ba392e220
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \


### PR DESCRIPTION
## Motivation

Renovate keeps the distroless digest pins current on `master` only, so the release branches drift. `master` has been on the current digests since 17 August; this branch was still on base-nossl digests from January.

That drift is why the published images lag their own base. Checking the digests directly rather than trusting the tag:

| File | This branch | master |
|:--|:--|:--|
| `base.Dockerfile` | libc6 `2.36-9+deb12u13` | libc6 `2.36-9+deb12u14` |
| `base-root.Dockerfile` | libc6 `2.36-9+deb12u13` | libc6 `2.36-9+deb12u14` |

## Implementation

Only the digests move. The tags are unchanged, so this is a rebuild on the same base rather than a version change.

`static.Dockerfile` is untouched: this branch already pins a digest carrying the same busybox as master, so there is nothing to gain there.

## What is deliberately left out

`kuma-init.Dockerfile` and `envoy.Dockerfile` both differ from master too, but those are version bumps rather than digest refreshes and deserve their own consideration:

- `distroless-iptables` would go from v0.8.8 to v0.9.6, which changes the bundled iptables. The transparent proxy depends on that, so it is not a safe drive-by on a patch branch.
- The `envoy` stage would go from `debian:13.2` to `debian:13.6`. That base never ships - it exists only to supply a binary that is copied out - so the bump buys nothing here.

## Verification

Both libc6 versions above were read out of the actual images, by exporting each digest and checking `var/lib/dpkg/status.d/libc6`. Nothing here is inferred from the tag.

`release-2.14` needs none of this; its pins already carry libc6 `deb12u14`.
