### PR TITLE
test(multizone): outwait drain on dynamic-tag spec

### DIFF
--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -100,14 +100,14 @@ func MeshTrafficPermission() {
 		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
 	})
 
-	trafficAllowed := func(url string) {
+	trafficAllowed := func(url string, intervals ...any) {
 		Eventually(func(g Gomega) {
 			_, err := client.CollectEchoResponse(
 				multizone.KubeZone1, "demo-client", url,
 				client.FromKubernetesPod(namespace, "demo-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-		}).Should(Succeed())
+		}, intervals...).Should(Succeed())
 	}
 
 	trafficBlocked := func(url string) {
@@ -231,7 +231,13 @@ spec:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		trafficAllowed("test-server.mesh")
+		// MeshTrafficPermission authorizes on the peer certificate, and the
+		// connection Envoy pooled during trafficBlocked still presents the
+		// pre-label SANs. Requests keep failing until that connection is recycled,
+		// which waits on the destination draining the filter chain this policy
+		// replaced. That drain takes the sidecar drain time, 30s, which is exactly
+		// the default Eventually window.
+		trafficAllowed("test-server.mesh", "2m")
 	})
 
 	It("should allow the traffic to the external service through the egress", func() {

--- a/test/e2e_env/multizone/trafficpermission/trafficpermission.go
+++ b/test/e2e_env/multizone/trafficpermission/trafficpermission.go
@@ -65,14 +65,14 @@ func TrafficPermission() {
 		Expect(multizone.Global.DeleteMesh(meshName)).To(Succeed())
 	})
 
-	trafficAllowed := func() {
+	trafficAllowed := func(intervals ...any) {
 		Eventually(func(g Gomega) {
 			_, err := client.CollectEchoResponse(
 				multizone.KubeZone1, "demo-client", "test-server.mesh",
 				client.FromKubernetesPod(namespace, "demo-client"),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
-		}).Should(Succeed())
+		}, intervals...).Should(Succeed())
 	}
 
 	trafficBlocked := func() {
@@ -179,6 +179,12 @@ destinations:
 		Expect(err).ToNot(HaveOccurred())
 
 		// then
-		trafficAllowed()
+		// TrafficPermission authorizes on the peer certificate, and the connection
+		// Envoy pooled during trafficBlocked still presents the pre-label SANs.
+		// Requests keep failing until that connection is recycled, which waits on
+		// the destination draining the filter chain this policy replaced. That
+		// drain takes the sidecar drain time, 30s, which is exactly the default
+		// Eventually window.
+		trafficAllowed("2m")
 	})
 }


### PR DESCRIPTION
> Changelog: skip

## Motivation

`MeshTrafficPermission should allow the traffic with tags added dynamically on Kubernetes` flaked on `release-2.13` ([run 32485717943](https://github.com/kumahq/kuma/actions/runs/32485717943)), timing out after 30.001s with all 45 curl attempts returning 403.

The config had fully converged 28 seconds before the test gave up: the destination's inbound listener carried the RBAC principal `kuma://newtag/client` at 13:50:08.577, and the client's identity certificate was reissued with a matching `URI:kuma://newtag/client` SAN at 13:50:09.239.

MeshTrafficPermission authorizes on the TLS peer certificate, which is bound at handshake time. The connection Envoy pooled during the preceding `trafficBlocked` step still presented the pre-label SANs, and a tag change only pushes a new SDS secret — no CDS or LDS change reaches the client, so the pool keeps reusing it. Requests every ~0.7s keep it from idling out. It is recycled when the destination finishes draining the filter chain the policy replaced, which takes kuma-dp's drain time of 30s — exactly the default `Eventually` window. The destination saw 7 connections carry 59 requests over the whole 21-minute suite.

## Implementation information

Let `trafficAllowed` forward optional intervals to `Eventually`, and give the dynamic-tag spec a 2m window. Every other spec keeps the 30s default. The same fix is applied to the legacy `TrafficPermission` twin, which has the identical dynamic-label pattern. Both specs were removed on `master` by #17495 when `MeshSubset` was dropped from `from[].targetRef`, so there is nothing to backport.

## Supporting documentation

Widening the window does not paper over a product bug so much as make the test wait for behaviour that is real: relabelling a pod to gain access does not take effect until existing connections churn. That gap is worth tracking separately.