### PR TITLE
fix(k8s): only delete MeshZoneAddress we own

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/meshzoneaddress_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshzoneaddress_controller.go
@@ -75,7 +75,7 @@ func (r *MeshZoneAddressReconciler) Reconcile(ctx context.Context, req kube_ctrl
 
 	// Only handle Services labeled as zone-proxy ingress.
 	if svc.GetLabels()[metadata.KumaZoneProxyTypeLabel] != KumaZoneProxyTypeIngress {
-		return kube_ctrl.Result{}, r.deleteIfExists(ctx, req.NamespacedName)
+		return kube_ctrl.Result{}, r.deleteIfExists(ctx, svc)
 	}
 
 	// Require at least one ready endpoint before publishing the address.
@@ -85,7 +85,7 @@ func (r *MeshZoneAddressReconciler) Reconcile(ctx context.Context, req kube_ctrl
 	}
 	if !ready {
 		log.V(1).Info("no ready endpoints, removing MeshZoneAddress")
-		return kube_ctrl.Result{}, r.deleteIfExists(ctx, req.NamespacedName)
+		return kube_ctrl.Result{}, r.deleteIfExists(ctx, svc)
 	}
 
 	// Resolve public address and port from the Service.
@@ -96,7 +96,7 @@ func (r *MeshZoneAddressReconciler) Reconcile(ctx context.Context, req kube_ctrl
 	if address == "" {
 		r.Eventf(svc, nil, kube_core.EventTypeWarning, NoPublicAddressForZoneProxyReason, "NoPublicAddress",
 			"unable to determine public address for zone ingress Service; ensure it exposes a reachable external address (LoadBalancer, NodePort with suitable node addresses, or spec.externalIPs) and that the address is ready")
-		return kube_ctrl.Result{}, r.deleteIfExists(ctx, req.NamespacedName)
+		return kube_ctrl.Result{}, r.deleteIfExists(ctx, svc)
 	}
 
 	meshName := util.MeshOfByLabel(svc, namespace)
@@ -111,12 +111,10 @@ func (r *MeshZoneAddressReconciler) Reconcile(ctx context.Context, req kube_ctrl
 	result, err := kube_controllerutil.CreateOrUpdate(ctx, r.Client, mza, func() error {
 		// If the MeshZoneAddress already exists and is not owned by this Service,
 		// skip mutation to avoid clobbering user-managed resources.
-		if mza.GetGeneration() != 0 {
-			if owners := mza.GetOwnerReferences(); len(owners) == 0 || owners[0].UID != svc.GetUID() {
-				r.Eventf(svc, nil, kube_core.EventTypeWarning, NoPublicAddressForZoneProxyReason, "Conflict",
-					"MeshZoneAddress %s already exists and is not owned by this Service", req.Name)
-				return errors.Errorf("MeshZoneAddress already exists and is not owned by Service")
-			}
+		if mza.GetGeneration() != 0 && !ownedBy(mza, svc) {
+			r.Eventf(svc, nil, kube_core.EventTypeWarning, NoPublicAddressForZoneProxyReason, "Conflict",
+				"MeshZoneAddress %s already exists and is not owned by this Service", req.Name)
+			return errors.Errorf("MeshZoneAddress already exists and is not owned by Service")
 		}
 		if mza.Labels == nil {
 			mza.Labels = map[string]string{}
@@ -235,17 +233,35 @@ func (r *MeshZoneAddressReconciler) hasReadyEndpoints(ctx context.Context, svc *
 	return false, nil
 }
 
-func (r *MeshZoneAddressReconciler) deleteIfExists(ctx context.Context, key kube_types.NamespacedName) error {
-	mza := &meshzoneaddress_k8s.MeshZoneAddress{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
+func (r *MeshZoneAddressReconciler) deleteIfExists(ctx context.Context, svc *kube_core.Service) error {
+	// Look the MeshZoneAddress up in the cache first. This reconciler runs for every
+	// Service in the cluster and almost none of them have a MeshZoneAddress, so an
+	// unconditional Delete costs one API server call per Service event.
+	mza := &meshzoneaddress_k8s.MeshZoneAddress{}
+	if err := r.Get(ctx, kube_client.ObjectKeyFromObject(svc), mza); err != nil {
+		if kube_apierrs.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "unable to fetch MeshZoneAddress")
+	}
+	// Names collide with any Service in the namespace, so only collect what this
+	// Service owns. The create path refuses to mutate a foreign one for the same reason.
+	if !ownedBy(mza, svc) {
+		return nil
 	}
 	if err := r.Delete(ctx, mza); err != nil && !kube_apierrs.IsNotFound(err) {
 		return errors.Wrap(err, "unable to delete MeshZoneAddress")
 	}
 	return nil
+}
+
+func ownedBy(mza *meshzoneaddress_k8s.MeshZoneAddress, svc *kube_core.Service) bool {
+	for _, owner := range mza.GetOwnerReferences() {
+		if owner.UID == svc.GetUID() {
+			return true
+		}
+	}
+	return false
 }
 
 const zoneProxyTypeLabelIndex = "metadata.labels.zone-proxy-type"
@@ -265,6 +281,10 @@ func (r *MeshZoneAddressReconciler) SetupWithManager(mgr kube_ctrl.Manager) erro
 	return kube_ctrl.NewControllerManagedBy(mgr).
 		Named("kuma-mesh-zone-address-controller").
 		For(&kube_core.Service{}).
+		// The delete path decides from the cache, so a MeshZoneAddress written but not yet
+		// observed would leak until the next resync. Owning it re-queues the Service as soon
+		// as the write lands. MatchEveryOwner because we set a plain, non-controller owner ref.
+		Owns(&meshzoneaddress_k8s.MeshZoneAddress{}, builder.MatchEveryOwner).
 		Watches(
 			&kube_discovery.EndpointSlice{},
 			kube_handler.EnqueueRequestsFromMapFunc(EndpointSliceToServicesMapper(r.Log, mgr.GetClient())),

--- a/pkg/plugins/runtime/k8s/controllers/meshzoneaddress_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/meshzoneaddress_controller_test.go
@@ -11,11 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
 	kube_discovery "k8s.io/api/discovery/v1"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_events "k8s.io/client-go/tools/events"
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/yaml"
 
 	meshzoneaddress_k8s "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshzoneaddress/k8s/v1alpha1"
@@ -28,6 +30,7 @@ const (
 	testZone      = "zone-1"
 	testNamespace = "kuma-system"
 	testSvcName   = "zone-ingress"
+	testSvcUID    = "11111111-1111-1111-1111-111111111111"
 )
 
 var _ = Describe("MeshZoneAddressReconciler", func() {
@@ -145,6 +148,90 @@ var _ = Describe("MeshZoneAddressReconciler", func() {
 		Entry("updates existing MeshZoneAddress", testCase{
 			inputFile:  "13.update-existing.resources.yaml",
 			outputFile: "13.update-existing.mza.yaml",
+		}),
+	)
+
+	// The fake client reads straight from its tracker, so these cases pin the decision the
+	// reconciler makes from stored state. Informer lag on a freshly written MeshZoneAddress
+	// is handled by the Owns() watch, not here.
+	type deleteCase struct {
+		mza             bool
+		ownerUID        kube_types.UID
+		expectedDeletes int
+		remaining       int
+	}
+
+	DescribeTable("should only delete a MeshZoneAddress owned by the Service",
+		func(given deleteCase) {
+			// given
+			objects := []kube_client.Object{
+				&kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: testNamespace}},
+				&kube_core.Service{ObjectMeta: kube_meta.ObjectMeta{
+					Name: testSvcName, Namespace: testNamespace, UID: testSvcUID,
+				}},
+			}
+			if given.mza {
+				meta := kube_meta.ObjectMeta{Name: testSvcName, Namespace: testNamespace}
+				if given.ownerUID != "" {
+					meta.OwnerReferences = []kube_meta.OwnerReference{{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Name:       testSvcName,
+						UID:        given.ownerUID,
+					}}
+				}
+				objects = append(objects, &meshzoneaddress_k8s.MeshZoneAddress{ObjectMeta: meta})
+			}
+
+			deletes := 0
+			kubeClient := kube_client_fake.NewClientBuilder().
+				WithObjects(objects...).
+				WithScheme(k8sClientScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(
+						ctx context.Context,
+						client kube_client.WithWatch,
+						obj kube_client.Object,
+						opts ...kube_client.DeleteOption,
+					) error {
+						deletes++
+						return client.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			reconciler := &MeshZoneAddressReconciler{
+				Client:        kubeClient,
+				Log:           logr.Discard(),
+				Scheme:        k8sClientScheme,
+				EventRecorder: kube_events.NewFakeRecorder(10),
+				ZoneName:      testZone,
+			}
+
+			// when a Service without the zone-proxy label is reconciled
+			_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+				NamespacedName: kube_types.NamespacedName{Name: testSvcName, Namespace: testNamespace},
+			})
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletes).To(Equal(given.expectedDeletes))
+
+			mzas := &meshzoneaddress_k8s.MeshZoneAddressList{}
+			Expect(kubeClient.List(context.Background(), mzas)).To(Succeed())
+			Expect(mzas.Items).To(HaveLen(given.remaining))
+		},
+		Entry("no MeshZoneAddress to remove", deleteCase{
+			mza: false, expectedDeletes: 0, remaining: 0,
+		}),
+		Entry("stale MeshZoneAddress to remove", deleteCase{
+			mza: true, ownerUID: testSvcUID, expectedDeletes: 1, remaining: 0,
+		}),
+		Entry("keeps a MeshZoneAddress owned by another Service", deleteCase{
+			mza: true, ownerUID: "22222222-2222-2222-2222-222222222222", expectedDeletes: 0, remaining: 1,
+		}),
+		Entry("keeps a user-managed MeshZoneAddress", deleteCase{
+			mza: true, ownerUID: "", expectedDeletes: 0, remaining: 1,
 		}),
 	)
 })

--- a/pkg/plugins/runtime/k8s/controllers/testdata/meshzoneaddress/12.delete-on-label-removed.resources.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/meshzoneaddress/12.delete-on-label-removed.resources.yaml
@@ -8,6 +8,7 @@ kind: Service
 metadata:
   name: zone-ingress
   namespace: kuma-system
+  uid: 11111111-1111-1111-1111-111111111111
 spec:
   type: LoadBalancer
 ---
@@ -16,6 +17,11 @@ kind: MeshZoneAddress
 metadata:
   name: zone-ingress
   namespace: kuma-system
+  ownerReferences:
+    - apiVersion: v1
+      kind: Service
+      name: zone-ingress
+      uid: 11111111-1111-1111-1111-111111111111
 spec:
   address: old.lb.example.com
   port: 10001


### PR DESCRIPTION
## Motivation

`MeshZoneAddressReconciler` reconciles every `Service` in the cluster. The branch for Services without the `k8s.kuma.io/zone-proxy-type: ingress` label called `deleteIfExists`, which issued an unconditional `Delete` against a name it had never read — one API server write per Service event for an object that in practice never exists.

That blind delete is also unscoped. A `MeshZoneAddress` is named after its Service, so a `MeshZoneAddress` a user created themselves is collected as soon as a Service of the same name exists in that namespace without the label. The create path already refuses to mutate a `MeshZoneAddress` it does not own; the delete path applied no such rule.

## Implementation information

`deleteIfExists` now reads the `MeshZoneAddress` through the cache-backed client, returns early on `NotFound`, and deletes only when an owner reference points at the Service being reconciled. The ownership test is shared with the `CreateOrUpdate` path so both agree on what the controller owns.

Deciding from cached state opens a window: a `MeshZoneAddress` written by `CreateOrUpdate` but not yet observed by the informer reads as absent, and a delete decision taken inside that window would leave it behind until the next resync — a stale zone ingress address published over KDS for as long as it takes. The Service now `Owns` the `MeshZoneAddress`, so the write re-queues the Service and the following reconcile runs against a warm cache. `builder.MatchEveryOwner` is required because `SetOwnerReference` writes a plain owner reference and `Owns` filters on the controller reference by default.

A label predicate on `For(&kube_core.Service{})` was considered and rejected. It would not apply to the `EndpointSlice`, `Node` and `Namespace` watches that enqueue Service keys through their own mappers, and it would leave a resource uncollected when the control plane restarts between the label removal and the reconcile.

## Supporting documentation

The golden cases in `pkg/plugins/runtime/k8s/controllers/testdata/meshzoneaddress` pin the observable behavior, including deletion when the label is removed; case 12 now carries the owner reference the controller actually writes. A table test counts `Delete` calls through fake-client interceptors across four states — absent, owned by this Service, owned by another Service, and user-managed with no owner reference.
