### PR TITLE
fix(gatewayapi): harden generated meshhttproute names

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/common_suite_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/common_suite_test.go
@@ -1,0 +1,11 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestCommon(t *testing.T) {
+	test.RunSpecs(t, "Gateway API common support")
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile.go
@@ -73,21 +73,12 @@ func ReconcileLabelledObject(
 		return err
 	}
 
-	// Delete unneeded objects
 	existingObjs := map[string]k8s_model.KubernetesObject{}
+	var unneededObjs []k8s_model.KubernetesObject
 	for _, existing := range existingList.GetItems() {
 		desired, ok := owned[existing.GetName()]
 		if !ok || existing.GetNamespace() != desired.Namespace {
-			err := client.Delete(ctx, existing)
-			switch {
-			case kube_apierrs.IsNotFound(err):
-				log.V(1).Info("object not found. Nothing to delete")
-			case err == nil:
-				log.Info("object deleted")
-			default:
-				return err
-			}
-			// We don't care about this anymore
+			unneededObjs = append(unneededObjs, existing)
 			continue
 		}
 		existingObjs[existing.GetName()] = existing
@@ -152,6 +143,20 @@ func ReconcileLabelledObject(
 			return errors.Wrapf(err, "could not create owned %T", ownedType)
 		}
 		logger.Info("object created")
+	}
+
+	// Delete unneeded objects after desired objects are reconciled. This keeps
+	// existing config serving if a replacement create or update fails.
+	for _, existing := range unneededObjs {
+		err := client.Delete(ctx, existing)
+		switch {
+		case kube_apierrs.IsNotFound(err):
+			log.V(1).Info("object not found. Nothing to delete")
+		case err == nil:
+			log.Info("object deleted")
+		default:
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile_test.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_runtime "k8s.io/apimachinery/pkg/runtime"
+	kube_types "k8s.io/apimachinery/pkg/types"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
+	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	kube_interceptor "sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	meshhttproute_k8s "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/k8s/v1alpha1"
+	k8s_registry "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/registry"
+)
+
+func TestReconcileLabelledObjectKeepsUnneededObjectWhenReplacementCreateFails(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	scheme := kube_runtime.NewScheme()
+	g.Expect(meshhttproute_k8s.AddToScheme(scheme)).To(Succeed())
+
+	owner := kube_types.NamespacedName{Namespace: "route-ns", Name: "my-route"}
+	stale := &meshhttproute_k8s.MeshHTTPRoute{
+		ObjectMeta: kube_meta.ObjectMeta{
+			Name:      "legacy-route",
+			Namespace: "kuma-system",
+			Labels: map[string]string{
+				ownerLabel: hashNamespacedName(owner),
+			},
+		},
+	}
+
+	writeErr := errors.New("simulated replacement create failure")
+	deleteCalled := false
+	client := kube_client_fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(kube_interceptor.Funcs{
+			Create: func(ctx context.Context, client kube_client.WithWatch, obj kube_client.Object, opts ...kube_client.CreateOption) error {
+				if _, ok := obj.(*meshhttproute_k8s.MeshHTTPRoute); ok {
+					return writeErr
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+			Delete: func(ctx context.Context, client kube_client.WithWatch, obj kube_client.Object, opts ...kube_client.DeleteOption) error {
+				deleteCalled = true
+				return client.Delete(ctx, obj, opts...)
+			},
+		}).
+		WithObjects(stale).
+		Build()
+
+	err := ReconcileLabelledObject(
+		ctx,
+		logr.Discard(),
+		k8s_registry.Global(),
+		client,
+		owner,
+		"default",
+		&meshhttproute_api.MeshHTTPRoute{},
+		map[string]OwnedObject{
+			"replacement-route": {
+				Namespace: "kuma-system",
+				Spec:      &meshhttproute_api.MeshHTTPRoute{},
+			},
+		},
+	)
+	g.Expect(err).To(MatchError(ContainSubstring("could not create owned")))
+	g.Expect(err).To(MatchError(ContainSubstring(writeErr.Error())))
+	g.Expect(deleteCalled).To(BeFalse())
+
+	routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+	g.Expect(client.List(ctx, routes)).To(Succeed())
+	g.Expect(routes.Items).To(HaveLen(1))
+	g.Expect(routes.Items[0].Name).To(Equal("legacy-route"))
+}

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/common/reconcile_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
-	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,12 +27,10 @@ func TestReconcileLabelledObjectKeepsUnneededObjectWhenReplacementCreateFails(t 
 
 	owner := kube_types.NamespacedName{Namespace: "route-ns", Name: "my-route"}
 	stale := &meshhttproute_k8s.MeshHTTPRoute{
-		ObjectMeta: kube_meta.ObjectMeta{
-			Name:      "legacy-route",
-			Namespace: "kuma-system",
-			Labels: map[string]string{
-				ownerLabel: hashNamespacedName(owner),
-			},
+		Name:      "legacy-route",
+		Namespace: "kuma-system",
+		Labels: map[string]string{
+			ownerLabel: hashNamespacedName(owner),
 		},
 	}
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -165,7 +165,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 		ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &meshhttproute_api.MeshHTTPRoute{}, meshRouteSpecs,
 	); err != nil {
 		reconcileErr := errors.Wrap(err, "could not reconcile owned MeshHTTPRoute.kuma.io")
-		if statusErr := r.updateStatus(ctx, httpRoute, generatedRouteWriteFailureConditions(httpRoute, conditions, reconcileErr)); statusErr != nil {
+		if statusErr := r.updateStatus(ctx, httpRoute, generatedRouteWriteFailureConditions(conditions, reconcileErr)); statusErr != nil {
 			r.Log.Error(statusErr, "unable to update HTTPRoute status after MeshHTTPRoute reconcile failure", "name", httpRoute.Name, "namespace", httpRoute.Namespace)
 		}
 		return kube_ctrl.Result{}, reconcileErr
@@ -412,14 +412,14 @@ func generatedMeshHTTPRouteNameSegment(label string, value string) string {
 	return fmt.Sprintf("%s-%d-%s", label, len(value), value)
 }
 
-func generatedRouteWriteFailureConditions(route *gatewayapi.HTTPRoute, existing ParentConditions, reconcileErr error) ParentConditions {
-	if len(route.Spec.ParentRefs) == 0 {
+func generatedRouteWriteFailureConditions(existing ParentConditions, reconcileErr error) ParentConditions {
+	if len(existing) == 0 {
 		return nil
 	}
 
 	failed := ParentConditions{}
-	for _, ref := range route.Spec.ParentRefs {
-		conditions := append([]kube_meta.Condition{}, existing[ref]...)
+	for ref, existingConditions := range existing {
+		conditions := append([]kube_meta.Condition{}, existingConditions...)
 		conditions = append(conditions, kube_meta.Condition{
 			Type:    string(gatewayapi.RouteConditionAccepted),
 			Status:  kube_meta.ConditionFalse,

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -30,6 +31,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers/gatewayapi/common"
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	k8s_util "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/util"
+	k8s_names "github.com/kumahq/kuma/v3/pkg/util/k8s"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
@@ -162,7 +164,11 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 	if err := common.ReconcileLabelledObject(
 		ctx, r.Log, r.TypeRegistry, r.Client, req.NamespacedName, mesh, &meshhttproute_api.MeshHTTPRoute{}, meshRouteSpecs,
 	); err != nil {
-		return kube_ctrl.Result{}, errors.Wrap(err, "could not reconcile owned MeshHTTPRoute.kuma.io")
+		reconcileErr := errors.Wrap(err, "could not reconcile owned MeshHTTPRoute.kuma.io")
+		if statusErr := r.updateStatus(ctx, httpRoute, generatedRouteWriteFailureConditions(httpRoute, conditions, reconcileErr)); statusErr != nil {
+			r.Log.Error(statusErr, "unable to update HTTPRoute status after MeshHTTPRoute reconcile failure", "name", httpRoute.Name, "namespace", httpRoute.Namespace)
+		}
+		return kube_ctrl.Result{}, reconcileErr
 	}
 
 	if err := r.updateStatus(ctx, httpRoute, conditions); err != nil {
@@ -173,6 +179,8 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req kube_ctrl.Reque
 }
 
 type ParentConditions map[gatewayapi.ParentReference][]kube_meta.Condition
+
+const maxGeneratedMeshHTTPRouteNameLength = 253
 
 // gapiToKumaRoutes returns some number of GatewayRoutes that should be created
 // for this HTTPRoute along with any statuses to be set on the HTTPRoute.
@@ -253,13 +261,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
-			routeSubName := fmt.Sprintf(
-				"%s-%s-%s.%s",
-				route.Name,
-				route.Namespace,
-				parent.GetName(),
-				parent.GetNamespace(),
-			)
+			routeSubName := generatedMeshHTTPRouteName(route, "Service", parent.GetNamespace(), parent.GetName())
 
 			meshRoute, ok := r.gapiServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port, ref.SectionName)
 			if !ok {
@@ -312,13 +314,7 @@ func (r *HTTPRouteReconciler) gapiToKumaRoutes(
 				continue
 			}
 
-			routeSubName := fmt.Sprintf(
-				"%s-%s-meshservice-%s.%s",
-				route.Name,
-				route.Namespace,
-				parent.GetName(),
-				parent.GetNamespace(),
-			)
+			routeSubName := generatedMeshHTTPRouteName(route, "MeshService", parent.GetNamespace(), parent.GetName())
 
 			meshRoute, ok := r.gapiMeshServiceToMeshRoute(route.Namespace, rules, &parent, ref.Port, ref.SectionName)
 			if !ok {
@@ -383,6 +379,57 @@ func storeMeshHTTPRoute(routes map[string]common.OwnedObject, name string, names
 		}
 	}
 	existingRoute.To = pointer.To(merged)
+}
+
+func generatedMeshHTTPRouteName(route *gatewayapi.HTTPRoute, parentKind, parentNamespace, parentName string) string {
+	normalizedParentKind := strings.ToLower(parentKind)
+	normalizedParentNamespace := strings.ToLower(parentNamespace)
+	normalizedParentName := strings.ToLower(parentName)
+
+	fullName := strings.Join([]string{
+		generatedMeshHTTPRouteNameSegment("rns", route.Namespace),
+		generatedMeshHTTPRouteNameSegment("rn", route.Name),
+		generatedMeshHTTPRouteNameSegment("pk", normalizedParentKind),
+		generatedMeshHTTPRouteNameSegment("pns", normalizedParentNamespace),
+		generatedMeshHTTPRouteNameSegment("pn", normalizedParentName),
+	}, "--")
+	if len(fullName) <= maxGeneratedMeshHTTPRouteNameLength {
+		return fullName
+	}
+
+	hasher := k8s_names.NewHasher()
+	hasher.Write([]byte(fullName))
+	hashSuffix := k8s_names.HashToString(hasher)
+	prefix := k8s_names.EnsureMaxLength(fullName, maxGeneratedMeshHTTPRouteNameLength-len(hashSuffix)-1)
+	prefix = strings.TrimRight(prefix, "-.")
+	if prefix == "" {
+		return hashSuffix
+	}
+	return fmt.Sprintf("%s-%s", prefix, hashSuffix)
+}
+
+func generatedMeshHTTPRouteNameSegment(label string, value string) string {
+	return fmt.Sprintf("%s-%d-%s", label, len(value), value)
+}
+
+func generatedRouteWriteFailureConditions(route *gatewayapi.HTTPRoute, existing ParentConditions, reconcileErr error) ParentConditions {
+	if len(route.Spec.ParentRefs) == 0 {
+		return nil
+	}
+
+	failed := ParentConditions{}
+	for _, ref := range route.Spec.ParentRefs {
+		conditions := append([]kube_meta.Condition{}, existing[ref]...)
+		conditions = append(conditions, kube_meta.Condition{
+			Type:    string(gatewayapi.RouteConditionAccepted),
+			Status:  kube_meta.ConditionFalse,
+			Reason:  string(gatewayapi.RouteReasonPending),
+			Message: fmt.Sprintf("Failed to write generated MeshHTTPRoute: %s", reconcileErr.Error()),
+		})
+		failed[ref] = prepareConditions(conditions)
+	}
+
+	return failed
 }
 
 // routesForService returns a function that calculates which HTTPRoutes might

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -667,13 +667,15 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 			Name:      gatewayapi.ObjectName("backend"),
 		}
 		firstRoute := &gatewayapi.HTTPRoute{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "blue-green", Namespace: firstRouteNamespace.Name},
+			Name:      "blue-green",
+			Namespace: firstRouteNamespace.Name,
 			Spec: gatewayapi.HTTPRouteSpec{
 				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{parentRef}},
 			},
 		}
 		secondRoute := &gatewayapi.HTTPRoute{
-			ObjectMeta: kube_meta.ObjectMeta{Name: "blue", Namespace: secondRouteNamespace.Name},
+			Name:      "blue",
+			Namespace: secondRouteNamespace.Name,
 			Spec: gatewayapi.HTTPRouteSpec{
 				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{parentRef}},
 			},

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -751,6 +751,58 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionTrue))
 	})
 
+	It("updates only supported parentRef statuses when writing the generated MeshHTTPRoute fails", func() {
+		svc := &kube_core.Service{
+			Name: "backend", Namespace: routeNamespace,
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		serviceRef := withSectionName(serviceParentRef(), "http")
+		unsupportedGroup := gatewayapi.Group(gatewayapi.GroupName)
+		unsupportedKind := gatewayapi.Kind("Mesh")
+		unsupportedRef := gatewayapi.ParentReference{
+			Group: &unsupportedGroup,
+			Kind:  &unsupportedKind,
+			Name:  gatewayapi.ObjectName("mesh"),
+		}
+		route := newRoute(serviceRef, unsupportedRef)
+		writeErr := errors.New("simulated create failure")
+
+		client := kube_client_fake.NewClientBuilder().
+			WithScheme(reconciler.Scheme).
+			WithStatusSubresource(&gatewayapi.HTTPRoute{}).
+			WithIndex(&gatewayapi.HTTPRoute{}, servicesOfRouteField, servicesOfRoute).
+			WithInterceptorFuncs(kube_interceptor.Funcs{
+				Create: func(ctx context.Context, client kube_client.WithWatch, obj kube_client.Object, opts ...kube_client.CreateOption) error {
+					if _, ok := obj.(*meshhttproute_k8s.MeshHTTPRoute); ok {
+						return writeErr
+					}
+					return client.Create(ctx, obj, opts...)
+				},
+			}).
+			WithObjects(namespace, svc, route).
+			Build()
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).To(MatchError(ContainSubstring("could not reconcile owned MeshHTTPRoute.kuma.io")))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		Expect(updatedRoute.Status.Parents[0].ParentRef).To(Equal(serviceRef))
+
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi.RouteReasonPending)))
+		Expect(accepted.Message).To(ContainSubstring(writeErr.Error()))
+	})
+
 	It("reports Accepted=False when the parentRef names a Service port the Service does not have", func() {
 		svc := &kube_core.Service{
 			Name: "backend", Namespace: routeNamespace,

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -2,6 +2,8 @@ package gatewayapi
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -14,6 +16,7 @@ import (
 	kube_ctrl "sigs.k8s.io/controller-runtime"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	kube_interceptor "sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	kube_event "sigs.k8s.io/controller-runtime/pkg/event"
 	kube_handler "sigs.k8s.io/controller-runtime/pkg/handler"
 	kube_reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -78,6 +81,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 
 		reconciler = &HTTPRouteReconciler{
 			Log:             logr.Discard(),
+			Scheme:          scheme,
 			TypeRegistry:    k8s_registry.Global(),
 			SystemNamespace: "kuma-system",
 		}
@@ -103,7 +107,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
 		Expect(client.List(context.Background(), routes)).To(Succeed())
 		Expect(routes.Items).To(HaveLen(1))
-		Expect(routes.Items[0].Name).To(Equal("my-route-kuma-demo-meshservice-backend.kuma-demo"))
+		Expect(routes.Items[0].Name).To(Equal("rns-9-kuma-demo--rn-8-my-route--pk-11-meshservice--pns-9-kuma-demo--pn-7-backend"))
 
 		spec := routes.Items[0].Spec
 		Expect(spec).ToNot(BeNil())
@@ -342,6 +346,37 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a MeshService parentRef", f
 		Expect(routes.Items[0].Labels).To(HaveKeyWithValue(metadata.GatewayAPIRouteCreationTimestampLabel, "1700000000000000000"))
 	})
 
+	It("bounds long generated MeshHTTPRoute names to a valid Kubernetes name", func() {
+		ms := &meshservice_k8s.MeshService{
+			Name: "backend", Namespace: "kuma-demo",
+			Spec: &meshservice_api.MeshService{
+				Ports: []meshservice_api.Port{{Port: 80, Name: pointer.To("http")}},
+			},
+		}
+		route := newRoute(meshServiceParentRef("backend"))
+		route.Name = strings.Repeat("a", 220)
+
+		client := newClientBuilder(ms, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		Expect(routes.Items[0].Name).To(Equal(generatedMeshHTTPRouteName(route, "MeshService", ms.Namespace, ms.Name)))
+		Expect(len(routes.Items[0].Name)).To(BeNumerically("<=", maxGeneratedMeshHTTPRouteNameLength))
+		Expect(routes.Items[0].Name).To(MatchRegexp(`^[a-z0-9]([-.a-z0-9]*[a-z0-9])?$`))
+
+		spec := routes.Items[0].Spec
+		Expect(spec).ToNot(BeNil())
+		Expect(*spec.To).To(HaveLen(1))
+		Expect(*(*spec.To)[0].TargetRef.SectionName).To(Equal("http"))
+	})
+
 	It("keeps labels it does not manage on a generated MeshHTTPRoute", func() {
 		ms := &meshservice_k8s.MeshService{
 			Name: "backend", Namespace: "kuma-demo",
@@ -431,6 +466,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 
 		reconciler = &HTTPRouteReconciler{
 			Log:             logr.Discard(),
+			Scheme:          scheme,
 			TypeRegistry:    k8s_registry.Global(),
 			SystemNamespace: "kuma-system",
 		}
@@ -608,6 +644,111 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 			Expect(accepted).ToNot(BeNil())
 			Expect(accepted.Status).To(Equal(kube_meta.ConditionTrue))
 		}
+	})
+
+	It("creates distinct generated routes for HTTPRoutes whose old generated names would collide", func() {
+		sharedNamespace := &kube_core.Namespace{Name: "shared"}
+		firstRouteNamespace := &kube_core.Namespace{Name: "team-a"}
+		secondRouteNamespace := &kube_core.Namespace{Name: "green-team-a"}
+		svc := &kube_core.Service{
+			Name: "backend", Namespace: sharedNamespace.Name,
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		serviceGroup := gatewayapi.Group("")
+		serviceKind := gatewayapi.Kind("Service")
+		sharedGatewayNamespace := gatewayapi.Namespace(sharedNamespace.Name)
+		parentRef := gatewayapi.ParentReference{
+			Group:     &serviceGroup,
+			Kind:      &serviceKind,
+			Namespace: &sharedGatewayNamespace,
+			Name:      gatewayapi.ObjectName("backend"),
+		}
+		firstRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "blue-green", Namespace: firstRouteNamespace.Name},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{parentRef}},
+			},
+		}
+		secondRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: kube_meta.ObjectMeta{Name: "blue", Namespace: secondRouteNamespace.Name},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: []gatewayapi.ParentReference{parentRef}},
+			},
+		}
+
+		client := newClientBuilder(sharedNamespace, firstRouteNamespace, secondRouteNamespace, svc, firstRoute, secondRoute)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(firstRoute),
+		})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(secondRoute),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(2))
+		Expect(routes.Items[0].Namespace).To(Equal("kuma-system"))
+		Expect(routes.Items[1].Namespace).To(Equal("kuma-system"))
+		Expect([]string{routes.Items[0].Name, routes.Items[1].Name}).To(ConsistOf(
+			generatedMeshHTTPRouteName(firstRoute, "Service", svc.Namespace, svc.Name),
+			generatedMeshHTTPRouteName(secondRoute, "Service", svc.Namespace, svc.Name),
+		))
+		Expect(routes.Items[0].Name).ToNot(Equal(routes.Items[1].Name))
+	})
+
+	It("updates HTTPRoute status when writing the generated MeshHTTPRoute fails", func() {
+		svc := &kube_core.Service{
+			Name: "backend", Namespace: routeNamespace,
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
+		writeErr := errors.New("simulated create failure")
+
+		client := kube_client_fake.NewClientBuilder().
+			WithScheme(reconciler.Scheme).
+			WithStatusSubresource(&gatewayapi.HTTPRoute{}).
+			WithIndex(&gatewayapi.HTTPRoute{}, servicesOfRouteField, servicesOfRoute).
+			WithInterceptorFuncs(kube_interceptor.Funcs{
+				Create: func(ctx context.Context, client kube_client.WithWatch, obj kube_client.Object, opts ...kube_client.CreateOption) error {
+					if _, ok := obj.(*meshhttproute_k8s.MeshHTTPRoute); ok {
+						return writeErr
+					}
+					return client.Create(ctx, obj, opts...)
+				},
+			}).
+			WithObjects(namespace, svc, route).
+			Build()
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).To(MatchError(ContainSubstring("could not reconcile owned MeshHTTPRoute.kuma.io")))
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi.RouteReasonPending)))
+		Expect(accepted.Message).To(ContainSubstring("Failed to write generated MeshHTTPRoute"))
+		Expect(accepted.Message).To(ContainSubstring(writeErr.Error()))
+
+		resolvedRefs := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionTrue))
 	})
 
 	It("reports Accepted=False when the parentRef names a Service port the Service does not have", func() {


### PR DESCRIPTION
## Motivation
Prevent generated route names from colliding across namespaces or exceeding Kubernetes name limits, leaving affected HTTPRoutes without policies or status conditions.

## Implementation information
- Hardened generated MeshHTTPRoute names to avoid silent collisions and handle long route names safely.
- Addressed review feedback related to the naming fix.

Closes https://github.com/kumahq/kuma/issues/18262

_Generated by Sybra harness_