### PR TITLE
fix(helm): restore global zone sync service

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.dump-values.yaml
@@ -188,6 +188,26 @@ controlPlane:
     # -- Map of serviceMonitor annotations.
     annotations: {}
 
+  globalZoneSyncService:
+    # -- Whether to create a k8s service for the global zone sync
+    # service. It will only be created when enabled and deploying the global
+    # control plane.
+    enabled: true
+    # -- Service type of the Global-zone sync
+    type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
+    # -- Optionally specify allowed source ranges that can access the load balancer
+    loadBalancerSourceRanges: []
+    # -- Additional annotations to put on the Global Zone Sync Service
+    annotations: { }
+    # -- Port on which Global Zone Sync Service is exposed on Node for service of type NodePort
+    nodePort: 30685
+    # -- Port on which Global Zone Sync Service is exposed
+    port: 5685
+    # -- Protocol of the Global Zone Sync service port
+    protocol: grpc
+
   defaults:
     # -- Whether to skip creating the default Mesh
     skipMeshCreation: false

--- a/deployments/charts/kuma/README.md
+++ b/deployments/charts/kuma/README.md
@@ -61,6 +61,14 @@ A Helm chart for the Kuma Control Plane
 | controlPlane.ingress.servicePort | int | `5681` | Port from kuma-cp to use to expose API and GUI. Switch to 5682 to expose TLS port |
 | controlPlane.serviceMonitor.enabled | bool | `false` | Install CoreOS ServiceMonitor custom resource that configures metrics scraping. |
 | controlPlane.serviceMonitor.annotations | object | `{}` | Map of serviceMonitor annotations. |
+| controlPlane.globalZoneSyncService.enabled | bool | `true` | Whether to create a k8s service for the global zone sync service. It will only be created when enabled and deploying the global control plane. |
+| controlPlane.globalZoneSyncService.type | string | `"LoadBalancer"` | Service type of the Global-zone sync |
+| controlPlane.globalZoneSyncService.loadBalancerIP | string | `nil` | Optionally specify IP to be used by cloud provider when configuring load balancer |
+| controlPlane.globalZoneSyncService.loadBalancerSourceRanges | list | `[]` | Optionally specify allowed source ranges that can access the load balancer |
+| controlPlane.globalZoneSyncService.annotations | object | `{}` | Additional annotations to put on the Global Zone Sync Service |
+| controlPlane.globalZoneSyncService.nodePort | int | `30685` | Port on which Global Zone Sync Service is exposed on Node for service of type NodePort |
+| controlPlane.globalZoneSyncService.port | int | `5685` | Port on which Global Zone Sync Service is exposed |
+| controlPlane.globalZoneSyncService.protocol | string | `"grpc"` | Protocol of the Global Zone Sync service port |
 | controlPlane.defaults.skipMeshCreation | bool | `false` | Whether to skip creating the default Mesh |
 | controlPlane.automountServiceAccountToken | bool | `true` | Whether to automountServiceAccountToken for cp. Optionally set to false |
 | controlPlane.resources | object | `{"limits":{"memory":"256Mi"},"requests":{"cpu":"500m","memory":"256Mi"}}` | Optionally override the resource spec |

--- a/deployments/charts/kuma/templates/_helpers.tpl
+++ b/deployments/charts/kuma/templates/_helpers.tpl
@@ -57,6 +57,11 @@ Create chart name and version as used by the chart label.
 {{ printf "%s" (default $defaultSvcName .Values.controlPlane.service.name) }}
 {{- end }}
 
+{{- define "kuma.controlPlane.globalZoneSync.serviceName" -}}
+{{- $defaultSvcName := printf "%s-global-zone-sync" (include "kuma.name" .) -}}
+{{ printf "%s" (default $defaultSvcName .Values.controlPlane.globalZoneSyncService.name) }}
+{{- end }}
+
 {{/*
 Common labels
 */}}

--- a/deployments/charts/kuma/templates/cp-global-sync-service.yaml
+++ b/deployments/charts/kuma/templates/cp-global-sync-service.yaml
@@ -1,0 +1,33 @@
+{{- if and (eq .Values.controlPlane.mode "global") .Values.controlPlane.globalZoneSyncService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kuma.controlPlane.globalZoneSync.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.controlPlane.globalZoneSyncService.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels: {{ include "kuma.cpLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.controlPlane.globalZoneSyncService.type }}
+  {{- if .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controlPlane.globalZoneSyncService.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.controlPlane.globalZoneSyncService.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.controlPlane.globalZoneSyncService.loadBalancerSourceRanges }}
+    - {{.}}
+  {{- end }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.controlPlane.globalZoneSyncService.port }}
+      appProtocol: {{ .Values.controlPlane.globalZoneSyncService.protocol }}
+      {{- if and (eq .Values.controlPlane.globalZoneSyncService.type "NodePort") .Values.controlPlane.globalZoneSyncService.nodePort }}
+      nodePort: {{ .Values.controlPlane.globalZoneSyncService.nodePort }}
+      {{- end }}
+      name: global-zone-sync
+  selector:
+    app: {{ include "kuma.name" . }}-control-plane
+  {{ include "kuma.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deployments/charts/kuma/values.yaml
+++ b/deployments/charts/kuma/values.yaml
@@ -188,6 +188,26 @@ controlPlane:
     # -- Map of serviceMonitor annotations.
     annotations: {}
 
+  globalZoneSyncService:
+    # -- Whether to create a k8s service for the global zone sync
+    # service. It will only be created when enabled and deploying the global
+    # control plane.
+    enabled: true
+    # -- Service type of the Global-zone sync
+    type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
+    # -- Optionally specify allowed source ranges that can access the load balancer
+    loadBalancerSourceRanges: []
+    # -- Additional annotations to put on the Global Zone Sync Service
+    annotations: { }
+    # -- Port on which Global Zone Sync Service is exposed on Node for service of type NodePort
+    nodePort: 30685
+    # -- Port on which Global Zone Sync Service is exposed
+    port: 5685
+    # -- Protocol of the Global Zone Sync service port
+    protocol: grpc
+
   defaults:
     # -- Whether to skip creating the default Mesh
     skipMeshCreation: false

--- a/docs/generated/raw/helm-values.yaml
+++ b/docs/generated/raw/helm-values.yaml
@@ -188,6 +188,26 @@ controlPlane:
     # -- Map of serviceMonitor annotations.
     annotations: {}
 
+  globalZoneSyncService:
+    # -- Whether to create a k8s service for the global zone sync
+    # service. It will only be created when enabled and deploying the global
+    # control plane.
+    enabled: true
+    # -- Service type of the Global-zone sync
+    type: LoadBalancer
+    # -- (string) Optionally specify IP to be used by cloud provider when configuring load balancer
+    loadBalancerIP:
+    # -- Optionally specify allowed source ranges that can access the load balancer
+    loadBalancerSourceRanges: []
+    # -- Additional annotations to put on the Global Zone Sync Service
+    annotations: { }
+    # -- Port on which Global Zone Sync Service is exposed on Node for service of type NodePort
+    nodePort: 30685
+    # -- Port on which Global Zone Sync Service is exposed
+    port: 5685
+    # -- Protocol of the Global Zone Sync service port
+    protocol: grpc
+
   defaults:
     # -- Whether to skip creating the default Mesh
     skipMeshCreation: false


### PR DESCRIPTION
Restores the Helm chart Service used to expose global zone sync for universal global control planes.

This was removed with the Kubernetes global CP path, but universal global CP on Kubernetes still needs the Service when the chart is used as an embedded chart.

Verification:
- helm template deployments/charts/kuma with controlPlane.mode=global and controlPlane.environment=universal renders kuma-global-zone-sync on port 5685
- helm template deployments/charts/kuma with controlPlane.mode=zone does not render kuma-global-zone-sync
- git diff --check