### PR TITLE
chore(deps): bump distroless base images

### DIFF
--- a/tools/releases/dockerfiles/base-root.Dockerfile
+++ b/tools/releases/dockerfiles/base-root.Dockerfile
@@ -1,5 +1,5 @@
 # use only when root is really needed
-FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:12dbb4f46c5f712fe3da1c7a441602ee91eb87a5d46b0e725b4440b852000538
+FROM gcr.io/distroless/base-nossl-debian12:debug@sha256:94b009dc8031fbdcb3038ba6452fbdb267ddb8cf2512538c1a9e556ef3cf9568
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/base.Dockerfile
+++ b/tools/releases/dockerfiles/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:d86c78b580ebcd04f3606c8201fd1ea76e457c21059cc1d2a17695b6f9ebf121
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:73a38455a118dc5dcd63ff83469b3b2de6b64e4747ee79e758c6c80ba392e220
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \

--- a/tools/releases/dockerfiles/static.Dockerfile
+++ b/tools/releases/dockerfiles/static.Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug-nonroot@sha256:633d5fa264a127052ca34c3fdaf81ef5a58204770736df9047745919a5b318f6
+FROM gcr.io/distroless/static-debian12:debug-nonroot@sha256:2b3c67db50828b3b13277c0e00ec9550cac00dd2b7e0683235c7770c2227e0df
 
 COPY /tools/releases/templates/LICENSE \
     /tools/releases/templates/README \


### PR DESCRIPTION
## Motivation

Renovate keeps the distroless digest pins current on `master` only, so the release branches drift. `master` has been on the current digests since 17 August; this branch was still on ones it moved off months ago.

That drift is why the published images lag their own base. Checking the digests directly rather than trusting the tag:

| File | This branch | master |
|:--|:--|:--|
| `base.Dockerfile` | libc6 `2.36-9+deb12u13` | libc6 `2.36-9+deb12u14` |
| `base-root.Dockerfile` | libc6 `2.36-9+deb12u13` | libc6 `2.36-9+deb12u14` |
| `static.Dockerfile` | busybox `1.36.1` | busybox `1.37.0` |

## Implementation

Only the digests move. The tags are unchanged, so this is a rebuild on the same base rather than a version change.

## What is deliberately left out

`kuma-init.Dockerfile` and `envoy.Dockerfile` both differ from master too, but those are version bumps rather than digest refreshes and deserve their own consideration:

- `distroless-iptables` would go from v0.8.8 to v0.9.6, which changes the bundled iptables. The transparent proxy depends on that, so it is not a safe drive-by on a patch branch.
- The `envoy` stage would go from `debian:12.11` to `debian:13.6`. That base never ships - it exists only to supply a binary that is copied out - so the bump buys nothing here.

## Verification

Every version in the table above was read out of the actual image, by exporting each digest and checking `var/lib/dpkg/status.d` and the busybox build string. Nothing here is inferred from the tag.

Worth noting on busybox: 1.37.0 is not free of findings either - it carries CVE-2025-60876 in `wget`. But 1.36.1 carries CVE-2022-48174 at critical, so this is a strict improvement rather than a clean fix.

`release-2.14` needs none of this; its pins already carry libc6 `deb12u14` and busybox 1.37.0.
