### PR TITLE
fix(gatewayapi): deny traffic when a backendRef is not permitted

### DIFF
--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners.go
@@ -222,7 +222,7 @@ func prepareRoutes(
 	for _, rule := range apiRules {
 		filters := pointer.Deref(rule.Default.Filters)
 		backendRefs := pointer.Deref(rule.Default.BackendRefs)
-		hasExplicitBackendRefs := len(backendRefs) > 0
+		hasExplicitBackendRefs := rule.Default.BackendRefs != nil
 		matchesHash := api.HashMatches(rule.Matches)
 		routeName := string(matchesHash)
 		origin := originByMatches[matchesHash]

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/listeners_internal_test.go
@@ -219,6 +219,70 @@ var _ = Describe("prepareRoutes", func() {
 		Entry("all resolved keeps zero unresolved share", []string{"payments", "payments"}, []uint{30, 70}, false, []string{"payments", "payments"}, uint(0)),
 	)
 
+	It("treats an explicit empty backendRefs list as all unresolved without injecting the default backend", func() {
+		backend := builders.MeshService().
+			WithName("backend").
+			WithMesh(core_model.DefaultMesh).
+			AddIntPort(8080, 8080, core_meta.ProtocolHTTP).
+			Build()
+
+		meshCtx := xds_builders.Context().
+			WithMeshLocalResources([]core_model.Resource{backend}).
+			Build().
+			Mesh
+
+		matches := []api.Match{{
+			Path: &api.PathMatch{Type: api.PathPrefix, Value: "/explicit-empty"},
+		}}
+		policyMeta := &test_model.ResourceMeta{
+			Name: "web-route",
+			Mesh: core_model.DefaultMesh,
+			Labels: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			},
+		}
+		backendRefs := []common_api.BackendRef{}
+		toRules := core_rules.ToRules{
+			ResourceRules: outbound.ResourceRules{
+				kri.From(backend): {
+					Resource: backend.GetMeta(),
+					Conf: []any{api.PolicyDefault{
+						Rules: []api.Rule{{
+							Matches: matches,
+							Default: api.RuleConf{
+								BackendRefs: &backendRefs,
+							},
+						}},
+					}},
+					OriginByMatches: map[common_api.MatchesHash]common.Origin{
+						api.HashMatches(matches): {Resource: policyMeta},
+					},
+				},
+			},
+		}
+		svc := meshroute_xds.DestinationService{
+			Outbound: &xds_types.Outbound{
+				Resource: kri.WithSectionName(kri.From(backend), "8080"),
+				Port:     8080,
+			},
+			Protocol: core_meta.ProtocolHTTP,
+		}
+
+		routes := prepareRoutes(toRules, svc, meshCtx)
+
+		var matched *api.Route
+		for i := range routes {
+			if routes[i].Match.Path != nil && routes[i].Match.Path.Value == "/explicit-empty" {
+				matched = &routes[i]
+				break
+			}
+		}
+		Expect(matched).ToNot(BeNil())
+		Expect(matched.BackendRefs).To(BeEmpty())
+		Expect(matched.AllBackendRefsUnresolved).To(BeTrue())
+		Expect(matched.UnresolvedBackendRefsWeight).To(BeZero())
+	})
+
 	DescribeTable("should keep resolved backendRefs while tracking missing-port declared weight", func(refPorts []uint32, refWeights []uint, expectedAllUnresolved bool, expectedResolved []uint32, expectedUnresolvedWeight uint) {
 		backend := builders.MeshService().
 			WithName("backend").

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -414,10 +414,7 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		}
 
 		route := &gatewayapi.HTTPRoute{
-			ObjectMeta: kube_meta.ObjectMeta{
-				Name:      "my-route",
-				Namespace: "route-ns",
-			},
+			Name: "my-route", Namespace: "route-ns",
 		}
 		rule := gatewayapi.HTTPRouteRule{
 			BackendRefs: []gatewayapi.HTTPBackendRef{

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kube_core "k8s.io/api/core/v1"
+	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -369,6 +371,69 @@ var _ = Describe("uncheckedGapiToKumaRef", func() {
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 			}),
 		}))
+	})
+})
+
+var _ = Describe("gapiToKumaMeshRule", func() {
+	serviceBackendRef := func(namespace, name string, port gatewayapi.PortNumber) gatewayapi.HTTPBackendRef {
+		group := gatewayapi.Group("")
+		kind := gatewayapi.Kind("Service")
+		ns := gatewayapi.Namespace(namespace)
+		weight := int32(1)
+		return gatewayapi.HTTPBackendRef{
+			Group:     &group,
+			Kind:      &kind,
+			Namespace: &ns,
+			Name:      gatewayapi.ObjectName(name),
+			Port:      &port,
+			Weight:    &weight,
+		}
+	}
+
+	It("keeps an explicit empty BackendRefs list when a denied cross-namespace backendRef is filtered out", func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		frontend := &kube_core.Service{
+			Name:      "frontend",
+			Namespace: "route-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		backend := &kube_core.Service{
+			Name:      "backend",
+			Namespace: "backend-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+
+		reconciler := &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(frontend, backend).Build(),
+		}
+
+		route := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{
+				Name:      "my-route",
+				Namespace: "route-ns",
+			},
+		}
+		rule := gatewayapi.HTTPRouteRule{
+			BackendRefs: []gatewayapi.HTTPBackendRef{
+				serviceBackendRef("backend-ns", "backend", 8080),
+			},
+		}
+
+		kumaRule, conditions, err := reconciler.gapiToKumaMeshRule(context.Background(), route, rule)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kumaRule.Default.BackendRefs).ToNot(BeNil())
+		Expect(pointer.Deref(kumaRule.Default.BackendRefs)).To(BeEmpty())
+		resolvedRefs := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(resolvedRefs.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
 	})
 })
 


### PR DESCRIPTION
## Motivation

When an HTTPRoute backendRef references a Service in another namespace without a ReferenceGrant, Kuma marks the route ResolvedRefs=False with reason RefNotPermitted but continues serving traffic. This contradicts Kuma's behavior for non-existent backends, which correctly returns 500. Cluster operators expect permission denials to block traffic.

## Implementation information

- Preserve explicit empty backend refs when a backendRef is not permitted
- Prevents traffic routing to the parent Service
- Returns 500 instead of serving traffic through the route

Closes https://github.com/kumahq/kuma/issues/18259

_Generated by Sybra harness_