### PR TITLE
fix(gatewayapi): break HTTPRoute conflicts by creationTimestamp

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,16 @@ If a mesh has both a generated producer route and a hand-written `MeshHTTPRoute`
 
 If any policy selects the generated route by its old `k8s.kuma.io/namespace: <kuma-system>` label (or your system namespace), update it to the `HTTPRoute`'s namespace instead. The control plane moves each existing generated route to its new namespace the next time its `HTTPRoute` is reconciled, so no manual migration of the `MeshHTTPRoute` object itself is needed.
 
+### Gateway API HTTPRoute conflicts on the same parent now resolve by creationTimestamp
+
+When two Gateway API `HTTPRoute`s attach to the same parent with equally specific matches, the generated `MeshHTTPRoute`s used to tie-break by resource name alone, so which route won depended on name rather than which `HTTPRoute` was applied first. Each generated `MeshHTTPRoute` now carries its owning `HTTPRoute`'s `creationTimestamp` as a label, and that label breaks the tie in favor of the older `HTTPRoute`; name order is used only when the timestamps also match.
+
+A hand-written `MeshHTTPRoute` has no such label, so it still takes precedence over any generated route it ties with on an exact conflict, same as before this change.
+
+**Action required**
+
+None. Existing generated `MeshHTTPRoute`s are backfilled with the timestamp label the next time their `HTTPRoute` is reconciled. If two `HTTPRoute`s previously tied and were resolved by name, check whether the new creationTimestamp-based outcome matches what you expect.
+
 ### The `BUILTIN` gateway type and its statistics are removed from the API
 
 The built-in gateway implementation was removed over the previous releases, and the Dataplane validator has been rejecting `networking.gateway.type: BUILTIN` since then. The remaining API surface is now gone too:

--- a/pkg/plugins/policies/core/rules/outbound/sort.go
+++ b/pkg/plugins/policies/core/rules/outbound/sort.go
@@ -16,6 +16,7 @@ func Sort[T interface {
 	slices.SortStableFunc(list, sort.Compose(
 		sort.CompareByPolicyAttributes[T],
 		CompareByToEntry[T],
+		sort.CompareByRouteCreationTimestamp[T],
 		sort.CompareByDisplayName[T],
 	))
 }

--- a/pkg/plugins/policies/core/rules/outbound/testdata/sort/by-route-creation-timestamp.golden.yaml
+++ b/pkg/plugins/policies/core/rules/outbound/testdata/sort/by-route-creation-timestamp.golden.yaml
@@ -1,0 +1,49 @@
+- Entry:
+    default:
+      connectionTimeout: 2s
+    targetRef:
+      kind: Mesh
+  Meta:
+    creationTime: "0001-01-01T00:00:00Z"
+    kri: kri_mt_mesh-1___matched-for-rules-aaa-second_
+    labels:
+      gateways.kuma.io/gateway.networking.k8s.io-route-creation-timestamp: "200"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: matched-for-rules-aaa-second
+    type: MeshTimeout
+  RuleIndex: 0
+  TopLevel:
+    kind: Mesh
+- Entry:
+    default:
+      connectionTimeout: 1s
+    targetRef:
+      kind: Mesh
+  Meta:
+    creationTime: "0001-01-01T00:00:00Z"
+    kri: kri_mt_mesh-1___matched-for-rules-zzz-first_
+    labels:
+      gateways.kuma.io/gateway.networking.k8s.io-route-creation-timestamp: "100"
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: matched-for-rules-zzz-first
+    type: MeshTimeout
+  RuleIndex: 0
+  TopLevel:
+    kind: Mesh
+- Entry:
+    default:
+      connectionTimeout: 3s
+    targetRef:
+      kind: Mesh
+  Meta:
+    creationTime: "0001-01-01T00:00:00Z"
+    kri: kri_mt_mesh-1___matched-for-rules-mmm-third_
+    mesh: mesh-1
+    modificationTime: "0001-01-01T00:00:00Z"
+    name: matched-for-rules-mmm-third
+    type: MeshTimeout
+  RuleIndex: 0
+  TopLevel:
+    kind: Mesh

--- a/pkg/plugins/policies/core/rules/outbound/testdata/sort/by-route-creation-timestamp.input.yaml
+++ b/pkg/plugins/policies/core/rules/outbound/testdata/sort/by-route-creation-timestamp.input.yaml
@@ -1,0 +1,40 @@
+# gateway-api-generated MeshHTTPRoutes with the same specificity are sorted by creationTimestamp, oldest wins, and an unlabelled hand-written policy beats both
+type: MeshTimeout
+name: matched-for-rules-zzz-first
+mesh: mesh-1
+labels:
+  gateways.kuma.io/gateway.networking.k8s.io-route-creation-timestamp: "100"
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        connectionTimeout: 1s
+---
+type: MeshTimeout
+name: matched-for-rules-aaa-second
+mesh: mesh-1
+labels:
+  gateways.kuma.io/gateway.networking.k8s.io-route-creation-timestamp: "200"
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        connectionTimeout: 2s
+---
+type: MeshTimeout
+name: matched-for-rules-mmm-third
+mesh: mesh-1
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: Mesh
+      default:
+        connectionTimeout: 3s

--- a/pkg/plugins/policies/core/rules/sort/sort.go
+++ b/pkg/plugins/policies/core/rules/sort/sort.go
@@ -39,11 +39,11 @@ func CompareByRouteCreationTimestamp[T common.PolicyAttributes](a, b T) int {
 		if !ok {
 			return time.Time{}
 		}
-		sec, err := strconv.ParseInt(label, 10, 64)
+		nanos, err := strconv.ParseInt(label, 10, 64)
 		if err != nil {
 			return time.Time{}
 		}
-		return time.Unix(sec, 0)
+		return time.Unix(0, nanos)
 	}
 
 	return keyOf(b).Compare(keyOf(a))

--- a/pkg/plugins/policies/core/rules/sort/sort.go
+++ b/pkg/plugins/policies/core/rules/sort/sort.go
@@ -2,9 +2,12 @@ package sort
 
 import (
 	"cmp"
+	"strconv"
+	"time"
 
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/common"
+	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 )
 
 func CompareByPolicyAttributes[T common.PolicyAttributes](a, b T) int {
@@ -27,6 +30,23 @@ func CompareByPolicyAttributes[T common.PolicyAttributes](a, b T) int {
 	}
 
 	return 0
+}
+
+// CompareByRouteCreationTimestamp sorts by metadata.GatewayAPIRouteCreationTimestampLabel, oldest last; missing/unparsable label sorts as oldest.
+func CompareByRouteCreationTimestamp[T common.PolicyAttributes](a, b T) int {
+	keyOf := func(item T) time.Time {
+		label, ok := item.GetResourceMeta().GetLabels()[metadata.GatewayAPIRouteCreationTimestampLabel]
+		if !ok {
+			return time.Time{}
+		}
+		sec, err := strconv.ParseInt(label, 10, 64)
+		if err != nil {
+			return time.Time{}
+		}
+		return time.Unix(sec, 0)
+	}
+
+	return keyOf(b).Compare(keyOf(a))
 }
 
 func CompareByDisplayName[T common.PolicyAttributes](a, b T) int {

--- a/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
+++ b/pkg/plugins/policies/meshhttproute/plugin/v1alpha1/merge_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/outbound"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	plugin "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/plugin/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/samples"
@@ -67,6 +68,19 @@ func routeOrigin(name string) rules_common.Origin {
 	}
 }
 
+func gatewayRouteOrigin(name, creationTimestamp string) rules_common.Origin {
+	return rules_common.Origin{
+		Resource: &test_model.ResourceMeta{
+			Mesh: core_model.DefaultMesh,
+			Name: name,
+			Labels: map[string]string{
+				metadata.GatewayAPIRouteCreationTimestampLabel: creationTimestamp,
+			},
+		},
+		RuleIndex: 0,
+	}
+}
+
 func expectedBackendRoute(
 	conf api.PolicyDefault,
 	origins []rules_common.Origin,
@@ -84,441 +98,530 @@ func expectedBackendRoute(
 	}
 }
 
-var _ = DescribeTable("MatchedPolicies", func(given policiesTestCase) {
-	routes, err := plugin.NewPlugin().(core_plugins.PolicyPlugin).MatchedPolicies(given.dataplane, given.resources)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(routes.ToRules).To(Equal(given.expectedRoutes))
-}, Entry("basic-kind-specificity", policiesTestCase{
-	dataplane: samples.DataplaneWeb(),
-	resources: xds_context.Resources{
-		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
-			meshservice_api.MeshServiceType: backendMeshServiceList(),
-			api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
-				Items: []*api.MeshHTTPRouteResource{{
-					Meta: &test_model.ResourceMeta{
-						Mesh: core_model.DefaultMesh,
-						Name: "route-1",
-					},
-					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
-						To: &[]api.To{{
-							TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
-							Rules: []api.Rule{{
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/v1",
+var _ = DescribeTable(
+	"MatchedPolicies", func(given policiesTestCase) {
+		routes, err := plugin.NewPlugin().(core_plugins.PolicyPlugin).MatchedPolicies(given.dataplane, given.resources)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(routes.ToRules).To(Equal(given.expectedRoutes))
+	}, Entry("basic-kind-specificity", policiesTestCase{
+		dataplane: samples.DataplaneWeb(),
+		resources: xds_context.Resources{
+			MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+				meshservice_api.MeshServiceType: backendMeshServiceList(),
+				api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+					Items: []*api.MeshHTTPRouteResource{{
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "route-1",
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v1",
+										},
+									}},
+									Default: api.RuleConf{
+										Filters: &[]api.Filter{{}},
 									},
 								}},
-								Default: api.RuleConf{
-									Filters: &[]api.Filter{{}},
-								},
 							}},
+						},
+					}, {
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "route-2",
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefDataplaneName("web-01"))),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v1",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v1"}, ""),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v2",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v2"}, ""),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}},
+							}},
+						},
+					}},
+				},
+			},
+		},
+		expectedRoutes: expectedBackendRoute(
+			api.PolicyDefault{
+				Rules: []api.Rule{{
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/v1",
+						},
+					}},
+					Default: api.RuleConf{
+						Filters: &[]api.Filter{{}},
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v1"}, ""),
+							Weight:    pointer.To(uint(100)),
 						}},
 					},
 				}, {
-					Meta: &test_model.ResourceMeta{
-						Mesh: core_model.DefaultMesh,
-						Name: "route-2",
-					},
-					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefDataplaneName("web-01"))),
-						To: &[]api.To{{
-							TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
-							Rules: []api.Rule{{
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/v1",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v1"}, ""),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/v2",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v2"}, ""),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}},
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/v2",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v2"}, ""),
+							Weight:    pointer.To(uint(100)),
 						}},
 					},
 				}},
 			},
-		},
-	},
-	expectedRoutes: expectedBackendRoute(
-		api.PolicyDefault{
-			Rules: []api.Rule{{
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/v1",
-					},
-				}},
-				Default: api.RuleConf{
-					Filters: &[]api.Filter{{}},
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v1"}, ""),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}, {
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/v2",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "backend", "version": "v2"}, ""),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}},
-		},
-		[]rules_common.Origin{routeOrigin("route-1"), routeOrigin("route-2")},
-		map[common_api.MatchesHash]rules_common.Origin{
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): routeOrigin("route-2"),
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v2"}}}): routeOrigin("route-2"),
-		},
-	),
-}), Entry("tie-breaking", policiesTestCase{
-	dataplane: samples.DataplaneWeb(),
-	resources: xds_context.Resources{
-		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
-			meshservice_api.MeshServiceType: backendMeshServiceList(),
-			api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
-				Items: []*api.MeshHTTPRouteResource{{
-					Meta: &test_model.ResourceMeta{
-						Mesh: core_model.DefaultMesh,
-						Name: "a-route",
-					},
-					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
-						To: &[]api.To{{
-							TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
-							Rules: []api.Rule{{
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/v1",
+			[]rules_common.Origin{routeOrigin("route-1"), routeOrigin("route-2")},
+			map[common_api.MatchesHash]rules_common.Origin{
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): routeOrigin("route-2"),
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v2"}}}): routeOrigin("route-2"),
+			},
+		),
+	}), Entry("tie-breaking", policiesTestCase{
+		dataplane: samples.DataplaneWeb(),
+		resources: xds_context.Resources{
+			MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+				meshservice_api.MeshServiceType: backendMeshServiceList(),
+				api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+					Items: []*api.MeshHTTPRouteResource{{
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "a-route",
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v1",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "a-backend", "version": "v1"}, ""),
+											Weight:    pointer.To(uint(100)),
+										}},
 									},
 								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "a-backend", "version": "v1"}, ""),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
 							}},
-						}},
-					},
-				}, {
-					Meta: &test_model.ResourceMeta{
-						Mesh: core_model.DefaultMesh,
-						Name: "b-route",
-					},
-					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
-						To: &[]api.To{{
-							TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
-							Rules: []api.Rule{{
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/v1",
+						},
+					}, {
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "b-route",
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v1",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "b-backend", "version": "v1"}, ""),
+											Weight:    pointer.To(uint(100)),
+										}},
 									},
 								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "b-backend", "version": "v1"}, ""),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
 							}},
+						},
+					}},
+				},
+			},
+		},
+		expectedRoutes: expectedBackendRoute(
+			api.PolicyDefault{
+				Rules: []api.Rule{{
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/v1",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "a-backend", "version": "v1"}, ""),
+							Weight:    pointer.To(uint(100)),
 						}},
 					},
 				}},
 			},
-		},
-	},
-	expectedRoutes: expectedBackendRoute(
-		api.PolicyDefault{
-			Rules: []api.Rule{{
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/v1",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "a-backend", "version": "v1"}, ""),
-						Weight:    pointer.To(uint(100)),
+			[]rules_common.Origin{routeOrigin("b-route"), routeOrigin("a-route")},
+			map[common_api.MatchesHash]rules_common.Origin{
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): routeOrigin("a-route"),
+			},
+		),
+	}), Entry("creation-timestamp-tie-breaking", policiesTestCase{
+		dataplane: samples.DataplaneWeb(),
+		resources: xds_context.Resources{
+			MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+				meshservice_api.MeshServiceType: backendMeshServiceList(),
+				api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+					Items: []*api.MeshHTTPRouteResource{{
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "a-route",
+							Labels: map[string]string{
+								metadata.GatewayAPIRouteCreationTimestampLabel: "200",
+							},
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v1",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "a-backend", "version": "v1"}, ""),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}},
+							}},
+						},
+					}, {
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "z-route",
+							Labels: map[string]string{
+								metadata.GatewayAPIRouteCreationTimestampLabel: "100",
+							},
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/v1",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "z-backend", "version": "v1"}, ""),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}},
+							}},
+						},
 					}},
 				},
-			}},
+			},
 		},
-		[]rules_common.Origin{routeOrigin("b-route"), routeOrigin("a-route")},
-		map[common_api.MatchesHash]rules_common.Origin{
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): routeOrigin("a-route"),
-		},
-	),
-}), Entry("ordering", policiesTestCase{
-	dataplane: samples.DataplaneWeb(),
-	resources: xds_context.Resources{
-		MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
-			meshservice_api.MeshServiceType: backendMeshServiceList(),
-			api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
-				Items: []*api.MeshHTTPRouteResource{{
-					Meta: &test_model.ResourceMeta{
-						Mesh: core_model.DefaultMesh,
-						Name: "a-route",
-					},
-					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
-						To: &[]api.To{{
-							TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
-							Rules: []api.Rule{{
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/a-first-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/a-second-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("first-time-in-list-backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/should-be-first-shared-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("a-backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/should-be-second-shared-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("a-backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/a-second-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("second-time-in-list-backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}},
-						}},
-					},
-				}, {
-					Meta: &test_model.ResourceMeta{
-						Mesh: core_model.DefaultMesh,
-						Name: "b-route",
-					},
-					Spec: &api.MeshHTTPRoute{
-						TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
-						To: &[]api.To{{
-							TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
-							Rules: []api.Rule{{
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/b-first-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/should-be-second-shared-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("b-backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/should-be-first-shared-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("b-backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}, {
-								Matches: []api.Match{{
-									Path: &api.PathMatch{
-										Type:  api.PathPrefix,
-										Value: "/b-second-prefix",
-									},
-								}},
-								Default: api.RuleConf{
-									BackendRefs: &[]common_api.BackendRef{{
-										TargetRef: builders.TargetRefService("backend"),
-										Weight:    pointer.To(uint(100)),
-									}},
-								},
-							}},
+		expectedRoutes: expectedBackendRoute(
+			api.PolicyDefault{
+				Rules: []api.Rule{{
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/v1",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefMeshServiceLabels(map[string]string{mesh_proto.DisplayName: "z-backend", "version": "v1"}, ""),
+							Weight:    pointer.To(uint(100)),
 						}},
 					},
 				}},
 			},
+			[]rules_common.Origin{gatewayRouteOrigin("a-route", "200"), gatewayRouteOrigin("z-route", "100")},
+			map[common_api.MatchesHash]rules_common.Origin{
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/v1"}}}): gatewayRouteOrigin("z-route", "100"),
+			},
+		),
+	}), Entry("ordering", policiesTestCase{
+		dataplane: samples.DataplaneWeb(),
+		resources: xds_context.Resources{
+			MeshLocalResources: map[core_model.ResourceType]core_model.ResourceList{
+				meshservice_api.MeshServiceType: backendMeshServiceList(),
+				api.MeshHTTPRouteType: &api.MeshHTTPRouteResourceList{
+					Items: []*api.MeshHTTPRouteResource{{
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "a-route",
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/a-first-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/a-second-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("first-time-in-list-backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/should-be-first-shared-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("a-backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/should-be-second-shared-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("a-backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/a-second-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("second-time-in-list-backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}},
+							}},
+						},
+					}, {
+						Meta: &test_model.ResourceMeta{
+							Mesh: core_model.DefaultMesh,
+							Name: "b-route",
+						},
+						Spec: &api.MeshHTTPRoute{
+							TargetRef: pointer.To(builders.ToTopLevelTargetRef(builders.TargetRefMesh())),
+							To: &[]api.To{{
+								TargetRef: builders.ToOutboundTargetRef(builders.TargetRefService("backend")),
+								Rules: []api.Rule{{
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/b-first-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/should-be-second-shared-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("b-backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/should-be-first-shared-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("b-backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}, {
+									Matches: []api.Match{{
+										Path: &api.PathMatch{
+											Type:  api.PathPrefix,
+											Value: "/b-second-prefix",
+										},
+									}},
+									Default: api.RuleConf{
+										BackendRefs: &[]common_api.BackendRef{{
+											TargetRef: builders.TargetRefService("backend"),
+											Weight:    pointer.To(uint(100)),
+										}},
+									},
+								}},
+							}},
+						},
+					}},
+				},
+			},
 		},
-	},
-	expectedRoutes: expectedBackendRoute(
-		api.PolicyDefault{
-			Rules: []api.Rule{{
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/a-first-prefix",
+		expectedRoutes: expectedBackendRoute(
+			api.PolicyDefault{
+				Rules: []api.Rule{{
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/a-first-prefix",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
+				}, {
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/a-second-prefix",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("first-time-in-list-backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
+				}, {
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/should-be-first-shared-prefix",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("a-backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
+				}, {
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/should-be-second-shared-prefix",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("a-backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
+				}, {
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/b-first-prefix",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
+					},
+				}, {
+					Matches: []api.Match{{
+						Path: &api.PathMatch{
+							Type:  api.PathPrefix,
+							Value: "/b-second-prefix",
+						},
+					}},
+					Default: api.RuleConf{
+						BackendRefs: &[]common_api.BackendRef{{
+							TargetRef: builders.TargetRefService("backend"),
+							Weight:    pointer.To(uint(100)),
+						}},
 					},
 				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}, {
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/a-second-prefix",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("first-time-in-list-backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}, {
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/should-be-first-shared-prefix",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("a-backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}, {
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/should-be-second-shared-prefix",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("a-backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}, {
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/b-first-prefix",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}, {
-				Matches: []api.Match{{
-					Path: &api.PathMatch{
-						Type:  api.PathPrefix,
-						Value: "/b-second-prefix",
-					},
-				}},
-				Default: api.RuleConf{
-					BackendRefs: &[]common_api.BackendRef{{
-						TargetRef: builders.TargetRefService("backend"),
-						Weight:    pointer.To(uint(100)),
-					}},
-				},
-			}},
-		},
-		[]rules_common.Origin{routeOrigin("b-route"), routeOrigin("a-route")},
-		map[common_api.MatchesHash]rules_common.Origin{
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-first-prefix"}}}):                 routeOrigin("a-route"),
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-second-prefix"}}}):                routeOrigin("a-route"),
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-first-prefix"}}}):                 routeOrigin("b-route"),
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-second-prefix"}}}):                routeOrigin("b-route"),
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-first-shared-prefix"}}}):  routeOrigin("a-route"),
-			api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-second-shared-prefix"}}}): routeOrigin("a-route"),
-		},
-	),
-}),
+			},
+			[]rules_common.Origin{routeOrigin("b-route"), routeOrigin("a-route")},
+			map[common_api.MatchesHash]rules_common.Origin{
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-first-prefix"}}}):                 routeOrigin("a-route"),
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/a-second-prefix"}}}):                routeOrigin("a-route"),
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-first-prefix"}}}):                 routeOrigin("b-route"),
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/b-second-prefix"}}}):                routeOrigin("b-route"),
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-first-shared-prefix"}}}):  routeOrigin("a-route"),
+				api.HashMatches([]api.Match{{Path: &api.PathMatch{Type: api.PathPrefix, Value: "/should-be-second-shared-prefix"}}}): routeOrigin("a-route"),
+			},
+		),
+	}),
 )

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -99,9 +99,9 @@ func ReconcileLabelledObject(
 	}
 
 	for ownedName, ownedObj := range owned {
-		desiredLabels := map[string]string{}
-		for k, v := range ownedObj.Labels {
-			desiredLabels[k] = v
+		desiredLabels := maps.Clone(ownedObj.Labels)
+		if desiredLabels == nil {
+			desiredLabels = map[string]string{}
 		}
 		desiredLabels[ownerLabel] = ownerLabelValue
 
@@ -111,12 +111,17 @@ func ReconcileLabelledObject(
 			if err != nil {
 				return err
 			}
-			labelsChanged := !maps.Equal(existing.GetLabels(), desiredLabels)
+			mergedLabels := maps.Clone(existing.GetLabels())
+			if mergedLabels == nil {
+				mergedLabels = map[string]string{}
+			}
+			maps.Copy(mergedLabels, desiredLabels)
+			labelsChanged := !maps.Equal(existing.GetLabels(), mergedLabels)
 			if core_model.Equal(existingSpec, ownedObj.Spec) && !labelsChanged {
 				log.V(1).Info("object is the same. Nothing to update")
 				continue
 			}
-			existing.SetLabels(desiredLabels)
+			existing.SetLabels(mergedLabels)
 			existing.SetSpec(ownedObj.Spec)
 
 			if err := client.Update(ctx, existing); err != nil {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"maps"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -24,6 +25,7 @@ const ownerLabel = "gateways.kuma.io/gateway.networking.k8s.io-owner"
 type OwnedObject struct {
 	Namespace string
 	Spec      core_model.ResourceSpec
+	Labels    map[string]string
 }
 
 func hashNamespacedName(name kube_types.NamespacedName) string {
@@ -97,16 +99,24 @@ func ReconcileLabelledObject(
 	}
 
 	for ownedName, ownedObj := range owned {
+		desiredLabels := map[string]string{}
+		for k, v := range ownedObj.Labels {
+			desiredLabels[k] = v
+		}
+		desiredLabels[ownerLabel] = ownerLabelValue
+
 		// Update existing
 		if existing, ok := existingObjs[ownedName]; ok {
 			existingSpec, err := existing.GetSpec()
 			if err != nil {
 				return err
 			}
-			if core_model.Equal(existingSpec, ownedObj.Spec) {
+			labelsChanged := !maps.Equal(existing.GetLabels(), desiredLabels)
+			if core_model.Equal(existingSpec, ownedObj.Spec) && !labelsChanged {
 				log.V(1).Info("object is the same. Nothing to update")
 				continue
 			}
+			existing.SetLabels(desiredLabels)
 			existing.SetSpec(ownedObj.Spec)
 
 			if err := client.Update(ctx, existing); err != nil {
@@ -127,9 +137,7 @@ func ReconcileLabelledObject(
 			&kube_meta.ObjectMeta{
 				Name:      ownedName,
 				Namespace: ownedObj.Namespace,
-				Labels: map[string]string{
-					ownerLabel: ownerLabelValue,
-				},
+				Labels:    desiredLabels,
 			},
 		)
 		newObj.SetMesh(ownerMesh)

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -187,7 +187,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	conditions := ParentConditions{}
 
 	labels := map[string]string{
-		metadata.GatewayAPIRouteCreationTimestampLabel: strconv.FormatInt(route.CreationTimestamp.Unix(), 10),
+		metadata.GatewayAPIRouteCreationTimestampLabel: strconv.FormatInt(route.CreationTimestamp.UnixNano(), 10),
 	}
 
 	for i, ref := range route.Spec.ParentRefs {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ import (
 	k8s_registry "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/registry"
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers/gatewayapi/attachment"
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
+	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	k8s_util "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/util"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
@@ -184,6 +186,10 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	// The conditions we accumulate for each ParentRef
 	conditions := ParentConditions{}
 
+	labels := map[string]string{
+		metadata.GatewayAPIRouteCreationTimestampLabel: strconv.FormatInt(route.CreationTimestamp.Unix(), 10),
+	}
+
 	for i, ref := range route.Spec.ParentRefs {
 		refAttachment, refKind, err := attachment.EvaluateParentRefAttachment(ref)
 		if err != nil {
@@ -218,7 +224,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 					return nil, nil, err
 				}
 
-				parentConditions = append(parentConditions,
+				parentConditions = append(
+					parentConditions,
 					kube_meta.Condition{
 						Type:    string(gatewayapi.RouteConditionAccepted),
 						Status:  kube_meta.ConditionFalse,
@@ -232,7 +239,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 			}
 
 			if parent.Spec.ClusterIP == kube_core.ClusterIPNone {
-				parentConditions = append(parentConditions,
+				parentConditions = append(
+					parentConditions,
 					kube_meta.Condition{
 						Type:    string(gatewayapi.RouteConditionAccepted),
 						Status:  kube_meta.ConditionFalse,
@@ -255,7 +263,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 
 			meshRoute, ok := r.gapiServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port, ref.SectionName)
 			if !ok {
-				parentConditions = append(parentConditions,
+				parentConditions = append(
+					parentConditions,
 					kube_meta.Condition{
 						Type:    string(gatewayapi.RouteConditionAccepted),
 						Status:  kube_meta.ConditionFalse,
@@ -273,7 +282,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				ownedNamespace = route.Namespace
 			}
 
-			storeMeshHTTPRoute(routes, routeSubName, ownedNamespace, meshRoute)
+			storeMeshHTTPRoute(routes, routeSubName, ownedNamespace, labels, meshRoute)
 		case attachment.MeshService:
 			namespace := route.Namespace
 			if ref.Namespace != nil {
@@ -289,7 +298,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 					return nil, nil, err
 				}
 
-				parentConditions = append(parentConditions,
+				parentConditions = append(
+					parentConditions,
 					kube_meta.Condition{
 						Type:    string(gatewayapi.RouteConditionAccepted),
 						Status:  kube_meta.ConditionFalse,
@@ -312,7 +322,8 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 
 			meshRoute, ok := r.gapiMeshServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port, ref.SectionName)
 			if !ok {
-				parentConditions = append(parentConditions,
+				parentConditions = append(
+					parentConditions,
 					kube_meta.Condition{
 						Type:    string(gatewayapi.RouteConditionAccepted),
 						Status:  kube_meta.ConditionFalse,
@@ -330,7 +341,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				ownedNamespace = route.Namespace
 			}
 
-			storeMeshHTTPRoute(routes, routeSubName, ownedNamespace, meshRoute)
+			storeMeshHTTPRoute(routes, routeSubName, ownedNamespace, labels, meshRoute)
 		}
 
 		conditions[ref] = prepareConditions(append(parentConditions, rulesConditions...))
@@ -339,22 +350,22 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 	return routes, conditions, nil
 }
 
-func storeMeshHTTPRoute(routes map[string]common.OwnedObject, name string, namespace string, spec core_model.ResourceSpec) {
+func storeMeshHTTPRoute(routes map[string]common.OwnedObject, name string, namespace string, labels map[string]string, spec core_model.ResourceSpec) {
 	route, ok := spec.(*meshhttproute_api.MeshHTTPRoute)
 	if !ok {
-		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec}
+		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec, Labels: labels}
 		return
 	}
 
 	existing, ok := routes[name]
 	if !ok {
-		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec}
+		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec, Labels: labels}
 		return
 	}
 
 	existingRoute, ok := existing.Spec.(*meshhttproute_api.MeshHTTPRoute)
 	if !ok {
-		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec}
+		routes[name] = common.OwnedObject{Namespace: namespace, Spec: spec, Labels: labels}
 		return
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -2,6 +2,7 @@ package gatewayapi
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -24,6 +25,7 @@ import (
 	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
 	meshhttproute_k8s "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/k8s/v1alpha1"
 	k8s_registry "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/registry"
+	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
@@ -278,6 +280,66 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		condition := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))
 		Expect(condition).ToNot(BeNil())
 		Expect(condition.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+
+	It("stamps the generated MeshHTTPRoute with the HTTPRoute's creationTimestamp", func() {
+		ms := &meshservice_k8s.MeshService{
+			Name: "backend", Namespace: "kuma-demo",
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		route := newRoute(meshServiceParentRef("backend"))
+		route.CreationTimestamp = kube_meta.NewTime(time.Unix(1700000000, 0))
+
+		client := newClientBuilder(ms, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
+	})
+
+	It("backfills the creationTimestamp label onto a generated MeshHTTPRoute created before the label existed", func() {
+		ms := &meshservice_k8s.MeshService{
+			Name: "backend", Namespace: "kuma-demo",
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		route := newRoute(meshServiceParentRef("backend"))
+		route.CreationTimestamp = kube_meta.NewTime(time.Unix(1700000000, 0))
+
+		client := newClientBuilder(ms, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+
+		generated := &routes.Items[0]
+		delete(generated.Labels, metadata.GatewayAPIRouteCreationTimestampLabel)
+		Expect(client.Update(context.Background(), generated)).To(Succeed())
+
+		_, err = reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
 	})
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -341,6 +341,44 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		Expect(routes.Items).To(HaveLen(1))
 		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
 	})
+
+	It("keeps labels it does not manage on a generated MeshHTTPRoute", func() {
+		ms := &meshservice_k8s.MeshService{
+			Name: "backend", Namespace: "kuma-demo",
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		route := newRoute(meshServiceParentRef("backend"))
+		route.CreationTimestamp = kube_meta.NewTime(time.Unix(1700000000, 0))
+
+		client := newClientBuilder(ms, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+
+		generated := &routes.Items[0]
+		generated.Labels["team"] = "payments"
+		delete(generated.Labels, metadata.GatewayAPIRouteCreationTimestampLabel)
+		Expect(client.Update(context.Background(), generated)).To(Succeed())
+
+		_, err = reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue("team", "payments"))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
+	})
 })
 
 var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func() {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -303,7 +303,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(HaveLen(1))
-		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000000000000"))
 	})
 
 	It("backfills the creationTimestamp label onto a generated MeshHTTPRoute created before the label existed", func() {
@@ -339,7 +339,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(HaveLen(1))
-		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000000000000"))
 	})
 
 	It("keeps labels it does not manage on a generated MeshHTTPRoute", func() {
@@ -377,7 +377,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(HaveLen(1))
 		Expect(routes.Items[0].Labels).To(HaveKeyWithValue("team", "payments"))
-		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000"))
+		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000000000000"))
 	})
 })
 

--- a/pkg/plugins/runtime/k8s/metadata/labels.go
+++ b/pkg/plugins/runtime/k8s/metadata/labels.go
@@ -15,7 +15,7 @@ const (
 
 	// GatewayAPIRouteCreationTimestampLabel records the creationTimestamp of
 	// the gateway-api HTTPRoute that a generated MeshHTTPRoute originates
-	// from. Value is the decimal Unix timestamp in seconds. Used to break
-	// route conflicts in favor of the oldest route.
+	// from. Value is the decimal Unix timestamp in nanoseconds. Used to
+	// break route conflicts in favor of the oldest route.
 	GatewayAPIRouteCreationTimestampLabel = "gateways.kuma.io/gateway.networking.k8s.io-route-creation-timestamp"
 )

--- a/pkg/plugins/runtime/k8s/metadata/labels.go
+++ b/pkg/plugins/runtime/k8s/metadata/labels.go
@@ -12,4 +12,10 @@ const (
 	// proxies.
 	// Allowed values: ingress or egress.
 	KumaZoneProxyTypeLabel = "k8s.kuma.io/zone-proxy-type"
+
+	// GatewayAPIRouteCreationTimestampLabel records the creationTimestamp of
+	// the gateway-api HTTPRoute that a generated MeshHTTPRoute originates
+	// from. Value is the decimal Unix timestamp in seconds. Used to break
+	// route conflicts in favor of the oldest route.
+	GatewayAPIRouteCreationTimestampLabel = "gateways.kuma.io/gateway.networking.k8s.io-route-creation-timestamp"
 )


### PR DESCRIPTION
## Motivation
Ensure HTTPRoute conflicts follow Gateway API precedence by creation time, preventing a newly created route from changing the behavior of an older route with an equally specific match.

## Implementation information
- Break HTTPRoute conflicts using creationTimestamp.
- Use nanosecond precision for route timestamps.
- Address review comments related to the implementation.

Closes https://github.com/kumahq/kuma/issues/18261

_Generated by Sybra harness_