### PR TITLE
fix(kds): omit MeshTrust status from sync

### DIFF
--- a/pkg/kds/context/context.go
+++ b/pkg/kds/context/context.go
@@ -22,6 +22,7 @@ import (
 	config_manager "github.com/kumahq/kuma/v3/pkg/core/config/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	hostnamegenerator_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	resource_labels "github.com/kumahq/kuma/v3/pkg/core/resources/labels"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -108,6 +109,10 @@ func DefaultContext(
 		kds_reconcile.If(
 			kds_reconcile.IsKubernetes(cfg.Store.Type),
 			RemoveK8sSystemNamespaceSuffixMapper(cfg.Store.Kubernetes.SystemNamespace)),
+		kds_reconcile.If(
+			// MeshTrust status contains zone-local provenance.
+			kds_reconcile.TypeIs(meshtrust_api.MeshTrustType),
+			RemoveStatus()),
 		HashSuffixMapper(false, mesh_proto.ZoneTag, mesh_proto.KubeNamespaceTag),
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, VersionHeader, version.Build.Version)

--- a/pkg/kds/context/context_test.go
+++ b/pkg/kds/context/context_test.go
@@ -15,6 +15,8 @@ import (
 	config_manager "github.com/kumahq/kuma/v3/pkg/core/config/manager"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	meshzoneaddress_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1"
 	core_system "github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -143,6 +145,47 @@ var _ = Describe("Context", func() {
 				},
 			}),
 		)
+
+		It("should strip Status from a MeshTrust before it is sent from Zone to Global", func() {
+			kri := "kri_mt_default_zone-1_"
+			given := &meshtrust_api.MeshTrustResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "mt-1",
+				},
+				Spec: &meshtrust_api.MeshTrust{
+					TrustDomain: "example.com",
+					CABundles: []meshtrust_api.CABundle{
+						{Type: meshtrust_api.PemCABundleType, PEM: &meshtrust_api.PEM{Value: "cert"}},
+					},
+				},
+				Status: &meshtrust_api.MeshTrustStatus{
+					Origin: &meshtrust_api.Origin{KRI: &kri},
+				},
+			}
+
+			out, err := mapper(kds.Features{}, given)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.GetStatus()).To(Equal(&meshtrust_api.MeshTrustStatus{}))
+			Expect(out.GetSpec()).To(Equal(given.Spec))
+		})
+
+		It("should not strip Status from a MeshService (Global needs its VIP/hostname status)", func() {
+			given := &meshservice_api.MeshServiceResource{
+				Meta: &test_model.ResourceMeta{
+					Name: "backend",
+				},
+				Spec: &meshservice_api.MeshService{},
+				Status: &meshservice_api.MeshServiceStatus{
+					VIPs: []meshservice_api.VIP{{IP: "10.0.0.1"}},
+				},
+			}
+
+			out, err := mapper(kds.Features{}, given)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.GetStatus()).To(Equal(given.Status))
+		})
 	})
 	Describe("GlobalProvidedFilter", func() {
 		var rm manager.ResourceManager


### PR DESCRIPTION
## Motivation

`MeshTrust.status.origin` contains zone-local MeshIdentity provenance, but KDS currently copies it from Zone to Global. This leaves meaningless status on the Global resource.

> Changelog: fix(kds): omit MeshTrust status from sync

## Implementation information

Strip status from MeshTrust resources in the Zone-to-Global mapper. Keep MeshService status unchanged because Global uses its VIP and hostname data.

Tests cover both behaviors. The KDS package suite and a real in-process Global/Zone gRPC sync passed.

Closes #16407

## Supporting documentation

None.
