### PR TITLE
fix(gatewayapi): reject headless service route parents

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -231,6 +231,20 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
+			if parent.Spec.ClusterIP == kube_core.ClusterIPNone {
+				parentConditions = append(parentConditions,
+					kube_meta.Condition{
+						Type:    string(gatewayapi.RouteConditionAccepted),
+						Status:  kube_meta.ConditionFalse,
+						Reason:  string(gatewayapi_v1.RouteReasonNoMatchingParent),
+						Message: fmt.Sprintf("Service %q has no MeshService to attach to", kube_types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}.String()),
+					},
+				)
+
+				conditions[ref] = prepareConditions(append(parentConditions, rulesConditions...))
+				continue
+			}
+
 			routeSubName := fmt.Sprintf(
 				"%s-%s-%s.%s",
 				route.Name,

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -528,7 +528,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(accepted.Message).To(ContainSubstring("has no MeshService to attach to"))
 	})
 
-	It("requeues a parent-only route when a headless Service becomes a ClusterIP Service", func() {
+	It("requeues a parent-only route when a headless Service is replaced by a ClusterIP Service", func() {
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
 			Spec: kube_core.ServiceSpec{
@@ -549,12 +549,13 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(BeEmpty())
 
-		var updatedSvc kube_core.Service
-		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(svc), &updatedSvc)).To(Succeed())
-		updatedSvc.Spec.ClusterIP = "10.0.0.9"
-		Expect(client.Update(context.Background(), &updatedSvc)).To(Succeed())
+		recreatedSvc := svc.DeepCopy()
+		recreatedSvc.Spec.ClusterIP = "10.0.0.9"
+		Expect(client.Delete(context.Background(), svc)).To(Succeed())
+		recreatedSvc.ResourceVersion = ""
+		Expect(client.Create(context.Background(), recreatedSvc)).To(Succeed())
 
-		requests := routesForService(logr.Discard(), client)(context.Background(), &updatedSvc)
+		requests := routesForService(logr.Discard(), client)(context.Background(), recreatedSvc)
 		Expect(requests).To(ConsistOf(req))
 
 		_, err = reconciler.Reconcile(context.Background(), req)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -292,6 +292,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
 			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
 				Ports: []kube_core.ServicePort{
 					{Name: "http", Port: 80},
 					{Name: "https", Port: 443},
@@ -329,6 +330,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
 			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
 				Ports: []kube_core.ServicePort{
 					{Name: "http", Port: 80},
 					{Name: "https", Port: 443},
@@ -372,7 +374,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
 			Spec: kube_core.ServiceSpec{
-				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
 			},
 		}
 		route := newRoute(withSectionName(serviceParentRef(), "grpc"))
@@ -402,7 +405,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
 			Spec: kube_core.ServiceSpec{
-				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
 			},
 		}
 		route := newRoute(withSectionName(serviceParentRef(), "http"))
@@ -446,7 +450,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		svc := &kube_core.Service{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
 			Spec: kube_core.ServiceSpec{
-				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
 			},
 		}
 		route := newRoute(withSectionName(serviceParentRef(), "grpc"))
@@ -482,6 +487,85 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(spec).ToNot(BeNil())
 		Expect(*spec.To).To(HaveLen(1))
 		Expect(*(*spec.To)[0].TargetRef.SectionName).To(Equal("grpc"))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+
+	It("reports Accepted=False and generates no MeshHTTPRoute for a headless Service parentRef", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: kube_core.ClusterIPNone,
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(BeEmpty())
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi_v1.RouteReasonNoMatchingParent)))
+		Expect(accepted.Message).To(ContainSubstring("has no MeshService to attach to"))
+	})
+
+	It("requeues a parent-only route when a headless Service becomes a ClusterIP Service", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: kube_core.ClusterIPNone,
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		req := kube_ctrl.Request{NamespacedName: kube_client.ObjectKeyFromObject(route)}
+		_, err := reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(BeEmpty())
+
+		var updatedSvc kube_core.Service
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(svc), &updatedSvc)).To(Succeed())
+		updatedSvc.Spec.ClusterIP = "10.0.0.9"
+		Expect(client.Update(context.Background(), &updatedSvc)).To(Succeed())
+
+		requests := routesForService(logr.Discard(), client)(context.Background(), &updatedSvc)
+		Expect(requests).To(ConsistOf(req))
+
+		_, err = reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		spec := routes.Items[0].Spec
+		Expect(spec).ToNot(BeNil())
+		Expect(*spec.To).To(HaveLen(1))
+		Expect(*(*spec.To)[0].TargetRef.SectionName).To(Equal("http"))
 
 		var updatedRoute gatewayapi.HTTPRoute
 		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())


### PR DESCRIPTION
## Motivation

HTTPRoute parented to a headless Service silently fails (no matching MeshService exists), but reports Accepted true. The misconfiguration stays hidden from users.

## Implementation information

- Reject parentRefs to headless Services in validation
- Such routes report Accepted false with message explaining no MeshService exists for the parent
- No MeshHTTPRoute created for rejected parentRefs
- Converting headless Service to ClusterIP makes the route accepted without edits
- Routes to hand-made MeshServices continue working

Closes https://github.com/kumahq/kuma/issues/18073

_Generated by Sybra harness_