### PR TITLE
fix(xds): stop mutating the shared Dataplane's legacy outbound list

### DIFF
--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -114,9 +114,6 @@ func (p *DataplaneProxyBuilder) resolveVIPOutbounds(
 		}
 		newOutbounds = append(newOutbounds, outbound)
 	}
-	// VIP outbounds never carry a legacy outbound, so the dataplane's legacy
-	// outbound list is always cleared here.
-	dataplane.Spec.Networking.Outbound = nil
 	return newOutbounds
 }
 

--- a/pkg/xds/sync/dataplane_proxy_builder_internal_test.go
+++ b/pkg/xds/sync/dataplane_proxy_builder_internal_test.go
@@ -1,0 +1,35 @@
+package sync
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
+)
+
+// resolveVIPOutbounds used to unconditionally null out dataplane.Spec.Networking.Outbound
+// on the VIP-outbounds branch. The Dataplane passed in comes straight from the shared,
+// cached xDS mesh context (meshContext.DataplanesByName), so that write was visible to every
+// other reader of the same object - the API server, KDS, the mesh-context hasher, etc. - not
+// just to this proxy build. See https://github.com/kumahq/kuma/issues/18015 (finding #1).
+var _ = Describe("DataplaneProxyBuilder resolveVIPOutbounds", func() {
+	It("does not mutate the shared Dataplane's legacy outbound list", func() {
+		// given a Dataplane with a legacy outbound, as it would come out of the store
+		dataplane := builders.Dataplane().
+			WithName("dp-1").
+			WithMesh("default").
+			AddOutboundToService("backend").
+			Build()
+		originalOutbounds := dataplane.Spec.GetNetworking().GetOutbound()
+		Expect(originalOutbounds).To(HaveLen(1))
+
+		builder := &DataplaneProxyBuilder{}
+
+		// when resolving VIP outbounds (bindOutbounds branch, the one that used to null the field)
+		builder.resolveVIPOutbounds(xds_context.MeshContext{}, dataplane, false, true)
+
+		// then the shared Dataplane's legacy outbound list is untouched
+		Expect(dataplane.Spec.GetNetworking().GetOutbound()).To(Equal(originalOutbounds))
+	})
+})


### PR DESCRIPTION
## Motivation

Part of the audit in #18015 (finding #1, the "mechanical, no design
decision" item the audit itself recommends fixing first).

`resolveVIPOutbounds` unconditionally nulled
`dataplane.Spec.Networking.Outbound` on the VIP-outbounds branch. The
`Dataplane` it operates on comes straight out of the shared, cached xDS
mesh context (`meshContext.DataplanesByName`), so that write was visible
to every other reader of the same object: the API server's dataplane and
overview endpoints, the KDS zone→global snapshot generator, insight
resyncers, and the mesh-context hasher concurrently marshaling the same
spec for its hash. In effect, Dataplanes were served to those other
consumers missing their user-authored legacy outbound list, even though
the store still has it.

## Implementation information

The value is never read again on this branch: it's only consumed by
`asOutbounds`, which runs on the *other* side of the
`tpEnabled`/`bindOutbounds` branch this function starts with — so the
mutation was write-only from the proxy build's own perspective. Deleting
it removes the shared-state write entirely, with no change to xDS
generation itself. I independently verified (grep across `pkg/`) that no
other code path in the proxy-build call graph reads this field
afterwards.

This addresses only finding #1 from the audit — the other 11 findings
either need a design decision (e.g. the k8s caching-converter sharing
question) or are broader systemic changes better done as their own PRs.

## Supporting documentation

Related to #18015 (not closing it — 11 other findings remain).