### PR TITLE
fix(k8s): enforce control-plane-owned labels on read

### DIFF
--- a/pkg/core/resources/labels/compute.go
+++ b/pkg/core/resources/labels/compute.go
@@ -171,8 +171,12 @@ func Compute(
 		}
 	}
 
+	// k8s.kuma.io/namespace and kuma.io/policy-role below are computed by the control
+	// plane, not supplied by the user: they drive namespaced policy matching and
+	// workload identity (SPIFFE ID, KRI), so they must always describe the namespace
+	// the object really lives in. Set them, overwriting whatever the object carried.
 	if labelsOpts.Namespace.value != "" && labelsOpts.IsK8s && core_model.IsLocallyOriginated(labelsOpts.Mode, labels) {
-		setIfNotExist(mesh_proto.KubeNamespaceTag, labelsOpts.Namespace.value)
+		set(mesh_proto.KubeNamespaceTag, labelsOpts.Namespace.value)
 	}
 
 	if labelsOpts.Namespace.value != "" && rd.IsPolicy && rd.IsPluginOriginated && core_model.IsLocallyOriginated(labelsOpts.Mode, labels) {

--- a/pkg/core/resources/labels/compute_test.go
+++ b/pkg/core/resources/labels/compute_test.go
@@ -251,6 +251,34 @@ var _ = Describe("Compute", func() {
 				"kuma.io/env":           "kubernetes",
 			},
 		}),
+		Entry("user-supplied k8s.kuma.io/namespace label is overwritten with the real namespace", testCase{
+			mode:      core.Zone,
+			isK8s:     true,
+			localZone: "zone-1",
+			// lives in app-ns, carries a label pointing at other-ns
+			r: func() core_model.Resource {
+				r := builders.MeshTimeout().
+					WithMesh("mesh-1").
+					WithName("idle-timeout").
+					WithNamespace("app-ns").
+					WithTargetRef(builders.TargetRefMesh()).
+					AddTo(builders.TargetRefMesh(), meshtimeout_api.Conf{
+						IdleTimeout: &kube_meta.Duration{Duration: 123 * time.Second},
+					}).
+					Build()
+				r.GetMeta().GetLabels()[mesh_proto.KubeNamespaceTag] = "other-ns"
+				return r
+			}(),
+			expectedLabels: map[string]string{
+				"k8s.kuma.io/namespace": "app-ns",
+				"kuma.io/display-name":  "idle-timeout",
+				"kuma.io/policy-role":   "consumer",
+				"kuma.io/mesh":          "mesh-1",
+				"kuma.io/origin":        "zone",
+				"kuma.io/zone":          "zone-1",
+				"kuma.io/env":           "kubernetes",
+			},
+		}),
 		Entry("gateway dataplane proxy", testCase{
 			mode:      core.Zone,
 			isK8s:     true,

--- a/pkg/core/resources/labels/enforce.go
+++ b/pkg/core/resources/labels/enforce.go
@@ -1,0 +1,45 @@
+package labels
+
+import (
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+)
+
+// EnforcedReadLabels returns the control-plane-owned labels, recomputed from the
+// object's own identity instead of being read back from storage: the namespace it
+// really lives in, and the policy role that follows from that namespace and the spec.
+// A stored object can disagree with either - it predates the label, or it was written
+// while the defaulting webhook did not cover its namespace.
+//
+// Returns nil when there is nothing to enforce: UnsetNamespace (Universal, and KDS
+// metas, which carry no name extensions) and the system namespace, where the stored
+// values are either legitimately mesh-wide or KDS imports whose labels record the
+// producing CP's decision.
+func EnforcedReadLabels(
+	rd core_model.ResourceTypeDescriptor,
+	spec core_model.ResourceSpec,
+	ns Namespace,
+) map[string]string {
+	if ns.value == "" || ns.system {
+		return nil
+	}
+	// The namespace label is always set alongside the role: a workload-owner policy
+	// without it matches no dataplane at all, since dppSelectedByNamespace requires
+	// the label to be present.
+	enforced := map[string]string{mesh_proto.KubeNamespaceTag: ns.value}
+	if rd.IsPolicy && rd.IsPluginOriginated {
+		if policy, ok := spec.(core_model.Policy); ok {
+			role, err := ComputePolicyRole(policy, ns)
+			if err != nil {
+				// Only reachable for a policy admission never validated (mixed
+				// producer and consumer items). Fall back to the narrowest role
+				// rather than returning an error: this runs on every read, and
+				// ToCoreList aborts on the first failure, so one malformed stored
+				// object would otherwise break policy matching mesh-wide.
+				role = mesh_proto.WorkloadOwnerPolicyRole
+			}
+			enforced[mesh_proto.PolicyRoleLabel] = string(role)
+		}
+	}
+	return enforced
+}

--- a/pkg/core/resources/labels/enforce_test.go
+++ b/pkg/core/resources/labels/enforce_test.go
@@ -1,0 +1,120 @@
+package labels_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	resource_labels "github.com/kumahq/kuma/v3/pkg/core/resources/labels"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	meshaccesslog_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
+	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+)
+
+var _ = Describe("EnforcedReadLabels", func() {
+	idleTimeout := meshtimeout_api.Conf{
+		IdleTimeout: &kube_meta.Duration{Duration: 123 * time.Second},
+	}
+
+	type testCase struct {
+		r         core_model.Resource
+		namespace resource_labels.Namespace
+		expected  map[string]string
+	}
+
+	DescribeTable("should recompute the control-plane-owned labels",
+		func(given testCase) {
+			Expect(resource_labels.EnforcedReadLabels(
+				given.r.Descriptor(),
+				given.r.GetSpec(),
+				given.namespace,
+			)).To(Equal(given.expected))
+		},
+		Entry("workload-owner policy in an app namespace", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			expected: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+				mesh_proto.PolicyRoleLabel:  string(mesh_proto.ConsumerPolicyRole),
+			},
+		}),
+		Entry("rules-based policy with no to[] is workload-owner", testCase{
+			r: builders.MeshAccessLog().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddRule(builders.MeshAccessLogConf().
+					AddBackends(make([]meshaccesslog_api.Backend, 0))).
+				Build(),
+			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			expected: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+				mesh_proto.PolicyRoleLabel:  string(mesh_proto.WorkloadOwnerPolicyRole),
+			},
+		}),
+		Entry("a producer policy stays producer", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMeshServiceLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend",
+					mesh_proto.KubeNamespaceTag: "kuma-demo",
+				}, ""), idleTimeout).
+				Build(),
+			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			expected: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+				mesh_proto.PolicyRoleLabel:  string(mesh_proto.ProducerPolicyRole),
+			},
+		}),
+		// A policy that mixes producer and consumer items is rejected at admission, so
+		// it can only be stored in a namespace the webhooks never covered. Fall back to
+		// the narrowest role rather than propagating an error out of every read.
+		Entry("mixed producer and consumer to[] falls back to workload-owner", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMeshServiceLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-1",
+					mesh_proto.KubeNamespaceTag: "kuma-demo",
+				}, ""), idleTimeout).
+				AddTo(builders.TargetRefMeshServiceLabels(map[string]string{
+					mesh_proto.DisplayName:      "backend-2",
+					mesh_proto.KubeNamespaceTag: "other-ns",
+				}, ""), idleTimeout).
+				Build(),
+			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			expected: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+				mesh_proto.PolicyRoleLabel:  string(mesh_proto.WorkloadOwnerPolicyRole),
+			},
+		}),
+		Entry("nothing is enforced in the system namespace", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			namespace: resource_labels.NewNamespace("kuma-system", true),
+			expected:  nil,
+		}),
+		Entry("nothing is enforced on Universal", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			namespace: resource_labels.UnsetNamespace,
+			expected:  nil,
+		}),
+		Entry("a non-policy resource gets no role", testCase{
+			r:         meshservice_api.NewMeshServiceResource(),
+			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			expected: map[string]string{
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+			},
+		}),
+	)
+})

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -111,9 +111,9 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 
 	b.WithExtensions(k8s_extensions.NewSecretClientContext(b.Extensions(), secretClient))
 	if expTime := b.Config().Runtime.Kubernetes.MarshalingCacheExpirationTime.Duration; expTime > 0 {
-		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewCachingConverter(expTime)))
+		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewCachingConverter(expTime, systemNamespace)))
 	} else {
-		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewSimpleConverter()))
+		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewSimpleConverter(systemNamespace)))
 	}
 	b.WithExtensions(k8s_extensions.NewCompositeValidatorContext(b.Extensions(), &k8s_common.CompositeValidator{}))
 	zoneName := core_metrics.ZoneNameOrMode(b.Config().Mode, b.Config().Multizone.Zone.Name)

--- a/pkg/plugins/config/k8s/store_test.go
+++ b/pkg/plugins/config/k8s/store_test.go
@@ -74,7 +74,7 @@ var _ = Describe("KubernetesStore", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		s, err = k8s.NewStore(k8sClient, ns, k8sClientScheme, k8s_resources.NewSimpleConverter())
+		s, err = k8s.NewStore(k8sClient, ns, k8sClientScheme, k8s_resources.NewSimpleConverter("kuma-system"))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/plugins/resources/k8s/caching_converter.go
+++ b/pkg/plugins/resources/k8s/caching_converter.go
@@ -34,12 +34,13 @@ type cachedEntry struct {
 	labels map[string]string
 }
 
-func NewCachingConverter(expirationTime time.Duration) k8s_common.Converter {
+func NewCachingConverter(expirationTime time.Duration, systemNamespace string) k8s_common.Converter {
 	return &cachingConverter{
 		KubeFactory: &SimpleKubeFactory{
 			KubeTypes: k8s_registry.Global(),
 		},
-		cache: cache.New(expirationTime, time.Duration(int64(float64(expirationTime)*0.9))),
+		SystemNamespace: systemNamespace,
+		cache:           cache.New(expirationTime, time.Duration(int64(float64(expirationTime)*0.9))),
 	}
 }
 
@@ -52,15 +53,11 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 	}, ":")
 	if v, ok := c.cache.Get(key); ok {
 		entry := v.(cachedEntry)
-		// Pre-populate cachedLabels with a fresh clone so the adapter's
-		// GetLabels skips the annotation-merge work, while keeping the cached
-		// map isolated from downstream consumers that mutate labels in place
-		// (e.g. removeDisplayNameLabel in the ServiceInsight endpoints).
-		out.SetMeta(&KubernetesMetaAdapter{
-			ObjectMeta:   *obj.GetObjectMeta(),
-			Mesh:         obj.GetMesh(),
-			cachedLabels: maps.Clone(entry.labels),
-		})
+		// Reuse the labels computed on the miss - enforcement included - as a fresh
+		// clone, so the cached map stays isolated from downstream consumers that
+		// mutate labels in place (e.g. removeDisplayNameLabel in the ServiceInsight
+		// endpoints).
+		out.SetMeta(newMetaAdapterWithLabels(obj, maps.Clone(entry.labels)))
 		if err := out.SetSpec(entry.spec); err != nil {
 			return err
 		}
@@ -76,15 +73,18 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 		}
 		return nil
 	}
-	adapter := &KubernetesMetaAdapter{ObjectMeta: *obj.GetObjectMeta(), Mesh: obj.GetMesh()}
-	out.SetMeta(adapter)
 	spec, err := obj.GetSpec()
 	if err != nil {
 		return err
 	}
+	// SetSpec first, then derive labels from out.GetSpec(): a stored object with an
+	// omitted spec yields a typed-nil here, and SetSpec normalizes it to an empty
+	// spec. Deriving from the raw value would call policy methods on a nil pointer.
 	if err := out.SetSpec(spec); err != nil {
 		return err
 	}
+	adapter := newMetaAdapter(obj, c.SystemNamespace, out.Descriptor(), out.GetSpec())
+	out.SetMeta(adapter)
 	if out.Descriptor().HasStatus {
 		status, err := obj.GetStatus()
 		if err != nil {

--- a/pkg/plugins/resources/k8s/caching_converter_test.go
+++ b/pkg/plugins/resources/k8s/caching_converter_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("CachingConverter", func() {
 	It("should preserve status on cache hit", func() {
 		// setup
-		converter := k8s.NewCachingConverter(5 * time.Minute)
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
 
 		// given - K8s Workload object with status
 		k8sWorkload := &workload_k8s.Workload{
@@ -62,7 +62,7 @@ var _ = Describe("CachingConverter", func() {
 
 	It("should preserve status even when cache hit with different status values", func() {
 		// setup
-		converter := k8s.NewCachingConverter(5 * time.Minute)
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
 
 		// given - K8s Workload object with initial status
 		k8sWorkload := &workload_k8s.Workload{
@@ -103,20 +103,24 @@ var _ = Describe("CachingConverter", func() {
 		Expect(out2.Status.DataplaneProxies.Total).To(Equal(int32(7)))
 	})
 
-	It("should memoize labels on the meta adapter across repeated GetLabels calls", func() {
-		adapter := &k8s.KubernetesMetaAdapter{
-			Name:      "backend",
-			Namespace: "demo",
-			Labels:    map[string]string{"app": "backend"},
+	It("should return a stable label map across repeated GetLabels calls", func() {
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		out := workload_api.NewWorkloadResource()
+		Expect(converter.ToCoreResource(&workload_k8s.Workload{
+			APIVersion: workload_k8s.GroupVersion.String(),
+			Kind:       "Workload",
+			Name:       "backend",
+			Namespace:  "demo",
+			Labels:     map[string]string{"app": "backend"},
 			Annotations: map[string]string{
 				v1alpha1.DisplayName:        "Backend Display",
 				metadata.KumaServiceAccount: "sa-backend",
 			},
-			Mesh: "default",
-		}
+			Spec: &workload_api.Workload{},
+		}, out)).To(Succeed())
 
-		first := adapter.GetLabels()
-		second := adapter.GetLabels()
+		first := out.GetMeta().GetLabels()
+		second := out.GetMeta().GetLabels()
 
 		// same map instance returned on repeat calls -> no per-call maps.Clone
 		Expect(reflect.ValueOf(first).Pointer()).To(Equal(reflect.ValueOf(second).Pointer()))
@@ -126,7 +130,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should serve labels from cache for the same resourceVersion", func() {
-		converter := k8s.NewCachingConverter(5 * time.Minute)
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
 		k8sWorkload := &workload_k8s.Workload{
 			APIVersion:      workload_k8s.GroupVersion.String(),
 			Kind:            "Workload",
@@ -159,7 +163,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should not corrupt the cache when consumers mutate the returned labels map", func() {
-		converter := k8s.NewCachingConverter(5 * time.Minute)
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
 		k8sWorkload := &workload_k8s.Workload{
 			APIVersion:      workload_k8s.GroupVersion.String(),
 			Kind:            "Workload",
@@ -200,7 +204,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should route ToCoreList through the caching ToCoreResource", func() {
-		converter := k8s.NewCachingConverter(5 * time.Minute)
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
 		list := &workload_k8s.WorkloadList{
 			APIVersion: workload_k8s.GroupVersion.String(),
 			Kind:       "WorkloadList",
@@ -236,7 +240,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should compute fresh labels when resourceVersion changes", func() {
-		converter := k8s.NewCachingConverter(5 * time.Minute)
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
 		k8sWorkload := &workload_k8s.Workload{
 			APIVersion:      workload_k8s.GroupVersion.String(),
 			Kind:            "Workload",

--- a/pkg/plugins/resources/k8s/converter.go
+++ b/pkg/plugins/resources/k8s/converter.go
@@ -12,12 +12,14 @@ import (
 var _ k8s_common.Converter = &SimpleConverter{}
 
 type SimpleConverter struct {
-	KubeFactory KubeFactory
+	KubeFactory     KubeFactory
+	SystemNamespace string
 }
 
-func NewSimpleConverter() k8s_common.Converter {
+func NewSimpleConverter(systemNamespace string) k8s_common.Converter {
 	return &SimpleConverter{
-		KubeFactory: NewSimpleKubeFactory(),
+		KubeFactory:     NewSimpleKubeFactory(),
+		SystemNamespace: systemNamespace,
 	}
 }
 
@@ -54,7 +56,17 @@ func (c *SimpleConverter) ToKubernetesList(rl core_model.ResourceList) (k8s_mode
 }
 
 func (c *SimpleConverter) ToCoreResource(obj k8s_model.KubernetesObject, out core_model.Resource) error {
-	out.SetMeta(&KubernetesMetaAdapter{ObjectMeta: *obj.GetObjectMeta(), Mesh: obj.GetMesh()})
+	spec, err := obj.GetSpec()
+	if err != nil {
+		return err
+	}
+	// SetSpec first, then derive labels from out.GetSpec(): a stored object with an
+	// omitted spec yields a typed-nil here, and SetSpec normalizes it to an empty
+	// spec. Deriving from the raw value would call policy methods on a nil pointer.
+	if err := out.SetSpec(spec); err != nil {
+		return err
+	}
+	out.SetMeta(newMetaAdapter(obj, c.SystemNamespace, out.Descriptor(), out.GetSpec()))
 	if out.Descriptor().HasStatus {
 		status, err := obj.GetStatus()
 		if err != nil {
@@ -64,11 +76,7 @@ func (c *SimpleConverter) ToCoreResource(obj k8s_model.KubernetesObject, out cor
 			return err
 		}
 	}
-	spec, err := obj.GetSpec()
-	if err != nil {
-		return err
-	}
-	return out.SetSpec(spec)
+	return nil
 }
 
 func (c *SimpleConverter) ToCoreList(in k8s_model.KubernetesList, out core_model.ResourceList, predicate k8s_common.ConverterPredicate) error {

--- a/pkg/plugins/resources/k8s/enforced_labels_test.go
+++ b/pkg/plugins/resources/k8s/enforced_labels_test.go
@@ -1,0 +1,164 @@
+package k8s
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	workload_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/api/v1alpha1"
+	workload_k8s "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/k8s/v1alpha1"
+	k8s_common "github.com/kumahq/kuma/v3/pkg/plugins/common/k8s"
+	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	meshtimeout_k8s "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/k8s/v1alpha1"
+)
+
+const systemNamespaceForTest = "kuma-system"
+
+var _ = Describe("newMetaAdapter", func() {
+	DescribeTable("namespace label",
+		func(namespace string, stored map[string]string, expected string) {
+			obj := &workload_k8s.Workload{
+				Name: "res-1", Namespace: namespace, Labels: stored,
+				Spec: &workload_api.Workload{},
+			}
+			out := workload_api.NewWorkloadResource()
+			adapter := newMetaAdapter(obj, systemNamespaceForTest, out.Descriptor(), obj.Spec)
+
+			Expect(adapter.GetLabels()).To(HaveKeyWithValue(v1alpha1.KubeNamespaceTag, expected))
+		},
+		Entry("overwrites a stored label that disagrees with the namespace",
+			"app-ns",
+			map[string]string{v1alpha1.KubeNamespaceTag: "other-ns"},
+			"app-ns"),
+		Entry("sets the label when it is absent (pre-2.9 resource)",
+			"app-ns", nil, "app-ns"),
+		Entry("overwrites a stored label even when the origin label says global",
+			"app-ns",
+			map[string]string{
+				v1alpha1.KubeNamespaceTag:    "other-ns",
+				v1alpha1.ResourceOriginLabel: string(v1alpha1.GlobalResourceOrigin),
+			},
+			"app-ns"),
+		Entry("keeps the label of a resource imported over KDS",
+			systemNamespaceForTest,
+			map[string]string{
+				v1alpha1.KubeNamespaceTag:    "app-ns-on-the-other-cp",
+				v1alpha1.ResourceOriginLabel: string(v1alpha1.GlobalResourceOrigin),
+			},
+			"app-ns-on-the-other-cp"),
+	)
+
+	It("should not add the namespace label to a cluster-scoped object", func() {
+		obj := &workload_k8s.Workload{
+			Name: "default",
+			Spec: &workload_api.Workload{},
+		}
+		out := workload_api.NewWorkloadResource()
+
+		Expect(newMetaAdapter(obj, systemNamespaceForTest, out.Descriptor(), obj.Spec).GetLabels()).
+			NotTo(HaveKey(v1alpha1.KubeNamespaceTag))
+	})
+})
+
+var _ = Describe("enforced label derivation through the converters", func() {
+	// A policy stored in a namespace the admission webhooks never covered, so
+	// labels.Compute never ran on it: no namespace label and no role label.
+	policyIn := func(namespace string, stored map[string]string) *meshtimeout_k8s.MeshTimeout {
+		return &meshtimeout_k8s.MeshTimeout{
+			APIVersion:      meshtimeout_k8s.GroupVersion.String(),
+			Kind:            "MeshTimeout",
+			Namespace:       namespace,
+			Name:            "idle-timeout",
+			ResourceVersion: "1",
+			Labels:          stored,
+			Spec: &meshtimeout_api.MeshTimeout{
+				TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
+			},
+		}
+	}
+
+	labelsOf := func(converter k8s_common.Converter, obj *meshtimeout_k8s.MeshTimeout) map[string]string {
+		out := meshtimeout_api.NewMeshTimeoutResource()
+		Expect(converter.ToCoreResource(obj, out)).To(Succeed())
+		return out.GetMeta().GetLabels()
+	}
+
+	simple := func() k8s_common.Converter { return NewSimpleConverter(systemNamespaceForTest) }
+	caching := func() k8s_common.Converter { return NewCachingConverter(5*time.Minute, systemNamespaceForTest) }
+
+	stale := map[string]string{
+		v1alpha1.KubeNamespaceTag:    "other-ns",
+		v1alpha1.PolicyRoleLabel:     string(v1alpha1.SystemPolicyRole),
+		v1alpha1.ResourceOriginLabel: string(v1alpha1.GlobalResourceOrigin),
+	}
+
+	DescribeTable("should derive both labels from the object namespace",
+		func(newConverter func() k8s_common.Converter, namespace string, stored map[string]string, expected map[string]string) {
+			Expect(labelsOf(newConverter(), policyIn(namespace, stored))).To(SatisfyAll(
+				HaveKeyWithValue(v1alpha1.KubeNamespaceTag, expected[v1alpha1.KubeNamespaceTag]),
+				HaveKeyWithValue(v1alpha1.PolicyRoleLabel, expected[v1alpha1.PolicyRoleLabel]),
+			))
+		},
+		Entry("SimpleConverter overwrites stale labels", simple, "app-ns", stale, map[string]string{
+			v1alpha1.KubeNamespaceTag: "app-ns",
+			v1alpha1.PolicyRoleLabel:  string(v1alpha1.WorkloadOwnerPolicyRole),
+		}),
+		Entry("CachingConverter overwrites stale labels", caching, "app-ns", stale, map[string]string{
+			v1alpha1.KubeNamespaceTag: "app-ns",
+			v1alpha1.PolicyRoleLabel:  string(v1alpha1.WorkloadOwnerPolicyRole),
+		}),
+		Entry("SimpleConverter derives labels a missing webhook never wrote", simple, "app-ns", nil, map[string]string{
+			v1alpha1.KubeNamespaceTag: "app-ns",
+			v1alpha1.PolicyRoleLabel:  string(v1alpha1.WorkloadOwnerPolicyRole),
+		}),
+		Entry("CachingConverter derives labels a missing webhook never wrote", caching, "app-ns", nil, map[string]string{
+			v1alpha1.KubeNamespaceTag: "app-ns",
+			v1alpha1.PolicyRoleLabel:  string(v1alpha1.WorkloadOwnerPolicyRole),
+		}),
+		Entry("SimpleConverter keeps the stored labels in the system namespace", simple, systemNamespaceForTest, stale, map[string]string{
+			v1alpha1.KubeNamespaceTag: "other-ns",
+			v1alpha1.PolicyRoleLabel:  string(v1alpha1.SystemPolicyRole),
+		}),
+		Entry("CachingConverter keeps the stored labels in the system namespace", caching, systemNamespaceForTest, stale, map[string]string{
+			v1alpha1.KubeNamespaceTag: "other-ns",
+			v1alpha1.PolicyRoleLabel:  string(v1alpha1.SystemPolicyRole),
+		}),
+	)
+
+	// On a cache hit the adapter is handed the labels stored on the miss, so the
+	// derivation has to already be baked into the cached entry.
+	It("should return the derived labels on a CachingConverter cache hit", func() {
+		converter := NewCachingConverter(5*time.Minute, systemNamespaceForTest)
+		obj := policyIn("app-ns", stale)
+
+		miss := labelsOf(converter, obj)
+		hit := labelsOf(converter, obj)
+
+		Expect(miss).To(HaveKeyWithValue(v1alpha1.KubeNamespaceTag, "app-ns"))
+		Expect(miss).To(HaveKeyWithValue(v1alpha1.PolicyRoleLabel, string(v1alpha1.WorkloadOwnerPolicyRole)))
+		Expect(hit).To(Equal(miss))
+	})
+
+	// The same missing webhook that leaves the role label off also leaves the spec
+	// unvalidated, so a stored policy can have no spec at all. GetSpec hands back a
+	// typed nil for it, and deriving a role from that would dereference a nil policy
+	// on every read, panicking every conversion of that type.
+	DescribeTable("should not panic on a stored policy with no spec",
+		func(newConverter func() k8s_common.Converter) {
+			obj := policyIn("app-ns", nil)
+			obj.Spec = nil
+			out := meshtimeout_api.NewMeshTimeoutResource()
+
+			Expect(newConverter().ToCoreResource(obj, out)).To(Succeed())
+			Expect(out.GetMeta().GetLabels()).To(SatisfyAll(
+				HaveKeyWithValue(v1alpha1.KubeNamespaceTag, "app-ns"),
+				HaveKeyWithValue(v1alpha1.PolicyRoleLabel, string(v1alpha1.WorkloadOwnerPolicyRole)),
+			))
+		},
+		Entry("SimpleConverter", simple),
+		Entry("CachingConverter", caching),
+	)
+})

--- a/pkg/plugins/resources/k8s/mapper.go
+++ b/pkg/plugins/resources/k8s/mapper.go
@@ -12,6 +12,7 @@ type ResourceMapperFunc func(resource model.Resource, namespace string) (k8s_mod
 // NewKubernetesMapper creates a ResourceMapper that returns the k8s object as is. This is meant to be used when the underlying store is kubernetes
 func NewKubernetesMapper(kubeFactory KubeFactory) ResourceMapperFunc {
 	return func(resource model.Resource, namespace string) (k8s_model.KubernetesObject, error) {
+		// SystemNamespace unused: core -> k8s builds no meta adapter.
 		res, err := (&SimpleConverter{KubeFactory: kubeFactory}).ToKubernetesObject(resource)
 		if err != nil {
 			return nil, err

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"maps"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/labels"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
@@ -285,11 +285,58 @@ type KubernetesMetaAdapter struct {
 	kube_meta.ObjectMeta
 	Mesh string
 
-	// cachedLabels memoizes the result of GetLabels. May be pre-populated by
-	// CachingConverter on cache hit to reuse labels computed for an earlier
-	// call against the same resourceVersion.
-	cachedLabels map[string]string
-	labelsOnce   sync.Once
+	// labels is the materialized label set: the object's stored labels, the entries
+	// derived from annotations, and the control-plane-owned ones recomputed by
+	// labels.EnforcedReadLabels. Callers MUST treat it as read-only - it is handed
+	// out as is, and when the adapter came from cachingConverter a clone of it also
+	// sits in the cache.
+	labels map[string]string
+}
+
+// newMetaAdapter is the only place an adapter's labels are computed from a Kubernetes
+// object. Taking rd and spec forces every conversion path to supply what
+// labels.EnforcedReadLabels needs, so a new converter cannot silently skip the
+// read-side recomputation. newMetaAdapterWithLabels is not a second computation: it
+// only re-wraps a set this function already produced.
+func newMetaAdapter(
+	obj k8s_model.KubernetesObject,
+	systemNamespace string,
+	rd core_model.ResourceTypeDescriptor,
+	spec core_model.ResourceSpec,
+) *KubernetesMetaAdapter {
+	objMeta := obj.GetObjectMeta()
+
+	computed := maps.Clone(objMeta.GetLabels())
+	if computed == nil {
+		computed = map[string]string{}
+	}
+	if displayName, ok := objMeta.GetAnnotations()[v1alpha1.DisplayName]; ok {
+		computed[v1alpha1.DisplayName] = displayName
+	} else {
+		computed[v1alpha1.DisplayName] = objMeta.GetName()
+	}
+	if sa, ok := objMeta.GetAnnotations()[metadata.KumaServiceAccount]; ok {
+		computed[metadata.KumaServiceAccount] = sa
+	}
+	if workload, ok := objMeta.GetAnnotations()[metadata.KumaWorkload]; ok {
+		computed[metadata.KumaWorkload] = workload
+	}
+	ns := labels.NewNamespace(objMeta.GetNamespace(), objMeta.GetNamespace() == systemNamespace)
+	maps.Copy(computed, labels.EnforcedReadLabels(rd, spec, ns))
+
+	return &KubernetesMetaAdapter{
+		ObjectMeta: *objMeta,
+		Mesh:       obj.GetMesh(),
+		labels:     computed,
+	}
+}
+
+func newMetaAdapterWithLabels(obj k8s_model.KubernetesObject, labels map[string]string) *KubernetesMetaAdapter {
+	return &KubernetesMetaAdapter{
+		ObjectMeta: *obj.GetObjectMeta(),
+		Mesh:       obj.GetMesh(),
+		labels:     labels,
+	}
 }
 
 func (m *KubernetesMetaAdapter) GetName() string {
@@ -319,36 +366,14 @@ func (m *KubernetesMetaAdapter) GetModificationTime() time.Time {
 	return m.GetObjectMeta().GetCreationTimestamp().Time
 }
 
-// GetLabels returns the labels of the underlying Kubernetes object enriched
-// with annotation-derived entries (display name, Kuma service account, Kuma
-// workload). The computation is memoized per adapter instance: callers MUST
-// treat the returned map as read-only. Mutating it would corrupt both the
-// adapter's cache and, when the adapter was produced by CachingConverter, the
-// cross-reconcile entry shared via resourceVersion key.
+// GetLabels returns the materialized label set built at construction time: the
+// object's stored labels, the annotation-derived entries (display name, Kuma service
+// account, Kuma workload), and the control-plane-owned ones recomputed by
+// labels.EnforcedReadLabels. Callers MUST treat the returned map as read-only.
+// Mutating it would corrupt both this adapter and, when the adapter was produced by
+// cachingConverter, the cross-reconcile entry shared via the resourceVersion key.
 func (m *KubernetesMetaAdapter) GetLabels() map[string]string {
-	m.labelsOnce.Do(func() {
-		if m.cachedLabels != nil {
-			// Pre-populated by CachingConverter on cache hit; nothing to do.
-			return
-		}
-		labels := maps.Clone(m.GetObjectMeta().GetLabels())
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		if displayName, ok := m.GetObjectMeta().GetAnnotations()[v1alpha1.DisplayName]; ok {
-			labels[v1alpha1.DisplayName] = displayName
-		} else {
-			labels[v1alpha1.DisplayName] = m.GetObjectMeta().GetName()
-		}
-		if sa, ok := m.GetObjectMeta().GetAnnotations()[metadata.KumaServiceAccount]; ok {
-			labels[metadata.KumaServiceAccount] = sa
-		}
-		if workload, ok := m.GetObjectMeta().GetAnnotations()[metadata.KumaWorkload]; ok {
-			labels[metadata.KumaWorkload] = workload
-		}
-		m.cachedLabels = labels
-	})
-	return m.cachedLabels
+	return m.labels
 }
 
 type KubeFactory interface {

--- a/pkg/plugins/resources/k8s/store_template_test.go
+++ b/pkg/plugins/resources/k8s/store_template_test.go
@@ -30,9 +30,8 @@ var _ = Describe("KubernetesStore template", func() {
 		return &k8s.KubernetesStore{
 			Client: k8sClient,
 			Converter: &k8s.SimpleConverter{
-				KubeFactory: &k8s.SimpleKubeFactory{
-					KubeTypes: kubeTypes,
-				},
+				KubeFactory:     &k8s.SimpleKubeFactory{KubeTypes: kubeTypes},
+				SystemNamespace: "kuma-system",
 			},
 			Scheme: k8sClientScheme,
 		}

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("MeshReconciler", func() {
 					return []string{string(secret.Type)}
 				}).
 			Build()
-		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter())
+		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter("kuma-system"))
 		Expect(err).ToNot(HaveOccurred())
 
 		// we need to bring in the actual scheme we're using so that the Mesh CRD can be hooked up as owner,

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -412,13 +412,13 @@ var _ = Describe("PodReconciler", func() {
 			Scheme:        k8sClientScheme,
 			Log:           core.Log.WithName("test"),
 			PodConverter: PodConverter{
-				ResourceConverter: k8s.NewSimpleConverter(),
+				ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
 				Mode:              config_core.Zone,
 				Zone:              "zone-1",
 				SystemNamespace:   "kuma-system",
 			},
 			SystemNamespace:   "kuma-system",
-			ResourceConverter: k8s.NewSimpleConverter(),
+			ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
 		}
 	})
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 					NodeLabelsToCopy: given.nodeLabelsToCopy,
 				},
 				Zone:              "zone-1",
-				ResourceConverter: k8s.NewSimpleConverter(),
+				ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
 				WorkloadLabels:    given.workloadLabels,
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
@@ -163,7 +163,7 @@ var _ = Describe("PodStatusReconciler", func() {
 			EventRecorder:     kube_events.NewFakeRecorder(10),
 			Scheme:            k8sClientScheme,
 			Log:               core.Log.WithName("test"),
-			ResourceConverter: k8s.NewSimpleConverter(),
+			ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
 			EnvoyAdminClient: &runtime.DummyEnvoyAdminClient{
 				PostQuitCalled: &postQuitCalled,
 			},

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -58,7 +58,7 @@ func (p *plugin) Customize(rt core_runtime.Runtime) error {
 
 	// Mutators and Validators convert resources from Request (not from the Store)
 	// these resources doesn't have ResourceVersion, we can't cache them
-	simpleConverter := k8s.NewSimpleConverter()
+	simpleConverter := k8s.NewSimpleConverter(rt.Config().Store.Kubernetes.SystemNamespace)
 	if err := addValidators(mgr, rt, simpleConverter); err != nil {
 		return err
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
@@ -15,19 +15,12 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
-	k8s_common "github.com/kumahq/kuma/v3/pkg/plugins/common/k8s"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1"
 	k8s_resources "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
 	. "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/webhooks"
 )
 
 var _ = Describe("Defaulter", func() {
-	var converter k8s_common.Converter
-
-	BeforeEach(func() {
-		converter = k8s_resources.NewSimpleConverter()
-	})
-
 	type testCase struct {
 		inputObject string
 		expected    string
@@ -61,7 +54,9 @@ var _ = Describe("Defaulter", func() {
 
 	DescribeTable("should apply defaults on a target object",
 		func(given testCase) {
-			// given
+			// given - in production both the converter and the checker read the system
+			// namespace from the same config, so they always agree
+			converter := k8s_resources.NewSimpleConverter(given.checker.SystemNamespace)
 			handler := DefaultingWebhookFor(scheme, converter, given.checker)
 
 			req := kube_admission.Request{

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -113,7 +113,7 @@ spec:
 				Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 				cfg.CaCertFile = caCertPath
 				cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
+				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, false, systemNamespace, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// and create mesh
@@ -868,7 +868,7 @@ spec:
 			"http://kuma-control-plane.kuma-system:5681",
 			k8sClient,
 			false,
-			k8s.NewSimpleConverter(),
+			k8s.NewSimpleConverter("kuma-system"),
 			9901,
 			9902,
 			false,
@@ -926,7 +926,7 @@ metadata:
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
 			cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, false, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1033,7 +1033,7 @@ metadata:
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
 			cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter(), 9901, 9902, false, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, false, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1117,7 +1117,7 @@ metadata:
 				"http://kuma-control-plane.kuma-system:5681",
 				k8sClient,
 				true,
-				k8s.NewSimpleConverter(),
+				k8s.NewSimpleConverter("kuma-system"),
 				9901,
 				9902,
 				false,

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -82,7 +82,7 @@ func newValidatingWebhook(mode core.CpMode, federatedZone bool) *kube_admission.
 		SystemNamespace:              "kuma-system",
 		ZoneName:                     "zone-1",
 	}
-	handler := webhooks.NewValidatingWebhook(k8s_resources.NewSimpleConverter(), core_registry.Global(), k8s_registry.Global(), checker)
+	handler := webhooks.NewValidatingWebhook(k8s_resources.NewSimpleConverter("kuma-system"), core_registry.Global(), k8s_registry.Global(), checker)
 	handler.InjectDecoder(kube_admission.NewDecoder(scheme))
 	return &kube_admission.Webhook{
 		Handler: handler,

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -45,7 +45,7 @@ func NewStore(reader kube_client.Reader, writer kube_client.Writer, scheme *runt
 		writer:             writer,
 		scheme:             scheme,
 		secretsConverter:   DefaultConverter(),
-		resourcesConverter: k8s.NewSimpleConverter(),
+		resourcesConverter: k8s.NewSimpleConverter(namespace),
 		namespace:          namespace,
 	}, nil
 }

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -792,7 +792,7 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		return err
 	}
 
-	converter := resources_k8s.NewSimpleConverter()
+	converter := resources_k8s.NewSimpleConverter(Config.KumaNamespace)
 	for name, updateFuncs := range c.opts.meshUpdateFuncs {
 		for _, f := range updateFuncs {
 			Logf("applying update function to mesh %q", name)


### PR DESCRIPTION
## Motivation

`k8s.kuma.io/namespace` and `kuma.io/policy-role` are computed by the control plane, not supplied by the user: they drive namespaced policy matching (`dppSelectedByNamespace` and the `Consumer`/`WorkloadOwner` checks) and workload identity (SPIFFE ID, KRI). They must always describe the namespace an object really lives in, and two paths could leave them saying something else.

On the write path `labels.Compute` set `k8s.kuma.io/namespace` with `setIfNotExist`, so a value already present on the submitted object survived instead of being replaced with the object's own namespace.

On the read path nothing recomputed either label, so a stored object kept whatever it had. That covers objects written before the label existed, and objects created in a namespace the Kuma CRD webhooks do not select — those never go through `labels.Compute`, so they carry no `kuma.io/policy-role` at all, and `core_model.PolicyRole` reads a missing label as `SystemPolicyRole`, which makes the policy apply to every dataplane in the mesh.

## Implementation information

**Write side** (`labels.Compute`): set `k8s.kuma.io/namespace` with `set()` instead of `setIfNotExist()`, so the object's own namespace always wins.

**Read side** (`labels.EnforcedReadLabels`): a new read-side sibling of `Compute` that recomputes both `k8s.kuma.io/namespace` and, for plugin-originated policies, `kuma.io/policy-role` from the object's real namespace and spec. The k8s→core converters apply it through a new `newMetaAdapter` constructor that takes the descriptor and spec, so a new converter cannot build an adapter without supplying what the derivation needs. The converter is the single k8s→core waist — the store, the webhooks and the controllers all route through it.

The system namespace stays exempt: KDS writes imports there, and their stored labels are the only record of the namespace that owned them on the producing CP. Universal is unaffected — the derivation returns nothing for `UnsetNamespace`.

## Supporting documentation

Updates https://github.com/kumahq/kuma/issues/16049
