### PR TITLE
fix(gatewayapi): give a generated producer route the producer role

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,13 +14,13 @@ A `MeshHTTPRoute` generated from a Gateway API `HTTPRoute` whose parent (a `Serv
 
 A generated route whose parent is in a different namespace (a consumer route) still lands in the Kuma system namespace and keeps its `system` role and precedence unchanged.
 
-Because the route now lives in the `HTTPRoute`'s namespace, its `kuma.io/namespace` label changes to match, it now syncs across zones like any other namespaced policy, and it applies to dataplanes in remote zones the same way a hand-written route in that namespace would.
+Because the route now lives in the `HTTPRoute`'s namespace, its `k8s.kuma.io/namespace` label changes to match, it now syncs across zones like any other namespaced policy, and it applies to dataplanes in remote zones the same way a hand-written route in that namespace would.
 
 **Action required**
 
 If a mesh has both a generated producer route and a hand-written `MeshHTTPRoute` targeting the same `Mesh` and `to` entry, check which one you expect to win: before this upgrade the hand-written route always won, after it the two tie and the outcome falls back to resource name. Remove or adjust one of them if you relied on the previous, implicit precedence.
 
-If any policy selects the generated route by its old `kuma.io/namespace: <kuma-system>` label (or your system namespace), update it to the `HTTPRoute`'s namespace instead. The control plane moves each existing generated route to its new namespace the next time its `HTTPRoute` is reconciled, so no manual migration of the `MeshHTTPRoute` object itself is needed.
+If any policy selects the generated route by its old `k8s.kuma.io/namespace: <kuma-system>` label (or your system namespace), update it to the `HTTPRoute`'s namespace instead. The control plane moves each existing generated route to its new namespace the next time its `HTTPRoute` is reconciled, so no manual migration of the `MeshHTTPRoute` object itself is needed.
 
 ### The `BUILTIN` gateway type and its statistics are removed from the API
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,20 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
+### Generated Gateway API producer routes now win the same ties as hand-written ones
+
+A `MeshHTTPRoute` generated from a Gateway API `HTTPRoute` whose parent (a `Service` or `MeshService`) lives in the `HTTPRoute`'s own namespace is now created in that namespace, instead of always landing in the Kuma system namespace. This is what the policy role model calls a producer route, and putting it in the right namespace gives it `kuma.io/policy-role=producer`, the same role a hand-written `MeshHTTPRoute` targeting the same `Mesh` and `to` entry gets. Before this change, every generated route landed in the system namespace and was ranked `system`, so it always lost to an equivalent hand-written producer route even when the two expressed the same intent.
+
+A generated route whose parent is in a different namespace (a consumer route) still lands in the Kuma system namespace and keeps its `system` role and precedence unchanged.
+
+Because the route now lives in the `HTTPRoute`'s namespace, its `kuma.io/namespace` label changes to match, it now syncs across zones like any other namespaced policy, and it applies to dataplanes in remote zones the same way a hand-written route in that namespace would.
+
+**Action required**
+
+If a mesh has both a generated producer route and a hand-written `MeshHTTPRoute` targeting the same `Mesh` and `to` entry, check which one you expect to win: before this upgrade the hand-written route always won, after it the two tie and the outcome falls back to resource name. Remove or adjust one of them if you relied on the previous, implicit precedence.
+
+If any policy selects the generated route by its old `kuma.io/namespace: <kuma-system>` label (or your system namespace), update it to the `HTTPRoute`'s namespace instead. The control plane moves each existing generated route to its new namespace the next time its `HTTPRoute` is reconciled, so no manual migration of the `MeshHTTPRoute` object itself is needed.
+
 ### The `BUILTIN` gateway type and its statistics are removed from the API
 
 The built-in gateway implementation was removed over the previous releases, and the Dataplane validator has been rejecting `networking.gateway.type: BUILTIN` since then. The remaining API surface is now gone too:

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -19,6 +19,13 @@ import (
 
 const ownerLabel = "gateways.kuma.io/gateway.networking.k8s.io-owner"
 
+// OwnedObject describes an object owned by a gateway-api resource,
+// including the namespace it should live in.
+type OwnedObject struct {
+	Namespace string
+	Spec      core_model.ResourceSpec
+}
+
 func hashNamespacedName(name kube_types.NamespacedName) string {
 	hash := fnv.New32()
 	hash.Write([]byte(name.Namespace))
@@ -44,8 +51,7 @@ func ReconcileLabelledObject(
 	owner kube_types.NamespacedName,
 	ownerMesh string,
 	ownedType k8s_registry.ResourceType,
-	ownedNamespace string,
-	owned map[string]core_model.ResourceSpec,
+	owned map[string]OwnedObject,
 ) error {
 	log := logger.WithValues("type", ownedType, "name", owner.Name, "namespace", owner.Namespace)
 	// First we list which existing objects are owned by this owner.
@@ -68,7 +74,8 @@ func ReconcileLabelledObject(
 	// Delete unneeded objects
 	existingObjs := map[string]k8s_model.KubernetesObject{}
 	for _, existing := range existingList.GetItems() {
-		if _, ok := owned[existing.GetName()]; !ok {
+		desired, ok := owned[existing.GetName()]
+		if !ok || existing.GetNamespace() != desired.Namespace {
 			err := client.Delete(ctx, existing)
 			switch {
 			case kube_apierrs.IsNotFound(err):
@@ -89,18 +96,18 @@ func ReconcileLabelledObject(
 		return fmt.Errorf("could not reconcile object, owner mesh must not be empty")
 	}
 
-	for ownedName, ownedSpec := range owned {
+	for ownedName, ownedObj := range owned {
 		// Update existing
 		if existing, ok := existingObjs[ownedName]; ok {
 			existingSpec, err := existing.GetSpec()
 			if err != nil {
 				return err
 			}
-			if core_model.Equal(existingSpec, ownedSpec) {
+			if core_model.Equal(existingSpec, ownedObj.Spec) {
 				log.V(1).Info("object is the same. Nothing to update")
 				continue
 			}
-			existing.SetSpec(ownedSpec)
+			existing.SetSpec(ownedObj.Spec)
 
 			if err := client.Update(ctx, existing); err != nil {
 				return errors.Wrapf(err, "could not update owned %T", ownedType)
@@ -111,24 +118,24 @@ func ReconcileLabelledObject(
 		}
 
 		// Or create new
-		owned, err := registry.NewObject(ownedType)
+		newObj, err := registry.NewObject(ownedType)
 		if err != nil {
 			return errors.Wrapf(err, "could not get new %T from registry", ownedType)
 		}
 
-		owned.SetObjectMeta(
+		newObj.SetObjectMeta(
 			&kube_meta.ObjectMeta{
 				Name:      ownedName,
-				Namespace: ownedNamespace,
+				Namespace: ownedObj.Namespace,
 				Labels: map[string]string{
 					ownerLabel: ownerLabelValue,
 				},
 			},
 		)
-		owned.SetMesh(ownerMesh)
-		owned.SetSpec(ownedSpec)
+		newObj.SetMesh(ownerMesh)
+		newObj.SetSpec(ownedObj.Spec)
 
-		if err := client.Create(ctx, owned); err != nil {
+		if err := client.Create(ctx, newObj); err != nil {
 			return errors.Wrapf(err, "could not create owned %T", ownedType)
 		}
 		logger.Info("object created")

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -134,7 +134,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 			// We don't know the mesh, but we don't need it to delete our
 			// object.
 			if err := common.ReconcileLabelledObject(
-				ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, core_model.NoMesh, &meshhttproute_api.MeshHTTPRoute{}, r.SystemNamespace, nil,
+				ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, core_model.NoMesh, &meshhttproute_api.MeshHTTPRoute{}, nil,
 			); err != nil {
 				return kube_ctrl.Result{}, errors.Wrap(err, "could not delete owned MeshHTTPRoute.kuma.io")
 			}
@@ -158,7 +158,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	}
 
 	if err := common.ReconcileLabelledObject(
-		ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &meshhttproute_api.MeshHTTPRoute{}, r.SystemNamespace, meshRouteSpecs,
+		ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &meshhttproute_api.MeshHTTPRoute{}, meshRouteSpecs,
 	); err != nil {
 		return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned MeshHTTPRoute.kuma.io")
 	}
@@ -178,8 +178,8 @@ type ParentConditions map[gatewayapi.ParentReference][]kube_meta.Condition
 func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	ctx context.Context,
 	route *gatewayapi.HTTPRoute,
-) (map[string]core_model.ResourceSpec, ParentConditions, error) {
-	routes := map[string]core_model.ResourceSpec{}
+) (map[string]common.OwnedObject, ParentConditions, error) {
+	routes := map[string]common.OwnedObject{}
 
 	// The conditions we accumulate for each ParentRef
 	conditions := ParentConditions{}
@@ -268,7 +268,12 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
-			storeMeshHTTPRoute(routes, routeSubName, meshRoute)
+			ownedNamespace := r.SystemNamespace
+			if route.Namespace == parent.GetNamespace() {
+				ownedNamespace = route.Namespace
+			}
+
+			storeMeshHTTPRoute(routes, routeSubName, ownedNamespace, meshRoute)
 		case attachment.MeshService:
 			namespace := route.Namespace
 			if ref.Namespace != nil {
@@ -320,7 +325,12 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
-			storeMeshHTTPRoute(routes, routeSubName, meshRoute)
+			ownedNamespace := r.SystemNamespace
+			if route.Namespace == parent.GetNamespace() {
+				ownedNamespace = route.Namespace
+			}
+
+			storeMeshHTTPRoute(routes, routeSubName, ownedNamespace, meshRoute)
 		}
 
 		conditions[ref] = prepareConditions(append(parentConditions, rulesConditions...))
@@ -329,22 +339,22 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	return routes, conditions, nil
 }
 
-func storeMeshHTTPRoute(routes map[string]core_model.ResourceSpec, name string, spec core_model.ResourceSpec) {
+func storeMeshHTTPRoute(routes map[string]common.OwnedObject, name string, namespace string, spec core_model.ResourceSpec) {
 	route, ok := spec.(*meshhttproute_api.MeshHTTPRoute)
 	if !ok {
-		routes[name] = spec
+		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec}
 		return
 	}
 
 	existing, ok := routes[name]
 	if !ok {
-		routes[name] = spec
+		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec}
 		return
 	}
 
-	existingRoute, ok := existing.(*meshhttproute_api.MeshHTTPRoute)
+	existingRoute, ok := existing.Spec.(*meshhttproute_api.MeshHTTPRoute)
 	if !ok {
-		routes[name] = spec
+		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec}
 		return
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -116,6 +116,54 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		Expect(condition.Status).To(Equal(kube_meta.ConditionTrue))
 	})
 
+	It("creates the generated route in the HTTPRoute namespace when the parent MeshService is in the same namespace", func() {
+		ms := &meshservice_k8s.MeshService{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "kuma-demo"},
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		route := newRoute(meshServiceParentRef("backend"))
+
+		client := newClientBuilder(ms, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Namespace).To(Equal(routeNamespace))
+	})
+
+	It("creates the generated route in the system namespace when the parent MeshService is in a different namespace", func() {
+		otherNamespace := &kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "other-ns"}}
+		ms := &meshservice_k8s.MeshService{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "other-ns"},
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		route := newRoute(meshServiceParentRef("backend"))
+		route.Spec.ParentRefs[0].Namespace = pointer.To(gatewayapi.Namespace("other-ns"))
+
+		client := newClientBuilder(otherNamespace, ms, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Namespace).To(Equal("kuma-system"))
+	})
+
 	It("applies a parentRef sectionName as the port name", func() {
 		ms := &meshservice_k8s.MeshService{
 			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "kuma-demo"},
@@ -324,6 +372,98 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
 		Expect(accepted).ToNot(BeNil())
 		Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+
+	It("creates the generated route in the HTTPRoute namespace when the parent Service is in the same namespace", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Namespace).To(Equal(routeNamespace))
+	})
+
+	It("creates the generated route in the system namespace when the parent Service is in a different namespace", func() {
+		otherNamespace := &kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "other-ns"}}
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "other-ns"},
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		ns := gatewayapi.Namespace("other-ns")
+		ref := serviceParentRef()
+		ref.Namespace = &ns
+		route := newRoute(withSectionName(ref, "http"))
+
+		client := newClientBuilder(otherNamespace, svc, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Namespace).To(Equal("kuma-system"))
+	})
+
+	It("moves a generated route that already exists in the system namespace into the HTTPRoute namespace", func() {
+		svc := &kube_core.Service{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
+
+		client := newClientBuilder(svc, route)
+		reconciler.Client = client
+
+		req := kube_ctrl.Request{NamespacedName: kube_client.ObjectKeyFromObject(route)}
+		_, err := reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Namespace).To(Equal(routeNamespace))
+
+		stale := routes.Items[0].DeepCopy()
+		stale.ObjectMeta = kube_meta.ObjectMeta{
+			Name:      stale.Name,
+			Namespace: "kuma-system",
+			Labels:    stale.Labels,
+		}
+		stale.ResourceVersion = ""
+		Expect(client.Delete(context.Background(), &routes.Items[0])).To(Succeed())
+		Expect(client.Create(context.Background(), stale)).To(Succeed())
+
+		_, err = reconciler.Reconcile(context.Background(), req)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Namespace).To(Equal(routeNamespace))
 	})
 
 	It("merges multiple section-specific parentRefs for the same Service", func() {


### PR DESCRIPTION
## Motivation

Routes generated from HTTPRoute were losing precedence to equivalent hand-written MeshHTTPRoute because they landed in the system namespace. This was a regression from before policy roles existed and contradicts the GAMMA role model design that was adopted.

## Implementation information

- Assign the producer role to routes generated from HTTPRoute
- Ensures generated producer routes have equal precedence with equivalent hand-written MeshHTTPRoute
- Consumer routes retain their current precedence
- HTTPRoute deletion removes the generated route
- Upgrade path preserves existing behavior where only generated routes exist

Closes https://github.com/kumahq/kuma/issues/17986

_Generated by Sybra harness_