### PR TITLE
fix(api-server): avoid nil deref in _layout

### DIFF
--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -75,6 +75,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 	baseMeshContext, err := dle.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 	if err != nil {
 		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build MeshContext")
+		return
 	}
 
 	if baseMeshContext.Mesh.Spec.GetMeshServices().GetMode() != v1alpha1.Mesh_MeshServices_Exclusive {

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/mesh_not_found.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/mesh_not_found.golden.json
@@ -1,0 +1,7 @@
+{
+ "type": "/std-errors",
+ "status": 404,
+ "title": "Failed to build MeshContext",
+ "detail": "Not found",
+ "details": "Not found"
+}

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/mesh_not_found.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/mesh_not_found.input.yaml
@@ -1,0 +1,13 @@
+#/meshes/non-existent/dataplanes/dp-1/_layout 404
+type: Mesh
+name: default
+---
+type: Dataplane
+name: dp-1
+mesh: default
+networking:
+  address: 127.0.0.1
+  inbound:
+    - port: 8080
+      tags:
+        kuma.io/service: foo


### PR DESCRIPTION
## Motivation

`GET /meshes/{mesh}/dataplanes/{name}/_layout` panics and crashes the control plane whenever the mesh cannot be loaded — most easily triggered by requesting a mesh that does not exist.

## Implementation information

`getLayout` called `rest_errors.HandleError` on the `BuildBaseMeshContextIfChanged` error but did not return. `BuildBaseMeshContextIfChanged` returns `nil, err`, so execution fell through to `baseMeshContext.Mesh.Spec.GetMeshServices()` and dereferenced nil. Added the missing `return`, plus a golden test that requests a non-existent mesh and expects 404.

Already fixed on `master` by #17101; this backports only the `return` since the surrounding `MeshServicesMode()` refactor does not apply to 2.14.

## Supporting documentation

Panic observed in production on 2.14:

```
github.com/kumahq/kuma/v2/pkg/api-server.(*dataplaneLayoutEndpoint).getLayout
	pkg/api-server/dataplane_layout_endpoint.go:80
```
