### PR TITLE
fix(meshproxypatch): dedupe breaker thresholds

### DIFF
--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod.go
@@ -2,8 +2,10 @@ package v1alpha1
 
 import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/jsonpatch"
@@ -47,11 +49,65 @@ func (c *clusterModificator) patch(resources *core_xds.ResourceSet, clusterMod *
 				continue
 			}
 
-			util_proto.Merge(cluster.Resource, clusterMod)
+			mod := clusterMod
+			if target, ok := cluster.Resource.(*envoy_cluster.Cluster); ok && clusterMod.GetCircuitBreakers() != nil {
+				// copied because the modification is shared by every cluster it matches
+				mod = proto.Clone(clusterMod).(*envoy_cluster.Cluster)
+				mergeCircuitBreakers(target, mod.CircuitBreakers)
+			}
+
+			util_proto.Merge(cluster.Resource, mod)
 		}
 	}
 
 	return nil
+}
+
+// mergeCircuitBreakers merges the patched thresholds into the ones the cluster
+// already carries and takes them out of the patch, so that the merge that follows
+// doesn't append them a second time.
+//
+// Envoy reads a single threshold per routing priority and ignores every later
+// entry for that priority, while proto merge appends to repeated fields. Since
+// every generated cluster already carries a DEFAULT threshold, an appended patch
+// would end up second in the list and never take effect.
+func mergeCircuitBreakers(cluster *envoy_cluster.Cluster, patch *envoy_cluster.CircuitBreakers) {
+	if cluster.CircuitBreakers == nil {
+		cluster.CircuitBreakers = &envoy_cluster.CircuitBreakers{}
+	}
+	breakers := cluster.CircuitBreakers
+
+	breakers.Thresholds = mergeThresholds(breakers.Thresholds, patch.Thresholds)
+	breakers.PerHostThresholds = mergeThresholds(breakers.PerHostThresholds, patch.PerHostThresholds)
+	patch.Thresholds, patch.PerHostThresholds = nil, nil
+}
+
+// mergeThresholds merges every patched threshold into the entries it applies to.
+// A patch that names a priority updates the entry for that priority, and a patch
+// that leaves the priority out updates all of them, since limits written without
+// a priority are meant for the whole cluster. Priorities the cluster doesn't have
+// yet are appended.
+func mergeThresholds(
+	thresholds []*envoy_cluster.CircuitBreakers_Thresholds,
+	patches []*envoy_cluster.CircuitBreakers_Thresholds,
+) []*envoy_cluster.CircuitBreakers_Thresholds {
+	for _, patch := range patches {
+		applied := false
+
+		for _, threshold := range thresholds {
+			if patch.GetPriority() == envoy_core.RoutingPriority_DEFAULT ||
+				patch.GetPriority() == threshold.GetPriority() {
+				util_proto.Merge(threshold, patch)
+				applied = true
+			}
+		}
+
+		if !applied {
+			thresholds = append(thresholds, patch)
+		}
+	}
+
+	return thresholds
 }
 
 func (c *clusterModificator) remove(resources *core_xds.ResourceSet) {

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
@@ -351,5 +351,182 @@ var _ = Describe("Cluster modifications", func() {
                     sni: foo-service{mesh=default}
             `,
 		}),
+		Entry("should not duplicate circuit breaker thresholds for the same priority", testCase{
+			clusters: []testCaseCluster{{
+				yaml: `
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true`,
+			}},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                         - maxConnections: 8192`,
+			},
+			// A second DEFAULT-priority threshold would be ignored by Envoy, which
+			// only honours the first match, silently dropping maxConnections.
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true
+                      maxConnections: 8192`,
+		}),
+		Entry("should keep circuit breaker thresholds of distinct priorities", testCase{
+			clusters: []testCaseCluster{{
+				yaml: `
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true`,
+			}},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: backend
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                         - maxConnections: 8192
+                         - priority: HIGH
+                           maxConnections: 4096`,
+			},
+			expected: `
+            resources:
+            - name: backend
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true
+                      maxConnections: 8192
+                    - priority: HIGH
+                      maxConnections: 4096`,
+		}),
+		Entry("should apply a threshold without priority to every priority", testCase{
+			clusters: []testCaseCluster{{
+				yaml: `
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true
+                    - priority: HIGH
+                      maxRetries: 5`,
+			}},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: backend
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                         - maxConnections: 8192`,
+			},
+			// limits written without a priority are meant for the whole cluster,
+			// so they land on the HIGH threshold as well
+			expected: `
+            resources:
+            - name: backend
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true
+                      maxConnections: 8192
+                    - priority: HIGH
+                      maxRetries: 5
+                      maxConnections: 8192`,
+		}),
+		Entry("should apply a threshold with a priority only to that priority", testCase{
+			clusters: []testCaseCluster{{
+				yaml: `
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true
+                    - priority: HIGH
+                      maxRetries: 5`,
+			}},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: backend
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                         - priority: HIGH
+                           maxConnections: 4096`,
+			},
+			expected: `
+            resources:
+            - name: backend
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  thresholds:
+                    - trackRemaining: true
+                    - priority: HIGH
+                      maxRetries: 5
+                      maxConnections: 4096`,
+		}),
+		Entry("should dedupe per host thresholds as well", testCase{
+			clusters: []testCaseCluster{{
+				yaml: `
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  perHostThresholds:
+                    - maxConnections: 1024`,
+			}},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: backend
+                   value: |
+                     circuitBreakers:
+                       perHostThresholds:
+                         - maxConnections: 4096`,
+			},
+			expected: `
+            resources:
+            - name: backend
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                name: backend
+                type: EDS
+                circuitBreakers:
+                  perHostThresholds:
+                    - maxConnections: 4096`,
+		}),
 	)
 })


### PR DESCRIPTION
## Motivation

Since 2.14.0 a `MeshProxyPatch` that patches `circuitBreakers` on a cluster is silently ignored: the policy is accepted and the value shows up in `/config_dump`, but Envoy keeps its default limits. #16757 started calling `EnsureTrackRemaining` on every generated cluster, so from 2.14.0 every cluster already carries a `DEFAULT`-priority threshold before any `MeshProxyPatch` runs.

`clusterModificator.patch` applies the modification with `util_proto.Merge`, and proto merge semantics append to repeated fields. `CircuitBreakers.thresholds` is repeated, so the patch produced two entries for the same priority. Envoy resolves circuit breakers by taking the first threshold matching a routing priority and ignoring the rest, so the pre-existing entry won and the patched limits never applied. On 2.13.x the same policy worked, because the cluster had no `circuit_breakers` block for the merge to append to.

The practical effect is that a cluster whose `maxConnections` was raised through `MeshProxyPatch` silently drops back to Envoy's default of 1024 when the data plane is upgraded, after which `circuit_breakers.default.cx_open` flips to 1 and further connections are rejected with 503 and response flag `UO`.

## Implementation information

After merging a cluster modification, collapse `circuit_breakers.thresholds` so at most one entry per routing priority remains. Duplicates are merged into the first entry for that priority, so later values win per field and `trackRemaining` set by the circuit breaker plugin is preserved alongside the patched limits. Thresholds for distinct priorities are left untouched, and the relative order of the surviving entries is kept.

The normalisation runs only on the proto-merge path. The `jsonPatches` path already replaces rather than appends, and a user writing an explicit JSON patch against `/circuitBreakers/thresholds` should keep full control of that list.

Two alternatives were considered and discarded. Reverting #16757 would restore the patch behaviour but give up emitting `remaining_*` metrics without a matching policy. Registering a custom merge function for `CircuitBreakers` in `pkg/util/proto`, alongside the existing `Duration` exception, would fix every caller of `util_proto.Merge`, but it pulls an Envoy domain type into a package that is deliberately generic over protobuf.

Both new test cases fail on `master` and pass with the change.

## Supporting documentation

Fix #18205
