### PR TITLE
fix(meshproxypatch): honor circuit breaker patches

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1876,6 +1876,14 @@ controlPlane:
       drop: []
 ```
 
+### `MeshProxyPatch` can now change circuit breaker thresholds
+
+Since 2.14.0 every generated cluster carries a `DEFAULT`-priority circuit breaker threshold, and a `MeshProxyPatch` patching `circuitBreakers` appended a second one for that same priority. Envoy honours only the first threshold matching a routing priority, so the patched entry was dead config: `/config_dump` showed the requested values while Envoy kept what `MeshCircuitBreaker`, or its own defaults, had set. The patch now merges into the existing threshold of the same priority instead of appending. A threshold whose priority is not yet on the cluster still appends, and a `value` listing the same priority twice keeps the first entry, matching how Envoy resolves them.
+
+**Action required**
+
+Review every `MeshProxyPatch` that patches `circuitBreakers`. Where the same cluster is also covered by a `MeshCircuitBreaker`, the patch now overrides that policy for each field it sets, instead of being ignored — `MeshProxyPatch` runs last, so it wins the fields it names and the policy keeps the rest. Remove patches you wrote before 2.14.0 and no longer rely on, and drop any workaround you put in place because the patch appeared to do nothing.
+
 ## Upgrade to `2.13.7`
 
 Patch releases normally do not require upgrade instructions. The entry below is included because the underlying change is a security fix that alters TLS verification behavior in a way some deployments may notice.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -2552,8 +2552,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -2552,8 +2552,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -2552,8 +2552,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -4950,8 +4950,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshproxypatches.yaml
@@ -129,8 +129,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -9881,6 +9881,27 @@ components:
                             description: >-
                               Value of xDS resource in YAML format to add or
                               patch.
+
+
+                              Patch merges the value into the matched cluster,
+                              and repeated fields are
+
+                              appended to what the cluster already has. Circuit
+                              breaker thresholds are
+
+                              the exception: Envoy resolves them by routing
+                              priority and ignores every
+
+                              threshold after the first one of a given priority,
+                              so appending would be
+
+                              dead config. They are merged into the existing
+                              threshold with the same
+
+                              priority instead, and a value listing one priority
+                              twice keeps only the
+
+                              first entry.
                             type: string
                         required:
                           - operation

--- a/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshproxypatches.yaml
@@ -129,8 +129,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/meshproxypatch.go
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/meshproxypatch.go
@@ -72,6 +72,14 @@ type ClusterMod struct {
 	// +kubebuilder:validation:Enum=Add;Remove;Patch
 	Operation ModOperation `json:"operation"`
 	// Value of xDS resource in YAML format to add or patch.
+	//
+	// Patch merges the value into the matched cluster, and repeated fields are
+	// appended to what the cluster already has. Circuit breaker thresholds are
+	// the exception: Envoy resolves them by routing priority and ignores every
+	// threshold after the first one of a given priority, so appending would be
+	// dead config. They are merged into the existing threshold with the same
+	// priority instead, and a value listing one priority twice keeps only the
+	// first entry.
 	Value *string `json:"value,omitempty"`
 	// JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
 	// resource

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -227,7 +227,16 @@ components:
                               - Patch
                             type: string
                           value:
-                            description: Value of xDS resource in YAML format to add or patch.
+                            description: |-
+                              Value of xDS resource in YAML format to add or patch.
+
+                              Patch merges the value into the matched cluster, and repeated fields are
+                              appended to what the cluster already has. Circuit breaker thresholds are
+                              the exception: Envoy resolves them by routing priority and ignores every
+                              threshold after the first one of a given priority, so appending would be
+                              dead config. They are merged into the existing threshold with the same
+                              priority instead, and a value listing one priority twice keeps only the
+                              first entry.
                             type: string
                         required:
                           - operation

--- a/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
+++ b/pkg/plugins/policies/meshproxypatch/k8s/crd/kuma.io_meshproxypatches.yaml
@@ -129,8 +129,16 @@ spec:
                               - Patch
                               type: string
                             value:
-                              description: Value of xDS resource in YAML format to
-                                add or patch.
+                              description: |-
+                                Value of xDS resource in YAML format to add or patch.
+
+                                Patch merges the value into the matched cluster, and repeated fields are
+                                appended to what the cluster already has. Circuit breaker thresholds are
+                                the exception: Envoy resolves them by routing priority and ignores every
+                                threshold after the first one of a given priority, so appending would be
+                                dead config. They are merged into the existing threshold with the same
+                                priority instead, and a value listing one priority twice keeps only the
+                                first entry.
                               type: string
                           required:
                           - operation

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod.go
@@ -13,13 +13,14 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/metadata"
 )
 
-// circuitBreakerMergeOptions treats circuit breaker thresholds as keyed by
-// routing priority rather than as an ordered list. Proto merge appends to
-// repeated fields, and since every generated cluster already carries a
-// DEFAULT-priority threshold, appending leaves two entries for one priority.
-// Envoy honors the first threshold matching a priority and ignores the rest,
-// so the patched entry would be dead config.
-var circuitBreakerMergeOptions = []util_proto.OptionFn{
+// clusterMergeOptions treats circuit breaker thresholds as keyed by routing
+// priority rather than as an ordered list. Proto merge appends to repeated
+// fields, and since every generated cluster already carries a DEFAULT-priority
+// threshold, appending leaves two entries for one priority. Envoy honors the
+// first threshold matching a priority and ignores the rest, so the patched
+// entry would be dead config.
+var clusterMergeOptions = []util_proto.OptionFn{
+	util_proto.ReplaceDurationOptionFn,
 	util_proto.KeyedListOptionFn("envoy.config.cluster.v3.CircuitBreakers.thresholds", "priority"),
 	util_proto.KeyedListOptionFn("envoy.config.cluster.v3.CircuitBreakers.per_host_thresholds", "priority"),
 }
@@ -58,7 +59,7 @@ func (c *clusterModificator) patch(resources *core_xds.ResourceSet, clusterMod *
 				continue
 			}
 
-			util_proto.Merge(cluster.Resource, clusterMod, circuitBreakerMergeOptions...)
+			util_proto.Merge(cluster.Resource, clusterMod, clusterMergeOptions...)
 		}
 	}
 

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod.go
@@ -13,6 +13,17 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/xds/generator/metadata"
 )
 
+// circuitBreakerMergeOptions treats circuit breaker thresholds as keyed by
+// routing priority rather than as an ordered list. Proto merge appends to
+// repeated fields, and since every generated cluster already carries a
+// DEFAULT-priority threshold, appending leaves two entries for one priority.
+// Envoy honors the first threshold matching a priority and ignores the rest,
+// so the patched entry would be dead config.
+var circuitBreakerMergeOptions = []util_proto.OptionFn{
+	util_proto.KeyedListOptionFn("envoy.config.cluster.v3.CircuitBreakers.thresholds", "priority"),
+	util_proto.KeyedListOptionFn("envoy.config.cluster.v3.CircuitBreakers.per_host_thresholds", "priority"),
+}
+
 type clusterModificator api.ClusterMod
 
 func (c *clusterModificator) apply(resources *core_xds.ResourceSet) error {
@@ -47,7 +58,7 @@ func (c *clusterModificator) patch(resources *core_xds.ResourceSet, clusterMod *
 				continue
 			}
 
-			util_proto.Merge(cluster.Resource, clusterMod)
+			util_proto.Merge(cluster.Resource, clusterMod, circuitBreakerMergeOptions...)
 		}
 	}
 

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
@@ -263,7 +263,9 @@ var _ = Describe("Cluster modifications", func() {
                    value: |
                      circuitBreakers:
                        thresholds:
-                       - maxConnections: 8192`,
+                       - maxConnections: 8192
+                       - priority: HIGH
+                         maxConnections: 2048`,
 			},
 			expected: `
             resources:
@@ -273,6 +275,45 @@ var _ = Describe("Cluster modifications", func() {
                 circuitBreakers:
                   thresholds:
                   - maxConnections: 8192
+                    trackRemaining: true
+                  - maxConnections: 2048
+                    priority: HIGH
+                lbPolicy: CLUSTER_PROVIDED
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST`,
+		}),
+		Entry("should patch per host circuit breaker threshold instead of appending a duplicate priority entry", testCase{
+			clusters: []testCaseCluster{
+				{
+					yaml: `
+                    circuitBreakers:
+                      perHostThresholds:
+                      - trackRemaining: true
+                    lbPolicy: CLUSTER_PROVIDED
+                    name: outbound:passthrough:ipv4
+                    type: ORIGINAL_DST
+`,
+				},
+			},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     circuitBreakers:
+                       perHostThresholds:
+                       - maxConnections: 512`,
+			},
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                circuitBreakers:
+                  perHostThresholds:
+                  - maxConnections: 512
                     trackRemaining: true
                 lbPolicy: CLUSTER_PROVIDED
                 name: outbound:passthrough:ipv4

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
@@ -319,6 +319,166 @@ var _ = Describe("Cluster modifications", func() {
                 name: outbound:passthrough:ipv4
                 type: ORIGINAL_DST`,
 		}),
+		Entry("should patch the circuit breaker threshold matching the patched priority", testCase{
+			clusters: []testCaseCluster{
+				{
+					yaml: `
+                    circuitBreakers:
+                      thresholds:
+                      - trackRemaining: true
+                      - priority: HIGH
+                        maxRequests: 5
+                    lbPolicy: CLUSTER_PROVIDED
+                    name: outbound:passthrough:ipv4
+                    type: ORIGINAL_DST
+`,
+				},
+			},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                       - priority: HIGH
+                         maxConnections: 77`,
+			},
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                circuitBreakers:
+                  thresholds:
+                  - trackRemaining: true
+                  - maxConnections: 77
+                    maxRequests: 5
+                    priority: HIGH
+                lbPolicy: CLUSTER_PROVIDED
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST`,
+		}),
+		Entry("should patch the generated threshold when the patch states priority DEFAULT explicitly", testCase{
+			clusters: []testCaseCluster{
+				{
+					yaml: `
+                    circuitBreakers:
+                      thresholds:
+                      - trackRemaining: true
+                    lbPolicy: CLUSTER_PROVIDED
+                    name: outbound:passthrough:ipv4
+                    type: ORIGINAL_DST
+`,
+				},
+			},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                       - priority: DEFAULT
+                         maxConnections: 8192`,
+			},
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                circuitBreakers:
+                  thresholds:
+                  - maxConnections: 8192
+                    trackRemaining: true
+                lbPolicy: CLUSTER_PROVIDED
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST`,
+		}),
+		Entry("should drop a second threshold repeating a priority already patched", testCase{
+			clusters: []testCaseCluster{
+				{
+					yaml: `
+                    circuitBreakers:
+                      thresholds:
+                      - trackRemaining: true
+                    lbPolicy: CLUSTER_PROVIDED
+                    name: outbound:passthrough:ipv4
+                    type: ORIGINAL_DST
+`,
+				},
+			},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                       - maxConnections: 1
+                       - maxConnections: 2`,
+			},
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                circuitBreakers:
+                  thresholds:
+                  - maxConnections: 1
+                    trackRemaining: true
+                lbPolicy: CLUSTER_PROVIDED
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST`,
+		}),
+		Entry("should keep appending repeated fields that are not keyed", testCase{
+			clusters: []testCaseCluster{
+				{
+					yaml: `
+                    healthChecks:
+                    - timeout: 5s
+                      interval: 10s
+                      tcpHealthCheck: {}
+                    lbPolicy: CLUSTER_PROVIDED
+                    name: outbound:passthrough:ipv4
+                    type: ORIGINAL_DST
+`,
+				},
+			},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     healthChecks:
+                     - timeout: 2s
+                       interval: 3s
+                       tcpHealthCheck: {}`,
+			},
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                healthChecks:
+                - interval: 10s
+                  tcpHealthCheck: {}
+                  timeout: 5s
+                - interval: 3s
+                  tcpHealthCheck: {}
+                  timeout: 2s
+                lbPolicy: CLUSTER_PROVIDED
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST`,
+		}),
 		Entry("should patch cluster matching origins with JsonPatch", testCase{
 			clusters: []testCaseCluster{
 				{

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/cluster_mod_test.go
@@ -241,6 +241,43 @@ var _ = Describe("Cluster modifications", func() {
                   enforcingSuccessRate: 100
                 type: ORIGINAL_DST`,
 		}),
+		Entry("should patch circuit breaker threshold instead of appending a duplicate priority entry", testCase{
+			clusters: []testCaseCluster{
+				{
+					yaml: `
+                    circuitBreakers:
+                      thresholds:
+                      - trackRemaining: true
+                    lbPolicy: CLUSTER_PROVIDED
+                    name: outbound:passthrough:ipv4
+                    type: ORIGINAL_DST
+`,
+				},
+			},
+			modifications: []string{
+				`
+                cluster:
+                   operation: Patch
+                   match:
+                     name: outbound:passthrough:ipv4
+                   value: |
+                     circuitBreakers:
+                       thresholds:
+                       - maxConnections: 8192`,
+			},
+			expected: `
+            resources:
+            - name: outbound:passthrough:ipv4
+              resource:
+                '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+                circuitBreakers:
+                  thresholds:
+                  - maxConnections: 8192
+                    trackRemaining: true
+                lbPolicy: CLUSTER_PROVIDED
+                name: outbound:passthrough:ipv4
+                type: ORIGINAL_DST`,
+		}),
 		Entry("should patch cluster matching origins with JsonPatch", testCase{
 			clusters: []testCaseCluster{
 				{

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/listener_mod.go
@@ -48,7 +48,7 @@ func (l *listenerModificator) patch(resources *core_xds.ResourceSet, listenerPat
 				continue
 			}
 
-			util_proto.Merge(listener.Resource, listenerPatch)
+			util_proto.Merge(listener.Resource, listenerPatch, util_proto.ReplaceDurationOptionFn)
 		}
 	}
 

--- a/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_mod.go
+++ b/pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/virtual_host_mod.go
@@ -89,7 +89,7 @@ func (c *virtualHostModificator) patch(routeCfg *envoy_route.RouteConfiguration,
 				continue
 			}
 
-			util_proto.Merge(vHost, vHostPatch)
+			util_proto.Merge(vHost, vHostPatch, util_proto.ReplaceDurationOptionFn)
 		}
 	}
 

--- a/pkg/util/proto/any.go
+++ b/pkg/util/proto/any.go
@@ -65,7 +65,7 @@ func MergeAnys(dst *anypb.Any, src *anypb.Any) (*anypb.Any, error) {
 		return nil, err
 	}
 
-	Merge(dstMsg, srcMsg)
+	Merge(dstMsg, srcMsg, ReplaceDurationOptionFn)
 	return MarshalAnyDeterministic(dstMsg)
 }
 

--- a/pkg/util/proto/google_proto.go
+++ b/pkg/util/proto/google_proto.go
@@ -86,14 +86,14 @@ func Replace(dst, src proto.Message) {
 	ReplaceMergeFn(dst.ProtoReflect(), src.ProtoReflect())
 }
 
-func Merge(dst, src proto.Message) {
+// Merge merges src into dst with proto merge semantics, except that Duration is
+// replaced rather than merged. Callers whose resources have list semantics of
+// their own pass them in via opts.
+func Merge(dst, src proto.Message, opts ...OptionFn) {
 	duration := &durationpb.Duration{}
-	merge(dst, src,
+	merge(dst, src, append([]OptionFn{
 		MergeFunctionOptionFn(duration.ProtoReflect().Descriptor().FullName(), ReplaceMergeFn),
-		// Envoy honors only the first threshold matching a routing priority,
-		// so appending a duplicate priority entry silently disables the merged one.
-		KeyedListOptionFn("envoy.config.cluster.v3.CircuitBreakers.thresholds", "priority"),
-	)
+	}, opts...)...)
 }
 
 // Merge Code of proto.Merge with modifications to support custom types

--- a/pkg/util/proto/google_proto.go
+++ b/pkg/util/proto/google_proto.go
@@ -88,18 +88,16 @@ func Replace(dst, src proto.Message) {
 	ReplaceMergeFn(dst.ProtoReflect(), src.ProtoReflect())
 }
 
-// Merge merges src into dst with proto merge semantics, except that Duration is
-// replaced rather than merged. Callers whose resources have list semantics of
-// their own pass them in via opts.
-func Merge(dst, src proto.Message, opts ...OptionFn) {
-	duration := &durationpb.Duration{}
-	merge(dst, src, append([]OptionFn{
-		MergeFunctionOptionFn(duration.ProtoReflect().Descriptor().FullName(), ReplaceMergeFn),
-	}, opts...)...)
-}
+// ReplaceDurationOptionFn replaces a Duration instead of merging it field by
+// field, so that a patched duration overrides the existing one rather than
+// taking seconds from one and nanos from the other.
+var ReplaceDurationOptionFn = MergeFunctionOptionFn(
+	(&durationpb.Duration{}).ProtoReflect().Descriptor().FullName(),
+	ReplaceMergeFn,
+)
 
-// Merge Code of proto.Merge with modifications to support custom types
-func merge(dst, src proto.Message, opts ...OptionFn) {
+// Merge merges src into dst with proto merge semantics
+func Merge(dst, src proto.Message, opts ...OptionFn) {
 	mo := mergeOptions{
 		customMergeFn: map[protoreflect.FullName]MergeFunction{},
 		keyedLists:    map[protoreflect.FullName]protoreflect.Name{},

--- a/pkg/util/proto/google_proto.go
+++ b/pkg/util/proto/google_proto.go
@@ -47,6 +47,7 @@ type (
 	MergeFunction func(dst, src protoreflect.Message)
 	mergeOptions  struct {
 		customMergeFn map[protoreflect.FullName]MergeFunction
+		keyedLists    map[protoreflect.FullName]protoreflect.Name
 	}
 )
 type OptionFn func(options mergeOptions) mergeOptions
@@ -54,6 +55,17 @@ type OptionFn func(options mergeOptions) mergeOptions
 func MergeFunctionOptionFn(name protoreflect.FullName, function MergeFunction) OptionFn {
 	return func(options mergeOptions) mergeOptions {
 		options.customMergeFn[name] = function
+		return options
+	}
+}
+
+// KeyedListOptionFn marks the repeated message field listField as a keyed
+// list: instead of appending, a src entry is merged into the dst entry whose
+// keyField has the same value, so merging never produces duplicates by key.
+// Entries with a key not present in dst are appended as usual.
+func KeyedListOptionFn(listField protoreflect.FullName, keyField protoreflect.Name) OptionFn {
+	return func(options mergeOptions) mergeOptions {
+		options.keyedLists[listField] = keyField
 		return options
 	}
 }
@@ -76,12 +88,20 @@ func Replace(dst, src proto.Message) {
 
 func Merge(dst, src proto.Message) {
 	duration := &durationpb.Duration{}
-	merge(dst, src, MergeFunctionOptionFn(duration.ProtoReflect().Descriptor().FullName(), ReplaceMergeFn))
+	merge(dst, src,
+		MergeFunctionOptionFn(duration.ProtoReflect().Descriptor().FullName(), ReplaceMergeFn),
+		// Envoy honors only the first threshold matching a routing priority,
+		// so appending a duplicate priority entry silently disables the merged one.
+		KeyedListOptionFn("envoy.config.cluster.v3.CircuitBreakers.thresholds", "priority"),
+	)
 }
 
 // Merge Code of proto.Merge with modifications to support custom types
 func merge(dst, src proto.Message, opts ...OptionFn) {
-	mo := mergeOptions{customMergeFn: map[protoreflect.FullName]MergeFunction{}}
+	mo := mergeOptions{
+		customMergeFn: map[protoreflect.FullName]MergeFunction{},
+		keyedLists:    map[protoreflect.FullName]protoreflect.Name{},
+	}
 	for _, opt := range opts {
 		mo = opt(mo)
 	}
@@ -98,7 +118,11 @@ func (o mergeOptions) mergeMessage(dst, src protoreflect.Message) {
 	src.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		switch {
 		case fd.IsList():
-			o.mergeList(dst.Mutable(fd).List(), v.List(), fd)
+			if keyField, ok := o.keyedLists[fd.FullName()]; ok {
+				o.mergeListByKey(dst.Mutable(fd).List(), v.List(), fd, keyField)
+			} else {
+				o.mergeList(dst.Mutable(fd).List(), v.List(), fd)
+			}
 		case fd.IsMap():
 			o.mergeMap(dst.Mutable(fd).Map(), v.Map(), fd.MapValue())
 		case fd.Message() != nil:
@@ -133,6 +157,35 @@ func (o mergeOptions) mergeList(dst, src protoreflect.List, fd protoreflect.Fiel
 			dst.Append(o.cloneBytes(v))
 		default:
 			dst.Append(v)
+		}
+	}
+}
+
+func (o mergeOptions) mergeListByKey(dst, src protoreflect.List, fd protoreflect.FieldDescriptor, keyField protoreflect.Name) {
+	var keyFd protoreflect.FieldDescriptor
+	if fd.Message() != nil {
+		keyFd = fd.Message().Fields().ByName(keyField)
+	}
+	if keyFd == nil {
+		o.mergeList(dst, src, fd)
+		return
+	}
+
+	for i, n := 0, src.Len(); i < n; i++ {
+		srcElem := src.Get(i).Message()
+		merged := false
+		for j := 0; j < dst.Len(); j++ {
+			dstElem := dst.Get(j).Message()
+			if dstElem.Get(keyFd).Equal(srcElem.Get(keyFd)) {
+				o.mergeMessage(dstElem, srcElem)
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			dstv := dst.NewElement()
+			o.mergeMessage(dstv.Message(), srcElem)
+			dst.Append(dstv)
 		}
 	}
 }

--- a/pkg/util/proto/google_proto.go
+++ b/pkg/util/proto/google_proto.go
@@ -62,7 +62,9 @@ func MergeFunctionOptionFn(name protoreflect.FullName, function MergeFunction) O
 // KeyedListOptionFn marks the repeated message field listField as a keyed
 // list: instead of appending, a src entry is merged into the dst entry whose
 // keyField has the same value, so merging never produces duplicates by key.
-// Entries with a key not present in dst are appended as usual.
+// Entries with a key not present in dst are appended as usual, and src entries
+// that repeat a key are dropped. keyField must name a comparable scalar field,
+// otherwise listField keeps plain append semantics.
 func KeyedListOptionFn(listField protoreflect.FullName, keyField protoreflect.Name) OptionFn {
 	return func(options mergeOptions) mergeOptions {
 		options.keyedLists[listField] = keyField
@@ -161,21 +163,49 @@ func (o mergeOptions) mergeList(dst, src protoreflect.List, fd protoreflect.Fiel
 	}
 }
 
+// isComparableScalar reports whether fd holds a value that can be used as a map
+// key, which rules out repeated fields, messages, groups and bytes.
+func isComparableScalar(fd protoreflect.FieldDescriptor) bool {
+	if fd.IsList() || fd.IsMap() || fd.Message() != nil {
+		return false
+	}
+	return fd.Kind() != protoreflect.BytesKind
+}
+
 func (o mergeOptions) mergeListByKey(dst, src protoreflect.List, fd protoreflect.FieldDescriptor, keyField protoreflect.Name) {
 	var keyFd protoreflect.FieldDescriptor
 	if fd.Message() != nil {
 		keyFd = fd.Message().Fields().ByName(keyField)
 	}
-	if keyFd == nil {
+	// Anything that is not a comparable scalar cannot identify an entry, so an
+	// unusable registration degrades to plain append semantics.
+	if keyFd == nil || !isComparableScalar(keyFd) {
 		o.mergeList(dst, src, fd)
 		return
 	}
 
+	// A keyed list holds at most one entry per key, so src entries that repeat
+	// a key are dropped rather than merged on top of each other. The consumers
+	// of a keyed list resolve duplicates first-wins, which makes the later
+	// entries dead config no matter what we do with them.
+	seen := map[any]struct{}{}
+
 	for i, n := 0, src.Len(); i < n; i++ {
 		srcElem := src.Get(i).Message()
+		key := srcElem.Get(keyFd).Interface()
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+
 		merged := false
 		for j := 0; j < dst.Len(); j++ {
 			dstElem := dst.Get(j).Message()
+			// mergeMessage panics on an invalid message, and unlike mergeList
+			// this merges into existing dst entries rather than fresh ones.
+			if !dstElem.IsValid() {
+				continue
+			}
 			if dstElem.Get(keyFd).Equal(srcElem.Get(keyFd)) {
 				o.mergeMessage(dstElem, srcElem)
 				merged = true

--- a/pkg/util/proto/google_proto_test.go
+++ b/pkg/util/proto/google_proto_test.go
@@ -42,4 +42,38 @@ var _ = Describe("MergeKuma", func() {
 		Expect(dest.EdsClusterConfig.EdsConfig.InitialFetchTimeout.AsDuration()).To(Equal(time.Second))
 		Expect(dest.EdsClusterConfig.EdsConfig.ResourceApiVersion).To(Equal(envoy_config_core_v3.ApiVersion_V3))
 	})
+
+	It("should merge circuit breaker thresholds by priority instead of appending", func() {
+		dest := &envoy_cluster.Cluster{
+			Name: "cluster",
+			CircuitBreakers: &envoy_cluster.CircuitBreakers{
+				Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+					{
+						Priority:       envoy_config_core_v3.RoutingPriority_DEFAULT,
+						TrackRemaining: true,
+					},
+				},
+			},
+		}
+		src := &envoy_cluster.Cluster{
+			CircuitBreakers: &envoy_cluster.CircuitBreakers{
+				Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+					{
+						MaxConnections: util_proto.UInt32(8192),
+					},
+					{
+						Priority:       envoy_config_core_v3.RoutingPriority_HIGH,
+						MaxConnections: util_proto.UInt32(2048),
+					},
+				},
+			},
+		}
+		util_proto.Merge(dest, src)
+		Expect(dest.CircuitBreakers.Thresholds).To(HaveLen(2))
+		Expect(dest.CircuitBreakers.Thresholds[0].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_DEFAULT))
+		Expect(dest.CircuitBreakers.Thresholds[0].TrackRemaining).To(BeTrue())
+		Expect(dest.CircuitBreakers.Thresholds[0].MaxConnections.GetValue()).To(Equal(uint32(8192)))
+		Expect(dest.CircuitBreakers.Thresholds[1].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_HIGH))
+		Expect(dest.CircuitBreakers.Thresholds[1].MaxConnections.GetValue()).To(Equal(uint32(2048)))
+	})
 })

--- a/pkg/util/proto/google_proto_test.go
+++ b/pkg/util/proto/google_proto_test.go
@@ -42,38 +42,4 @@ var _ = Describe("MergeKuma", func() {
 		Expect(dest.EdsClusterConfig.EdsConfig.InitialFetchTimeout.AsDuration()).To(Equal(time.Second))
 		Expect(dest.EdsClusterConfig.EdsConfig.ResourceApiVersion).To(Equal(envoy_config_core_v3.ApiVersion_V3))
 	})
-
-	It("should merge circuit breaker thresholds by priority instead of appending", func() {
-		dest := &envoy_cluster.Cluster{
-			Name: "cluster",
-			CircuitBreakers: &envoy_cluster.CircuitBreakers{
-				Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
-					{
-						Priority:       envoy_config_core_v3.RoutingPriority_DEFAULT,
-						TrackRemaining: true,
-					},
-				},
-			},
-		}
-		src := &envoy_cluster.Cluster{
-			CircuitBreakers: &envoy_cluster.CircuitBreakers{
-				Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
-					{
-						MaxConnections: util_proto.UInt32(8192),
-					},
-					{
-						Priority:       envoy_config_core_v3.RoutingPriority_HIGH,
-						MaxConnections: util_proto.UInt32(2048),
-					},
-				},
-			},
-		}
-		util_proto.Merge(dest, src)
-		Expect(dest.CircuitBreakers.Thresholds).To(HaveLen(2))
-		Expect(dest.CircuitBreakers.Thresholds[0].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_DEFAULT))
-		Expect(dest.CircuitBreakers.Thresholds[0].TrackRemaining).To(BeTrue())
-		Expect(dest.CircuitBreakers.Thresholds[0].MaxConnections.GetValue()).To(Equal(uint32(8192)))
-		Expect(dest.CircuitBreakers.Thresholds[1].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_HIGH))
-		Expect(dest.CircuitBreakers.Thresholds[1].MaxConnections.GetValue()).To(Equal(uint32(2048)))
-	})
 })

--- a/pkg/util/proto/google_proto_test.go
+++ b/pkg/util/proto/google_proto_test.go
@@ -42,4 +42,184 @@ var _ = Describe("MergeKuma", func() {
 		Expect(dest.EdsClusterConfig.EdsConfig.InitialFetchTimeout.AsDuration()).To(Equal(time.Second))
 		Expect(dest.EdsClusterConfig.EdsConfig.ResourceApiVersion).To(Equal(envoy_config_core_v3.ApiVersion_V3))
 	})
+
+	Context("keyed lists", func() {
+		thresholdsKeyedByPriority := util_proto.KeyedListOptionFn(
+			"envoy.config.cluster.v3.CircuitBreakers.thresholds",
+			"priority",
+		)
+
+		It("should merge into the dst entry with the same key", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+						{Priority: envoy_config_core_v3.RoutingPriority_HIGH, MaxRequests: util_proto.UInt32(5)},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_HIGH, MaxConnections: util_proto.UInt32(77)},
+					},
+				},
+			}
+
+			util_proto.Merge(dest, src, thresholdsKeyedByPriority)
+
+			thresholds := dest.CircuitBreakers.Thresholds
+			Expect(thresholds).To(HaveLen(2))
+			Expect(thresholds[0].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_DEFAULT))
+			Expect(thresholds[0].TrackRemaining).To(BeTrue())
+			Expect(thresholds[1].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_HIGH))
+			Expect(thresholds[1].MaxConnections.GetValue()).To(Equal(uint32(77)))
+			Expect(thresholds[1].MaxRequests.GetValue()).To(Equal(uint32(5)))
+		})
+
+		It("should append a src entry whose key is not in dst", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_HIGH, MaxConnections: util_proto.UInt32(2048)},
+					},
+				},
+			}
+
+			util_proto.Merge(dest, src, thresholdsKeyedByPriority)
+
+			thresholds := dest.CircuitBreakers.Thresholds
+			Expect(thresholds).To(HaveLen(2))
+			Expect(thresholds[0].TrackRemaining).To(BeTrue())
+			Expect(thresholds[1].Priority).To(Equal(envoy_config_core_v3.RoutingPriority_HIGH))
+			Expect(thresholds[1].MaxConnections.GetValue()).To(Equal(uint32(2048)))
+		})
+
+		It("should skip nil dst entries instead of panicking", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						nil,
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{MaxConnections: util_proto.UInt32(8192)},
+					},
+				},
+			}
+
+			Expect(func() { util_proto.Merge(dest, src, thresholdsKeyedByPriority) }).ToNot(Panic())
+
+			thresholds := dest.CircuitBreakers.Thresholds
+			Expect(thresholds).To(HaveLen(2))
+			Expect(thresholds[0]).To(BeNil())
+			Expect(thresholds[1].TrackRemaining).To(BeTrue())
+			Expect(thresholds[1].MaxConnections.GetValue()).To(Equal(uint32(8192)))
+		})
+
+		It("should leave lists that were not registered as keyed appending", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					PerHostThresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					PerHostThresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{MaxConnections: util_proto.UInt32(512)},
+					},
+				},
+			}
+
+			util_proto.Merge(dest, src, thresholdsKeyedByPriority)
+
+			Expect(dest.CircuitBreakers.PerHostThresholds).To(HaveLen(2))
+		})
+
+		It("should drop src entries that repeat a key", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{MaxConnections: util_proto.UInt32(1)},
+						{MaxConnections: util_proto.UInt32(2)},
+					},
+				},
+			}
+
+			util_proto.Merge(dest, src, thresholdsKeyedByPriority)
+
+			thresholds := dest.CircuitBreakers.Thresholds
+			Expect(thresholds).To(HaveLen(1))
+			Expect(thresholds[0].TrackRemaining).To(BeTrue())
+			Expect(thresholds[0].MaxConnections.GetValue()).To(Equal(uint32(1)))
+		})
+
+		It("should fall back to appending when the key field is not a comparable scalar", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{MaxConnections: util_proto.UInt32(8192)},
+					},
+				},
+			}
+
+			util_proto.Merge(dest, src, util_proto.KeyedListOptionFn(
+				"envoy.config.cluster.v3.CircuitBreakers.thresholds",
+				"max_connections",
+			))
+
+			Expect(dest.CircuitBreakers.Thresholds).To(HaveLen(2))
+		})
+
+		It("should fall back to appending when the key field does not exist", func() {
+			dest := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{Priority: envoy_config_core_v3.RoutingPriority_DEFAULT, TrackRemaining: true},
+					},
+				},
+			}
+			src := &envoy_cluster.Cluster{
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{
+						{MaxConnections: util_proto.UInt32(8192)},
+					},
+				},
+			}
+
+			util_proto.Merge(dest, src, util_proto.KeyedListOptionFn(
+				"envoy.config.cluster.v3.CircuitBreakers.thresholds",
+				"no_such_field",
+			))
+
+			Expect(dest.CircuitBreakers.Thresholds).To(HaveLen(2))
+		})
+	})
 })

--- a/pkg/util/proto/google_proto_test.go
+++ b/pkg/util/proto/google_proto_test.go
@@ -34,13 +34,24 @@ var _ = Describe("MergeKuma", func() {
 				},
 			},
 		}
-		util_proto.Merge(dest, src)
+		util_proto.Merge(dest, src, util_proto.ReplaceDurationOptionFn)
 		Expect(dest.ConnectTimeout.AsDuration()).To(Equal(time.Millisecond * 500))
 		Expect(dest.Name).To(Equal("new"))
 		Expect(dest.EdsClusterConfig.ServiceName).To(Equal("srv"))
 		Expect(dest.EdsClusterConfig.EdsConfig.InitialFetchTimeout.AsDuration()).To(Equal(time.Second))
 		Expect(dest.EdsClusterConfig.EdsConfig.InitialFetchTimeout.AsDuration()).To(Equal(time.Second))
 		Expect(dest.EdsClusterConfig.EdsConfig.ResourceApiVersion).To(Equal(envoy_config_core_v3.ApiVersion_V3))
+	})
+
+	It("should merge durations field by field without the option", func() {
+		dest := &envoy_cluster.Cluster{
+			ConnectTimeout: durationpb.New(time.Second * 10),
+		}
+		src := &envoy_cluster.Cluster{
+			ConnectTimeout: &durationpb.Duration{Nanos: 5},
+		}
+		util_proto.Merge(dest, src)
+		Expect(dest.ConnectTimeout.AsDuration()).To(Equal(time.Second*10 + 5))
 	})
 
 	Context("keyed lists", func() {

--- a/test/e2e_env/universal/envoyconfig/sidecars.go
+++ b/test/e2e_env/universal/envoyconfig/sidecars.go
@@ -17,6 +17,7 @@ import (
 	meshhttproute "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	meshloadbalancing "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1"
 	meshmetric "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/api/v1alpha1"
+	meshproxypatch "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshproxypatch/api/v1alpha1"
 	meshratelimit "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshratelimit/api/v1alpha1"
 	meshretry "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshretry/api/v1alpha1"
 	meshtimeout "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
@@ -65,6 +66,7 @@ func Sidecars() {
 		meshretry.MeshRetryResourceTypeDescriptor,
 		meshloadbalancing.MeshLoadBalancingStrategyResourceTypeDescriptor,
 		meshmetric.MeshMetricResourceTypeDescriptor,
+		meshproxypatch.MeshProxyPatchResourceTypeDescriptor,
 		meshtrafficpermission.MeshTrafficPermissionResourceTypeDescriptor,
 		meshopentelemetrybackend.MeshOpenTelemetryBackendResourceTypeDescriptor,
 	))
@@ -81,6 +83,7 @@ func Sidecars() {
 		test.EntriesForFolder(filepath.Join("sidecars", "meshloadbalancingstrategy"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshtrafficpermission"), "envoyconfig"),
 		test.EntriesForFolder(filepath.Join("sidecars", "meshmetric"), "envoyconfig"),
+		test.EntriesForFolder(filepath.Join("sidecars", "meshproxypatch"), "envoyconfig"),
 	)
 }
 

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.demo-client.golden.json
@@ -1,0 +1,973 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/thresholds/0/maxConnections",
+      "value": 8192
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "kri_msvc_envoyconfig_kuma-3__demo-client_3000": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "system_trust_bundle",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "kri_mid_envoyconfig_kuma-3__envoyconfig-identity_",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "sni.msvc.envoyconfig.kuma-3.demo-client.3000"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "kri_msvc_envoyconfig_kuma-3__test-server_80": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "system_trust_bundle",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "kri_mid_envoyconfig_kuma-3__envoyconfig-identity_",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "sni.msvc.envoyconfig.kuma-3.test-server.80"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "self_inbound_dp_3000": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "self_inbound_dp_3000",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 3000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "self_inbound_dp_3000",
+        "type": "STATIC",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "self_transparentproxy_no_destination_inbound": {
+        "altStatName": "self_transparentproxy_no_destination_inbound",
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "name": "self_transparentproxy_no_destination_inbound",
+        "type": "STATIC"
+      },
+      "self_transparentproxy_passthrough_inbound_ipv4": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_inbound_ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "self_transparentproxy_passthrough_inbound_ipv6": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_inbound_ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "self_transparentproxy_passthrough_outbound_ipv4": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "maxConnections": 8192,
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_outbound_ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "self_transparentproxy_passthrough_outbound_ipv6": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_outbound_ipv6",
+        "type": "ORIGINAL_DST"
+      },
+      "system_envoy_admin": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "system_envoy_admin",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "ADMIN_REDACTED",
+                        "portValue": 0
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "system_envoy_admin",
+        "type": "STATIC"
+      },
+      "system_probe_readiness": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "system_probe_readiness",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "ADMIN_REDACTED",
+                        "portValue": 0
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "system_probe_readiness",
+        "type": "STATIC"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "kri_msvc_envoyconfig_kuma-3__demo-client_3000": {
+        "clusterName": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/display-name": "demo-client",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/workload": "demo-client",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/display-name": "demo-client",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/workload": "demo-client",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "kri_msvc_envoyconfig_kuma-3__test-server_80": {
+        "clusterName": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/display-name": "test-server",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/workload": "test-server",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/display-name": "test-server",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/workload": "test-server",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "kri_msvc_envoyconfig_kuma-3__demo-client_3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND"
+      },
+      "kri_msvc_envoyconfig_kuma-3__test-server_80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND"
+      },
+      "self_inbound_dp_3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.rbac",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                  "matcher": {
+                    "matcherList": {
+                      "matchers": [
+                        {
+                          "onMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "name": "kri_mtp_envoyconfig_kuma-3__allow-all-envoyconfig-0_"
+                              }
+                            }
+                          },
+                          "predicate": {
+                            "singlePredicate": {
+                              "input": {
+                                "name": "envoy.matching.inputs.uri_san",
+                                "typedConfig": {
+                                  "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput"
+                                }
+                              },
+                              "valueMatch": {
+                                "prefix": "spiffe://envoyconfig.kuma-3.mesh.local"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "onNoMatch": {
+                      "action": {
+                        "name": "envoy.filters.rbac.action",
+                        "typedConfig": {
+                          "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                          "action": "DENY",
+                          "name": "default"
+                        }
+                      }
+                    }
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              },
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_inbound_dp_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig.kuma-3.mesh.local/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "system_trust_bundle",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "kri_mid_envoyconfig_kuma-3__envoyconfig-identity_",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/display-name": "demo-client",
+              "kuma.io/env": "universal",
+              "kuma.io/mesh": "envoyconfig",
+              "kuma.io/origin": "zone",
+              "kuma.io/service": "demo-client",
+              "kuma.io/workload": "demo-client",
+              "kuma.io/zone": "kuma-3",
+              "team": "client-owners"
+            }
+          }
+        },
+        "name": "self_inbound_dp_3000",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "INBOUND"
+      },
+      "self_transparentproxy_passthrough_inbound_ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filterChainMatch": {
+              "destinationPort": 3000
+            },
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_inbound_ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_inbound_ipv4",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "self_transparentproxy_passthrough_inbound_ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filterChainMatch": {
+              "destinationPort": 3000
+            },
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_inbound_ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_inbound_ipv6",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "self_transparentproxy_passthrough_outbound_ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_outbound_ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_outbound_ipv4",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "self_transparentproxy_passthrough_outbound_ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_outbound_ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_outbound_ipv6",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "system_envoy_admin": {
+        "address": {
+          "socketAddress": {
+            "address": "ADMIN_REDACTED",
+            "portValue": 0
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "routeConfig": {
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "system_envoy_admin",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/ready"
+                            },
+                            "route": {
+                              "cluster": "system_probe_readiness",
+                              "prefixRewrite": "/ready"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          },
+          {
+            "filterChainMatch": {
+              "transportProtocol": "tls"
+            },
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "routeConfig": {
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "system_envoy_admin",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/ready"
+                            },
+                            "route": {
+                              "cluster": "system_probe_readiness",
+                              "prefixRewrite": "/ready"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "system_envoy_admin",
+                              "prefixRewrite": "/"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "tlsCertificates": [
+                    {
+                      "certificateChain": {
+                        "inlineBytes": ""
+                      },
+                      "privateKey": {
+                        "inlineBytes": ""
+                      }
+                    }
+                  ],
+                  "validationContext": {
+                    "matchTypedSubjectAltNames": [
+                      {
+                        "matcher": {
+                          "exact": "kuma-cp"
+                        },
+                        "sanType": "DNS"
+                      }
+                    ],
+                    "trustedCa": {
+                      "inlineBytes": ""
+                    }
+                  }
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "listenerFilters": [
+          {
+            "name": "envoy.filters.listener.tls_inspector",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+            }
+          }
+        ],
+        "name": "system_envoy_admin",
+        "trafficDirection": "INBOUND"
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "system_trust_bundle": {
+        "name": "system_trust_bundle",
+        "validationContext": {
+          "customValidatorConfig": {
+            "name": "envoy.tls.cert_validator.spiffe",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+              "trustDomains": [
+                {
+                  "name": "envoyconfig.kuma-3.mesh.local",
+                  "trustBundle": {
+                    "inlineBytes": "CERT_REDACTED"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.demo-client.golden.json
@@ -2,8 +2,25 @@
   "diff": [
     {
       "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/perHostThresholds",
+      "value": [
+        {
+          "maxConnections": 512
+        }
+      ]
+    },
+    {
+      "op": "add",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/thresholds/0/maxConnections",
       "value": 8192
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/thresholds/1",
+      "value": {
+        "maxConnections": 2048,
+        "priority": "HIGH"
+      }
     }
   ],
   "xds": {
@@ -235,10 +252,19 @@
       },
       "self_transparentproxy_passthrough_outbound_ipv4": {
         "circuitBreakers": {
+          "perHostThresholds": [
+            {
+              "maxConnections": 512
+            }
+          ],
           "thresholds": [
             {
               "maxConnections": 8192,
               "trackRemaining": true
+            },
+            {
+              "maxConnections": 2048,
+              "priority": "HIGH"
             }
           ]
         },

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.input.yaml
@@ -16,3 +16,7 @@ spec:
             circuitBreakers:
               thresholds:
                 - maxConnections: 8192
+                - priority: HIGH
+                  maxConnections: 2048
+              perHostThresholds:
+                - maxConnections: 512

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.input.yaml
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.input.yaml
@@ -1,0 +1,18 @@
+type: MeshProxyPatch
+name: mpp-cb-thresholds
+mesh: envoyconfig
+labels:
+  kuma.io/effect: shadow
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    appendModifications:
+      - cluster:
+          operation: Patch
+          match:
+            name: self_transparentproxy_passthrough_outbound_ipv4
+          value: |
+            circuitBreakers:
+              thresholds:
+                - maxConnections: 8192

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.test-server.golden.json
@@ -1,0 +1,1049 @@
+{
+  "diff": [
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/thresholds/0/maxConnections",
+      "value": 8192
+    }
+  ],
+  "xds": {
+    "type.googleapis.com/envoy.config.cluster.v3.Cluster": {
+      "kri_msvc_envoyconfig_kuma-3__demo-client_3000": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/demo-client"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "system_trust_bundle",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "kri_mid_envoyconfig_kuma-3__envoyconfig-identity_",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "sni.msvc.envoyconfig.kuma-3.demo-client.3000"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "kri_msvc_envoyconfig_kuma-3__test-server_80": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "edsClusterConfig": {
+          "edsConfig": {
+            "ads": {},
+            "resourceApiVersion": "V3"
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "alpnProtocols": [
+                "kuma"
+              ],
+              "combinedValidationContext": {
+                "defaultValidationContext": {
+                  "matchTypedSubjectAltNames": [
+                    {
+                      "matcher": {
+                        "exact": "spiffe://envoyconfig.kuma-3.mesh.local/workload/test-server"
+                      },
+                      "sanType": "URI"
+                    }
+                  ]
+                },
+                "validationContextSdsSecretConfig": {
+                  "name": "system_trust_bundle",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              },
+              "tlsCertificateSdsSecretConfigs": [
+                {
+                  "name": "kri_mid_envoyconfig_kuma-3__envoyconfig-identity_",
+                  "sdsConfig": {
+                    "ads": {},
+                    "resourceApiVersion": "V3"
+                  }
+                }
+              ]
+            },
+            "sni": "sni.msvc.envoyconfig.kuma-3.test-server.80"
+          }
+        },
+        "type": "EDS",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "http2ProtocolOptions": {}
+            }
+          }
+        }
+      },
+      "self_inbound_dp_80": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "self_inbound_dp_80",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "IP_REDACTED",
+                        "portValue": 8080
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "self_inbound_dp_80",
+        "type": "STATIC",
+        "typedExtensionProtocolOptions": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "commonHttpProtocolOptions": {
+              "idleTimeout": "3600s",
+              "maxConnectionDuration": "0s",
+              "maxStreamDuration": "0s"
+            },
+            "explicitHttpConfig": {
+              "httpProtocolOptions": {}
+            }
+          }
+        },
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "self_transparentproxy_no_destination_inbound": {
+        "altStatName": "self_transparentproxy_no_destination_inbound",
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "name": "self_transparentproxy_no_destination_inbound",
+        "type": "STATIC"
+      },
+      "self_transparentproxy_passthrough_inbound_ipv4": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_inbound_ipv4",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "self_transparentproxy_passthrough_inbound_ipv6": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_inbound_ipv6",
+        "type": "ORIGINAL_DST",
+        "upstreamBindConfig": {
+          "sourceAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 0
+          }
+        }
+      },
+      "self_transparentproxy_passthrough_outbound_ipv4": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "maxConnections": 8192,
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_outbound_ipv4",
+        "type": "ORIGINAL_DST"
+      },
+      "self_transparentproxy_passthrough_outbound_ipv6": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "lbPolicy": "CLUSTER_PROVIDED",
+        "name": "self_transparentproxy_passthrough_outbound_ipv6",
+        "type": "ORIGINAL_DST"
+      },
+      "system_envoy_admin": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "system_envoy_admin",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "ADMIN_REDACTED",
+                        "portValue": 0
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "system_envoy_admin",
+        "type": "STATIC"
+      },
+      "system_probe_readiness": {
+        "circuitBreakers": {
+          "thresholds": [
+            {
+              "trackRemaining": true
+            }
+          ]
+        },
+        "connectTimeout": "5s",
+        "loadAssignment": {
+          "clusterName": "system_probe_readiness",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "ADMIN_REDACTED",
+                        "portValue": 0
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "system_probe_readiness",
+        "type": "STATIC"
+      }
+    },
+    "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment": {
+      "kri_msvc_envoyconfig_kuma-3__demo-client_3000": {
+        "clusterName": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 3000
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "kuma.io/display-name": "demo-client",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/workload": "demo-client",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    },
+                    "envoy.transport_socket_match": {
+                      "kuma.io/display-name": "demo-client",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/workload": "demo-client",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "client-owners"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      },
+      "kri_msvc_envoyconfig_kuma-3__test-server_80": {
+        "clusterName": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "IP_REDACTED",
+                      "portValue": 80
+                    }
+                  }
+                },
+                "loadBalancingWeight": 1,
+                "metadata": {
+                  "filterMetadata": {
+                    "envoy.lb": {
+                      "instance": "1",
+                      "kuma.io/display-name": "test-server",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/workload": "test-server",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    },
+                    "envoy.transport_socket_match": {
+                      "instance": "1",
+                      "kuma.io/display-name": "test-server",
+                      "kuma.io/env": "universal",
+                      "kuma.io/mesh": "envoyconfig",
+                      "kuma.io/origin": "zone",
+                      "kuma.io/protocol": "http",
+                      "kuma.io/workload": "test-server",
+                      "kuma.io/zone": "kuma-3",
+                      "team": "server-owners",
+                      "version": "v1"
+                    }
+                  }
+                }
+              }
+            ],
+            "locality": {
+              "zone": "kuma-3"
+            }
+          }
+        ]
+      }
+    },
+    "type.googleapis.com/envoy.config.listener.v3.Listener": {
+      "kri_msvc_envoyconfig_kuma-3__demo-client_3000": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 3000
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+                  "idleTimeout": "3600s",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000"
+            }
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__demo-client_3000",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND"
+      },
+      "kri_msvc_envoyconfig_kuma-3__test-server_80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "normalizePath": true,
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "name": "9Zuf5Tg79OuZcQITwBbQykxAk2u4fRKrwYn3//AL4Yo=",
+                            "route": {
+                              "cluster": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "kuma.io/unified-name": "kri_msvc_envoyconfig_kuma-3__test-server_80"
+            }
+          }
+        },
+        "name": "kri_msvc_envoyconfig_kuma-3__test-server_80",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND"
+      },
+      "self_inbound_dp_80": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 80
+          }
+        },
+        "bindToPort": false,
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "idleTimeout": "0s"
+                  },
+                  "forwardClientCertDetails": "SANITIZE_SET",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.rbac",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                        "matcher": {
+                          "matcherList": {
+                            "matchers": [
+                              {
+                                "onMatch": {
+                                  "action": {
+                                    "name": "envoy.filters.rbac.action",
+                                    "typedConfig": {
+                                      "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                      "name": "kri_mtp_envoyconfig_kuma-3__allow-all-envoyconfig-0_"
+                                    }
+                                  }
+                                },
+                                "predicate": {
+                                  "singlePredicate": {
+                                    "input": {
+                                      "name": "envoy.matching.inputs.uri_san",
+                                      "typedConfig": {
+                                        "@type": "type.googleapis.com/envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput"
+                                      }
+                                    },
+                                    "valueMatch": {
+                                      "prefix": "spiffe://envoyconfig.kuma-3.mesh.local"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "onNoMatch": {
+                            "action": {
+                              "name": "envoy.filters.rbac.action",
+                              "typedConfig": {
+                                "@type": "type.googleapis.com/envoy.config.rbac.v3.Action",
+                                "action": "DENY",
+                                "name": "default"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 8
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 16
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 12
+                      },
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "requestHeadersTimeout": "0s",
+                  "routeConfig": {
+                    "name": "self_inbound_dp_80",
+                    "requestHeadersToRemove": [
+                      "x-kuma-tags"
+                    ],
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "self_inbound_dp_80",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "self_inbound_dp_80",
+                              "idleTimeout": "1800s",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "setCurrentClientCertDetails": {
+                    "uri": true
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED",
+                  "streamIdleTimeout": "3600s"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "combinedValidationContext": {
+                    "defaultValidationContext": {
+                      "matchTypedSubjectAltNames": [
+                        {
+                          "matcher": {
+                            "prefix": "spiffe://envoyconfig.kuma-3.mesh.local/"
+                          },
+                          "sanType": "URI"
+                        }
+                      ]
+                    },
+                    "validationContextSdsSecretConfig": {
+                      "name": "system_trust_bundle",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  },
+                  "tlsCertificateSdsSecretConfigs": [
+                    {
+                      "name": "kri_mid_envoyconfig_kuma-3__envoyconfig-identity_",
+                      "sdsConfig": {
+                        "ads": {},
+                        "resourceApiVersion": "V3"
+                      }
+                    }
+                  ]
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "metadata": {
+          "filterMetadata": {
+            "io.kuma.tags": {
+              "instance": "1",
+              "kuma.io/display-name": "test-server",
+              "kuma.io/env": "universal",
+              "kuma.io/mesh": "envoyconfig",
+              "kuma.io/origin": "zone",
+              "kuma.io/service": "test-server",
+              "kuma.io/workload": "test-server",
+              "kuma.io/zone": "kuma-3",
+              "team": "server-owners",
+              "version": "v1"
+            }
+          }
+        },
+        "name": "self_inbound_dp_80",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "INBOUND"
+      },
+      "self_transparentproxy_passthrough_inbound_ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filterChainMatch": {
+              "destinationPort": 80
+            },
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_inbound_ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_inbound_ipv4",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "self_transparentproxy_passthrough_inbound_ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15006
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filterChainMatch": {
+              "destinationPort": 80
+            },
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_inbound_ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_inbound_ipv6",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "INBOUND",
+        "useOriginalDst": true
+      },
+      "self_transparentproxy_passthrough_outbound_ipv4": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_outbound_ipv4",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_outbound_ipv4",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "self_transparentproxy_passthrough_outbound_ipv6": {
+        "address": {
+          "socketAddress": {
+            "address": "IP_REDACTED",
+            "portValue": 15001
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.tcp_proxy",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                  "cluster": "self_transparentproxy_passthrough_outbound_ipv6",
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          }
+        ],
+        "name": "self_transparentproxy_passthrough_outbound_ipv6",
+        "statPrefix": "STAT_PREFIX_REDACTED",
+        "trafficDirection": "OUTBOUND",
+        "useOriginalDst": true
+      },
+      "system_envoy_admin": {
+        "address": {
+          "socketAddress": {
+            "address": "ADMIN_REDACTED",
+            "portValue": 0
+          }
+        },
+        "enableReusePort": true,
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "routeConfig": {
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "system_envoy_admin",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/ready"
+                            },
+                            "route": {
+                              "cluster": "system_probe_readiness",
+                              "prefixRewrite": "/ready"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ]
+          },
+          {
+            "filterChainMatch": {
+              "transportProtocol": "tls"
+            },
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
+                    }
+                  ],
+                  "internalAddressConfig": {
+                    "cidrRanges": [
+                      {
+                        "addressPrefix": "IP_REDACTED",
+                        "prefixLen": 32
+                      }
+                    ]
+                  },
+                  "routeConfig": {
+                    "validateClusters": false,
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "system_envoy_admin",
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/ready"
+                            },
+                            "route": {
+                              "cluster": "system_probe_readiness",
+                              "prefixRewrite": "/ready"
+                            }
+                          },
+                          {
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "system_envoy_admin",
+                              "prefixRewrite": "/"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "STAT_PREFIX_REDACTED"
+                }
+              }
+            ],
+            "transportSocket": {
+              "name": "envoy.transport_sockets.tls",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                "commonTlsContext": {
+                  "tlsCertificates": [
+                    {
+                      "certificateChain": {
+                        "inlineBytes": ""
+                      },
+                      "privateKey": {
+                        "inlineBytes": ""
+                      }
+                    }
+                  ],
+                  "validationContext": {
+                    "matchTypedSubjectAltNames": [
+                      {
+                        "matcher": {
+                          "exact": "kuma-cp"
+                        },
+                        "sanType": "DNS"
+                      }
+                    ],
+                    "trustedCa": {
+                      "inlineBytes": ""
+                    }
+                  }
+                },
+                "requireClientCertificate": true
+              }
+            }
+          }
+        ],
+        "listenerFilters": [
+          {
+            "name": "envoy.filters.listener.tls_inspector",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+            }
+          }
+        ],
+        "name": "system_envoy_admin",
+        "trafficDirection": "INBOUND"
+      }
+    },
+    "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret": {
+      "system_trust_bundle": {
+        "name": "system_trust_bundle",
+        "validationContext": {
+          "customValidatorConfig": {
+            "name": "envoy.tls.cert_validator.spiffe",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig",
+              "trustDomains": [
+                {
+                  "name": "envoyconfig.kuma-3.mesh.local",
+                  "trustBundle": {
+                    "inlineBytes": "CERT_REDACTED"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.test-server.golden.json
@@ -2,8 +2,25 @@
   "diff": [
     {
       "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/perHostThresholds",
+      "value": [
+        {
+          "maxConnections": 512
+        }
+      ]
+    },
+    {
+      "op": "add",
       "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/thresholds/0/maxConnections",
       "value": 8192
+    },
+    {
+      "op": "add",
+      "path": "/type.googleapis.com~1envoy.config.cluster.v3.Cluster/self_transparentproxy_passthrough_outbound_ipv4/circuitBreakers/thresholds/1",
+      "value": {
+        "maxConnections": 2048,
+        "priority": "HIGH"
+      }
     }
   ],
   "xds": {
@@ -248,10 +265,19 @@
       },
       "self_transparentproxy_passthrough_outbound_ipv4": {
         "circuitBreakers": {
+          "perHostThresholds": [
+            {
+              "maxConnections": 512
+            }
+          ],
           "thresholds": [
             {
               "maxConnections": 8192,
               "trackRemaining": true
+            },
+            {
+              "maxConnections": 2048,
+              "priority": "HIGH"
             }
           ]
         },

--- a/test/e2e_env/universal/meshproxypatch/meshproxypatch.go
+++ b/test/e2e_env/universal/meshproxypatch/meshproxypatch.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/kumahq/kuma/v3/test/framework"
 	"github.com/kumahq/kuma/v3/test/framework/client"
+	"github.com/kumahq/kuma/v3/test/framework/envoy_admin/stats"
 	"github.com/kumahq/kuma/v3/test/framework/envs/universal"
 )
 
@@ -74,6 +75,43 @@ spec:
 			responses, err := client.CollectResponses(universal.Cluster, "demo-client", "test-server.svc.mesh.local")
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(responses[0].Received.Headers["X-Header"]).To(ContainElements("test"))
+		}, "30s", "1s").Should(Succeed())
+	})
+
+	It("should apply a circuit breaker threshold patched onto the generated one", func() {
+		// given a cluster that already carries a DEFAULT-priority threshold
+		policy := fmt.Sprintf(`
+type: MeshProxyPatch
+mesh: %s
+name: circuit-breaker-thresholds
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      kuma.io/service: demo-client
+  default:
+    appendModifications:
+      - cluster:
+          operation: Patch
+          match:
+            name: self_transparentproxy_passthrough_outbound_ipv4
+          value: |
+            circuitBreakers:
+              thresholds:
+                - maxConnections: 8192
+`, mesh)
+
+		// when
+		Expect(universal.Cluster.Install(YamlUniversal(policy))).To(Succeed())
+
+		// then the limit Envoy resolved changes, not just the one /config_dump reports
+		admin := universal.Cluster.GetApp(AppModeDemoClient).GetEnvoyAdminTunnel()
+		Eventually(func(g Gomega) {
+			// anchored: the filter is a regex, and an unanchored remaining_cx
+			// also matches remaining_cx_pools
+			s, err := admin.GetStats("cluster.self_transparentproxy_passthrough_outbound_ipv4.circuit_breakers.default.remaining_cx$")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(s).To(stats.BeEqual(float64(8192)))
 		}, "30s", "1s").Should(Succeed())
 	})
 }

--- a/test/e2e_env/universal/meshproxypatch/meshproxypatch.go
+++ b/test/e2e_env/universal/meshproxypatch/meshproxypatch.go
@@ -111,7 +111,9 @@ spec:
 			// also matches remaining_cx_pools
 			s, err := admin.GetStats("cluster.self_transparentproxy_passthrough_outbound_ipv4.circuit_breakers.default.remaining_cx$")
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(s).To(stats.BeEqual(float64(8192)))
+			// remaining_cx counts down as the cluster opens connections, so
+			// assert against Envoy's 1024 default rather than an exact 8192
+			g.Expect(s).To(stats.BeGreaterThan(float64(1024)))
 		}, "30s", "1s").Should(Succeed())
 	})
 }


### PR DESCRIPTION
Fixes #18205

## Motivation

Since 2.14.0 every generated cluster carries a DEFAULT-priority circuit breaker threshold (`trackRemaining: true`, added by #16757). A `MeshProxyPatch` that patches `circuitBreakers` uses `util_proto.Merge`, and proto merge semantics append to repeated fields, so the patched threshold lands as a second entry for the same priority. Envoy honors only the first threshold matching a routing priority, so the patch is silently ignored: `/config_dump` shows the requested value while the cluster keeps Envoy's defaults.

## Implementation information

`util_proto.Merge` is already a fork of `proto.Merge` with a hook for custom per-type merge behavior (used to replace `Duration` instead of merging it). This PR extends that mechanism with keyed-list merge: a repeated message field can be declared keyed, and a src entry is then merged into the dst entry with the same key value instead of being appended (entries with a new key still append). `envoy.config.cluster.v3.CircuitBreakers.thresholds` is registered keyed by `priority`, since duplicate same-priority thresholds are always dead config for Envoy. Registering another first-match-wins Envoy field is a one-liner.

Covered by unit tests in `util_proto` and `meshproxypatch` (the issue's exact scenario through `ApplyMods`), plus a universal envoyconfig golden test with a `MeshProxyPatch` patching `circuitBreakers` on the passthrough cluster.

## Supporting documentation

Envoy circuit breaker threshold resolution: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto