### PR TITLE
feat(validation): restrict crossZone to MeshMultizoneService

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
+### `MeshLoadBalancingStrategy` cross-zone settings now require a `MeshMultiZoneService` `to` target
+
+`MeshLoadBalancingStrategy.spec.to[].default.localityAwareness.crossZone` is now accepted only when that `to` entry targets a `MeshMultiZoneService`. Create and update validation now rejects the same `crossZone` block on `Mesh`, `MeshService`, and `MeshExternalService` targets.
+
+**Action required**
+
+Move any existing `crossZone` configuration under `to` entries whose `targetRef.kind` is `MeshMultiZoneService` before upgrading. Keep `localityAwareness.localZone`, `loadBalancer`, and other supported settings on the remaining target kinds as needed.
+
 ### Generated Gateway API producer routes now win the same ties as hand-written ones
 
 A `MeshHTTPRoute` generated from a Gateway API `HTTPRoute` whose parent (a `Service` or `MeshService`) lives in the `HTTPRoute`'s own namespace is now created in that namespace, instead of always landing in the Kuma system namespace. This is what the policy role model calls a producer route, and putting it in the right namespace gives it `kuma.io/policy-role=producer`, the same role a hand-written `MeshHTTPRoute` targeting the same `Mesh` and `to` entry gets. Before this change, every generated route landed in the system namespace and was ranked `system`, so it always lost to an equivalent hand-written producer route even when the two expressed the same intent.

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -1419,7 +1419,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -1419,7 +1419,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -1419,7 +1419,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -3817,7 +3817,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing

--- a/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -284,7 +284,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -9024,7 +9024,8 @@ components:
                               priorities when dataplane proxies inside local
                               zone
 
-                              are unavailable
+                              are unavailable. Supported only for
+                              to[].targetRef.kind MeshMultiZoneService.
                             properties:
                               failover:
                                 description: >-

--- a/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshloadbalancingstrategies.yaml
@@ -284,7 +284,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/meshloadbalancingstrategy.go
@@ -47,7 +47,7 @@ type LocalityAwareness struct {
 	// LocalZone defines locality aware load balancing priorities between dataplane proxies inside a zone
 	LocalZone *LocalZone `json:"localZone,omitempty"`
 	// CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-	// are unavailable
+	// are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
 	CrossZone *CrossZone `json:"crossZone,omitempty"`
 }
 

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -380,7 +380,7 @@ components:
                           crossZone:
                             description: |-
                               CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                              are unavailable
+                              are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                             properties:
                               failover:
                                 description: Failover defines list of load balancing rules in order of priority

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator.go
@@ -113,8 +113,9 @@ func validateCrossZone(crossZone *CrossZone, to To) validators.ValidationError {
 	if crossZone == nil {
 		return verr
 	}
-	if to.TargetRef.Kind == common_api.OutboundTargetRefKindMeshService && (pointer.Deref(to.TargetRef.SectionName) != "" || len(pointer.Deref(to.TargetRef.Labels)) > 0) {
-		verr.AddViolationAt(validators.Root(), fmt.Sprintf("%s: MeshService traffic is local", validators.MustNotBeSet))
+	if to.TargetRef.Kind != common_api.OutboundTargetRefKindMeshMultiZoneService {
+		verr.AddViolationAt(validators.Root(), "crossZone is only supported when targetRef.kind is MeshMultiZoneService")
+		return verr
 	}
 
 	for idx, failover := range pointer.Deref(crossZone.Failover) {

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -35,7 +35,7 @@ to: []
 				Message: "value 'MeshServiceSubset' is not supported",
 			}, {
 				Field:   "spec.to[1].default.localityAwareness.crossZone",
-				Message: "must not be set: MeshService traffic is local",
+				Message: "crossZone is only supported when targetRef.kind is MeshMultiZoneService",
 			}},
 			`
 type: MeshLoadBalancingStrategy
@@ -54,6 +54,38 @@ to:
       labels:
         kuma.io/display-name: real-mesh-service
       sectionName: http
+    default:
+      localityAwareness:
+        crossZone: {}
+`),
+		ErrorCases(
+			"crossZone on unsupported target kinds",
+			[]validators.Violation{
+				{
+					Field:   "spec.to[0].default.localityAwareness.crossZone",
+					Message: "crossZone is only supported when targetRef.kind is MeshMultiZoneService",
+				},
+				{
+					Field:   "spec.to[1].default.localityAwareness.crossZone",
+					Message: "crossZone is only supported when targetRef.kind is MeshMultiZoneService",
+				},
+			},
+			`
+type: MeshLoadBalancingStrategy
+mesh: mesh-1
+name: route-1
+targetRef:
+  kind: Mesh
+to:
+  - targetRef:
+      kind: Mesh
+    default:
+      localityAwareness:
+        crossZone: {}
+  - targetRef:
+      kind: MeshExternalService
+      labels:
+        kuma.io/display-name: httpbin
     default:
       localityAwareness:
         crossZone: {}

--- a/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/k8s/crd/kuma.io_meshloadbalancingstrategies.yaml
@@ -284,7 +284,7 @@ spec:
                             crossZone:
                               description: |-
                                 CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
-                                are unavailable
+                                are unavailable. Supported only for to[].targetRef.kind MeshMultiZoneService.
                               properties:
                                 failover:
                                   description: Failover defines list of load balancing


### PR DESCRIPTION
## Motivation

The `crossZone` field in MeshLoadBalancingStrategy only makes sense when using MeshMultizoneService. Without validation, users could misconfigure this field with other targetRef types, leading to unexpected behavior. Updating the OpenAPI description clarifies this constraint.

## Implementation information

Added validation to restrict `crossZone` configuration to MeshMultizoneService targetRef types. Updated OpenAPI schema documentation to explain that `crossZone` is only valid when used with MeshMultizoneService. Addressed review feedback to ensure validation logic is clear and complete.

_Generated by Sybra harness_