### PR TITLE
fix(k8s): drop terminating egress from endpoints

### DIFF
--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -95,6 +95,12 @@ const (
 	// "zoneingress", "zoneegress"
 	ProxyTypeLabel = "kuma.io/proxy-type"
 
+	// ProxyReadyLabel is auto-computed for zone proxies created out of a Pod. It is "false" while the Pod is
+	// terminating or not ready and "true" otherwise. Endpoint generation skips instances labeled "false", so a
+	// missing label means ready: proxies registered on Universal and resources written by an older CP keep
+	// receiving traffic.
+	ProxyReadyLabel = "kuma.io/proxy-ready"
+
 	// ManagedByLabel is used when a MeshService is auto-generated
 	ManagedByLabel = "kuma.io/managed-by"
 

--- a/pkg/core/resources/labels/registry.go
+++ b/pkg/core/resources/labels/registry.go
@@ -19,4 +19,5 @@ var AllComputedLabels = map[string]struct{}{
 	metadata.KumaWorkload:               {},
 	mesh_proto.ListenerZoneIngressLabel: {},
 	mesh_proto.ListenerZoneEgressLabel:  {},
+	mesh_proto.ProxyReadyLabel:          {},
 }

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"reflect"
 	"regexp"
+	"strconv"
 
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
@@ -159,7 +160,7 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 	labels, err := resource_labels.Compute(
 		core_mesh.ZoneEgressResourceTypeDescriptor,
 		currentSpec,
-		mergeLabels(zoneEgress.GetLabels(), pod.Labels),
+		zoneProxyLabels(zoneEgress.GetLabels(), pod),
 		model.NoMesh,
 		resource_labels.WithNamespace(resource_labels.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace)),
 		resource_labels.WithMode(p.Mode),
@@ -525,6 +526,30 @@ func MetricsAggregateFor(pod *kube_core.Pod) ([]*mesh_proto.PrometheusAggregateM
 		aggregateConfig = append(aggregateConfig, config)
 	}
 	return aggregateConfig, nil
+}
+
+// zoneProxyLabels merges the Pod labels into the labels of a zone proxy resource and records whether the Pod is
+// currently serving. Endpoint generation reads that label to stop pointing at an instance the moment it starts
+// terminating, instead of waiting for the Pod object to be garbage collected.
+func zoneProxyLabels(existingLabels map[string]string, pod *kube_core.Pod) map[string]string {
+	labels := mergeLabels(existingLabels, pod.Labels)
+	labels[mesh_proto.ProxyReadyLabel] = strconv.FormatBool(zoneProxyReady(pod))
+	return labels
+}
+
+// zoneProxyReady reports whether a zone proxy Pod should be routed to. A terminating Pod never is, otherwise the
+// kubelet's Ready condition decides. An absent condition counts as ready, so a Pod whose status has not been
+// populated yet is not withheld from clients on the strength of missing information.
+func zoneProxyReady(pod *kube_core.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == kube_core.PodReady {
+			return condition.Status != kube_core.ConditionFalse
+		}
+	}
+	return true
 }
 
 func mergeLabels(existingLabels map[string]string, labelSets ...map[string]string) map[string]string {

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -538,14 +538,16 @@ func zoneProxyLabels(existingLabels map[string]string, pod *kube_core.Pod) map[s
 }
 
 // zoneProxyReady reports whether a zone proxy Pod should be routed to. A terminating Pod never is, otherwise the
-// kubelet's Ready condition decides. An absent condition counts as ready, so a Pod whose status has not been
-// populated yet is not withheld from clients on the strength of missing information.
+// kubelet's ContainersReady condition decides. ContainersReady rather than Ready, because Ready is additionally
+// gated on the Pod's readiness gates, and a gate held by something that has nothing to do with the proxy would
+// withdraw a healthy instance from every client in the zone. An absent condition counts as ready, so a Pod whose
+// status has not been populated yet is not withheld from clients on the strength of missing information.
 func zoneProxyReady(pod *kube_core.Pod) bool {
 	if pod.DeletionTimestamp != nil {
 		return false
 	}
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == kube_core.PodReady {
+		if condition.Type == kube_core.ContainersReady {
 			return condition.Status != kube_core.ConditionFalse
 		}
 	}

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -160,7 +160,7 @@ func (p *PodConverter) PodToEgress(ctx context.Context, zoneEgress *mesh_k8s.Zon
 	labels, err := resource_labels.Compute(
 		core_mesh.ZoneEgressResourceTypeDescriptor,
 		currentSpec,
-		zoneProxyLabels(zoneEgress.GetLabels(), pod),
+		egressLabels(zoneEgress.GetLabels(), pod),
 		model.NoMesh,
 		resource_labels.WithNamespace(resource_labels.NewNamespace(pod.Namespace, pod.Namespace == p.SystemNamespace)),
 		resource_labels.WithMode(p.Mode),
@@ -528,21 +528,25 @@ func MetricsAggregateFor(pod *kube_core.Pod) ([]*mesh_proto.PrometheusAggregateM
 	return aggregateConfig, nil
 }
 
-// zoneProxyLabels merges the Pod labels into the labels of a zone proxy resource and records whether the Pod is
-// currently serving. Endpoint generation reads that label to stop pointing at an instance the moment it starts
-// terminating, instead of waiting for the Pod object to be garbage collected.
-func zoneProxyLabels(existingLabels map[string]string, pod *kube_core.Pod) map[string]string {
+// egressLabels merges the Pod labels into the labels of a ZoneEgress and records whether the Pod is currently
+// serving. Endpoint generation reads that label to stop pointing at an instance the moment it starts terminating,
+// instead of waiting for the Pod object to be garbage collected. ZoneIngress has the same gap and is left alone
+// here, so it still goes through mergeLabels.
+func egressLabels(existingLabels map[string]string, pod *kube_core.Pod) map[string]string {
 	labels := mergeLabels(existingLabels, pod.Labels)
-	labels[mesh_proto.ProxyReadyLabel] = strconv.FormatBool(zoneProxyReady(pod))
+	labels[mesh_proto.ProxyReadyLabel] = strconv.FormatBool(egressReady(pod))
 	return labels
 }
 
-// zoneProxyReady reports whether a zone proxy Pod should be routed to. A terminating Pod never is, otherwise the
-// kubelet's ContainersReady condition decides. ContainersReady rather than Ready, because Ready is additionally
-// gated on the Pod's readiness gates, and a gate held by something that has nothing to do with the proxy would
-// withdraw a healthy instance from every client in the zone. An absent condition counts as ready, so a Pod whose
-// status has not been populated yet is not withheld from clients on the strength of missing information.
-func zoneProxyReady(pod *kube_core.Pod) bool {
+// egressReady reports whether an egress Pod should be routed to. A terminating Pod never is, otherwise the kubelet's
+// ContainersReady condition decides. ContainersReady rather than Ready, because Ready is additionally gated on the
+// Pod's readiness gates, and a gate held by something that has nothing to do with the egress would withdraw a
+// healthy instance from every client in the zone. An absent condition counts as ready, so a Pod whose status has not
+// been populated yet is not withheld from clients on the strength of missing information.
+//
+// This is deliberately not podReady() from inbound_converter.go: that one reads the status of the kuma-sidecar
+// container and of the container backing an inbound, and an egress Pod has neither.
+func egressReady(pod *kube_core.Pod) bool {
 	if pod.DeletionTimestamp != nil {
 		return false
 	}

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -618,6 +618,16 @@ var _ = Describe("PodToDataplane(..)", func() {
 			dataplane:      "05.dataplane.yaml",
 			node:           "05.node.yaml",
 		}),
+		Entry("06. Terminating egress is marked not ready", testCase{
+			pod:            "06.pod.yaml",
+			servicesForPod: "06.services-for-pod.yaml",
+			dataplane:      "06.dataplane.yaml",
+		}),
+		Entry("07. Egress that has not passed its readiness probe is marked not ready", testCase{
+			pod:            "07.pod.yaml",
+			servicesForPod: "07.services-for-pod.yaml",
+			dataplane:      "07.dataplane.yaml",
+		}),
 		Entry("Existing ZoneEgress should be updated when pod labels changes", testCase{ // KIND / Minikube use case
 			pod:               "egress-exists-labels.pod.yaml",
 			servicesForPod:    "egress-exists-labels.services-for-pod.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/02.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/02.dataplane.yaml
@@ -2,6 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-ready: "true"
     kuma.io/proxy-type: zoneegress
 spec:
   networking:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/03.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/03.dataplane.yaml
@@ -2,6 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-ready: "true"
     kuma.io/proxy-type: zoneegress
 spec:
   networking:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/04.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/04.dataplane.yaml
@@ -2,6 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-ready: "true"
     kuma.io/proxy-type: zoneegress
 spec:
   networking:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/05.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/05.dataplane.yaml
@@ -2,6 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-ready: "true"
     kuma.io/proxy-type: zoneegress
 spec:
   networking:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.dataplane.yaml
@@ -2,7 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
-    kuma.io/proxy-ready: "true"
+    kuma.io/proxy-ready: "false"
     kuma.io/proxy-type: zoneegress
 spec:
   networking:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.pod.yaml
@@ -13,5 +13,5 @@ spec:
 status:
   podIP: 192.168.0.1
   conditions:
-    - type: Ready
+    - type: ContainersReady
       status: "True"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: kuma-system
+  name: kuma-egress
+  deletionTimestamp: "2026-08-19T10:00:00Z"
+  labels:
+    app: kuma-egress
+  annotations:
+    kuma.io/egress: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 10002
+status:
+  podIP: 192.168.0.1
+  conditions:
+    - type: Ready
+      status: "True"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/06.services-for-pod.yaml
@@ -1,0 +1,15 @@
+---
+metadata:
+  namespace: kuma-system
+  name: kuma-egress
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      targetPort: 10001
+  selector:
+    app: kuma-egress
+status:
+  loadBalancer:
+    egress:
+      - hostname: "kuma-egress.com"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.dataplane.yaml
@@ -2,7 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
-    kuma.io/proxy-ready: "true"
+    kuma.io/proxy-ready: "false"
     kuma.io/proxy-type: zoneegress
 spec:
   networking:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.pod.yaml
@@ -12,5 +12,5 @@ spec:
 status:
   podIP: 192.168.0.1
   conditions:
-    - type: Ready
+    - type: ContainersReady
       status: "False"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.pod.yaml
@@ -1,0 +1,16 @@
+metadata:
+  namespace: kuma-system
+  name: kuma-egress
+  labels:
+    app: kuma-egress
+  annotations:
+    kuma.io/egress: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 10002
+status:
+  podIP: 192.168.0.1
+  conditions:
+    - type: Ready
+      status: "False"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/07.services-for-pod.yaml
@@ -1,0 +1,15 @@
+---
+metadata:
+  namespace: kuma-system
+  name: kuma-egress
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 10001
+      targetPort: 10001
+  selector:
+    app: kuma-egress
+status:
+  loadBalancer:
+    egress:
+      - hostname: "kuma-egress.com"

--- a/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/egress/egress-exists-labels.dataplane.yaml
@@ -2,6 +2,7 @@ metadata:
   labels:
     app: kuma-egress
     k8s.kuma.io/namespace: kuma-system
+    kuma.io/proxy-ready: "true"
     kuma.io/proxy-type: zoneegress
     test: new
 spec:

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"slices"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -696,11 +697,17 @@ func resolveLegacyZoneEgresses(zoneEgresses []*core_mesh.ZoneEgressResource) []x
 // readyZoneEgresses drops the instances whose Pod is terminating or not ready yet. Only endpoint generation is
 // filtered: the unfiltered list stays in the mesh context so that a draining egress keeps being served its own
 // configuration for as long as it runs.
+//
+// The label is written by the Pod converter, so in practice the value is only ever "true" or "false". It is a plain
+// label though, so anything else - an absent label on Universal, a resource written by an older control plane, a
+// value nobody can parse - counts as ready and keeps traffic flowing.
 func readyZoneEgresses(zoneEgresses []*core_mesh.ZoneEgressResource) []*core_mesh.ZoneEgressResource {
 	var ready []*core_mesh.ZoneEgressResource
 	for _, ze := range zoneEgresses {
-		if ze.GetMeta().GetLabels()[mesh_proto.ProxyReadyLabel] == "false" {
-			continue
+		if value, found := ze.GetMeta().GetLabels()[mesh_proto.ProxyReadyLabel]; found {
+			if isReady, err := strconv.ParseBool(value); err == nil && !isReady {
+				continue
+			}
 		}
 		ready = append(ready, ze)
 	}

--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -188,7 +188,7 @@ func (m *meshContextBuilder) BuildIfChanged(ctx context.Context, meshName string
 		}
 	}
 	zoneIngresses := resources.ZoneIngresses().Items
-	zoneEgresses := resources.ZoneEgresses().Items
+	zoneEgresses := readyZoneEgresses(resources.ZoneEgresses().Items)
 	externalServices := resources.ExternalServices().Items
 	zoneEgressList := resolveZoneEgresses(dataplanes, resources.MeshIdentities().Items, m.zone)
 	if len(zoneEgressList) == 0 {
@@ -691,6 +691,20 @@ func resolveLegacyZoneEgresses(zoneEgresses []*core_mesh.ZoneEgressResource) []x
 		legacyEgresses = append(legacyEgresses, xds.ZoneEgressInstance{Address: n.GetAddress(), Port: n.GetPort()})
 	}
 	return legacyEgresses
+}
+
+// readyZoneEgresses drops the instances whose Pod is terminating or not ready yet. Only endpoint generation is
+// filtered: the unfiltered list stays in the mesh context so that a draining egress keeps being served its own
+// configuration for as long as it runs.
+func readyZoneEgresses(zoneEgresses []*core_mesh.ZoneEgressResource) []*core_mesh.ZoneEgressResource {
+	var ready []*core_mesh.ZoneEgressResource
+	for _, ze := range zoneEgresses {
+		if ze.GetMeta().GetLabels()[mesh_proto.ProxyReadyLabel] == "false" {
+			continue
+		}
+		ready = append(ready, ze)
+	}
+	return ready
 }
 
 func getCAsByTrustDomain(trusts []*meshtrust_api.MeshTrustResource) map[string][]PEMBytes {

--- a/pkg/xds/context/mesh_context_builder_test.go
+++ b/pkg/xds/context/mesh_context_builder_test.go
@@ -330,6 +330,23 @@ networking:
 			targets = append(targets, endpoint.Target)
 		}
 		Expect(targets).To(ConsistOf("192.168.0.1", "192.168.0.3"))
+
+		// and the terminating instance is still in the mesh context, so that it keeps being served its own
+		// configuration until it exits
+		var names []string
+		for _, ze := range meshContext.Resources.ZoneEgresses().Items {
+			names = append(names, ze.GetMeta().GetName())
+		}
+		Expect(names).To(ConsistOf("egress-ready", "egress-terminating", "egress-universal"))
+
+		// and it resolves by name, which is how the egress proxy builder finds it
+		aggregated, err := xds_context.AggregateMeshContexts(
+			context.Background(),
+			core_manager.NewResourceManager(resourceStore),
+			meshContextBuilder.Build,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(aggregated.ZoneEgressByName).To(HaveKey("egress-terminating"))
 	})
 })
 

--- a/pkg/xds/context/mesh_context_builder_test.go
+++ b/pkg/xds/context/mesh_context_builder_test.go
@@ -268,6 +268,71 @@ var _ = Describe("MeshZoneAddress", func() {
 	})
 })
 
+var _ = Describe("zone egress endpoints", func() {
+	lookupIPFunc := func(s string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP(s)}, nil
+	}
+
+	It("skips zone egresses whose pod is terminating or not ready", func() {
+		// given
+		resourceStore := memory.NewStore()
+		meshContextBuilder := newMeshContextBuilder(resourceStore, lookupIPFunc)
+		Expect(test_store.LoadResources(context.Background(), resourceStore, `
+type: Mesh
+name: default
+mtls:
+  enabledBackend: ca-1
+  backends:
+    - name: ca-1
+      type: builtin
+routing:
+  zoneEgress: true
+---
+type: ExternalService
+name: httpbin
+mesh: default
+networking:
+  address: httpbin.org:80
+tags:
+  kuma.io/service: httpbin
+---
+type: ZoneEgress
+name: egress-ready
+labels:
+  kuma.io/proxy-ready: "true"
+networking:
+  address: 192.168.0.1
+  port: 10002
+---
+type: ZoneEgress
+name: egress-terminating
+labels:
+  kuma.io/proxy-ready: "false"
+networking:
+  address: 192.168.0.2
+  port: 10002
+---
+type: ZoneEgress
+name: egress-universal
+networking:
+  address: 192.168.0.3
+  port: 10002
+`)).To(Succeed())
+
+		// when
+		meshContext, err := meshContextBuilder.BuildIfChanged(context.Background(), "default", nil)
+
+		// then the terminating instance is gone, while the one with no label at all - a Universal egress or one
+		// written by an older CP - is kept
+		Expect(err).ToNot(HaveOccurred())
+		var targets []string
+		for _, endpoint := range meshContext.EndpointMap["httpbin"] {
+			targets = append(targets, endpoint.Target)
+		}
+		Expect(targets).To(ConsistOf("192.168.0.1", "192.168.0.3"))
+	})
+})
+
 // failingListManager delegates Get to a real manager but fails every List, simulating a store error.
 type failingListManager struct {
 	core_manager.ReadOnlyResourceManager

--- a/test/e2e_env/multizone/multizone_suite_test.go
+++ b/test/e2e_env/multizone/multizone_suite_test.go
@@ -66,6 +66,8 @@ var (
 	_ = Describe("InboundPassthrough", Label("job-3"), inbound_communication.InboundPassthrough, Ordered)
 	_ = Describe("InboundPassthroughDisabled", Label("job-3"), inbound_communication.InboundPassthroughDisabled, Ordered)
 	_ = Describe("ZoneEgress Internal Services", Label("job-3"), zoneegress.InternalServices, Ordered)
+	// Serial: it scales the zone egress that every other spec in the zone routes through.
+	_ = Describe("ZoneEgress Scaling", Label("job-3"), zoneegress.Scaling, Ordered, Serial)
 	_ = Describe("Connectivity", Label("job-1"), connectivity.Connectivity, Ordered)
 	_ = Describe("Connectivity Gateway IPV6 CNI V2", Label("job-1"), connectivity.GatewayIPV6CNIV2, Ordered)
 	_ = Describe("Sync", Label("job-1"), multizone_sync.Sync, Ordered)

--- a/test/e2e_env/multizone/zoneegress/scaling.go
+++ b/test/e2e_env/multizone/zoneegress/scaling.go
@@ -1,0 +1,141 @@
+package zoneegress
+
+import (
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/kumahq/kuma/v2/pkg/util/channels"
+	. "github.com/kumahq/kuma/v2/test/framework"
+	"github.com/kumahq/kuma/v2/test/framework/client"
+	"github.com/kumahq/kuma/v2/test/framework/deployments/democlient"
+	"github.com/kumahq/kuma/v2/test/framework/deployments/testserver"
+	"github.com/kumahq/kuma/v2/test/framework/envs/multizone"
+)
+
+func Scaling() {
+	const meshName = "ze-scaling"
+	const namespace = "ze-scaling"
+
+	mesh := fmt.Sprintf(`
+type: Mesh
+name: %s
+mtls:
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
+routing:
+  zoneEgress: true
+`, meshName)
+
+	destination := fmt.Sprintf("test-server_%s_svc_80.mesh", namespace)
+
+	BeforeAll(func() {
+		err := NewClusterSetup().
+			Install(YamlUniversal(mesh)).
+			Install(MeshTrafficPermissionAllowAllUniversal(meshName)).
+			Setup(multizone.Global)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(WaitForMesh(meshName, multizone.Zones())).To(Succeed())
+
+		group := errgroup.Group{}
+		NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName))).
+			SetupInGroup(multizone.KubeZone1, &group)
+
+		NewClusterSetup().
+			Install(NamespaceWithSidecarInjection(namespace)).
+			Install(testserver.Install(
+				testserver.WithName("test-server"),
+				testserver.WithNamespace(namespace),
+				testserver.WithMesh(meshName),
+			)).
+			SetupInGroup(multizone.KubeZone2, &group)
+		Expect(group.Wait()).To(Succeed())
+	})
+
+	AfterEachFailure(func() {
+		DebugKube(multizone.KubeZone1, meshName, namespace)
+		DebugKube(multizone.KubeZone2, meshName, namespace)
+	})
+
+	AfterAll(func() {
+		Expect(ScaleApp(multizone.KubeZone1, Config.ZoneEgressApp, Config.KumaNamespace, 1)).To(Succeed())
+		Expect(multizone.KubeZone1.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.KubeZone2.TriggerDeleteNamespace(namespace)).To(Succeed())
+		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
+	})
+
+	It("should not drop requests while the zone egress scales up and down", func() {
+		// given cross-zone traffic flowing through the local zone egress
+		Eventually(func(g Gomega) {
+			responses, err := client.CollectResponsesAndFailures(
+				multizone.KubeZone1, "demo-client", destination,
+				client.FromKubernetesPod(namespace, "demo-client"),
+				client.WithNumberOfRequests(10),
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(responses).To(HaveEach(HaveField("ResponseCode", 200)))
+		}, "2m", "1s").Should(Succeed())
+
+		// and a client sending requests without interruption. A request that never reaches the server
+		// is reported with an exit code and no response code, so anything other than 200 is a drop.
+		var mtx sync.Mutex
+		var drops []client.FailureResponse
+		var errs []error
+		stopCh := make(chan struct{})
+		doneCh := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(doneCh)
+			for !channels.IsClosed(stopCh) {
+				responses, err := client.CollectResponsesAndFailures(
+					multizone.KubeZone1, "demo-client", destination,
+					client.FromKubernetesPod(namespace, "demo-client"),
+					client.WithNumberOfRequests(10),
+				)
+				mtx.Lock()
+				if err != nil {
+					errs = append(errs, err)
+				}
+				for _, response := range responses {
+					if response.ResponseCode != 200 {
+						drops = append(drops, response)
+					}
+				}
+				mtx.Unlock()
+			}
+		}()
+		defer func() {
+			close(stopCh)
+			Eventually(doneCh, "1m").Should(BeClosed())
+		}()
+
+		noDrops := func(g Gomega) {
+			mtx.Lock()
+			defer mtx.Unlock()
+			g.Expect(errs).To(BeEmpty())
+			g.Expect(drops).To(BeEmpty())
+		}
+
+		// when a second egress instance joins
+		Expect(ScaleApp(multizone.KubeZone1, Config.ZoneEgressApp, Config.KumaNamespace, 2)).To(Succeed())
+		Expect(multizone.KubeZone1.Install(WaitPodsAvailable(Config.KumaNamespace, Config.ZoneEgressApp))).To(Succeed())
+
+		// then nothing is dropped, and the clients have had time to pick the new instance up
+		Consistently(noDrops, "20s", "1s").Should(Succeed())
+
+		// when one of the two instances is terminated. ScaleApp returns once the Pod is actually gone,
+		// so the whole termination window - from SIGTERM to the process exiting - is covered by traffic.
+		Expect(ScaleApp(multizone.KubeZone1, Config.ZoneEgressApp, Config.KumaNamespace, 1)).To(Succeed())
+
+		// then nothing is dropped. Keep sending for a while after the Pod is gone: without the filter the
+		// endpoint outlives the process by a control plane reconcile, and that is where the resets land.
+		Consistently(noDrops, "20s", "1s").Should(Succeed())
+	})
+}


### PR DESCRIPTION
## Motivation

Restarting or upgrading a zone egress in a mesh with `routing.zoneEgress: true` drops requests. A `ZoneEgress` carries no readiness state, so `resolveLegacyZoneEgresses` hands every instance in the store to endpoint generation, and the resource outlives the Pod until garbage collection catches up. Clients keep an endpoint pointed at the instance from SIGTERM to the end of the grace period. The process then exits with connections still open, and the resets show up as 502s.

A regular Dataplane avoids this. `podReady` flips its inbounds to `NotReady` as soon as `deletionTimestamp` is set, and endpoint generation reads `GetHealthyInbounds()`.

Fixes https://github.com/kumahq/kuma/issues/18143.

## Implementation information

`PodToEgress` writes `kuma.io/proxy-ready` onto the `ZoneEgress`, computed from the Pod by `egressReady`. A terminating Pod is never ready. Otherwise the kubelet's `ContainersReady` condition decides. `ContainersReady` and not `Ready`, because `Ready` is additionally gated on the Pod's readiness gates: a gate held by something that has nothing to do with the egress would pull a healthy instance out of every client in the zone. A missing condition counts as ready, so a Pod whose status has not been populated yet keeps serving.

This is deliberately not `podReady()` from `inbound_converter.go`. That one reads the status of the `kuma-sidecar` container and of the container backing an inbound, and an egress Pod has neither, so it would collapse to a `deletionTimestamp` check and lose the not-ready case. The label is registered in `labels.AllComputedLabels`: it reaches the resource through `Compute`'s `existingLabels` argument, which bypasses the panic guard that would otherwise have caught the omission.

`readyZoneEgresses` filters the list in the mesh context builder before endpoint generation sees it, parsing the value with `strconv.ParseBool`. Only an instance that parses as false is withdrawn. A missing label, or a value nothing can parse, means ready, which keeps traffic flowing to egresses registered on Universal and to resources written by an older control plane. `ZoneIngress` has the same gap, and that one is a follow-up.

`resources.ZoneEgresses()` itself stays unfiltered, so a draining egress keeps its own configuration until it exits. `EgressProxyBuilder` resolves the proxy through `ZoneEgressByName`, which is built from that unfiltered list, and everything it generates — listener address, cross-zone clusters, external service clusters, permissions and policies — comes from sources the filter never touches. Only `BuildEdsEndpointMap`, `BuildIngressEndpointMap` and `BuildCrossMeshEndpointMap` see the filtered slice.

With the chart defaults (`maxSurge: 1`, `maxUnavailable: 0`) a ready replacement exists before the old Pod gets a `deletionTimestamp`, so an upgrade never loses endpoints. At `egress.replicas: 1` a plain delete or an eviction does leave external services without an endpoint until the new Pod is ready, which is exactly how a single-replica Dataplane already behaves.

## Supporting documentation

Two converter cases cover the producer: a terminating Pod, and one whose containers never became ready. A mesh context test loads three instances (ready, terminating, unlabeled) and asserts the external service endpoints hold the first and the third, that the terminating one is still in `meshContext.Resources.ZoneEgresses()`, and that it still resolves through `AggregateMeshContexts(...).ZoneEgressByName` — the map the egress proxy builder reads. Drop the filter and the first assertion fails; push it down into the store fetch and the other two do.

`ZoneEgress Scaling` is a multizone e2e that reproduces the report. A Kubernetes client sends requests cross-zone through its local egress without interruption while a second egress instance is added and then removed again. Scaling down returns only once the Pod object is gone, so the traffic window covers SIGTERM through the process exiting, and the assertion runs for another 20s after that, because the endpoint used to outlive the process by a control plane reconcile. Any response other than 200 — including a reset, which curl reports as an exit code and no response code — fails the spec. It is `Serial`: it scales the egress that every other spec in the zone routes through.

Also verified by hand on a cluster: scaled the egress up and down with cross-zone traffic flowing, no resets.
