### PR TITLE
chore(helm): drop unneeded container capabilities

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,7 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
-## Upgrade to `2.14.4`, `2.13.11`, `2.12.15`, `2.11.19`, `2.9.14`, `2.7.30`
+## Upgrade to `2.11.19`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the change alters the pod spec of workloads the chart ships.
 
@@ -29,7 +29,6 @@ controlPlane:
     capabilities:
       drop: []
 ```
-
 
 ## Upgrade to `2.11.x`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,31 @@ with `x.y.z` being the version you are planning to upgrade to.
 If such a section does not exist, the upgrade you want to perform
 does not have any particular instructions.
 
+## Upgrade to `2.14.4`, `2.13.11`, `2.12.15`, `2.11.19`, `2.9.14`, `2.7.30`
+
+Patch releases normally do not require upgrade instructions. The entry below is included because the change alters the pod spec of workloads the chart ships.
+
+### Control plane, hook, ingress and egress containers drop all Linux capabilities
+
+`controlPlane`, `hooks`, `ingress` and `egress` `containerSecurityContext` now default to `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]`, alongside the `readOnlyRootFilesystem: true` they already carried.
+
+None of those containers needs a capability. Every port they bind is above 1024, so `NET_BIND_SERVICE` was never required, and nothing in the codebase opens a raw or packet socket. The injected sidecar already ships with both settings.
+
+The transparent proxy init container is unaffected and keeps the `NET_ADMIN` and `NET_RAW` it adds for `iptables`, because the injector sets that in Go rather than from the chart. The CNI container reads `cni.containerSecurityContext`, which is unchanged and still runs as root.
+
+**Action required**
+
+Helm merges these values key by key, so overriding one key of `containerSecurityContext` no longer replaces the whole block: an override that sets only `readOnlyRootFilesystem` now also inherits the two new keys. If a container needs a capability, or you run a `SecurityContextConstraint` or admission policy that grants one, set it back explicitly:
+
+```yaml
+controlPlane:
+  containerSecurityContext:
+    allowPrivilegeEscalation: true
+    capabilities:
+      drop: []
+```
+
+
 ## Upgrade to `2.11.x`
 
 ### dp-server graceful shutdown is now time-bounded

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -721,6 +721,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -10918,6 +10918,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -347,6 +347,10 @@ controlPlane:
   # -- Security context at the container level for control plane.
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
   # The downside is that control plane requires permission to read Secrets in all namespaces.
@@ -575,6 +579,10 @@ ingress:
   # -- Security context at the container level for ingress
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- Annotations to add for Control Plane's Service Account
   serviceAccountAnnotations: { }
@@ -701,6 +709,10 @@ egress:
   # -- Security context at the container level for egress
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- Annotations to add for Control Plane's Service Account
   serviceAccountAnnotations: { }
@@ -746,6 +758,10 @@ hooks:
   # -- Security context at the container level for crd/webhook/ns
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
   # Changing below values will potentially break ebpf cleanup completely,

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -10918,6 +10918,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global-universal-on-k8s.golden.yaml
@@ -151,6 +151,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
@@ -195,6 +199,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION

--- a/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.global.golden.yaml
@@ -519,6 +519,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "kuma-ci/kuma-cp:greatest"
           imagePullPolicy: Never
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "gcr.io/octo/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.tproxy-ebpf-experimental-enabled.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-egress.golden.yaml
@@ -534,6 +534,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -710,6 +714,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -10980,6 +10980,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -11160,6 +11164,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME
@@ -11292,6 +11300,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-ingress.golden.yaml
@@ -534,6 +534,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -715,6 +719,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone-universal-on-k8s.golden.yaml
@@ -135,6 +135,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION
@@ -181,6 +185,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_DEFAULTS_SKIP_MESH_CREATION

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
@@ -232,6 +232,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -572,6 +572,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -751,6 +755,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME
@@ -886,6 +894,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -502,6 +502,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: MY_NODE_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -723,6 +723,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -741,6 +741,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -528,6 +528,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -547,6 +547,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -730,6 +734,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -793,6 +793,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -982,6 +986,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME
@@ -1117,6 +1125,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix5978.golden.yaml
@@ -565,6 +565,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -748,6 +752,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME
@@ -880,6 +888,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -506,6 +506,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7824.golden.yaml
@@ -580,6 +580,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -781,6 +785,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME
@@ -934,6 +942,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/ingressLbService.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/ingressLbService.golden.yaml
@@ -538,6 +538,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN
@@ -715,6 +719,10 @@ spec:
           image: "docker.io/kumahq/kuma-dp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: POD_NAME

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -503,6 +503,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -522,6 +522,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -504,6 +504,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
@@ -141,6 +141,10 @@ spec:
           image: "docker.io/kumahq/kuma-cp:0.0.1"
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             readOnlyRootFilesystem: true
           env:
             - name: KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -100,7 +100,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.hostNetwork | bool | `false` | Specifies if the deployment should be started in hostNetwork mode. |
 | controlPlane.admissionServerPort | int | `5443` | Define a new server port for the admission controller. Recommended to set in combination with hostNetwork to prevent multiple port bindings on the same port (like Calico in AWS EKS). |
 | controlPlane.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for control plane. |
-| controlPlane.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for control plane. |
+| controlPlane.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security context at the container level for control plane. |
 | controlPlane.supportGatewaySecretsInAllNamespaces | bool | `false` | If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace. The downside is that control plane requires permission to read Secrets in all namespaces. |
 | controlPlane.dns | object | `{"config":{"nameservers":[],"searches":[]},"policy":""}` | DNS configuration for the control-plane pod. This is equivalent to the [Kubernetes DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy). |
 | controlPlane.dns.policy | string | `""` | Defines how DNS resolution is configured for that Pod. |
@@ -169,7 +169,7 @@ A Helm chart for the Kuma Control Plane
 | ingress.topologySpreadConstraints | string | `nil` | Topology spread constraints rule for the Kuma Mesh Ingress pods. This is rendered as a template, so you can use variables to generate match labels. |
 | ingress.priorityClassName | string | `""` | Priority Class Name of the ingress |
 | ingress.podSecurityContext | object | `{"runAsGroup":5678,"runAsNonRoot":true,"runAsUser":5678}` | Security context at the pod level for ingress |
-| ingress.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for ingress |
+| ingress.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security context at the container level for ingress |
 | ingress.serviceAccountAnnotations | object | `{}` | Annotations to add for Control Plane's Service Account |
 | ingress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for cp. Optionally set to false |
 | ingress.dns | object | `{"config":{"nameservers":[],"searches":[]},"policy":""}` | DNS configuration for the ingress pod. This is equivalent to the [Kubernetes DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy). |
@@ -207,7 +207,7 @@ A Helm chart for the Kuma Control Plane
 | egress.topologySpreadConstraints | string | `nil` | Topology spread constraints rule for the Kuma Egress pods. This is rendered as a template, so you can use variables to generate match labels. |
 | egress.priorityClassName | string | `""` | Priority Class Name of the egress |
 | egress.podSecurityContext | object | `{"runAsGroup":5678,"runAsNonRoot":true,"runAsUser":5678}` | Security context at the pod level for egress |
-| egress.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for egress |
+| egress.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security context at the container level for egress |
 | egress.serviceAccountAnnotations | object | `{}` | Annotations to add for Control Plane's Service Account |
 | egress.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for cp. Optionally set to false |
 | egress.dns | object | `{"config":{"nameservers":[],"searches":[]},"policy":""}` | DNS configuration for the egress pod. This is equivalent to the [Kubernetes DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy). |
@@ -223,7 +223,7 @@ A Helm chart for the Kuma Control Plane
 | hooks.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the HELM hooks |
 | hooks.tolerations | list | `[]` | Tolerations for the HELM hooks |
 | hooks.podSecurityContext | object | `{"runAsNonRoot":true}` | Security context at the pod level for crd/webhook/ns |
-| hooks.containerSecurityContext | object | `{"readOnlyRootFilesystem":true}` | Security context at the container level for crd/webhook/ns |
+| hooks.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security context at the container level for crd/webhook/ns |
 | hooks.ebpfCleanup | object | `{"containerSecurityContext":{"readOnlyRootFilesystem":false},"podSecurityContext":{"runAsNonRoot":false}}` | ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs Changing below values will potentially break ebpf cleanup completely, so be cautious when doing so. |
 | hooks.ebpfCleanup.podSecurityContext | object | `{"runAsNonRoot":false}` | Security context at the pod level for crd/webhook/cleanup-ebpf |
 | hooks.ebpfCleanup.containerSecurityContext | object | `{"readOnlyRootFilesystem":false}` | Security context at the container level for crd/webhook/cleanup-ebpf |

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -347,6 +347,10 @@ controlPlane:
   # -- Security context at the container level for control plane.
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
   # The downside is that control plane requires permission to read Secrets in all namespaces.
@@ -575,6 +579,10 @@ ingress:
   # -- Security context at the container level for ingress
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- Annotations to add for Control Plane's Service Account
   serviceAccountAnnotations: { }
@@ -701,6 +709,10 @@ egress:
   # -- Security context at the container level for egress
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- Annotations to add for Control Plane's Service Account
   serviceAccountAnnotations: { }
@@ -746,6 +758,10 @@ hooks:
   # -- Security context at the container level for crd/webhook/ns
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
   # Changing below values will potentially break ebpf cleanup completely,

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -347,6 +347,10 @@ controlPlane:
   # -- Security context at the container level for control plane.
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- If true, then control plane can support TLS secrets for builtin gateway outside of mesh system namespace.
   # The downside is that control plane requires permission to read Secrets in all namespaces.
@@ -575,6 +579,10 @@ ingress:
   # -- Security context at the container level for ingress
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- Annotations to add for Control Plane's Service Account
   serviceAccountAnnotations: { }
@@ -701,6 +709,10 @@ egress:
   # -- Security context at the container level for egress
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- Annotations to add for Control Plane's Service Account
   serviceAccountAnnotations: { }
@@ -746,6 +758,10 @@ hooks:
   # -- Security context at the container level for crd/webhook/ns
   containerSecurityContext:
     readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # -- ebpf-cleanup hook needs write access to the root filesystem to clean ebpf programs
   # Changing below values will potentially break ebpf cleanup completely,


### PR DESCRIPTION
## Motivation

`controlPlane`, `hooks`, `ingress` and `egress` `containerSecurityContext` carry only `readOnlyRootFilesystem: true`, so those containers run with the full default Linux capability set and privilege escalation permitted. None of them needs any of it.

The data plane is already stricter: the injected sidecar has shipped with `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]` for a while. This brings the rest of the chart in line with it.

Master carries the same change for `controlPlane` and `hooks` in #18124. There the zoneproxy already defaulted to both settings, so it needed nothing further. On this branch `ingress` and `egress` are separate components that did not, so they are included here to reach the same end state.

## Implementation information

All four blocks gain the two keys. Rendered with defaults that reaches five containers - the control plane and one per hook job, `install-crds` having two - and seven with `ingress.enabled=true --set egress.enabled=true`.

Nothing that does need privilege is touched:

- the transparent proxy init container keeps the `NET_ADMIN` and `NET_RAW` it adds for `iptables`, because the injector builds that in Go rather than from the chart
- the CNI container reads `cni.containerSecurityContext`, which is unchanged

Why no capability is needed: every port these containers bind is above 1024, so `NET_BIND_SERVICE` was never required, and there is no `SOCK_RAW`, `AF_PACKET` or ICMP use anywhere in the tree. No template adds a capability, which is what would have conflicted with `allowPrivilegeEscalation: false`.

`docs/generated/raw/helm-values.yaml` is a copy of the chart values and the chart README is generated from it, so both move too. `UPGRADE.md` gets a note, because Helm merges these values key by key: an override that sets only `readOnlyRootFilesystem` now inherits the two new keys as well.

## Supporting documentation

Verified on k3d with the published 2.14.3 chart and images carrying the same four settings:

- control plane, ingress and egress all `1/1 Running` with 0 restarts
- a hook job caught mid-upgrade ran with `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` on both its containers, and the upgrade completed
- with `cni.enabled=true` the CNI daemonset is `1/1 Running` and its applied context is unchanged: `{"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}`
- traffic flows through the mesh with mTLS enabled while an unmeshed client is refused, which is what proves Envoy is in the path
- rendering the CNI daemonset before and after and diffing it gives no change, on every active branch

`go test ./app/kumactl/cmd/install/...` passes after regenerating the golden files. Every changed golden line is the same four, with no deletions.

The heading in `UPGRADE.md` names the next patch of each active branch. Adjust it if the release lands elsewhere.

> Changelog: chore(helm): control plane, hook, ingress and egress containers now drop all Linux capabilities and disallow privilege escalation
