### PR TITLE
fix(kds): NACK an existing resource on sync

### DIFF
--- a/pkg/kds/store/sync.go
+++ b/pkg/kds/store/sync.go
@@ -64,10 +64,9 @@ type ResourceSyncer interface {
 }
 
 type SyncOption struct {
-	Predicate            func(r core_model.Resource) bool
-	SkipConflictResource bool
-	IgnoreStatusChange   bool
-	Zone                 string
+	Predicate          func(r core_model.Resource) bool
+	IgnoreStatusChange bool
+	Zone               string
 }
 
 type SyncOptionFunc func(*SyncOption)
@@ -83,12 +82,6 @@ func NewSyncOptions(fs ...SyncOptionFunc) *SyncOption {
 func Zone(name string) SyncOptionFunc {
 	return func(opts *SyncOption) {
 		opts.Zone = name
-	}
-}
-
-func SkipConflictResource() SyncOptionFunc {
-	return func(opts *SyncOption) {
-		opts.SkipConflictResource = true
 	}
 }
 
@@ -285,7 +278,14 @@ func (s *syncResourceStore) Sync(syncCtx context.Context, upstreamResponse kds_c
 
 			if err := s.resourceStore.Create(ctx, r, createOpts...); err != nil {
 				switch {
-				case opts.SkipConflictResource && store.IsAlreadyExists(err):
+				case store.IsAlreadyExists(err):
+					// The key is taken by a copy the sync could not see: a Kubernetes
+					// informer that has not caught up with a create, or a copy the origin
+					// prefilter dropped because it lost its `kuma.io/origin` label. Skip
+					// the resource and NACK it. Failing here rolls back the whole response
+					// and cancels the connection, and the next connection reads the same
+					// store and fails again, so the zone never converges.
+					log.Info("resource already exists in the downstream store, skipping it", "name", rk.Name, "mesh", rk.Mesh)
 					nackError = std_errors.Join(util.ErrUserNack, nackError, err)
 				case store.IsInvalid(err):
 					// The store refused this one resource on its own merits (a quota, a
@@ -445,11 +445,6 @@ func ZoneSyncCallback(ctx context.Context, syncer ResourceSyncer, k8sStore bool,
 				// Therefore, we should ignore status field comparison, since the status is always synced as empty from the Global.
 				IgnoreStatusChange(),
 			}
-			// When there is no KDS hash suffix, we can have conflicts in resources so we simply skip them
-			if tDesc.SkipKDSHash {
-				syncOptions = append(syncOptions, SkipConflictResource())
-			}
-
 			return syncer.Sync(ctx, upstream, syncOptions...)
 		},
 	}

--- a/pkg/kds/store/sync_test.go
+++ b/pkg/kds/store/sync_test.go
@@ -219,7 +219,7 @@ var _ = Describe("SyncResourceStoreDelta", func() {
 		// when
 		err, nackError := syncer.Sync(context.Background(), upstreamResponse, kds_sync_store.PrefilterBy(func(r model.Resource) bool {
 			return r.GetMeta().GetLabels()[mesh_proto.ResourceOriginLabel] != "zone"
-		}), kds_sync_store.SkipConflictResource())
+		}))
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -307,7 +307,7 @@ var _ = Describe("SyncResourceStoreDelta errors", func() {
 		upstreamResponse.Type = upstream.GetItemType()
 		upstreamResponse.AddedResources = upstream
 
-		err, nackError := syncer.Sync(context.Background(), upstreamResponse, kds_sync_store.SkipConflictResource())
+		err, nackError := syncer.Sync(context.Background(), upstreamResponse)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(util.IsUserError(nackError)).To(BeTrue())
 		Expect(util.IsUserErrorMessage(nackError.Error())).To(BeTrue())
@@ -588,5 +588,102 @@ var _ = Describe("SyncResourceStoreDelta write conflicts on zone-owned status", 
 		// the zone owns the status, and the retry must not roll it back to the copy
 		// read before the allocator wrote
 		Expect(actual.Status.VIPs).To(Equal([]meshservice_api.VIP{{IP: "10.0.0.2"}}))
+	})
+})
+
+// hidingStore hides one resource from reads while writes keep seeing it, the way a
+// Kubernetes informer that has not caught up hides a create from the syncer, and the
+// way the origin prefilter hides a downstream copy that lost its `kuma.io/origin`
+// label.
+type hidingStore struct {
+	store.ResourceStore
+	hidden model.ResourceKey
+}
+
+func (h *hidingStore) List(ctx context.Context, list model.ResourceList, fs ...store.ListOptionsFunc) error {
+	if err := h.ResourceStore.List(ctx, list, fs...); err != nil {
+		return err
+	}
+	meshes, ok := list.(*mesh.MeshResourceList)
+	if !ok {
+		return nil
+	}
+	var kept []*mesh.MeshResource
+	for _, item := range meshes.Items {
+		if model.MetaToResourceKey(item.GetMeta()) != h.hidden {
+			kept = append(kept, item)
+		}
+	}
+	meshes.Items = kept
+	return nil
+}
+
+var _ = Describe("SyncResourceStoreDelta creates that collide with a hidden resource", func() {
+	var resourceStore *hidingStore
+	var syncer kds_sync_store.ResourceSyncer
+	var key model.ResourceKey
+
+	syncUpstream := func(indexes ...int) (error, error) {
+		upstream := &mesh.MeshResourceList{}
+		for _, i := range indexes {
+			m := meshBuilder(i)
+			m.Spec.SkipCreatingInitialPolicies = []string{"policy-changed"}
+			m.Meta.(*model2.ResourceMeta).Labels = map[string]string{
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.GlobalResourceOrigin),
+			}
+			Expect(upstream.AddItem(m)).To(Succeed())
+		}
+		return syncer.Sync(context.Background(), kds_client.UpstreamResponse{
+			Type:             upstream.GetItemType(),
+			AddedResources:   upstream,
+			IsInitialRequest: true,
+		})
+	}
+
+	BeforeEach(func() {
+		resourceStore = &hidingStore{ResourceStore: memory.NewStore()}
+		metrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		syncer, err = kds_sync_store.NewResourceSyncer(core.Log, resourceStore, store.NoTransactions{}, metrics, context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		// the copy the syncer cannot see: it is in the store, so the create fails
+		res := meshBuilder(1)
+		key = model.MetaToResourceKey(res.GetMeta())
+		Expect(resourceStore.Create(context.Background(), res, store.CreateBy(key), store.CreateWithLabels(map[string]string{
+			mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+		}))).To(Succeed())
+		resourceStore.hidden = key
+	})
+
+	It("should NACK the colliding resource instead of failing the whole response", func() {
+		err, nackError := syncUpstream(1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(util.IsUserError(nackError)).To(BeTrue())
+		Expect(nackError).To(MatchError(ContainSubstring("already exists")))
+	})
+
+	It("should leave the existing resource untouched", func() {
+		_, nackError := syncUpstream(1)
+		Expect(util.IsUserError(nackError)).To(BeTrue())
+
+		actual := mesh.NewMeshResource()
+		Expect(resourceStore.ResourceStore.Get(context.Background(), actual, store.GetBy(key))).To(Succeed())
+		Expect(actual.Spec.SkipCreatingInitialPolicies).To(Equal([]string{"policy-1"}))
+		// the resource keeps the labels that hid it, so every sync NACKs it again
+		Expect(actual.GetMeta().GetLabels()).To(HaveKeyWithValue(mesh_proto.ResourceOriginLabel, string(mesh_proto.ZoneResourceOrigin)))
+	})
+
+	It("should apply the rest of the batch", func() {
+		err, nackError := syncUpstream(1, 2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(util.IsUserError(nackError)).To(BeTrue())
+
+		actual := &mesh.MeshResourceList{}
+		Expect(resourceStore.ResourceStore.List(context.Background(), actual)).To(Succeed())
+		Expect(actual.Items).To(HaveLen(2))
+		created := mesh.NewMeshResource()
+		Expect(resourceStore.ResourceStore.Get(context.Background(), created, store.GetByKey("mesh-2", model.NoMesh))).To(Succeed())
+		Expect(created.Spec.SkipCreatingInitialPolicies).To(Equal([]string{"policy-changed"}))
 	})
 })


### PR DESCRIPTION
## Motivation

When the syncer creates a resource that already exists downstream, the `AlreadyExists` error propagates out of `Sync` and tears the stream down.
The next connection reads the same store, classifies the same resource as a create again, and fails again, so the loop is permanent and the zone stops receiving global config until someone deletes the object by hand.

A downstream copy can be absent from the list yet present in the store in two ways:

- the Kubernetes store reads through an informer cache (`mgr.GetClient()`), which can serve a list that predates a create;
- the origin prefilter in `ZoneSyncCallback` drops a downstream copy that is not global-origin, and `IsLocallyOriginated` treats a **missing** `kuma.io/origin` label as zone-local, so a synced resource that lost its label - or got `kuma.io/origin: zone`, which is what the zone admission webhook stamps on any re-apply of a resource in the system namespace - is invisible to the syncer and collides on every create.

Reproduced with a `HostnameGenerator` on a federated zone: relabel a `synced-*` generator to `kuma.io/origin: zone`, restart the zone CP, and the mux client restarts forever with `failed to store HostnameGenerator resources: resource already exists`, backoff pinned at the 1m cap, tearing down zone-to-global sync and the admin RPCs with it on every cycle.

## Implementation information

- `AlreadyExists` on create is skipped and NACKed instead of failing the response. The rest of the batch applies and the stream stays up.
- This is what hashless types already did through `SkipConflictResource`, so that option and the `SkipKDSHash` gate that set it are removed: the behaviour is now unconditional and every type is treated the same way.
- Tests add a store that hides a resource from reads while writes keep seeing it, covering the NACK, the untouched existing resource, and the rest of the batch still applying.

Note what this does **not** do: the colliding resource is left exactly as it is, so global keeps re-sending it every `NackBackoff` and the zone keeps NACKing it until an operator deletes the object. The sync is no longer wedged, but that one resource stays out of sync.

## Supporting documentation

Alternative to #18200, which takes the resource over and repairs it instead of NACKing, so the zone converges without manual cleanup. Open both to compare, only one should be merged.
Both are the create-side counterpart of #17738, which added the equivalent handling for updates that lose a write conflict.