### PR TITLE
feat(meshhealthcheck): support unhealthyInterval

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -8012,6 +8012,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -8012,6 +8012,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -8012,6 +8012,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -2604,6 +2604,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshhealthchecks.yaml
@@ -262,6 +262,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -8582,6 +8582,18 @@ components:
                           Maximum time to wait for a health check response.
                           If not specified then the default value is 15s
                         type: string
+                      unhealthyInterval:
+                        description: >-
+                          Interval between consecutive health checks for a host
+                          that is currently
+
+                          marked as unhealthy. As soon as the host is marked as
+                          healthy again Envoy
+
+                          shifts back to using the standard 'interval'.
+
+                          If not specified then the value of 'interval' is used.
+                        type: string
                       unhealthyThreshold:
                         description: >-
                           Number of consecutive unhealthy checks before

--- a/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshhealthchecks.yaml
@@ -262,6 +262,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/meshhealthcheck.go
@@ -32,6 +32,11 @@ type Conf struct {
 	// Interval between consecutive health checks.
 	// If not specified then the default value is 1m
 	Interval *k8s.Duration `json:"interval,omitempty"`
+	// Interval between consecutive health checks for a host that is currently
+	// marked as unhealthy. As soon as the host is marked as healthy again Envoy
+	// shifts back to using the standard 'interval'.
+	// If not specified then the value of 'interval' is used.
+	UnhealthyInterval *k8s.Duration `json:"unhealthyInterval,omitempty"`
 	// Maximum time to wait for a health check response.
 	// If not specified then the default value is 15s
 	Timeout *k8s.Duration `json:"timeout,omitempty"`

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -361,6 +361,13 @@ components:
                           Maximum time to wait for a health check response.
                           If not specified then the default value is 15s
                         type: string
+                      unhealthyInterval:
+                        description: |-
+                          Interval between consecutive health checks for a host that is currently
+                          marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                          shifts back to using the standard 'interval'.
+                          If not specified then the value of 'interval' is used.
+                        type: string
                       unhealthyThreshold:
                         description: |-
                           Number of consecutive unhealthy checks before considering a host

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator.go
@@ -49,6 +49,7 @@ func validateDefault(conf Conf) validators.ValidationError {
 	var verr validators.ValidationError
 	path := validators.RootedAt("default")
 	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("interval"), conf.Interval))
+	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("unhealthyInterval"), conf.UnhealthyInterval))
 	verr.Add(validators.ValidateDurationGreaterThanZeroOrNil(path.Field("timeout"), conf.Timeout))
 	verr.Add(validators.ValidateValueGreaterThanZeroOrNil(path.Field("unhealthyThreshold"), conf.UnhealthyThreshold))
 	verr.Add(validators.ValidateValueGreaterThanZeroOrNil(path.Field("healthyThreshold"), conf.HealthyThreshold))

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/validator_test.go
@@ -191,6 +191,7 @@ to:
         kuma.io/display-name: web-backend
     default:
       interval: -10s
+      unhealthyInterval: -7s
       timeout: -2s
       initialJitter: -5s
       intervalJitter: -6s
@@ -202,6 +203,8 @@ to:
 				expected: `
 violations:
   - field: spec.to[0].default.interval
+    message: must be greater than zero when defined
+  - field: spec.to[0].default.unhealthyInterval
     message: must be greater than zero when defined
   - field: spec.to[0].default.timeout
     message: must be greater than zero when defined

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/zz_generated.deepcopy.go
@@ -17,6 +17,11 @@ func (in *Conf) DeepCopyInto(out *Conf) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.UnhealthyInterval != nil {
+		in, out := &in.UnhealthyInterval, &out.UnhealthyInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)

--- a/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/k8s/crd/kuma.io_meshhealthchecks.yaml
@@ -262,6 +262,13 @@ spec:
                             Maximum time to wait for a health check response.
                             If not specified then the default value is 15s
                           type: string
+                        unhealthyInterval:
+                          description: |-
+                            Interval between consecutive health checks for a host that is currently
+                            marked as unhealthy. As soon as the host is marked as healthy again Envoy
+                            shifts back to using the standard 'interval'.
+                            If not specified then the value of 'interval' is used.
+                          type: string
                         unhealthyThreshold:
                           description: |-
                             Number of consecutive unhealthy checks before considering a host

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/plugin_test.go
@@ -161,6 +161,7 @@ var _ = Describe("MeshHealthCheck", func() {
 						Conf: []any{
 							api.Conf{
 								Interval:                     test.ParseDuration("10s"),
+								UnhealthyInterval:            test.ParseDuration("17s"),
 								Timeout:                      test.ParseDuration("2s"),
 								UnhealthyThreshold:           pointer.To[int32](3),
 								HealthyThreshold:             pointer.To[int32](1),

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_cluster.golden.yaml
@@ -33,5 +33,6 @@ healthChecks:
   noTrafficInterval: 16s
   reuseConnection: true
   timeout: 2s
+  unhealthyInterval: 17s
   unhealthyThreshold: 3
 name: kri_msvc_default___echo-http_80

--- a/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/v1alpha1/testdata/basic_http_health_check_split_cluster.golden.yaml
@@ -33,5 +33,6 @@ healthChecks:
   noTrafficInterval: 16s
   reuseConnection: true
   timeout: 2s
+  unhealthyInterval: 17s
   unhealthyThreshold: 3
 name: kri_msvc_default___echo-http_80-_0_

--- a/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshhealthcheck/plugin/xds/configurer.go
@@ -272,6 +272,9 @@ func buildHealthCheck(conf api.Conf) *envoy_core.HealthCheck {
 		HealthyThreshold:   util_proto.UInt32(uint32(healthyThreshold)),
 	}
 
+	if conf.UnhealthyInterval != nil {
+		hc.UnhealthyInterval = util_proto.Duration(conf.UnhealthyInterval.Duration)
+	}
 	if conf.InitialJitter != nil {
 		hc.InitialJitter = util_proto.Duration(conf.InitialJitter.Duration)
 	}


### PR DESCRIPTION
## Motivation

Envoy's health check config has [`unhealthy_interval`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-field-config-core-v3-healthcheck-unhealthy-interval) — a separate probe interval used while an endpoint is marked unhealthy, distinct from the normal `interval`. `MeshHealthCheck` currently exposes `interval`, `intervalJitter`, `intervalJitterPercent` and `noTrafficInterval`, but not `unhealthyInterval`, so there was no way to probe unhealthy hosts on a different cadence.

This came up in #17129: users configuring it via `ProxyTemplate` on older Kuma had no equivalent after moving onto `MeshHealthCheck`. It was also already listed in the L4 health-check proposal (`docs/proposals/HealthChecks-L4.md`) but never wired up.

## Implementation information

- New optional `unhealthyInterval` (`*k8s.Duration`) on the policy `Conf`, placed next to `interval`.
- Validated like the other durations — must be greater than zero when set.
- Passed straight through to the Envoy `HealthCheck` in the xDS configurer. When unset, Envoy keeps its current behaviour of falling back to `interval`, so this is fully backward compatible.
- Regenerated the dependent files (`zz_generated.deepcopy.go`, CRDs, `rest.yaml`, bundled OpenAPI, kumactl install goldens) with `controller-gen v0.21.0` / `policy-gen`.
- Tests: extended the validator negative-duration case, added `unhealthyInterval` to the HTTP health-check plugin entry, and refreshed the two affected xDS golden files (they now show `unhealthyInterval: 17s` in the emitted cluster).

`make test TEST_PKG_LIST=./pkg/plugins/policies/meshhealthcheck/...` passes locally. My local toolchain is a minor version behind the repo's pinned Go/golangci-lint, so if the generated-file or lint checks flag anything in CI a maintainer `/golden_files` + `/format` pass should sort it.

## Supporting documentation

- `docs/proposals/HealthChecks-L4.md` (lists `unhealthyInterval`)
- Envoy: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-field-config-core-v3-healthcheck-unhealthy-interval

Closes #17129