### PR TITLE
chore(deps): bump envoy from 1.36.9 to 1.36.10

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -8,7 +8,7 @@ GIT_COMMIT = $(word 3, $(BUILD_INFO))
 BUILD_DATE = $(word 4, $(BUILD_INFO))
 CI_TOOLS_VERSION = $(word 5, $(BUILD_INFO))
 # renovate: datasource=github-tags depName=envoy packageName=kumahq/envoy-builds versioning=semver
-ENVOY_VERSION ?= 1.36.9
+ENVOY_VERSION ?= 1.36.10
 KUMA_CHARTS_URL ?= https://kumahq.github.io/charts
 CHART_REPO_NAME ?= kuma
 PROJECT_NAME ?= kuma


### PR DESCRIPTION
## Motivation

`release-2.13` tracks the Envoy 1.36 line and is pinned to 1.36.9, while 1.36.10 is the newest patch published in `kumahq/envoy-builds`. Staying on the latest patch keeps the data plane on current upstream fixes.

## Implementation information

Bump `ENVOY_VERSION` in `mk/dev.mk` from 1.36.9 to 1.36.10. That pin is the only reference to the Envoy version on this branch; it drives builds, tests and the `kuma-dp` version string.

## Supporting documentation

https://github.com/kumahq/envoy-builds/releases/tag/v1.36.10
