### PR TITLE
chore(deps): bump envoy from 1.38.2 to 1.38.3

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -8,7 +8,7 @@ GIT_COMMIT = $(word 3, $(BUILD_INFO))
 BUILD_DATE = $(word 4, $(BUILD_INFO))
 CI_TOOLS_VERSION = $(word 5, $(BUILD_INFO))
 # renovate: datasource=github-tags depName=envoy packageName=kumahq/envoy-builds versioning=semver
-ENVOY_VERSION ?= 1.38.2
+ENVOY_VERSION ?= 1.38.3
 KUMA_CHARTS_URL ?= https://kumahq.github.io/charts
 CHART_REPO_NAME ?= kuma
 PROJECT_NAME ?= kuma


### PR DESCRIPTION
## Motivation

`release-2.14` tracks the Envoy 1.38.x line and is pinned to 1.38.2, while 1.38.3 is the newest patch published in `kumahq/envoy-builds`. Staying on the latest patch of the line keeps the data plane on the current upstream fixes without changing the minor version.

## Implementation information

Bump `ENVOY_VERSION` in `mk/dev.mk` from 1.38.2 to 1.38.3. No other change; this is the single pin consumed by builds, tests and the `kuma-dp` version string.

## Supporting documentation

https://github.com/kumahq/envoy-builds/releases/tag/v1.38.3

> Changelog: skip