### PR TITLE
fix(meshhttproute): return 500 for unresolvable backendref shares

### DIFF
--- a/api/common/v1alpha1/targetref.go
+++ b/api/common/v1alpha1/targetref.go
@@ -186,6 +186,7 @@ type BackendRef struct {
 	// +kuma:nolint // https://github.com/kumahq/kuma/issues/14107
 	TargetRef `json:","`
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=4294967295
 	// +kubebuilder:default=1
 	// +kuma:nolint // https://github.com/kumahq/kuma/issues/14107
 	Weight *uint `json:"weight,omitempty"`

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -392,6 +392,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -489,6 +490,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:
@@ -4202,6 +4204,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -392,6 +392,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -489,6 +490,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:
@@ -4202,6 +4204,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -392,6 +392,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -489,6 +490,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:
@@ -4202,6 +4204,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2790,6 +2790,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -2887,6 +2888,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:
@@ -6548,6 +6550,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:

--- a/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhttproutes.yaml
@@ -137,6 +137,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -234,6 +235,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:

--- a/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshtcproutes.yaml
@@ -132,6 +132,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -7765,6 +7765,7 @@ components:
                                     type: string
                                   weight:
                                     default: 1
+                                    maximum: 4294967295
                                     minimum: 0
                                     type: integer
                                 required:
@@ -7875,6 +7876,7 @@ components:
                                             type: string
                                           weight:
                                             default: 1
+                                            maximum: 4294967295
                                             minimum: 0
                                             type: integer
                                         required:
@@ -11599,6 +11601,7 @@ components:
                                     type: string
                                   weight:
                                     default: 1
+                                    maximum: 4294967295
                                     minimum: 0
                                     type: integer
                                 required:

--- a/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhttproutes.yaml
@@ -137,6 +137,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -234,6 +235,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:

--- a/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshtcproutes.yaml
@@ -132,6 +132,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:

--- a/pkg/core/validators/common_validators.go
+++ b/pkg/core/validators/common_validators.go
@@ -362,5 +362,8 @@ func ValidateBackendRef(b common_api.BackendRef) ValidationError {
 	if b.Kind == common_api.MeshMultiZoneService && b.Port == nil {
 		verr.AddViolationAt(RootedAt("port"), MustBeDefined+" with kind MeshMultiZoneService")
 	}
+	if b.Weight != nil && *b.Weight > math.MaxUint32 {
+		verr.AddViolationAt(RootedAt("weight"), fmt.Sprintf(HasToBeInRangeFormat, 0, uint64(math.MaxUint32)))
+	}
 	return verr
 }

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/compare.go
@@ -101,6 +101,9 @@ type Route struct {
 	Match       Match
 	Filters     []Filter
 	BackendRefs []resolve.ResolvedBackendRef
+	// UnresolvedBackendRefsWeight is the declared sum of backendRef weights that
+	// did not resolve to a routable backend for this rule.
+	UnresolvedBackendRefsWeight uint
 	// AllBackendRefsUnresolved is true when the rule declares backendRefs and
 	// none of them resolve, which is the case the Gateway API answers with 500.
 	AllBackendRefsUnresolved bool

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -235,6 +235,7 @@ components:
                                     type: string
                                   weight:
                                     default: 1
+                                    maximum: 4294967295
                                     minimum: 0
                                     type: integer
                                 required:
@@ -328,6 +329,7 @@ components:
                                             type: string
                                           weight:
                                             default: 1
+                                            maximum: 4294967295
                                             minimum: 0
                                             type: integer
                                         required:

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/validation_test.go
@@ -353,6 +353,44 @@ to:
             labels:
               kuma.io/display-name: test-server
 `),
+		ErrorCases("backendRef weights above uint32 max",
+			[]validators.Violation{{
+				Field:   `spec.to[0].rules[0].default.backendRefs[0].weight`,
+				Message: "must be in inclusive range [0, 4294967295]",
+			}, {
+				Field:   `spec.to[0].rules[0].default.filters[0].requestMirror.backendRef.weight`,
+				Message: "must be in inclusive range [0, 4294967295]",
+			}}, `
+type: MeshHTTPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: Mesh
+to:
+- targetRef:
+    kind: MeshService
+    labels:
+      kuma.io/display-name: frontend
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      default:
+        backendRefs:
+          - kind: MeshService
+            labels:
+              kuma.io/display-name: test-server
+            weight: 4294967296
+        filters:
+          - type: RequestMirror
+            requestMirror:
+              backendRef:
+                kind: MeshService
+                labels:
+                  kuma.io/display-name: mirror
+                weight: 4294967296
+`),
 		ErrorCases("hostnames and hostname to backend rewrite not allowed with services",
 			[]validators.Violation{{
 				Field:   `spec.to[0].hostnames`,

--- a/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
+++ b/pkg/plugins/policies/meshhttproute/k8s/crd/kuma.io_meshhttproutes.yaml
@@ -137,6 +137,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:
@@ -234,6 +235,7 @@ spec:
                                               type: string
                                             weight:
                                               default: 1
+                                              maximum: 4294967295
                                               minimum: 0
                                               type: integer
                                           required:

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -126,12 +126,13 @@ func generateFromService(
 			mirrorSplits[i] = mirrorSplit[0]
 		}
 		routes = append(routes, xds.OutboundRoute{
-			Name:                     route.Name,
-			Match:                    route.Match,
-			Filters:                  route.Filters,
-			AllBackendRefsUnresolved: route.AllBackendRefsUnresolved,
-			MirrorSplits:             mirrorSplits,
-			Split:                    split,
+			Name:                        route.Name,
+			Match:                       route.Match,
+			Filters:                     route.Filters,
+			UnresolvedBackendRefsWeight: route.UnresolvedBackendRefsWeight,
+			AllBackendRefsUnresolved:    route.AllBackendRefsUnresolved,
+			MirrorSplits:                mirrorSplits,
+			Split:                       split,
 		})
 	}
 
@@ -245,14 +246,17 @@ func prepareRoutes(
 
 		for _, match := range rule.Matches {
 			var refs []resolve.ResolvedBackendRef
+			var unresolvedWeight uint
 
 			for _, br := range backendRefs {
 				rbr, ok := resolve.BackendRef(originID, br, meshCtx.ResolveResourceIdentifier)
 				if !ok {
+					unresolvedWeight += pointer.DerefOr(br.Weight, 1)
 					continue
 				}
 				if rr := rbr.RealResourceBackendRef(); rr != nil {
 					if _, _, ok := meshroute_xds.DestinationPortFromRef(meshCtx, rr); !ok {
+						unresolvedWeight += rr.Weight
 						continue
 					}
 				}
@@ -262,13 +266,14 @@ func prepareRoutes(
 			routes = append(
 				routes,
 				api.Route{
-					Name:                     routeName,
-					Origin:                   originID,
-					Match:                    match,
-					Filters:                  filters,
-					BackendRefs:              refs,
-					AllBackendRefsUnresolved: hasExplicitBackendRefs && len(refs) == 0,
-					MirrorBackendRefs:        mirrorRefs,
+					Name:                        routeName,
+					Origin:                      originID,
+					Match:                       match,
+					Filters:                     filters,
+					BackendRefs:                 refs,
+					UnresolvedBackendRefsWeight: unresolvedWeight,
+					AllBackendRefsUnresolved:    hasExplicitBackendRefs && len(refs) == 0,
+					MirrorBackendRefs:           mirrorRefs,
 				},
 			)
 		}

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -254,11 +254,13 @@ func prepareRoutes(
 					unresolvedWeight += pointer.DerefOr(br.Weight, 1)
 					continue
 				}
-				if rr := rbr.RealResourceBackendRef(); rr != nil {
-					if _, _, ok := meshroute_xds.DestinationPortFromRef(meshCtx, rr); !ok {
+				if !backendRefProducesHTTPSplit(meshCtx, rbr) {
+					if rr := rbr.RealResourceBackendRef(); rr != nil {
 						unresolvedWeight += rr.Weight
-						continue
+					} else {
+						unresolvedWeight += pointer.DerefOr(br.Weight, 1)
 					}
+					continue
 				}
 				refs = append(refs, rbr)
 			}
@@ -320,4 +322,17 @@ func prepareRoutes(
 	}
 
 	return routes
+}
+
+func backendRefProducesHTTPSplit(
+	meshCtx xds_context.MeshContext,
+	ref resolve.ResolvedBackendRef,
+) bool {
+	rr := ref.RealResourceBackendRef()
+	if rr == nil || rr.Weight == 0 {
+		return false
+	}
+
+	_, port, ok := meshroute_xds.DestinationPortFromRef(meshCtx, rr)
+	return ok && core_meta.IsHTTPBased(port.GetProtocol())
 }

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -130,7 +130,7 @@ var _ = Describe("prepareRoutes", func() {
 		Entry("policy in team-b", "team-b"),
 	)
 
-	DescribeTable("should fail closed only when no explicit backendRef resolves", func(refNames []string, expectedAllUnresolved bool, expectedResolved []string) {
+	DescribeTable("should keep resolved backendRefs while tracking unresolved declared weight", func(refNames []string, refWeights []uint, expectedAllUnresolved bool, expectedResolved []string, expectedUnresolvedWeight uint) {
 		backend := builders.MeshService().
 			WithName("backend").
 			WithMesh(core_model.DefaultMesh).
@@ -162,10 +162,11 @@ var _ = Describe("prepareRoutes", func() {
 			},
 		}
 		var backendRefs []common_api.BackendRef
-		for _, name := range refNames {
+		for i, name := range refNames {
 			backendRefs = append(backendRefs, common_api.BackendRef{
 				TargetRef: builders.TargetRefMeshService(name, "kuma-demo", ""),
 				Port:      pointer.To(uint32(8080)),
+				Weight:    pointer.To(refWeights[i]),
 			})
 		}
 		toRules := core_rules.ToRules{
@@ -205,17 +206,20 @@ var _ = Describe("prepareRoutes", func() {
 		}
 		Expect(matched).ToNot(BeNil())
 		Expect(matched.AllBackendRefsUnresolved).To(Equal(expectedAllUnresolved))
+		Expect(matched.UnresolvedBackendRefsWeight).To(Equal(expectedUnresolvedWeight))
 		Expect(matched.BackendRefs).To(HaveLen(len(expectedResolved)))
 		for i, name := range expectedResolved {
 			Expect(matched.BackendRefs[i].ReferencesRealResource()).To(BeTrue())
 			Expect(matched.BackendRefs[i].Resource().Name).To(Equal(name))
 		}
 	},
-		Entry("a resolving backendRef keeps its traffic", []string{"payments", "missing-backend"}, false, []string{"payments"}),
-		Entry("no resolving backendRef fails closed", []string{"missing-backend", "other-missing"}, true, nil),
+		Entry("equal split unresolved share", []string{"payments", "missing-backend"}, []uint{1, 1}, false, []string{"payments"}, uint(1)),
+		Entry("90/10 unresolved share", []string{"payments", "missing-backend"}, []uint{90, 10}, false, []string{"payments"}, uint(10)),
+		Entry("all unresolved missing resources", []string{"missing-backend", "other-missing"}, []uint{30, 70}, true, nil, uint(100)),
+		Entry("all resolved keeps zero unresolved share", []string{"payments", "payments"}, []uint{30, 70}, false, []string{"payments", "payments"}, uint(0)),
 	)
 
-	DescribeTable("should fail closed when a backendRef names a port the destination does not have", func(refPorts []uint32, expectedAllUnresolved bool, expectedResolved []uint32) {
+	DescribeTable("should keep resolved backendRefs while tracking missing-port declared weight", func(refPorts []uint32, refWeights []uint, expectedAllUnresolved bool, expectedResolved []uint32, expectedUnresolvedWeight uint) {
 		backend := builders.MeshService().
 			WithName("backend").
 			WithMesh(core_model.DefaultMesh).
@@ -247,10 +251,11 @@ var _ = Describe("prepareRoutes", func() {
 			},
 		}
 		var backendRefs []common_api.BackendRef
-		for _, port := range refPorts {
+		for i, port := range refPorts {
 			backendRefs = append(backendRefs, common_api.BackendRef{
 				TargetRef: builders.TargetRefMeshService("payments", "kuma-demo", ""),
 				Port:      pointer.To(port),
+				Weight:    pointer.To(refWeights[i]),
 			})
 		}
 		toRules := core_rules.ToRules{
@@ -290,13 +295,14 @@ var _ = Describe("prepareRoutes", func() {
 		}
 		Expect(matched).ToNot(BeNil())
 		Expect(matched.AllBackendRefsUnresolved).To(Equal(expectedAllUnresolved))
+		Expect(matched.UnresolvedBackendRefsWeight).To(Equal(expectedUnresolvedWeight))
 		Expect(matched.BackendRefs).To(HaveLen(len(expectedResolved)))
 		for i, port := range expectedResolved {
 			Expect(matched.BackendRefs[i].ReferencesRealResource()).To(BeTrue())
 			Expect(matched.BackendRefs[i].Resource().SectionName).To(Equal(fmt.Sprintf("%d", port)))
 		}
 	},
-		Entry("a backendRef naming a missing port fails closed", []uint32{9999}, true, nil),
-		Entry("a backendRef naming an existing port next to one naming a missing port keeps only the resolving ref", []uint32{8080, 9999}, false, []uint32{8080}),
+		Entry("all unresolved missing ports", []uint32{9999, 9998}, []uint{40, 60}, true, nil, uint(100)),
+		Entry("mixed missing-port share", []uint32{8080, 9999}, []uint{90, 10}, false, []uint32{8080}, uint(10)),
 	)
 })

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -305,4 +305,100 @@ var _ = Describe("prepareRoutes", func() {
 		Entry("all unresolved missing ports", []uint32{9999, 9998}, []uint{40, 60}, true, nil, uint(100)),
 		Entry("mixed missing-port share", []uint32{8080, 9999}, []uint{90, 10}, false, []uint32{8080}, uint(10)),
 	)
+
+	DescribeTable("should track backendRefs that cannot produce an HTTP split", func(refNames []string, refWeights []uint, expectedAllUnresolved bool, expectedResolved []string, expectedUnresolvedWeight uint) {
+		backend := builders.MeshService().
+			WithName("backend").
+			WithMesh(core_model.DefaultMesh).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			Build()
+		httpBackend := builders.MeshService().
+			WithName("http-backend-hash").
+			WithMesh(core_model.DefaultMesh).
+			WithLabels(map[string]string{
+				mesh_proto.DisplayName:      "http-backend",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			}).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			Build()
+		tcpBackend := builders.MeshService().
+			WithName("tcp-backend-hash").
+			WithMesh(core_model.DefaultMesh).
+			WithLabels(map[string]string{
+				mesh_proto.DisplayName:      "tcp-backend",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			}).
+			AddIntPort(8080, 8080, core_meta.ProtocolTCP).
+			Build()
+
+		meshCtx := xds_builders.Context().
+			WithMeshLocalResources([]core_model.Resource{backend, httpBackend, tcpBackend}).
+			Build().
+			Mesh
+
+		matches := []api.Match{{
+			Path: &api.PathMatch{Type: api.PathPrefix, Value: "/split"},
+		}}
+		policyMeta := &test_model.ResourceMeta{
+			Name: "web-route",
+			Mesh: core_model.DefaultMesh,
+			Labels: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			},
+		}
+		var backendRefs []common_api.BackendRef
+		for i, name := range refNames {
+			backendRefs = append(backendRefs, common_api.BackendRef{
+				TargetRef: builders.TargetRefMeshService(name, "kuma-demo", ""),
+				Port:      pointer.To(uint32(8080)),
+				Weight:    pointer.To(refWeights[i]),
+			})
+		}
+		toRules := core_rules.ToRules{
+			ResourceRules: outbound.ResourceRules{
+				kri.From(backend): {
+					Resource: backend.GetMeta(),
+					Conf: []any{api.PolicyDefault{
+						Rules: []api.Rule{{
+							Matches: matches,
+							Default: api.RuleConf{
+								BackendRefs: &backendRefs,
+							},
+						}},
+					}},
+					OriginByMatches: map[common_api.MatchesHash]common.Origin{
+						api.HashMatches(matches): {Resource: policyMeta},
+					},
+				},
+			},
+		}
+		svc := meshroute_xds.DestinationService{
+			Outbound: &xds_types.Outbound{
+				Resource: kri.WithSectionName(kri.From(backend), "8080"),
+				Port:     8080,
+			},
+			Protocol: core_meta.ProtocolHTTP,
+		}
+
+		routes := prepareRoutes(toRules, svc, meshCtx)
+
+		var matched *api.Route
+		for i := range routes {
+			if routes[i].Match.Path != nil && routes[i].Match.Path.Value == "/split" {
+				matched = &routes[i]
+				break
+			}
+		}
+		Expect(matched).ToNot(BeNil())
+		Expect(matched.AllBackendRefsUnresolved).To(Equal(expectedAllUnresolved))
+		Expect(matched.UnresolvedBackendRefsWeight).To(Equal(expectedUnresolvedWeight))
+		Expect(matched.BackendRefs).To(HaveLen(len(expectedResolved)))
+		for i, name := range expectedResolved {
+			Expect(matched.BackendRefs[i].ReferencesRealResource()).To(BeTrue())
+			Expect(matched.BackendRefs[i].Resource().Name).To(Equal(name))
+		}
+	},
+		Entry("zero-weight HTTP backend plus missing backend", []string{"http-backend", "missing-backend"}, []uint{0, 100}, true, nil, uint(100)),
+		Entry("mixed HTTP and TCP backend share", []string{"http-backend", "tcp-backend"}, []uint{90, 10}, false, []string{"http-backend"}, uint(10)),
+	)
 })

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -1449,7 +1449,10 @@ var _ = Describe("MeshHTTPRoute", func() {
 											Default: api.RuleConf{
 												BackendRefs: &[]common_api.BackendRef{{
 													TargetRef: builders.TargetRefMeshService("backend", "", "80"),
-													Weight:    pointer.To(uint(100)),
+													Weight:    pointer.To(uint(90)),
+												}, {
+													TargetRef: builders.TargetRefMeshService("other-tcp", "", "80"),
+													Weight:    pointer.To(uint(10)),
 												}},
 											},
 										}},
@@ -1526,10 +1529,10 @@ var _ = Describe("MeshHTTPRoute", func() {
 											Default: api.RuleConf{
 												BackendRefs: &[]common_api.BackendRef{{
 													TargetRef: builders.TargetRefMeshService("backend", "", "80"),
-													Weight:    pointer.To(uint(1)),
+													Weight:    pointer.To(uint(0)),
 												}, {
 													TargetRef: builders.TargetRefMeshService("alias-backend", "", "80"),
-													Weight:    pointer.To(uint(1)),
+													Weight:    pointer.To(uint(100)),
 												}},
 											},
 										}},

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/plugin_test.go
@@ -1516,36 +1516,23 @@ var _ = Describe("MeshHTTPRoute", func() {
 							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
 								ResourceRules: map[kri.Identifier]outbound.ResourceRule{
 									backendMeshServiceIdentifier: test_policies.NewOutboundRule(nil, api.PolicyDefault{
-										Rules: []api.Rule{
-											{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v2",
-													},
-												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefMeshService("alias-backend", "", "80"),
-														Weight:    pointer.To(uint(100)),
-													}},
+										Rules: []api.Rule{{
+											Matches: []api.Match{{
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/v1",
 												},
-											},
-											{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v1",
-													},
+											}},
+											Default: api.RuleConf{
+												BackendRefs: &[]common_api.BackendRef{{
+													TargetRef: builders.TargetRefMeshService("backend", "", "80"),
+													Weight:    pointer.To(uint(1)),
+												}, {
+													TargetRef: builders.TargetRefMeshService("alias-backend", "", "80"),
+													Weight:    pointer.To(uint(1)),
 												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefMeshService("backend", "", "80"),
-														Weight:    pointer.To(uint(100)),
-													}},
-												},
 											},
-										},
+										}},
 									}),
 								},
 							}),
@@ -1609,36 +1596,23 @@ var _ = Describe("MeshHTTPRoute", func() {
 							WithToPolicy(api.MeshHTTPRouteType, core_rules.ToRules{
 								ResourceRules: map[kri.Identifier]outbound.ResourceRule{
 									backendMeshServiceIdentifier: test_policies.NewOutboundRule(nil, api.PolicyDefault{
-										Rules: []api.Rule{
-											{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v2",
-													},
-												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefMeshService("backend", "", "9999"),
-														Weight:    pointer.To(uint(100)),
-													}},
+										Rules: []api.Rule{{
+											Matches: []api.Match{{
+												Path: &api.PathMatch{
+													Type:  api.PathPrefix,
+													Value: "/v1",
 												},
-											},
-											{
-												Matches: []api.Match{{
-													Path: &api.PathMatch{
-														Type:  api.PathPrefix,
-														Value: "/v1",
-													},
+											}},
+											Default: api.RuleConf{
+												BackendRefs: &[]common_api.BackendRef{{
+													TargetRef: builders.TargetRefMeshService("backend", "", "80"),
+													Weight:    pointer.To(uint(90)),
+												}, {
+													TargetRef: builders.TargetRefMeshService("backend", "", "9999"),
+													Weight:    pointer.To(uint(10)),
 												}},
-												Default: api.RuleConf{
-													BackendRefs: &[]common_api.BackendRef{{
-														TargetRef: builders.TargetRefMeshService("backend", "", "80"),
-														Weight:    pointer.To(uint(100)),
-													}},
-												},
 											},
-										},
+										}},
 									}),
 								},
 							}),

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/mixed-tcp-and-http-outbounds.listeners.golden.yaml
@@ -28,6 +28,16 @@ resources:
               - '*'
               name: kri_msvc_default___backend_80
               routes:
+              - directResponse:
+                  body:
+                    inlineString: ""
+                  status: 500
+                match:
+                  prefix: /
+                  runtimeFraction:
+                    defaultValue:
+                      numerator: 10
+                name: kri_mhttpr_default___test-origin_rule_0
               - match:
                   prefix: /
                 name: kri_mhttpr_default___test-origin_rule_0

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend-port.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend-port.listeners.golden.yaml
@@ -33,14 +33,10 @@ resources:
                     inlineString: ""
                   status: 500
                 match:
-                  path: /v2
-                name: kri_mhttpr_default___test-origin_rule_0
-              - directResponse:
-                  body:
-                    inlineString: ""
-                  status: 500
-                match:
-                  prefix: /v2/
+                  path: /v1
+                  runtimeFraction:
+                    defaultValue:
+                      numerator: 10
                 name: kri_mhttpr_default___test-origin_rule_0
               - match:
                   path: /v1
@@ -48,6 +44,16 @@ resources:
                 route:
                   cluster: kri_msvc_default___backend_80
                   timeout: 0s
+              - directResponse:
+                  body:
+                    inlineString: ""
+                  status: 500
+                match:
+                  prefix: /v1/
+                  runtimeFraction:
+                    defaultValue:
+                      numerator: 10
+                name: kri_mhttpr_default___test-origin_rule_0
               - match:
                   prefix: /v1/
                 name: kri_mhttpr_default___test-origin_rule_0

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
@@ -34,32 +34,14 @@ resources:
                   status: 500
                 match:
                   path: /v1
-                  runtimeFraction:
-                    defaultValue:
-                      numerator: 50
                 name: kri_mhttpr_default___test-origin_rule_0
-              - match:
-                  path: /v1
-                name: kri_mhttpr_default___test-origin_rule_0
-                route:
-                  cluster: kri_msvc_default___backend_80
-                  timeout: 0s
               - directResponse:
                   body:
                     inlineString: ""
                   status: 500
                 match:
                   prefix: /v1/
-                  runtimeFraction:
-                    defaultValue:
-                      numerator: 50
                 name: kri_mhttpr_default___test-origin_rule_0
-              - match:
-                  prefix: /v1/
-                name: kri_mhttpr_default___test-origin_rule_0
-                route:
-                  cluster: kri_msvc_default___backend_80
-                  timeout: 0s
               - match:
                   prefix: /
                 name: 9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/testdata/unresolvable-backend.listeners.golden.yaml
@@ -33,14 +33,10 @@ resources:
                     inlineString: ""
                   status: 500
                 match:
-                  path: /v2
-                name: kri_mhttpr_default___test-origin_rule_0
-              - directResponse:
-                  body:
-                    inlineString: ""
-                  status: 500
-                match:
-                  prefix: /v2/
+                  path: /v1
+                  runtimeFraction:
+                    defaultValue:
+                      numerator: 50
                 name: kri_mhttpr_default___test-origin_rule_0
               - match:
                   path: /v1
@@ -48,6 +44,16 @@ resources:
                 route:
                   cluster: kri_msvc_default___backend_80
                   timeout: 0s
+              - directResponse:
+                  body:
+                    inlineString: ""
+                  status: 500
+                match:
+                  prefix: /v1/
+                  runtimeFraction:
+                    defaultValue:
+                      numerator: 50
+                name: kri_mhttpr_default___test-origin_rule_0
               - match:
                   prefix: /v1/
                 name: kri_mhttpr_default___test-origin_rule_0

--- a/pkg/plugins/policies/meshhttproute/xds/builder.go
+++ b/pkg/plugins/policies/meshhttproute/xds/builder.go
@@ -15,6 +15,9 @@ type OutboundRoute struct {
 	Name    string
 	Match   api.Match
 	Filters []api.Filter
+	// UnresolvedBackendRefsWeight is the declared sum of backendRef weights that
+	// did not resolve to a routable backend for this rule.
+	UnresolvedBackendRefsWeight uint
 	// AllBackendRefsUnresolved is true when the rule declares backendRefs and
 	// none of them resolve, which is the case the Gateway API answers with 500.
 	AllBackendRefsUnresolved bool
@@ -38,12 +41,13 @@ func (c *HttpOutboundRouteConfigurer) Configure(filterChain *envoy_listener.Filt
 	for _, route := range c.Routes {
 		route := envoy_virtual_hosts.AddVirtualHostConfigurer(
 			&RoutesConfigurer{
-				Name:                     route.Name,
-				Match:                    route.Match,
-				Filters:                  route.Filters,
-				AllBackendRefsUnresolved: route.AllBackendRefsUnresolved,
-				MirrorSplits:             route.MirrorSplits,
-				Split:                    route.Split,
+				Name:                        route.Name,
+				Match:                       route.Match,
+				Filters:                     route.Filters,
+				UnresolvedBackendRefsWeight: route.UnresolvedBackendRefsWeight,
+				AllBackendRefsUnresolved:    route.AllBackendRefsUnresolved,
+				MirrorSplits:                route.MirrorSplits,
+				Split:                       route.Split,
 			})
 		virtualHostBuilder = virtualHostBuilder.Configure(route)
 	}

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -1,65 +1,64 @@
 package xds
 
 import (
+	"math"
 	"strings"
 
+	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/xds/filters"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
+	envoy_listeners "github.com/kumahq/kuma/v3/pkg/xds/envoy/listeners/v3"
 	envoy_routes "github.com/kumahq/kuma/v3/pkg/xds/envoy/routes"
 )
 
 type RoutesConfigurer struct {
-	Name                     string
-	Match                    api.Match
-	Filters                  []api.Filter
-	AllBackendRefsUnresolved bool
-	MirrorSplits             map[int]envoy_common.Split
-	Split                    []envoy_common.Split
+	Name                        string
+	Match                       api.Match
+	Filters                     []api.Filter
+	UnresolvedBackendRefsWeight uint
+	AllBackendRefsUnresolved    bool
+	MirrorSplits                map[int]envoy_common.Split
+	Split                       []envoy_common.Split
 }
 
 func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error {
 	matches := c.routeMatch(c.Match)
 
 	for _, match := range matches {
-		rb := envoy_routes.NewRouteBuilder(envoy_common.APIV3, c.Name).
-			Configure(envoy_routes.RouteMustConfigureFunc(func(envoyRoute *envoy_route.Route) {
-				// todo: create configurers for Match and Action
-				envoyRoute.Match = match.routeMatch
-				envoyRoute.Action = &envoy_route.Route_Route{
-					Route: c.routeAction(c.Split),
-				}
-			}))
-
-		// We pass the information about whether this match was created from
-		// a prefix match along to the filters because it's no longer
-		// possible to know for sure with just an envoy_route.Route
-		for i, filter := range c.Filters {
-			switch filter.Type {
-			case api.RequestHeaderModifierType:
-				rb.Configure(filters.NewRequestHeaderModifier(*filter.RequestHeaderModifier))
-			case api.ResponseHeaderModifierType:
-				rb.Configure(filters.NewResponseHeaderModifier(*filter.ResponseHeaderModifier))
-			case api.RequestRedirectType:
-				rb.Configure(filters.NewRequestRedirect(*filter.RequestRedirect, match.prefixMatch))
-			case api.URLRewriteType:
-				rb.Configure(filters.NewURLRewrite(*filter.URLRewrite, match.prefixMatch))
-			case api.RequestMirrorType:
-				rb.Configure(filters.NewRequestMirror(*filter.RequestMirror, c.MirrorSplits[i]))
-			}
-		}
-
 		// A rule whose backendRefs all fail to resolve answers 500, unless a
 		// filter already terminates the request without an upstream.
 		if c.AllBackendRefsUnresolved && !hasTerminalFilter(c.Filters) {
+			rb := c.routeBuilder(match)
 			rb.Configure(envoy_routes.RouteActionDirectResponse(500, ""))
+			r, err := rb.Build()
+			if err != nil {
+				return err
+			}
+			virtualHost.Routes = append(virtualHost.Routes, r.(*envoy_route.Route))
+			continue
 		}
 
+		if c.UnresolvedBackendRefsWeight > 0 && !hasTerminalFilter(c.Filters) {
+			unresolvedMatch := *match.routeMatch
+			unresolvedMatch.RuntimeFraction = unresolvedRuntimeFraction(c.UnresolvedBackendRefsWeight, c.Split)
+
+			rb := c.routeBuilder(routeMatch{routeMatch: &unresolvedMatch, prefixMatch: match.prefixMatch})
+			rb.Configure(envoy_routes.RouteActionDirectResponse(500, ""))
+			r, err := rb.Build()
+			if err != nil {
+				return err
+			}
+			virtualHost.Routes = append(virtualHost.Routes, r.(*envoy_route.Route))
+		}
+
+		rb := c.routeBuilder(match)
 		r, err := rb.Build()
 		if err != nil {
 			return err
@@ -69,6 +68,37 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error 
 	}
 
 	return nil
+}
+
+func (c RoutesConfigurer) routeBuilder(match routeMatch) *envoy_routes.RouteBuilder {
+	rb := envoy_routes.NewRouteBuilder(envoy_common.APIV3, c.Name).
+		Configure(envoy_routes.RouteMustConfigureFunc(func(envoyRoute *envoy_route.Route) {
+			// todo: create configurers for Match and Action
+			envoyRoute.Match = match.routeMatch
+			envoyRoute.Action = &envoy_route.Route_Route{
+				Route: c.routeAction(c.Split),
+			}
+		}))
+
+	// We pass the information about whether this match was created from
+	// a prefix match along to the filters because it's no longer
+	// possible to know for sure with just an envoy_route.Route
+	for i, filter := range c.Filters {
+		switch filter.Type {
+		case api.RequestHeaderModifierType:
+			rb.Configure(filters.NewRequestHeaderModifier(*filter.RequestHeaderModifier))
+		case api.ResponseHeaderModifierType:
+			rb.Configure(filters.NewResponseHeaderModifier(*filter.ResponseHeaderModifier))
+		case api.RequestRedirectType:
+			rb.Configure(filters.NewRequestRedirect(*filter.RequestRedirect, match.prefixMatch))
+		case api.URLRewriteType:
+			rb.Configure(filters.NewURLRewrite(*filter.URLRewrite, match.prefixMatch))
+		case api.RequestMirrorType:
+			rb.Configure(filters.NewRequestMirror(*filter.RequestMirror, c.MirrorSplits[i]))
+		}
+	}
+
+	return rb
 }
 
 // hasTerminalFilter reports whether a filter sets the route action itself, so
@@ -271,4 +301,44 @@ func (c RoutesConfigurer) routeAction(split []envoy_common.Split) *envoy_route.R
 		}
 	}
 	return routeAction
+}
+
+func unresolvedRuntimeFraction(unresolvedWeight uint, split []envoy_common.Split) *envoy_config_core.RuntimeFractionalPercent {
+	totalWeight := uint64(unresolvedWeight)
+	for _, s := range split {
+		totalWeight += uint64(s.Weight())
+	}
+	if unresolvedWeight == 0 || totalWeight == 0 {
+		return nil
+	}
+
+	return &envoy_config_core.RuntimeFractionalPercent{
+		DefaultValue: fractionalPercent(uint64(unresolvedWeight), totalWeight),
+	}
+}
+
+func fractionalPercent(numerator uint64, denominator uint64) *envoy_type.FractionalPercent {
+	if denominator == 0 {
+		return nil
+	}
+
+	for _, candidate := range []struct {
+		scale       uint64
+		denominator envoy_type.FractionalPercent_DenominatorType
+	}{
+		{scale: 100, denominator: envoy_type.FractionalPercent_HUNDRED},
+		{scale: 10_000, denominator: envoy_type.FractionalPercent_TEN_THOUSAND},
+		{scale: 1_000_000, denominator: envoy_type.FractionalPercent_MILLION},
+	} {
+		scaled := numerator * candidate.scale
+		if scaled%denominator == 0 {
+			return &envoy_type.FractionalPercent{
+				Numerator:   uint32(scaled / denominator),
+				Denominator: candidate.denominator,
+			}
+		}
+	}
+
+	percentage := float64(numerator) * 100 / float64(denominator)
+	return envoy_listeners.ConvertPercentage(util_proto.Double(math.Round(percentage*10_000) / 10_000))
 }

--- a/pkg/plugins/policies/meshhttproute/xds/configurer.go
+++ b/pkg/plugins/policies/meshhttproute/xds/configurer.go
@@ -8,6 +8,7 @@ import (
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/protobuf/proto"
 
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/xds/filters"
@@ -46,10 +47,10 @@ func (c RoutesConfigurer) Configure(virtualHost *envoy_route.VirtualHost) error 
 		}
 
 		if c.UnresolvedBackendRefsWeight > 0 && !hasTerminalFilter(c.Filters) {
-			unresolvedMatch := *match.routeMatch
+			unresolvedMatch := proto.Clone(match.routeMatch).(*envoy_route.RouteMatch)
 			unresolvedMatch.RuntimeFraction = unresolvedRuntimeFraction(c.UnresolvedBackendRefsWeight, c.Split)
 
-			rb := c.routeBuilder(routeMatch{routeMatch: &unresolvedMatch, prefixMatch: match.prefixMatch})
+			rb := c.routeBuilder(routeMatch{routeMatch: unresolvedMatch, prefixMatch: match.prefixMatch})
 			rb.Configure(envoy_routes.RouteActionDirectResponse(500, ""))
 			r, err := rb.Build()
 			if err != nil {

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -232,6 +232,7 @@ components:
                                     type: string
                                   weight:
                                     default: 1
+                                    maximum: 4294967295
                                     minimum: 0
                                     type: integer
                                 required:

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/validator_test.go
@@ -104,6 +104,29 @@ to:
         labels:
           kuma.io/display-name: test-server
 `),
+		ErrorCase("backendRef weight above uint32 max",
+			validators.Violation{
+				Field:   "spec.to[0].rules[0].default.backendRefs[0].weight",
+				Message: "must be in inclusive range [0, 4294967295]",
+			}, `
+type: MeshTCPRoute
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: Mesh
+to:
+- targetRef:
+    kind: MeshService
+    labels:
+      kuma.io/display-name: backend
+  rules:
+  - default:
+      backendRefs:
+      - kind: MeshService
+        labels:
+          kuma.io/display-name: test-server
+        weight: 4294967296
+`),
 	)
 	DescribeValidCases(
 		api.NewMeshTCPRouteResource,

--- a/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
+++ b/pkg/plugins/policies/meshtcproute/k8s/crd/kuma.io_meshtcproutes.yaml
@@ -132,6 +132,7 @@ spec:
                                       type: string
                                     weight:
                                       default: 1
+                                      maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                   required:


### PR DESCRIPTION
## Motivation

Current behavior silently drops unresolvable backendRefs and redistributes traffic to remaining backends, masking configuration errors like typos in backend names. Gateway API specification requires returning 500 status for requests targeted at invalid backends, proportional to their declared weight. This change reverses the prior decision from #17982 to meet spec compliance.

## Implementation information

MeshHTTPRoute now returns 500 for requests aimed at unresolvable backends:
- Mixed resolvable/unresolvable: unresolvable share receives 500, others reach targets
- Response rates follow declared weights (90/10 split returns 500 to ~1 in 10 requests)
- All unresolvable: 500 to all requests
- All resolvable: unchanged behavior
- Valid backends never gain or lose traffic share due to sibling failures

BackendRef weight bounds in charts synchronized.

Closes https://github.com/kumahq/kuma/issues/18072

_Generated by Sybra harness_