### PR TITLE
chore(deps): bump envoy from 1.35.13 to 1.36.10

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -8,7 +8,7 @@ GIT_COMMIT = $(word 3, $(BUILD_INFO))
 BUILD_DATE = $(word 4, $(BUILD_INFO))
 CI_TOOLS_VERSION = $(word 5, $(BUILD_INFO))
 # renovate: datasource=github-tags depName=envoy packageName=kumahq/envoy-builds versioning=semver
-ENVOY_VERSION ?= 1.35.13
+ENVOY_VERSION ?= 1.36.10
 KUMA_CHARTS_URL ?= https://kumahq.github.io/charts
 CHART_REPO_NAME ?= kuma
 PROJECT_NAME ?= kuma


### PR DESCRIPTION
## Motivation

The Envoy 1.35 line is no longer supported, so `release-2.12` is pinned to a version that will not receive further upstream fixes. 1.36.10 is the latest patch of the supported 1.36 line and is already published in `kumahq/envoy-builds`.

## Implementation information

Bump `ENVOY_VERSION` in `mk/dev.mk` from 1.35.13 to 1.36.10. That pin is the only reference to the Envoy version on this branch; it drives builds, tests and the `kuma-dp` version string.

## Supporting documentation

https://github.com/kumahq/envoy-builds/releases/tag/v1.36.10

