### PR TITLE
fix(resyncer): change log level from error to info

### DIFF
--- a/pkg/insights/resyncer.go
+++ b/pkg/insights/resyncer.go
@@ -257,7 +257,7 @@ func (r *resyncer) Start(stop <-chan struct{}) error {
 		if resourceChanged, ok := event.(events.ResourceChangedEvent); ok {
 			desc, err := r.registry.DescriptorFor(resourceChanged.Type)
 			if err != nil {
-				log.Error(err, "Resource is not registered in the registry, ignoring it", "resource", resourceChanged.Type)
+				log.V(1).Info("resource is not registered in the registry, ignoring it", "resource", resourceChanged.Type)
 				return false
 			}
 			if desc.Scope == model.ScopeGlobal && desc.Name != core_mesh.MeshType {


### PR DESCRIPTION
## Motivation

The old resource types still might be in the store so the DB sends events (through the DB TRIGGER)

## Implementation information

Change the log level to `V(1).Info()`

## Supporting documentation

N/A
