### PR TITLE
fix(k8s): scope gateway mapper logger per call

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller.go
@@ -424,7 +424,7 @@ func GatewayToInstanceMapper(l logr.Logger, client kube_client.Client) kube_hand
 
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		gateway := obj.(*mesh_k8s.MeshGateway)
-		l = l.WithValues("gateway", obj.GetName(), "mesh", gateway.Mesh)
+		l := l.WithValues("gateway", obj.GetName(), "mesh", gateway.Mesh)
 
 		spec, err := gateway.GetSpec()
 		if err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gateway_instance_controller_test.go
@@ -1,0 +1,131 @@
+package controllers_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
+	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mesh_k8s "github.com/kumahq/kuma/v2/pkg/plugins/resources/k8s/native/api/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/plugins/runtime/k8s/controllers"
+)
+
+// recordingSink records the values every log entry is written with, so that we
+// can assert the logger doesn't accumulate them across invocations.
+type recordingSink struct {
+	values  []any
+	entries *[][]any
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo) {}
+
+func (s *recordingSink) Enabled(int) bool { return true }
+
+func (s *recordingSink) Info(_ int, _ string, keysAndValues ...any) {
+	*s.entries = append(*s.entries, s.merged(keysAndValues))
+}
+
+func (s *recordingSink) Error(_ error, _ string, keysAndValues ...any) {
+	*s.entries = append(*s.entries, s.merged(keysAndValues))
+}
+
+func (s *recordingSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return &recordingSink{values: s.merged(keysAndValues), entries: s.entries}
+}
+
+func (s *recordingSink) WithName(string) logr.LogSink { return s }
+
+func (s *recordingSink) merged(keysAndValues []any) []any {
+	values := make([]any, 0, len(s.values)+len(keysAndValues))
+	values = append(values, s.values...)
+	return append(values, keysAndValues...)
+}
+
+// emptyClient lists no objects, which is all the mapper needs from a client.
+type emptyClient struct {
+	kube_client.Client
+}
+
+func (emptyClient) List(context.Context, kube_client.ObjectList, ...kube_client.ListOption) error {
+	return nil
+}
+
+var _ = Describe("GatewayToInstanceMapper", func() {
+	gateway := func(name string, serviceTags ...string) *mesh_k8s.MeshGateway {
+		selectors := ""
+		for i, tag := range serviceTags {
+			if i > 0 {
+				selectors += ","
+			}
+			selectors += `{"match":{"kuma.io/service":"` + tag + `"}}`
+		}
+		return &mesh_k8s.MeshGateway{
+			Name: name,
+			Mesh: "default",
+			Spec: &apiextensionsv1.JSON{
+				Raw: []byte(`{"selectors":[` + selectors + `]}`),
+			},
+		}
+	}
+
+	newMapper := func(entries *[][]any) kube_handler.MapFunc {
+		return controllers.GatewayToInstanceMapper(logr.New(&recordingSink{entries: entries}), emptyClient{})
+	}
+
+	It("should map service tags to MeshGatewayInstance names", func() {
+		// given
+		var entries [][]any
+		mapper := newMapper(&entries)
+
+		// when
+		requests := mapper(context.Background(), gateway("edge-gateway", "gateway_kuma-demo_svc_8080"))
+
+		// then
+		Expect(requests).To(Equal([]kube_reconcile.Request{{
+			Name: "gateway", Namespace: "kuma-demo",
+		}}))
+		Expect(entries).To(BeEmpty())
+	})
+
+	It("should not accumulate log values across invocations", func() {
+		// given
+		var entries [][]any
+		mapper := newMapper(&entries)
+		// a service tag that isn't in the <name>_<namespace>_svc_<port> form makes
+		// the mapper log an error, which is what surfaces accumulated values
+		obj := gateway("edge-gateway", "edge-gateway")
+
+		// when
+		for range 3 {
+			Expect(mapper(context.Background(), obj)).To(BeEmpty())
+		}
+
+		// then
+		Expect(entries).To(Equal([][]any{
+			{"gateway", "edge-gateway", "mesh", "default"},
+			{"gateway", "edge-gateway", "mesh", "default"},
+			{"gateway", "edge-gateway", "mesh", "default"},
+		}))
+	})
+
+	It("should not leak values of one MeshGateway into another", func() {
+		// given
+		var entries [][]any
+		mapper := newMapper(&entries)
+
+		// when
+		Expect(mapper(context.Background(), gateway("edge-gateway", "edge-gateway"))).To(BeEmpty())
+		Expect(mapper(context.Background(), gateway("second-gateway", "second-gateway"))).To(BeEmpty())
+
+		// then
+		Expect(entries).To(Equal([][]any{
+			{"gateway", "edge-gateway", "mesh", "default"},
+			{"gateway", "second-gateway", "mesh", "default"},
+		}))
+	})
+})


### PR DESCRIPTION
## Motivation

`GatewayToInstanceMapper` reassigns the logger captured by the closure it returns, so every invocation appends `gateway` and `mesh` values to the single logger shared by all invocations. The key-value list grows without bound, is never released, and carries values of unrelated MeshGateways.

Measured on a k3d cluster running 2.14.3: after ~106 MeshGateway update events a single `failed to fetch GatewayInstances` line held 212 key-value pairs and 9935 bytes, and the first log line of a newly created MeshGateway already carried 11 entries belonging to a different gateway. With the fix each entry stays at one `gateway`/`mesh` pair and 230 bytes.

The bug reaches every branch that still has the built-in gateway controllers; it was introduced in f4b94a037f and first released in 1.8.0. It is gone from master, where the controllers were removed in 4895a75774, so this lands on release branches directly.

Fixes https://github.com/kumahq/kuma/issues/18158

## Implementation information

Shadow the logger inside the closure instead of reassigning the captured variable. The regression test records the values each log entry is written with through a `logr.LogSink` stub and asserts they stay scoped to their own invocation, both across repeated calls and across different MeshGateways.

## Supporting documentation

No behavior change beyond logging: the mapper's returned reconcile requests are unchanged and covered by the new test.