### PR TITLE
fix(kds): don't fail sync on an existing resource

### DIFF
--- a/pkg/kds/store/sync.go
+++ b/pkg/kds/store/sync.go
@@ -281,6 +281,7 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse kds_c
 			}
 
 			// some Stores try to cast ResourceMeta to own Store type that's why we have to set meta to nil
+			upstreamMeta := r.GetMeta()
 			r.SetMeta(nil)
 
 			if err := s.resourceStore.Create(ctx, r, createOpts...); err != nil {
@@ -297,6 +298,17 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse kds_c
 					// replay the same resource on reconnect forever.
 					log.Info("upstream resource rejected by the store, sending NACK", "name", rk.Name, "mesh", rk.Mesh, "err", err)
 					nackError = std_errors.Join(util.ErrUserNack, nackError, err)
+				case store.IsAlreadyExists(err):
+					// The downstream copy existed but we did not see it when we listed:
+					// a Kubernetes informer that has not caught up with a create yet, or
+					// a copy the origin prefilter dropped because it lost its
+					// `kuma.io/origin` label. It is the same resource we are syncing, so
+					// take it over with an update. Failing here rolls back the whole
+					// response and cancels the connection, and the next connection lists
+					// the same stale copy and fails again, so the zone never converges.
+					log.Info("resource already exists in the downstream store, updating it instead", "name", rk.Name, "mesh", rk.Mesh)
+					r.SetMeta(upstreamMeta)
+					conflicted = append(conflicted, OnUpdate{r: r, opts: []store.UpdateOptionsFunc{store.UpdateWithLabels(upstreamMeta.GetLabels())}})
 				default:
 					return err
 				}
@@ -334,9 +346,10 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse kds_c
 	return s.retryConflictedUpdates(ctx, conflicted, opts, log), nackError
 }
 
-// retryConflictedUpdates reapplies updates that lost a write conflict, rebased on a
-// fresh copy: zone-local writers (VIP allocator, hostname generators) invalidate the
-// version read at List time. It runs after the transaction commits, so the waits
+// retryConflictedUpdates reapplies updates that lost a write conflict, and creates
+// that turned out to already exist downstream, rebased on a fresh copy: zone-local
+// writers (VIP allocator, hostname generators) invalidate the version read at List
+// time, and a cached store can hide a copy that the create then collides with. It runs after the transaction commits, so the waits
 // hold no connection or row locks, and the batch shares one wait per attempt. Sync
 // is no longer all-or-nothing, which is fine for a convergent reconciliation of a
 // single type, and the Kubernetes store has no transactions anyway. Exhausting the
@@ -349,9 +362,14 @@ func (s *syncResourceStore) retryConflictedUpdates(ctx context.Context, pending 
 	backoff := retry.WithMaxRetries(updateConflictRetries, retry.WithFullJitter(retry.NewConstant(updateConflictBackoff)))
 	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
 		for _, upd := range pending {
-			log.Info("resource was modified in another place while syncing, retrying with a fresh copy",
+			log.Info("retrying a resource with a fresh copy of the downstream one",
 				"name", upd.r.GetMeta().GetName(), "mesh", upd.r.GetMeta().GetMesh())
 			if err := s.refreshForUpdate(ctx, upd, opts); err != nil {
+				if store.IsNotFound(err) {
+					// A cached store (Kubernetes informer) can still be behind the write
+					// we collided with, so wait for it instead of failing the response.
+					return retry.RetryableError(err)
+				}
 				return err
 			}
 		}
@@ -377,7 +395,7 @@ func (s *syncResourceStore) retryConflictedUpdates(ctx context.Context, pending 
 		}
 		return nil
 	})
-	if store.IsConflict(err) {
+	if store.IsConflict(err) || store.IsNotFound(err) {
 		log.Info("gave up syncing a resource that keeps being modified in another place, forcing a resync",
 			"name", pending[0].r.GetMeta().GetName(), "mesh", pending[0].r.GetMeta().GetMesh())
 	}

--- a/pkg/kds/store/sync_test.go
+++ b/pkg/kds/store/sync_test.go
@@ -590,3 +590,131 @@ var _ = Describe("SyncResourceStoreDelta write conflicts on zone-owned status", 
 		Expect(actual.Status.VIPs).To(Equal([]meshservice_api.VIP{{IP: "10.0.0.2"}}))
 	})
 })
+
+// hidingStore hides one resource from reads while writes keep seeing it, the way a
+// Kubernetes informer that has not caught up hides a create from the syncer, and the
+// way the origin prefilter hides a downstream copy that lost its `kuma.io/origin`
+// label.
+type hidingStore struct {
+	store.ResourceStore
+	hidden     model.ResourceKey
+	hiddenGets int // Gets that still return NotFound, negative hides it forever
+	gets       int
+}
+
+func (h *hidingStore) List(ctx context.Context, list model.ResourceList, fs ...store.ListOptionsFunc) error {
+	if err := h.ResourceStore.List(ctx, list, fs...); err != nil {
+		return err
+	}
+	meshes, ok := list.(*mesh.MeshResourceList)
+	if !ok {
+		return nil
+	}
+	var kept []*mesh.MeshResource
+	for _, item := range meshes.Items {
+		if model.MetaToResourceKey(item.GetMeta()) != h.hidden {
+			kept = append(kept, item)
+		}
+	}
+	meshes.Items = kept
+	return nil
+}
+
+func (h *hidingStore) Get(ctx context.Context, r model.Resource, fs ...store.GetOptionsFunc) error {
+	opts := store.NewGetOptions(fs...)
+	h.gets++
+	if key := (model.ResourceKey{Mesh: opts.Mesh, Name: opts.Name}); key == h.hidden && h.hiddenGets != 0 {
+		if h.hiddenGets > 0 {
+			h.hiddenGets--
+		}
+		return store.ErrorResourceNotFound(r.Descriptor().Name, opts.Name, opts.Mesh)
+	}
+	return h.ResourceStore.Get(ctx, r, fs...)
+}
+
+var _ = Describe("SyncResourceStoreDelta creates that collide with a hidden resource", func() {
+	var resourceStore *hidingStore
+	var syncer kds_sync_store.ResourceSyncer
+	var key model.ResourceKey
+
+	syncUpstream := func(indexes ...int) (error, error) {
+		upstream := &mesh.MeshResourceList{}
+		for _, i := range indexes {
+			m := meshBuilder(i)
+			m.Spec.SkipCreatingInitialPolicies = []string{"policy-changed"}
+			m.Meta.(*model2.ResourceMeta).Labels = map[string]string{
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.GlobalResourceOrigin),
+			}
+			Expect(upstream.AddItem(m)).To(Succeed())
+		}
+		return syncer.Sync(context.Background(), kds_client.UpstreamResponse{
+			Type:             upstream.GetItemType(),
+			AddedResources:   upstream,
+			IsInitialRequest: true,
+		})
+	}
+
+	BeforeEach(func() {
+		resourceStore = &hidingStore{ResourceStore: memory.NewStore()}
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		syncer, err = kds_sync_store.NewResourceSyncer(core.Log, resourceStore, store.NoTransactions{}, metrics, context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		// the copy the syncer cannot see: it is in the store, so the create fails
+		res := meshBuilder(1)
+		key = model.MetaToResourceKey(res.GetMeta())
+		Expect(resourceStore.Create(context.Background(), res, store.CreateBy(key), store.CreateWithLabels(map[string]string{
+			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+		}))).To(Succeed())
+		resourceStore.hidden = key
+	})
+
+	It("should update the existing resource instead of failing the whole response", func() {
+		err, nackError := syncUpstream(1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := mesh.NewMeshResource()
+		Expect(resourceStore.ResourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
+		Expect(actual.Spec.SkipCreatingInitialPolicies).To(Equal([]string{"policy-changed"}))
+		// the upstream labels win, so the next sync sees it as global-origin again
+		Expect(actual.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ResourceOriginLabel, string(mesh_proto.GlobalResourceOrigin)))
+	})
+
+	It("should apply the rest of the batch", func() {
+		err, nackError := syncUpstream(1, 2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := &mesh.MeshResourceList{}
+		Expect(resourceStore.ResourceStore.List(context.Background(), actual)).To(Succeed())
+		Expect(actual.Items).To(HaveLen(2))
+		for _, item := range actual.Items {
+			Expect(item.Spec.SkipCreatingInitialPolicies).To(Equal([]string{"policy-changed"}))
+		}
+	})
+
+	It("should wait for a cached store to catch up with the resource it collided with", func() {
+		// the read that rebases the update is served by the same stale cache
+		resourceStore.hiddenGets = 1
+
+		err, nackError := syncUpstream(1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nackError).ToNot(HaveOccurred())
+
+		actual := mesh.NewMeshResource()
+		Expect(resourceStore.ResourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
+		Expect(actual.Spec.SkipCreatingInitialPolicies).To(Equal([]string{"policy-changed"}))
+	})
+
+	It("should force a resync when the store never shows the resource it collided with", func() {
+		resourceStore.hiddenGets = -1
+
+		err, nackError := syncUpstream(1)
+		Expect(store.IsNotFound(err)).To(BeTrue())
+		Expect(nackError).ToNot(HaveOccurred())
+		// the immediate attempt, then 2 backed off ones
+		Expect(resourceStore.gets).To(Equal(3))
+	})
+})


### PR DESCRIPTION
## Motivation

When the syncer creates a resource that already exists downstream, the `AlreadyExists` error propagates out of `Sync` and tears the stream down.
The next connection lists the same store, classifies the same resource as a create again, and fails again, so the loop is permanent and the zone stops receiving global config until someone deletes the object by hand.

A downstream copy can be absent from the list yet present in the store when the Kubernetes store reads through an informer cache (`mgr.GetClient()`), which can serve a list that predates a create

## Implementation information

- `AlreadyExists` on create no longer fails the response. The upstream resource is rebased on the existing downstream copy and applied as an update, through the same `retryConflictedUpdates` path updates already use, so the upstream spec and labels win and the resource is back in a syncable state on the next response.
- The `SkipConflictResource` NACK case is untouched and still takes precedence.
- The follow-up read that rebases the change can be served by the same stale cache, so `NotFound` there is now retried instead of failing immediately. A read that stays empty across the retries still returns the error and forces a resync, as before.
- Tests add a store that hides a resource from reads while writes keep seeing it, covering: take-over instead of failure, the rest of the batch still applying, waiting for a lagging cached store, and giving up when the store never shows the resource.

Note this means the syncer takes over a downstream object whose key matches an upstream one, overwriting its spec and labels. That is the intended outcome for global-origin resources on a zone, and the only way out of the loop without manual deletion.

## Supporting documentation

This is the create-side counterpart of #17738, which did the same for updates that lose a write conflict, including the retry that lets a cached store catch up.

xrel https://github.com/Kong/team-mesh/issues/752