### PR TITLE
chore(lint): bump golangci-lint to 2.13.1

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -159,7 +159,7 @@ jobs:
           GOGC: "80"
         with:
           args: --fix=false --verbose
-          version: v2.11.3 # TODO: automate this version update via Renovate
+          version: v2.13.1 # TODO: automate this version update via Renovate
       # Lint and "make check" are redundant on a tag: release_sha_gate already
       # requires a green branch push run for this exact tree/SHA. We
       # intentionally keep metadata and SBOM/SCA on tag refs so release tags

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,9 @@ linters:
         - G602 # slice index out of range
         - G703 # path traversal via taint analysis
         - G704 # SSRF via taint analysis
+    govet:
+      disable:
+        - inline # only reports that a call could not be inlined, which is not a defect
     importas:
       alias:
         - pkg: github.com/kumahq/kuma/pkg/core/resources/apis/mesh
@@ -157,13 +160,28 @@ linters:
     rules:
       - linters:
           - staticcheck
-        text: 'SA1019: "github.com/golang/protobuf/jsonpb"'
+        text: 'SA1019: "?github.com/golang/protobuf/jsonpb"?'
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead\.'
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*\.Grpc is deprecated: set parameters through Http section' # Kuma still supports the deprecated Grpc timeout field for backwards compatibility.
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*\.(SafeRegexMatch|PrefixMatch) is deprecated: Marked as deprecated in envoy/config/route/v3/route_components\.proto' # TODO migrate to StringMatcher, deferred on a release branch.
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*\.EventLogPath is deprecated: Marked as deprecated in envoy/config/core/v3/health_check\.proto' # TODO no drop-in replacement, deferred on a release branch.
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*\.SplitSpansForRequest is deprecated: Marked as deprecated in envoy/config/trace/v3/zipkin\.proto' # TODO no drop-in replacement, deferred on a release branch.
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*\.Requeue is deprecated: Use `RequeueAfter` instead' # Switching to RequeueAfter needs an explicit duration, which would change behaviour.
       - linters:
           - staticcheck
         text: 'SA1019: .*CommonConfig is deprecated: Marked as deprecated in envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto'
-      - linters:
-          - staticcheck
-        text: 'SA1019: cfg.Runtime.Kubernetes.Injector.SidecarContainer.AdminPort is deprecated: Use KUMA_BOOTSTRAP_SERVER_PARAMS_ADMIN_PORT instead.'
       - linters:
           - staticcheck
         text: 'SA1019: .* for new policies use pkg/plugins/policies/xds/cluster.go'

--- a/mise.toml
+++ b/mise.toml
@@ -34,5 +34,5 @@ yq = "4.47.1"
 #     .github/workflows/transparentproxy-tests.yaml
 #     .github/workflows/update-insecure-dependencies.yaml
 buf = "1.57.2"
-golangci-lint = "2.11.3"
+golangci-lint = "2.13.1"
 skaffold = "2.16.1"

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -35,7 +35,7 @@ KUBEBUILDER_ASSETS_VERSION=1.32
 GO:=$(shell $(MISE) which go)
 export GO_VERSION:=$(shell $(GO) mod edit -json | jq -r .Go)
 # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver-coerced
-export GOLANGCI_LINT_VERSION=v2.11.3
+export GOLANGCI_LINT_VERSION=v2.13.1
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -96,7 +96,7 @@ func (l *Loader) LoadReader(r io.Reader) error {
 }
 
 func (l *Loader) LoadBytes(content []byte) error {
-	if reflect.ValueOf(l.cfg).Kind() != reflect.Ptr {
+	if reflect.ValueOf(l.cfg).Kind() != reflect.Pointer {
 		return errors.New("configuration must be a pointer; ensure the Config instance is passed by reference")
 	}
 

--- a/pkg/core/runtime/component/leader.go
+++ b/pkg/core/runtime/component/leader.go
@@ -52,5 +52,5 @@ func (p *LeaderInfoComponent) setLeader(leader bool) {
 }
 
 func (p *LeaderInfoComponent) IsLeader() bool {
-	return atomic.LoadInt32(&(p.leader)) == 1
+	return atomic.LoadInt32(&p.leader) == 1
 }

--- a/pkg/kds/envoyadmin/kds_client.go
+++ b/pkg/kds/envoyadmin/kds_client.go
@@ -72,7 +72,7 @@ func startTrace(ctx context.Context, tracer trace.Tracer, name string) (context.
 	return ctx, span
 }
 
-func doRequest[T message]( //nolint:nonamedreturns
+func doRequest[T message](
 	ctx context.Context,
 	tracer trace.Tracer,
 	resManager manager.ReadOnlyResourceManager,
@@ -80,7 +80,7 @@ func doRequest[T message]( //nolint:nonamedreturns
 	requestType string,
 	rpcs util_grpc.ReverseUnaryRPCs,
 	mkMsg func(id, typ, name, mesh string) util_grpc.ReverseUnaryMessage,
-) (resp T, retErr error) {
+) (resp T, retErr error) { //nolint:nonamedreturns // the deferred closure reports the returned error on the span
 	var t T
 	ctx, span := startTrace(ctx, tracer, requestType)
 	defer func() {

--- a/pkg/plugins/leader/postgres/leader_elector.go
+++ b/pkg/plugins/leader/postgres/leader_elector.go
@@ -106,7 +106,7 @@ func (p *postgresLeaderElector) setLeader(leader bool) {
 }
 
 func (p *postgresLeaderElector) IsLeader() bool {
-	return atomic.LoadInt32(&(p.leader)) == 1
+	return atomic.LoadInt32(&p.leader) == 1
 }
 
 type KumaPqLockLogger struct{}

--- a/pkg/plugins/resources/k8s/events/listener.go
+++ b/pkg/plugins/resources/k8s/events/listener.go
@@ -211,9 +211,8 @@ func (k *listener) createListerWatcher(gvk schema.GroupVersionKind) (cache.Liste
 		return nil, err
 	}
 	paramCodec := runtime.NewParameterCodec(k.mgr.GetScheme())
-	ctx := context.Background()
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			res := listObj.DeepCopyObject()
 			err := client.Get().
 				Resource(mapping.Resource.Resource).
@@ -223,7 +222,7 @@ func (k *listener) createListerWatcher(gvk schema.GroupVersionKind) (cache.Liste
 			return res, err
 		},
 		// Setup the watch function
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			// Watch needs to be set to true separately
 			opts.Watch = true
 			return client.Get().

--- a/pkg/plugins/resources/memory/store.go
+++ b/pkg/plugins/resources/memory/store.go
@@ -172,7 +172,7 @@ func (c *memoryStore) Update(_ context.Context, r core_model.Resource, fs ...sto
 
 	opts := store.NewUpdateOptions(fs...)
 
-	meta, ok := (r.GetMeta()).(memoryMeta)
+	meta, ok := r.GetMeta().(memoryMeta)
 	if !ok {
 		return fmt.Errorf("MemoryStore.Update() requires r.GetMeta() to be of type memoryMeta")
 	}
@@ -228,7 +228,7 @@ func (c *memoryStore) Delete(ctx context.Context, r core_model.Resource, fs ...s
 func (c *memoryStore) delete(r core_model.Resource, fs ...store.DeleteOptionsFunc) error {
 	opts := store.NewDeleteOptions(fs...)
 
-	_, ok := (r.GetMeta()).(memoryMeta)
+	_, ok := r.GetMeta().(memoryMeta)
 	if r.GetMeta() != nil && !ok {
 		return fmt.Errorf("MemoryStore.Delete() requires r.GetMeta() either to be nil or to be of type memoryMeta")
 	}

--- a/test/e2e_env/universal/transparentproxy/transparent_proxy.go
+++ b/test/e2e_env/universal/transparentproxy/transparent_proxy.go
@@ -54,7 +54,7 @@ func TransparentProxy() {
 		Eventually(func(g Gomega) {
 			failures, err := client.CollectFailure(universal.Cluster, "tp-client", "test-server.mesh")
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(failures.Exitcode).To((Or(Equal(6), Equal(28))))
+			g.Expect(failures.Exitcode).To(Or(Equal(6), Equal(28)))
 		}).Should(Succeed())
 
 		// and

--- a/test/framework/network/netns/builder.go
+++ b/test/framework/network/netns/builder.go
@@ -333,7 +333,7 @@ func (b *Builder) Build() (*NetNS, error) {
 			}
 
 			if err := netlink.AddrAdd(*b.sharedLink, b.sharedLinkAddress); err != nil {
-				done <- fmt.Errorf("cannot add address %s to link %s interface: %s", b.sharedLinkAddress.String(), *(b.sharedLink), err)
+				done <- fmt.Errorf("cannot add address %s to link %s interface: %s", b.sharedLinkAddress.String(), *b.sharedLink, err)
 			}
 		}
 

--- a/test/server/cmd/grpc_client.go
+++ b/test/server/cmd/grpc_client.go
@@ -94,8 +94,8 @@ func startStreamingRequests(c api.GreeterClient, streamCounter int) error {
 }
 
 func startUnaryRequests(c api.GreeterClient, streamCounter int) error {
+	requestCounter := 0
 	for {
-		requestCounter := 0
 		resp, err := c.SayHello(context.Background(), &api.HelloRequest{
 			Name: fmt.Sprintf("Request #%d.%d", streamCounter, requestCounter),
 		})

--- a/test/testenvconfig/envconfig.go
+++ b/test/testenvconfig/envconfig.go
@@ -107,7 +107,7 @@ var (
 func GatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 	s := reflect.ValueOf(spec)
 
-	if s.Kind() != reflect.Ptr {
+	if s.Kind() != reflect.Pointer {
 		return nil, ErrInvalidSpecification
 	}
 	s = s.Elem()
@@ -125,7 +125,7 @@ func GatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 			continue
 		}
 
-		for f.Kind() == reflect.Ptr {
+		for f.Kind() == reflect.Pointer {
 			if f.IsNil() {
 				if f.Type().Elem().Kind() != reflect.Struct {
 					// nil pointer to a non-struct: leave it alone


### PR DESCRIPTION
## Motivation

Renovate is bumping Go to 1.27 on the release branches (#18168 for this branch), but golangci-lint 2.11.3 is built with go1.26 and hard-refuses to run against a go1.27 target:

```
Error: can't load config: the Go language version (go1.26) used to build golangci-lint
is lower than the targeted Go version (1.27.0)
```

golangci-lint 2.13.1 is built with go1.27.0, so this bump is the prerequisite that unblocks the Go 1.27 update.

## Implementation

- Bump the version in **three** places: `mise.toml`, `GOLANGCI_LINT_VERSION` in `mk/dev.mk`, and the workflow. On this branch `mk/dev.mk` hardcodes the version rather than reading `mise.toml` (unlike release-2.7/2.9/2.11), and `make check` rewrites the workflow from it via `fmt/ci` — so all three must move together, otherwise `make check` reverts the workflow and fails on the diff.
- staticcheck now renders SA1019 as `(pkg.Type).Field` instead of `varname.Field`. That silently broke existing exclusions: the quoted `golang/protobuf` path (both quotes are now optional) and the variable-specific `AdminPort` rule, made receiver-agnostic.
- The same change makes staticcheck report deprecated struct *fields* it previously ignored. Excluded the envoy/kuma fields we deliberately are not migrating on a release branch: `Timeout_Conf.Grpc`, `SafeRegexMatch`, `PrefixMatch`, `EventLogPath`, `SplitSpansForRequest`, `Result.Requeue`.
- Disabled govet's new `inline` analyzer, which only reports that a call could not be inlined and never indicates a defect.
- Switched the k8s `ListWatch` to `ListWithContextFunc`/`WatchFuncWithContext`.
- Moved the `nonamedreturns` nolint onto the line that actually declares the named returns, and fixed its malformed `// nolint` spelling.
- `requestCounter` in `startUnaryRequests` was re-declared inside the loop every iteration and never counted anything; hoisted it out.

Verified with golangci-lint 2.13.1 under `GOOS=linux` and `--fix=false`, exactly as CI runs it: **0 issues**.

> Changelog: skip