### PR TITLE
fix(xds): use resolved dataplane addr in mesh ctx

### DIFF
--- a/pkg/xds/context/mesh_context_builder.go
+++ b/pkg/xds/context/mesh_context_builder.go
@@ -425,18 +425,17 @@ func (m *meshContextBuilder) fetchResourceList(ctx context.Context, resType core
 			}
 			return resolvedZoneIngress, nil
 		case core_mesh.DataplaneType:
-			list, err = modifyAllEntries(list, func(resource core_model.Resource) (core_model.Resource, error) {
-				dp, ok := resource.(*core_mesh.DataplaneResource)
-				if !ok {
-					return nil, errors.New("entry is not a dataplane this shouldn't happen")
-				}
-				zi, err := xds_topology.ResolveDataplaneAddress(m.ipFunc, dp)
-				if err != nil {
-					l.Error(err, "failed to resolve dataplane's domain name, ignoring dataplane", "mesh", dp.GetMeta().GetMesh(), "name", dp.GetMeta().GetName())
-					return nil, nil
-				}
-				return zi, nil
-			})
+			dp, ok := resource.(*core_mesh.DataplaneResource)
+			if !ok {
+				return nil, errors.New("entry is not a dataplane this shouldn't happen")
+			}
+
+			resolvedDataplane, err := xds_topology.ResolveDataplaneAddress(m.ipFunc, dp)
+			if err != nil {
+				l.Error(err, "failed to resolve dataplane's domain name, ignoring dataplane", "mesh", dp.GetMeta().GetMesh(), "name", dp.GetMeta().GetName())
+				return nil, nil
+			}
+			return resolvedDataplane, nil
 		}
 		return resource, nil
 	})

--- a/pkg/xds/context/mesh_context_builder_test.go
+++ b/pkg/xds/context/mesh_context_builder_test.go
@@ -146,6 +146,61 @@ var _ = Describe("hash", func() {
 		}
 	}, test.EntriesForFolder("meshcontext_hash"))
 
+	It("resolves a Dataplane address that is a DNS name", func() {
+		// given a builder whose lookup resolves a hostname, as it would on AWS ECS
+		// where the Dataplane is created before the container gets its IP
+		builderWithDNS := xds_context.NewMeshContextBuilder(
+			resourceStore,
+			xds_server.MeshResourceTypes(),
+			func(host string) ([]net.IP, error) {
+				switch host {
+				case "backend.dns.name":
+					return []net.IP{net.ParseIP("192.168.0.10")}, nil
+				case "backend.advertised.dns.name":
+					return []net.IP{net.ParseIP("192.168.0.11")}, nil
+				default:
+					return []net.IP{net.ParseIP(host)}, nil
+				}
+			},
+			"zone-1",
+			vips.NewPersistence(core_manager.NewResourceManager(resourceStore), manager.NewConfigManager(resourceStore), false),
+			"mesh",
+			80,
+			xds_context.AnyToAnyReachableServicesGraphBuilder,
+			nil,
+		)
+
+		Expect(test_store.LoadResources(context.Background(), resourceStore, `
+type: Mesh
+name: mesh-1
+---
+type: Dataplane
+name: dp-1
+mesh: mesh-1
+networking:
+  address: backend.dns.name
+  advertisedAddress: backend.advertised.dns.name
+  inbound:
+    - port: 8080
+      tags:
+        kuma.io/service: backend
+`)).To(Succeed())
+
+		// when
+		meshCtx, err := builderWithDNS.BuildIfChanged(context.Background(), "mesh-1", nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the dataplane stored in the mesh context is resolved
+		dataplanes := meshCtx.Resources.Dataplanes().Items
+		Expect(dataplanes).To(HaveLen(1))
+		Expect(dataplanes[0].Spec.GetNetworking().GetAddress()).To(Equal("192.168.0.10"))
+		Expect(dataplanes[0].Spec.GetNetworking().GetAdvertisedAddress()).To(Equal("192.168.0.11"))
+
+		// and so is the endpoint Envoy EDS gets, since it only accepts IPs
+		Expect(meshCtx.EndpointMap["backend"]).To(HaveLen(1))
+		Expect(meshCtx.EndpointMap["backend"][0].Target).To(Equal("192.168.0.11"))
+	})
+
 	It("returns an error instead of panicking when listing resources fails", func() {
 		// given a mesh exists but listing any other resource fails (e.g. DB connection lost).
 		// MeshService is a destination type, whose fetched list used to be read before the


### PR DESCRIPTION
## Motivation

Backport of #17836 to `release-2.14`. Dataplanes with a DNS name in `networking.address` / `advertisedAddress` reach EDS unresolved. Envoy requires an IP for `STATIC`/`EDS` clusters, so those endpoints are unusable — the feature `ResolveDataplaneAddress` exists for (AWS ECS, where the Dataplane is created before the container gets its IP) never actually worked on this branch.

The `Dataplane` branch of the post-processing switch in `fetchResourceList` runs a nested `modifyAllEntries` over the whole list, assigns it to the captured `list`, then falls through to `return resource, nil` — the unresolved entry. `modifyAllEntries` builds its output from the callback's return values, so the outer call produces a list of unresolved dataplanes and its result overwrites `list` at the end, discarding the nested call's work. `ResolveDataplaneAddress` returns a clone rather than mutating in place, so the resolution is genuinely thrown away. The nested call also runs once per dataplane over every dataplane, making it N² resolutions per mesh context build on the xDS hot path.

## Implementation information

Collapsed the `Dataplane` branch to `return resolvedDataplane, nil`, matching the `ZoneIngress` branch directly above it. Adapted by hand rather than cherry-picked: the master commit sits on a diverged `mesh_context_builder_test.go`, and the `zone-egress-dp` fixture it had to fix does not exist on `release-2.14`.

## Supporting documentation

- Fixes #17833 on `release-2.14`
- Structure dates back to #8182, where the per-type switch was introduced