### PR TITLE
feat(charts): make kuma-control-plane Deployment update strategy configurable

### DIFF
--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -30,6 +30,7 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.replicas | int | `1` | Number of replicas of the Kuma CP. Ignored when autoscaling is enabled |
 | controlPlane.restartPolicy | string | `"Always"` | Pod restart policy for the Control Plane. |
 | controlPlane.minReadySeconds | int | `0` | Minimum number of seconds for which a newly created pod should be ready for it to be considered available. |
+| controlPlane.deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}` | Update strategy for the `Deployment` resource. Override to e.g. raise `maxUnavailable` above `0` if the default `RollingUpdate` strategy deadlocks your rollout (for example, on a single-replica cluster with tight PodDisruptionBudget or resource constraints). |
 | controlPlane.deploymentAnnotations | object | `{}` | Annotations applied only to the `Deployment` resource |
 | controlPlane.podAnnotations | object | `{}` | Annotations applied only to the `Pod` resource |
 | controlPlane.autoscaling.enabled | bool | `false` | Whether to enable Horizontal Pod Autoscaling, which requires the [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in the cluster |

--- a/deployments/charts/kuma/templates/cp-deployment.yaml
+++ b/deployments/charts/kuma/templates/cp-deployment.yaml
@@ -66,10 +66,7 @@ spec:
   replicas: {{ .Values.controlPlane.replicas }}
   {{- end }}
   minReadySeconds: {{ .Values.controlPlane.minReadySeconds }}
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+  strategy: {{- toYaml .Values.controlPlane.deploymentStrategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "kuma.selectorLabels" . | nindent 6 }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -62,6 +62,12 @@ controlPlane:
   # -- Minimum number of seconds for which a newly created pod should be ready for it to be considered available.
   minReadySeconds: 0
 
+  # -- Update strategy for the `Deployment` resource. Override to e.g. raise `maxUnavailable` above `0` if the default `RollingUpdate` strategy deadlocks your rollout (for example, on a single-replica cluster with tight PodDisruptionBudget or resource constraints).
+  deploymentStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
   # -- Annotations applied only to the `Deployment` resource
   deploymentAnnotations: {}
 


### PR DESCRIPTION
## Motivation

The kuma-control-plane Deployment's rolling update strategy (`maxSurge: 1`,
`maxUnavailable: 0`) is hardcoded in the Helm chart template with no way to
override it via values. A fixed `maxUnavailable: 0` can deadlock a rollout
in resource- or replica-constrained clusters — e.g. a single-replica
control plane behind a tight PodDisruptionBudget, where Kubernetes can
never bring down the existing pod to make room for the new one without
violating the strategy.

## Implementation information

Adds `controlPlane.deploymentStrategy` to `values.yaml`, defaulting to the
existing hardcoded values, and renders it into the Deployment's `strategy`
field via `toYaml` so it can be fully overridden — including switching to
a `Recreate` strategy entirely.

Verified with `helm template`/`helm lint`:
- Default render is unchanged (confirmed by diffing full chart output
  before/after; the only diff was pre-existing `checksum/tls-secrets`
  nondeterminism from random cert generation, present even between two
  renders of the *unmodified* chart).
- `rollingUpdate.maxSurge`/`maxUnavailable` can be overridden.
- Full override to `type: Recreate` renders correctly.

## Supporting documentation

Fix #16644