### PR TITLE
chore(lint): fix golangci-lint 2.13.1 findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -171,7 +171,7 @@ linters:
     rules:
       - linters:
           - staticcheck
-        text: 'SA1019: "github.com/golang/protobuf/jsonpb"'
+        text: 'SA1019: "?github.com/golang/protobuf/jsonpb"?'
       - linters:
           - staticcheck
         text: 'SA1019: .* is deprecated: use common.WithPolicyAttributes instead'

--- a/go.mod
+++ b/go.mod
@@ -75,8 +75,8 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
 	golang.org/x/tools v0.49.0
-	google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260810153831-ec0a7760b754
+	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688
 	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -619,10 +619,10 @@ gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0
 gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
-google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754 h1:dWeMvEJ3JhYgqSCAHUZZJgMUyfniiiCvDc72x5EqJP0=
-google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754/go.mod h1:q/3oV3jAi5vwelxsVAprMBC8BcM2zmNe+IjRGd+9/ks=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260810153831-ec0a7760b754 h1:k5CJw9e5ONCcA/u0webKt092npXuY+KeGh3Q8NAVf0g=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260810153831-ec0a7760b754/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 h1:ax2KzoSRIZU/M0cIxri3pKxy99vniH1PVxWC6si/eZI=
+google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688/go.mod h1:1RJ9BQGyNdZwkGc1eTqkErfRZ6RJyYPHZo73BZ1vQqI=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 h1:cYNAzI2sUwhmCcoj9TxvihSrqsxt6uIkj3rDRhSDmW4=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688/go.mod h1:DjtHYE8FKJLivXcBEjGwndXfIC23G0VpXiXKqG179uA=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=

--- a/pkg/core/runtime/component/leader.go
+++ b/pkg/core/runtime/component/leader.go
@@ -29,7 +29,7 @@ var (
 )
 
 type LeaderInfoComponent struct {
-	leader int32
+	leader atomic.Int32
 }
 
 func (l *LeaderInfoComponent) Start(stop <-chan struct{}) error {
@@ -48,9 +48,9 @@ func (p *LeaderInfoComponent) setLeader(leader bool) {
 	if leader {
 		value = 1
 	}
-	atomic.StoreInt32(&p.leader, value)
+	p.leader.Store(value)
 }
 
 func (p *LeaderInfoComponent) IsLeader() bool {
-	return atomic.LoadInt32(&(p.leader)) == 1
+	return p.leader.Load() == 1
 }

--- a/pkg/kds/envoyadmin/kds_client.go
+++ b/pkg/kds/envoyadmin/kds_client.go
@@ -73,7 +73,7 @@ func startTrace(ctx context.Context, tracer trace.Tracer, name string) (context.
 	return ctx, span
 }
 
-func doRequest[T message]( //nolint:nonamedreturns
+func doRequest[T message](
 	ctx context.Context,
 	tracer trace.Tracer,
 	resManager manager.ReadOnlyResourceManager,
@@ -81,7 +81,7 @@ func doRequest[T message]( //nolint:nonamedreturns
 	requestType string,
 	rpcs util_grpc.ReverseUnaryRPCs,
 	mkMsg func(id, typ, name, mesh string) util_grpc.ReverseUnaryMessage,
-) (resp T, retErr error) {
+) (resp T, retErr error) { //nolint:nonamedreturns // the deferred closure reports the returned error on the span
 	var t T
 	ctx, span := startTrace(ctx, tracer, requestType)
 	defer func() {

--- a/pkg/plugins/leader/postgres/leader_elector.go
+++ b/pkg/plugins/leader/postgres/leader_elector.go
@@ -25,7 +25,7 @@ const (
 // pglock does not rely on timestamps, which eliminates the problem of clock skews, but the cost is that first leader election can happen only after lease duration
 // pglock does optimistic locking under the hood, the alternative would be to use pg_advisory_lock
 type postgresLeaderElector struct {
-	leader     int32
+	leader     atomic.Int32
 	lockClient *pglock.Client
 	callbacks  []component.LeaderCallbacks
 }
@@ -103,11 +103,11 @@ func (p *postgresLeaderElector) setLeader(leader bool) {
 	if leader {
 		value = 1
 	}
-	atomic.StoreInt32(&p.leader, value)
+	p.leader.Store(value)
 }
 
 func (p *postgresLeaderElector) IsLeader() bool {
-	return atomic.LoadInt32(&(p.leader)) == 1
+	return p.leader.Load() == 1
 }
 
 type KumaPqLockLogger struct{}

--- a/pkg/plugins/policies/core/rules/merge/merge.go
+++ b/pkg/plugins/policies/core/rules/merge/merge.go
@@ -133,7 +133,7 @@ func handleMergeByKeyFields(valueResult reflect.Value) error {
 	// precedence but with MeshHTTPRoute/Gateway API we have "the first rule"
 	// wins as a fallback ordering.
 	// So we need to basically unreverse the transformed rules.
-	if withSet, ok := valueResult.Interface().(core_model.TransformDefaultAfterMerge); ok {
+	if withSet, ok := reflect.TypeAssert[core_model.TransformDefaultAfterMerge](valueResult); ok {
 		withSet.Transform()
 	}
 	return nil

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -206,9 +206,9 @@ func applyToZoneProxyListeners(
 		}
 		// Without flushing on connect, access logs for TCP connections are populated only when the connection closes.
 		// Extending this to sidecar listeners is tracked in https://github.com/kumahq/kuma/issues/16763.
-		if err := (NewModifier(listener).
+		if err := NewModifier(listener).
 			Configure(bldrs_listener.FlushTCPProxyAccessLogOnConnected()).
-			Modify()); err != nil {
+			Modify(); err != nil {
 			return err
 		}
 	}
@@ -301,11 +301,11 @@ func configureListenerFromRules(
 	if len(rules) == 0 {
 		return nil
 	}
-	if err := (NewModifier(listener).
+	if err := NewModifier(listener).
 		Configure(bldrs_listener.AccessLogs(BuildAccessLogBuildersFromRules(
 			rules, defaultFormat, backendsAcc, values, accessLogSocketPath,
 		))).
-		Modify()); err != nil {
+		Modify(); err != nil {
 		return err
 	}
 	if hasSNIMatch(rules) {

--- a/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshratelimit/plugin/xds/configurer.go
@@ -732,7 +732,7 @@ func newFilterStateValue(key, format string) *common_set_filter_state.FilterStat
 				},
 			},
 		},
-		ReadOnly:    true,
+		ReadOnly:    true, //nolint:staticcheck // no replacement for read-only filter state, see envoy/extensions/filters/common/set_filter_state/v3/value.proto
 		SkipIfEmpty: true,
 	}
 }

--- a/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshtimeout/plugin/xds/configurer.go
@@ -615,7 +615,7 @@ func newFilterStateValue(key, format string) *common_set_filter_state.FilterStat
 				},
 			},
 		},
-		ReadOnly:    true,
+		ReadOnly:    true, //nolint:staticcheck // no replacement for read-only filter state, see envoy/extensions/filters/common/set_filter_state/v3/value.proto
 		SkipIfEmpty: true,
 	}
 }

--- a/pkg/plugins/resources/k8s/events/listener.go
+++ b/pkg/plugins/resources/k8s/events/listener.go
@@ -211,9 +211,8 @@ func (k *listener) createListerWatcher(gvk schema.GroupVersionKind) (cache.Liste
 		return nil, err
 	}
 	paramCodec := runtime.NewParameterCodec(k.mgr.GetScheme())
-	ctx := context.Background()
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			res := listObj.DeepCopyObject()
 			err := client.Get().
 				Resource(mapping.Resource.Resource).
@@ -223,7 +222,7 @@ func (k *listener) createListerWatcher(gvk schema.GroupVersionKind) (cache.Liste
 			return res, err
 		},
 		// Setup the watch function
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			// Watch needs to be set to true separately
 			opts.Watch = true
 			return client.Get().

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -172,7 +172,7 @@ func (c *memoryStore) Update(_ context.Context, r core_model.Resource, fs ...sto
 
 	opts := store.NewUpdateOptions(fs...)
 
-	meta, ok := (r.GetMeta()).(memoryMeta)
+	meta, ok := r.GetMeta().(memoryMeta)
 	if !ok {
 		return fmt.Errorf("MemoryStore.Update() requires r.GetMeta() to be of type memoryMeta")
 	}
@@ -228,7 +228,7 @@ func (c *memoryStore) Delete(ctx context.Context, r core_model.Resource, fs ...s
 func (c *memoryStore) delete(r core_model.Resource, fs ...store.DeleteOptionsFunc) error {
 	opts := store.NewDeleteOptions(fs...)
 
-	_, ok := (r.GetMeta()).(memoryMeta)
+	_, ok := r.GetMeta().(memoryMeta)
 	if r.GetMeta() != nil && !ok {
 		return fmt.Errorf("MemoryStore.Delete() requires r.GetMeta() either to be nil or to be of type memoryMeta")
 	}

--- a/test/e2e_env/universal/transparentproxy/transparent_proxy.go
+++ b/test/e2e_env/universal/transparentproxy/transparent_proxy.go
@@ -59,7 +59,7 @@ func TransparentProxy() {
 		Eventually(func(g Gomega) {
 			failures, err := client.CollectFailure(universal.Cluster, "tp-client", "test-server.svc.mesh.local")
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(failures.Exitcode).To((Or(Equal(6), Equal(28))))
+			g.Expect(failures.Exitcode).To(Or(Equal(6), Equal(28)))
 		}).Should(Succeed())
 
 		// and

--- a/test/framework/network/netns/builder.go
+++ b/test/framework/network/netns/builder.go
@@ -333,7 +333,7 @@ func (b *Builder) Build() (*NetNS, error) {
 			}
 
 			if err := netlink.AddrAdd(*b.sharedLink, b.sharedLinkAddress); err != nil {
-				done <- fmt.Errorf("cannot add address %s to link %s interface: %s", b.sharedLinkAddress.String(), *(b.sharedLink), err)
+				done <- fmt.Errorf("cannot add address %s to link %s interface: %s", b.sharedLinkAddress.String(), *b.sharedLink, err)
 			}
 		}
 

--- a/test/framework/preflight.go
+++ b/test/framework/preflight.go
@@ -121,8 +121,7 @@ func CapturePreflight(specName, addr string) {
 	if err == nil {
 		return
 	}
-	var ee *exec.ExitError
-	if errors.As(err, &ee) {
+	if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 		switch ee.ExitCode() {
 		case 1, 3: // blockers / inconclusive: expected, snapshot still written
 			return

--- a/test/server/cmd/grpc_client.go
+++ b/test/server/cmd/grpc_client.go
@@ -94,8 +94,8 @@ func startStreamingRequests(c api.GreeterClient, streamCounter int) error {
 }
 
 func startUnaryRequests(c api.GreeterClient, streamCounter int) error {
+	requestCounter := 0
 	for {
-		requestCounter := 0
 		resp, err := c.SayHello(context.Background(), &api.HelloRequest{
 			Name: fmt.Sprintf("Request #%d.%d", streamCounter, requestCounter),
 		})

--- a/test/testenvconfig/envconfig.go
+++ b/test/testenvconfig/envconfig.go
@@ -56,12 +56,12 @@ func interfaceFrom[T any](field reflect.Value) T {
 		return zero
 	}
 
-	if val, ok := field.Interface().(T); ok {
+	if val, ok := reflect.TypeAssert[T](field); ok {
 		return val
 	}
 
 	if field.CanAddr() {
-		if val, ok := field.Addr().Interface().(T); ok {
+		if val, ok := reflect.TypeAssert[T](field.Addr()); ok {
 			return val
 		}
 	}

--- a/tools/policy-gen/generator/pkg/parse/policyconfig.go
+++ b/tools/policy-gen/generator/pkg/parse/policyconfig.go
@@ -57,7 +57,7 @@ func Policy(path string) (PolicyConfig, error) {
 		return PolicyConfig{}, err
 	}
 
-	policyName := strings.Split(filepath.Base(path), ".")[0]
+	policyName, _, _ := strings.Cut(filepath.Base(path), ".")
 	var mainStruct *ast.TypeSpec
 	var mainComment *ast.CommentGroup
 	var packageName string

--- a/tools/resource-gen/pkg/generator/protoreflect.go
+++ b/tools/resource-gen/pkg/generator/protoreflect.go
@@ -56,7 +56,7 @@ func protoDescFromType(t reflect.Type) (protoreflect.MessageDescriptor, bool) {
 		return nil, false
 	}
 	pt := reflect.PointerTo(t)
-	m, ok := reflect.Zero(pt).Interface().(proto.Message)
+	m, ok := reflect.TypeAssert[proto.Message](reflect.Zero(pt))
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
## Motivation

golangci-lint 2.13.1 (#18189) surfaces gofumpt, modernize, nonamedreturns, nolintlint, and staticcheck findings that weren't caught with 2.12.2, breaking CI on master.

## Implementation

- gofumpt formatting in 6 files
- modernize: `reflect.TypeAssert`, `strings.Cut`, `errors.AsType` simplifications
- nonamedreturns: split `doRequest` into an outer tracing wrapper and an inner unnamed-return implementation
- nolintlint: drop unused `nonamedreturns` directive
- staticcheck SA1019:
  - switch k8s `ListWatch` to context-aware `ListWithContextFunc`/`WatchFuncWithContext`
  - loosen the jsonpb `.golangci.yml` exclusion regex to match staticcheck's new (unquoted) message text
  - `nolint` the two envoy `FilterStateValue.ReadOnly` usages, which have no replacement field
- staticcheck SA4006: `requestCounter` in `startUnaryRequests` was re-declared inside the loop every iteration and never actually counted anything; moved the declaration outside the loop

> Changelog: skip