### PR TITLE
chore(lint): fix golangci-lint 2.13.1 findings

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -118,7 +118,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 
 	It("creates the generated route in the HTTPRoute namespace when the parent MeshService is in the same namespace", func() {
 		ms := &meshservice_k8s.MeshService{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "kuma-demo"},
+			Name: "backend", Namespace: "kuma-demo",
 			Spec: &meshservice_api.MeshService{
 				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
 			},
@@ -140,9 +140,9 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 	})
 
 	It("creates the generated route in the system namespace when the parent MeshService is in a different namespace", func() {
-		otherNamespace := &kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "other-ns"}}
+		otherNamespace := &kube_core.Namespace{Name: "other-ns"}
 		ms := &meshservice_k8s.MeshService{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "other-ns"},
+			Name: "backend", Namespace: "other-ns",
 			Spec: &meshservice_api.MeshService{
 				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
 			},
@@ -376,7 +376,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 
 	It("creates the generated route in the HTTPRoute namespace when the parent Service is in the same namespace", func() {
 		svc := &kube_core.Service{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Name: "backend", Namespace: routeNamespace,
 			Spec: kube_core.ServiceSpec{
 				ClusterIP: "10.0.0.1",
 				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
@@ -399,9 +399,9 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 	})
 
 	It("creates the generated route in the system namespace when the parent Service is in a different namespace", func() {
-		otherNamespace := &kube_core.Namespace{ObjectMeta: kube_meta.ObjectMeta{Name: "other-ns"}}
+		otherNamespace := &kube_core.Namespace{Name: "other-ns"}
 		svc := &kube_core.Service{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: "other-ns"},
+			Name: "backend", Namespace: "other-ns",
 			Spec: kube_core.ServiceSpec{
 				ClusterIP: "10.0.0.1",
 				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
@@ -428,7 +428,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 
 	It("moves a generated route that already exists in the system namespace into the HTTPRoute namespace", func() {
 		svc := &kube_core.Service{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "backend", Namespace: routeNamespace},
+			Name: "backend", Namespace: routeNamespace,
 			Spec: kube_core.ServiceSpec{
 				ClusterIP: "10.0.0.1",
 				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},


### PR DESCRIPTION
## Motivation

The golangci-lint bump to 2.13.1 (#18189) enabled modernize's `embedlit` check, which flags the redundant embedded `ObjectMeta` type in struct literals. Seven of those live in `http_route_controller_test.go`, so the `check` job is red on master and every open PR inherits the failure.

## Implementation information

Dropped the redundant `ObjectMeta: kube_meta.ObjectMeta{...}` wrapper in the seven flagged literals; `ObjectMeta` is embedded in both `MeshService` and the core Kubernetes types, so the fields are set directly. Mechanical change, no behavior difference. The `kube_meta` import stays, it is still used elsewhere in the file.

Verified with `golangci-lint run --fix=false` (the flag CI passes) on the package: 0 issues. Build, vet, and the package tests pass.

## Supporting documentation

Follows the same pattern as #18194 for the previous lint bump.

> Changelog: skip