### PR TITLE
fix(k8s): avoid logging DataplaneInsight upsert as an error during namespace termination

### DIFF
--- a/pkg/core/resources/store/error.go
+++ b/pkg/core/resources/store/error.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	ErrIsAlreadyExists = errors.New("already exists")
-	ErrConflict        = errors.New("conflict")
-	ErrNotFound        = errors.New("not found")
+	ErrIsAlreadyExists      = errors.New("already exists")
+	ErrConflict             = errors.New("conflict")
+	ErrNotFound             = errors.New("not found")
+	ErrNamespaceTerminating = errors.New("namespace is terminating")
 	// ErrInvalid is the store's verdict on one specific resource: the resource is
 	// unacceptable on its own merits, so replaying it unchanged can never succeed.
 	// It is the opposite of a transient failure - a database outage, a lost
@@ -45,6 +46,14 @@ func ErrorResourceNotFound(rt model.ResourceType, name, mesh string) error {
 
 func IsNotFound(err error) bool {
 	return errors.Is(err, ErrNotFound)
+}
+
+func ErrorResourceNamespaceTerminating(rt model.ResourceType, name, mesh string) error {
+	return fmt.Errorf("resource %w: type=%q name=%q mesh=%q", ErrNamespaceTerminating, rt, name, mesh)
+}
+
+func IsNamespaceTerminating(err error) bool {
+	return errors.Is(err, ErrNamespaceTerminating)
 }
 
 func ErrorInvalid(reason string) error {

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	kube_core "k8s.io/api/core/v1"
 	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_runtime "k8s.io/apimachinery/pkg/runtime"
@@ -28,6 +29,14 @@ import (
 func typeIsUnregistered(err error) bool {
 	var typeErr *k8s_registry.UnknownTypeError
 	return errors.As(err, &typeErr)
+}
+
+// isNamespaceTerminating reports whether err is the Forbidden error the
+// NamespaceLifecycle admission controller returns when creating an object in
+// a namespace that is being deleted, so callers can treat it as an expected,
+// transient condition rather than an actionable failure.
+func isNamespaceTerminating(err error) bool {
+	return kube_apierrs.HasStatusCause(err, kube_core.NamespaceTerminatingCause)
 }
 
 var _ store.ResourceStore = &KubernetesStore{}
@@ -87,6 +96,13 @@ func (s *KubernetesStore) Create(ctx context.Context, r core_model.Resource, fs 
 		// the same bytes fail every time and the caller has to drop it.
 		if kube_apierrs.IsInvalid(err) {
 			return store.ErrorInvalid(err.Error())
+		}
+		// The namespace can start terminating between us deciding to create the
+		// object and the API server admitting it, e.g. while a namespace with an
+		// injected mesh is being deleted. The object would be garbage collected
+		// anyway, so callers can treat this the same as AlreadyExists/Conflict.
+		if isNamespaceTerminating(err) {
+			return store.ErrorResourceNamespaceTerminating(r.Descriptor().Name, opts.Name, opts.Mesh)
 		}
 		return errors.Wrap(err, "failed to create k8s resource")
 	}

--- a/pkg/plugins/resources/k8s/store_test.go
+++ b/pkg/plugins/resources/k8s/store_test.go
@@ -1,0 +1,60 @@
+package k8s_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kube_core "k8s.io/api/core/v1"
+	kube_apierrs "k8s.io/apimachinery/pkg/api/errors"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	meshexternalservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshexternalservice/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
+)
+
+var _ = Describe("KubernetesStore.Create", func() {
+	It("should surface a namespace-terminating Forbidden error distinctly from other create failures", func() {
+		// The NamespaceLifecycle admission controller returns this exact shape
+		// of StatusError when a create is attempted against a namespace that is
+		// being deleted.
+		namespaceTerminatingErr := &kube_apierrs.StatusError{
+			ErrStatus: kube_meta.Status{
+				Status:  kube_meta.StatusFailure,
+				Reason:  kube_meta.StatusReasonForbidden,
+				Message: `unable to create new content in namespace "demo" because it is being terminated`,
+				Details: &kube_meta.StatusDetails{
+					Causes: []kube_meta.StatusCause{{
+						Type:    kube_core.NamespaceTerminatingCause,
+						Message: `namespace "demo" is being terminated`,
+						Field:   "metadata.namespace",
+					}},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(k8sClientScheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return namespaceTerminatingErr
+				},
+			}).
+			Build()
+
+		s := &k8s.KubernetesStore{
+			Client:    fakeClient,
+			Converter: k8s.NewSimpleConverter(),
+			Scheme:    k8sClientScheme,
+		}
+
+		err := s.Create(context.Background(), meshexternalservice_api.NewMeshExternalServiceResource(), store.CreateByKey("demo-service.demo", "default"))
+
+		Expect(store.IsNamespaceTerminating(err)).To(BeTrue())
+		Expect(store.IsAlreadyExists(err)).To(BeFalse())
+	})
+})

--- a/pkg/xds/server/callbacks/dataplane_status_sink.go
+++ b/pkg/xds/server/callbacks/dataplane_status_sink.go
@@ -185,6 +185,9 @@ func (s *dataplaneInsightSink) Start(stop <-chan struct{}) {
 			case store.IsAlreadyExists(err) || store.IsConflict(err):
 				sinkLog.V(1).Info("failed to flush DataplaneInsight because it was updated in other place. Will retry in the next tick",
 					"dataplaneID", dataplaneID)
+			case store.IsNamespaceTerminating(err):
+				sinkLog.V(1).Info("failed to flush DataplaneInsight because its namespace is terminating",
+					"dataplaneID", dataplaneID)
 			default:
 				sinkLog.Error(err, "failed to flush DataplaneInsight", "dataplaneID", dataplaneID)
 			}


### PR DESCRIPTION
## Motivation

When a Kubernetes namespace with an injected mesh is deleted, the control
plane can log a very large number of `ERROR` lines while the namespace is
terminating. One reported case (deleting a namespace with 800 services, 2
replicas each) produced ~125,000 log lines.

Part of this was already fixed by #9133, which made the pod-to-Dataplane
reconciler skip work once it observes the namespace is terminating.

The remaining source is the `DataplaneInsight` flush loop
(`pkg/xds/server/callbacks/dataplane_status_sink.go`). While a namespace is
terminating, Kubernetes' `NamespaceLifecycle` admission controller rejects
any `Create` into it with a `Forbidden` error (e.g. `dataplaneinsights.kuma.io
"X" is forbidden: unable to create new content in namespace "Y" because it is
being terminated`). The sink's flush ticker retries this every tick and logs
it at `ERROR` level every time via the generic fallback branch, which is the
actual source of the log spam for this resource.

## Implementation information

- `pkg/core/resources/store/error.go`: added a new sentinel error
  (`ErrNamespaceTerminating`) with `ErrorResourceNamespaceTerminating`/
  `IsNamespaceTerminating` helpers, following the exact pattern already used
  for `ErrIsAlreadyExists`/`ErrConflict`.
- `pkg/plugins/resources/k8s/store.go`: `KubernetesStore.Create` now
  recognizes this specific admission error (via
  `kube_apierrs.HasStatusCause(err, kube_core.NamespaceTerminatingCause)`,
  the same typed cause the `NamespaceLifecycle` admission controller sets)
  and returns `store.ErrorResourceNamespaceTerminating` instead of a generic
  wrapped error, alongside the existing `AlreadyExists`/`Invalid` special
  cases.
- `pkg/xds/server/callbacks/dataplane_status_sink.go`: the flush loop now
  treats `store.IsNamespaceTerminating(err)` the same way it already treats
  `AlreadyExists`/`Conflict` — log at `V(1)` and retry on the next tick,
  instead of logging at `ERROR` every time.

This only changes the log level/error classification for this one expected,
transient condition; it does not change what data ends up stored, since the
insight would be garbage-collected with the namespace regardless.

## Supporting documentation

Fix #XX

<!--
> Changelog: skip
-->
<!--
Uncomment the above section to explicitly set a [`> Changelog:` entry here](https://github.com/kumahq/kuma/blob/master/CONTRIBUTING.md#submitting-a-patch)?
-->

Fixes #12858