### PR TITLE
fix(helm): allow universal global control plane

### DIFF
--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -237,10 +237,6 @@ controlPlane:
 			extraArgs: []string{"--mode", "global"},
 			errorMsg:  "Kubernetes-native Global Control Plane is not supported",
 		}),
-		Entry("--mode global with universal environment is still unsupported", errTestCase{
-			extraArgs: []string{"--mode", "global", "--set", "controlPlane.environment=universal"},
-			errorMsg:  "Kubernetes-native Global Control Plane is not supported",
-		}),
 		Entry("--zone is more than 253 characters", errTestCase{
 			extraArgs: []string{"--kds-global-address", "grpcs://192.168.0.1:5685", "--mode", "zone", "--zone", "takryywlpeftgnlwuwmwwfwohwzqxqlofjfsuuldtatoxlmnniytycvdnduwplvgnpnjwvzmbkqrvgnlovpynrtuyhhrqibdzwbfjrmhvwkkryzfnudghaxmegfvacjlytuyeikuawquolrykwwldjiynaxrpqgxmvwashrkigadzhxdeihcbjurhpmdrnulajpaspqcgzqxsnjrdenhruaawooojpyoprgnnoqiqdhncuztbgfsvhparjlippv"},
 			errorMsg:  "controlPlane.zone must be no more than 253 characters",

--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -44,7 +44,7 @@ controlPlane:
   # -- Kuma CP log output path: Defaults to /dev/stdout
   logOutputPath: ""
 
-  # -- Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
+  # -- Kuma CP modes: zone, global. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
   mode: "zone"
 
   # -- (string) Kuma CP zone, if running multizone

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -24,7 +24,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.extraLabels | object | `{}` | Labels to add to resources in addition to default labels |
 | controlPlane.logLevel | string | `"info"` | Kuma CP log level: one of off,info,debug |
 | controlPlane.logOutputPath | string | `""` | Kuma CP log output path: Defaults to /dev/stdout |
-| controlPlane.mode | string | `"zone"` | Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart |
+| controlPlane.mode | string | `"zone"` | Kuma CP modes: zone, global. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart |
 | controlPlane.zone | string | `nil` | Kuma CP zone, if running multizone |
 | controlPlane.kdsGlobalAddress | string | `""` | Only used in `zone` mode |
 | controlPlane.replicas | int | `1` | Number of replicas of the Kuma CP. Ignored when autoscaling is enabled |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -6,11 +6,11 @@
   {{ end }}
 {{ end }}
 
-{{ if eq .Values.controlPlane.mode "global" }}
+{{ if and (eq .Values.controlPlane.environment "kubernetes") (eq .Values.controlPlane.mode "global") }}
   {{ fail "Kubernetes-native Global Control Plane is not supported: controlPlane.mode=global cannot be deployed with this Helm chart. Deploy Zone control planes on Kubernetes; run the Global Control Plane on non-Kubernetes (Universal) infrastructure instead" }}
 {{ end }}
-{{ if ne .Values.controlPlane.mode "zone" }}
-  {{ $msg := printf "controlPlane.mode invalid got:'%s' supported values: zone" .Values.controlPlane.mode }}
+{{ if not (or (eq .Values.controlPlane.mode "zone") (eq .Values.controlPlane.mode "global")) }}
+  {{ $msg := printf "controlPlane.mode invalid got:'%s' supported values: zone, global" .Values.controlPlane.mode }}
   {{ fail $msg }}
 {{ end }}
 {{ if eq .Values.controlPlane.mode "zone" }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -44,7 +44,7 @@ controlPlane:
   # -- Kuma CP log output path: Defaults to /dev/stdout
   logOutputPath: ""
 
-  # -- Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
+  # -- Kuma CP modes: zone, global. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
   mode: "zone"
 
   # -- (string) Kuma CP zone, if running multizone

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -44,7 +44,7 @@ controlPlane:
   # -- Kuma CP log output path: Defaults to /dev/stdout
   logOutputPath: ""
 
-  # -- Kuma CP modes: zone. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
+  # -- Kuma CP modes: zone, global. Deploying a Global Control Plane on Kubernetes is not supported by this Helm chart
   mode: "zone"
 
   # -- (string) Kuma CP zone, if running multizone


### PR DESCRIPTION
## Motivation
PR https://github.com/kumahq/kuma/pull/17494 blocked all Helm installs with controlPlane.mode=global.
It was supposed to block only Kubernetes-native global control planes.

## Changes
- allow controlPlane.mode=global when controlPlane.environment=universal
- keep controlPlane.mode=global rejected for Kubernetes installs
- update Helm docs and kumactl golden output
- remove the obsolete kumactl negative test for universal/global

## Testing
- make test TEST_PKG_LIST=./app/kumactl/cmd/install
- make check (fails in unrelated golangci-lint staticcheck issues in test/framework/network/netns)
- helm template before/after comparison for universal/global and default k8s/zone