### PR TITLE
ci(runners): name the release-2.14 runner variables after the branch

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -45,7 +45,7 @@ env:
 jobs:
   build-binaries:
     timeout-minutes: 70
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -117,7 +117,7 @@ jobs:
         run: |
           make publish/pulp
   build-images:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -251,7 +251,7 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -272,7 +272,7 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/_get-active-branches.yaml
+++ b/.github/workflows/_get-active-branches.yaml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   get:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     outputs:
       out: ${{ steps.main.outputs.out }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -25,7 +25,7 @@ jobs:
   test_unit:
     timeout-minutes: 30
     if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       UNIT_CLEAN_TESTCACHE: ${{ inputs.IS_PULL_REQUEST && 'false' || 'true' }}
     steps:
@@ -52,7 +52,7 @@ jobs:
           make test
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -22,7 +22,7 @@ env:
   GH_REPO: ${{ github.repository }}
 jobs:
   pr-info:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     outputs:
       pr_title: ${{ steps.get-pr-info.outputs.pr_title }}
       pr_change_log: ${{ steps.get-pr-info.outputs.pr_change_log }}
@@ -101,7 +101,7 @@ jobs:
       branches: ${{ inputs.branches }}
   open-prs:
     needs: [pr-info, active-branches]
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   release_sha_gate:
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: read
@@ -108,7 +108,7 @@ jobs:
           echo "Trusted source run: ${run_url}"
   meta:
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
     outputs:
@@ -117,7 +117,7 @@ jobs:
       - run: echo "FULL_MATRIX=${{ env.FULL_MATRIX }}"
   build_check:
     timeout-minutes: 20
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -144,7 +144,7 @@ jobs:
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
       pull-requests: read # needed by paths-filter to access PR file list
     timeout-minutes: 40
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -280,12 +280,12 @@ jobs:
       IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       # Per-arch lookup (each side independent):
       #   1. fork PR                    -> free GitHub-hosted runners (security)
-      #   2. vars.RUNS_ON_MASTER_<ARCH> -> per-branch + per-arch override
+      #   2. vars.RUNS_ON_RELEASE_2_14_<ARCH> -> per-branch + per-arch override
       #   3. vars.RUNS_ON_<ARCH>        -> global per-arch override
       #   4. default                    -> the standard self-hosted Kong pool
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_RELEASE_2_14_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
     secrets: inherit
   build_publish:
     permissions:
@@ -326,7 +326,7 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,7 @@ permissions: {}
 jobs:
   pr-check:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: Check PR title
         # Check PR title against the Conventional Commits format using commitlint.

--- a/.github/workflows/ci-stability-master.yaml
+++ b/.github/workflows/ci-stability-master.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   trigger-build-test-distribute:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -25,7 +25,7 @@ jobs:
 
   trigger-build-test-distribute:
     needs: active-branches
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   trigger-ci:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - name: Generate GitHub app token

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analyze:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -18,7 +18,7 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   release:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,7 +12,7 @@ jobs:
   pr_comments:
     timeout-minutes: 120
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files') || contains(github.event.comment.body, '/golden_files_e2e') || contains(github.event.comment.body, '/tproxy_golden_files'))
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       # Commands are additive: one comment can request multiple actions, and all
       # matching steps below will run in order.

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,7 +12,7 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-modification.yaml
+++ b/.github/workflows/pr-modification.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
   find-prs:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     needs: active-branches
     permissions:
       contents: read
@@ -51,7 +51,7 @@ jobs:
 
   pr-comment:
     needs: find-prs
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     if: needs.find-prs.outputs.recent_prs != '[]'
     strategy:
       matrix: 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   release:
     timeout-minutes: 30
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
+++ b/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   dispatch-event:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest' }}
     timeout-minutes: 10
     env:
       TARGET_REPO: kuma-gui

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -52,7 +52,7 @@ jobs:
         !startsWith(github.event.workflow_run.head_branch, 'release-')
       )
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       contents: read # to confirm the ref is really a tag, via the git refs API
     outputs:
@@ -122,7 +122,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_smoke)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Trigger downstream smoke test"
@@ -165,7 +165,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_verify)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     permissions:
       # same-repo dispatch needs no cross-org token, unlike smoke; the default
       # GITHUB_TOKEN only gains workflow_dispatch rights with actions:write.

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -23,7 +23,7 @@ jobs:
   generate-docs:
     needs: active-branches
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # master

--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   workflows:
     name: "Validate Workflows"
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_actionlint ||
@@ -74,7 +74,7 @@ jobs:
 
   shellcheck:
     name: "Validate Shell Scripts"
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ vars.RUNS_ON_RELEASE_2_14_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_shellcheck ||


### PR DESCRIPTION
## Motivation

Every `runs-on` in this repository resolves through three tiers: `vars.RUNS_ON_<BRANCH>_<ARCH>` for a per-branch override, then the global `vars.RUNS_ON_<ARCH>`, then a plain `ubuntu-24.04`. `release-2.13` names `RUNS_ON_RELEASE_2_13_<ARCH>` for its first tier, as the comment in `build-test-distribute.yaml` describes.

`release-2.14` was cut without re-slugging, so all 23 workflows here still read `RUNS_ON_MASTER_<ARCH>`. The per-branch tier is therefore not per-branch on this branch: pinning master to a different runner pool drags `release-2.14` along with it, and pinning `release-2.14` on its own cannot be expressed at all.

## Implementation

`RUNS_ON_MASTER_` becomes `RUNS_ON_RELEASE_2_14_` throughout `.github/workflows`, which covers every `runs-on`, the `RUNNERS_BY_ARCH` expression that feeds the arch matrix, and the tier comment that documents them.

Nothing moves for anyone who has not set the per-branch variables: the old name and the new one are both unset, so each job still falls through to `vars.RUNS_ON_<ARCH>` and then to the default. Anyone who *has* set `RUNS_ON_MASTER_<ARCH>` and expects it to cover this branch would need `RUNS_ON_RELEASE_2_14_<ARCH>` as well, which is the point of the change.

This is not a backport candidate. `master` names `MASTER` correctly, and this is the only branch with the wrong slug.

## Validation

`actionlint` reports no findings on the changed files, and no `RUNS_ON_MASTER` reference is left in the tree.

> Changelog: skip
