### PR TITLE
fix(meshservice): don't mutate the cached resource in the status updater

### DIFF
--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -139,23 +139,33 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 			log.Info("mesh doesn't exists, skip", "mesh", ms.Meta.GetMesh())
 			continue
 		}
+
+		// ms is served from the read-only cache and is shared with the xDS mesh
+		// context, KDS and the API server. Compute the new spec/status on a copy
+		// so nothing unpersisted leaks to those readers, and so a conflicting
+		// Update doesn't leave a mutated object behind in the cache.
+		updated := meshservice_api.NewMeshServiceResource()
+		updated.Meta = ms.GetMeta()
+		ms.Spec.DeepCopyInto(updated.Spec)
+		ms.Status.DeepCopyInto(updated.Status)
+
 		mids := identityByMesh[mesh.Meta.GetName()]
 		identities := s.buildIdentities(dpps, mids)
 		if !reflect.DeepEqual(pointer.Deref(ms.Spec.Identities), identities) {
 			changeReasons = append(changeReasons, "identities")
-			ms.Spec.Identities = &identities
+			updated.Spec.Identities = &identities
 		}
 
 		tls := s.buildTLS(ms.Status.TLS, dpps, mids, trustDomains)
 		if !reflect.DeepEqual(ms.Status.TLS, tls) {
 			changeReasons = append(changeReasons, "tls status")
-			ms.Status.TLS = tls
+			updated.Status.TLS = tls
 		}
 
 		dataplaneProxies := buildDataplaneProxies(dpps, insightsByKey, ms.Spec.Ports)
 		if !reflect.DeepEqual(ms.Status.DataplaneProxies, dataplaneProxies) {
 			changeReasons = append(changeReasons, "data plane proxies")
-			ms.Status.DataplaneProxies = dataplaneProxies
+			updated.Status.DataplaneProxies = dataplaneProxies
 		}
 
 		state := meshservice_api.StateUnavailable
@@ -164,12 +174,12 @@ func (s *StatusUpdater) updateStatus(ctx context.Context) error {
 		}
 		if ms.Spec.State != state {
 			changeReasons = append(changeReasons, "availability state")
-			ms.Spec.State = state
+			updated.Spec.State = state
 		}
 
 		if len(changeReasons) > 0 {
 			log.Info("updating mesh service", "reason", changeReasons)
-			if err := s.resManager.Update(ctx, ms); err != nil {
+			if err := s.resManager.Update(ctx, updated); err != nil {
 				if store.IsConflict(err) {
 					log.Info("couldn't update mesh service, because it was modified in another place. Will try again in the next interval", "interval", s.interval)
 				} else {

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
 	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
+	"github.com/kumahq/kuma/v3/pkg/multitenant"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	test_metrics "github.com/kumahq/kuma/v3/pkg/test/metrics"
@@ -54,6 +55,40 @@ var _ = Describe("Updater", func() {
 
 	AfterEach(func() {
 		close(stopCh)
+	})
+
+	It("does not mutate the cached MeshService it reads", func() {
+		// given an updater whose read-only manager is the shared resource cache
+		ownMetrics, err := core_metrics.NewMetrics("")
+		Expect(err).ToNot(HaveOccurred())
+		cached, err := manager.NewCachedManager(resManager, time.Minute, ownMetrics, multitenant.SingleTenant)
+		Expect(err).ToNot(HaveOccurred())
+		u, err := NewStatusUpdater(logr.Discard(), cached, resManager, 50*time.Millisecond, ownMetrics, "east", config_core.KubernetesEnvironment)
+		Expect(err).ToNot(HaveOccurred())
+		updater := u.(*StatusUpdater)
+
+		Expect(samples.MeshServiceBackendBuilder().Create(resManager)).To(Succeed())
+		Expect(resManager.Create(context.TODO(), samples.DataplaneBackendBuilder().Build(), store.CreateByKey("dp-1", model.DefaultMesh), store.CreateWithLabels(map[string]string{
+			metadata.KumaWorkload: "backend",
+		}))).To(Succeed())
+
+		// when the updater runs against the cache
+		list := &meshservice_api.MeshServiceResourceList{}
+		Expect(cached.List(context.Background(), list)).To(Succeed())
+		Expect(list.Items).To(HaveLen(1))
+		cachedMs := list.Items[0]
+		hashBefore := model.Hash(cachedMs)
+
+		Expect(updater.updateStatus(context.Background())).To(Succeed())
+
+		// then the state landed in the store
+		stored := meshservice_api.NewMeshServiceResource()
+		Expect(resManager.Get(context.Background(), stored, store.GetByKey("backend", model.DefaultMesh))).To(Succeed())
+		Expect(stored.Spec.State).To(Equal(meshservice_api.StateAvailable))
+
+		// but the instance still held in the cache is untouched
+		Expect(model.Hash(cachedMs)).To(Equal(hashBefore))
+		Expect(cachedMs.Spec.State).To(BeEmpty())
 	})
 
 	It("should add identity to status of service", func() {


### PR DESCRIPTION
## Motivation

First concrete fix from the audit in #18015.

`MeshService` status updater (`pkg/core/resources/apis/meshservice/status/updater.go`) lists resources through `roResManager`, which is wired to the resource cache (`pkg/insights/components.go`). On a cache hit that returns the instance shared with the xDS `MeshContext`, KDS and the API server. The loop then wrote `Spec.Identities`, `Status.TLS`, `Status.DataplaneProxies` and `Spec.State` straight onto that shared instance before calling `Update`.

Consequences:

- other readers (KDS zone→global snapshot, API server MeshService + overview endpoints, MeshMultiZoneService updater) saw status that is not in any store;
- `MeshServiceResource.XDSHash()` hashes the spec, so the write also shifted the mesh-context hash while the cache held the object;
- on the `store.IsConflict` path the mutated object stays in the cache with nothing in the store to match it.

## Implementation information

Build the new spec/status on a copy (`NewMeshServiceResource` + `DeepCopyInto`) and pass that to `Update`. All the change detection still reads the pristine cached values. This is the same approach already used in the MeshService generator (`generate/generator.go`), and behaviour is unchanged.

Added a regression test that runs the updater with a real `NewCachedManager` and asserts the cached instance's hash is unchanged while the store still gets the update. It fails without the fix.

The other status updaters flagged in #18015 (`meshidentity`, `meshopentelemetrybackend`, `meshmultizoneservice`, `workload`) share this shape and can follow the same pattern in separate PRs.

`make test TEST_PKG_LIST=./pkg/core/resources/apis/meshservice/... ./pkg/insights/...` passes locally.

## Supporting documentation

Refs #18015

<!--
> Changelog: Fixed the MeshService status updater mutating a cached resource shared with xDS, KDS and the API server
-->