### PR TITLE
fix(secrets): list k8s Secrets missing kuma.io/mesh label in default mesh

### DIFF
--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -191,24 +191,26 @@ func (s *KubernetesStore) List(ctx context.Context, rs core_model.ResourceList, 
 	secrets := &kube_core.SecretList{}
 
 	fields := kube_client.MatchingFields{} // list only Kuma System secrets
-	labels := kube_client.MatchingLabels{}
 	switch rs.GetItemType() {
 	case secret_model.SecretType:
 		fields = kube_client.MatchingFields{ // list only Kuma System secrets
 			"type": common_k8s.MeshSecretType,
-		}
-		if opts.Mesh != "" {
-			labels[metadata.KumaMeshLabel] = opts.Mesh
 		}
 	case secret_model.GlobalSecretType:
 		fields = kube_client.MatchingFields{ // list only Kuma System secrets
 			"type": common_k8s.GlobalSecretType,
 		}
 	}
-	if err := s.reader.List(ctx, secrets, kube_client.InNamespace(s.namespace), labels, fields); err != nil {
+	// Note: the mesh is deliberately not passed as a k8s label selector here. A Secret with no
+	// "kuma.io/mesh" label is implicitly considered part of the default mesh everywhere else in
+	// this store (see KubernetesMetaAdapter.GetMesh() and Secret.GetMesh()), but a k8s label
+	// selector requires the label to be present to match. Filtering server-side on the label
+	// would therefore silently drop unlabeled default-mesh secrets from the result. Instead, the
+	// mesh filter is applied in Go, after conversion, in ToCoreList below.
+	if err := s.reader.List(ctx, secrets, kube_client.InNamespace(s.namespace), fields); err != nil {
 		return errors.Wrap(err, "failed to list k8s Secrets")
 	}
-	if err := s.secretsConverter.ToCoreList(secrets, rs); err != nil {
+	if err := s.secretsConverter.ToCoreList(secrets, rs, opts.Mesh); err != nil {
 		return errors.Wrap(err, "failed to convert k8s Secret into core counterpart")
 	}
 	return nil
@@ -264,7 +266,9 @@ func (m *KubernetesMetaAdapter) GetLabels() map[string]string {
 type Converter interface {
 	ToKubernetesObject(resource core_model.Resource) (*kube_core.Secret, error)
 	ToCoreResource(secret *kube_core.Secret, out core_model.Resource) error
-	ToCoreList(list *kube_core.SecretList, out core_model.ResourceList) error
+	// ToCoreList converts the k8s Secret list into the core resource list. When mesh is non-empty,
+	// only items resolving to that mesh (via ToCoreResource's mesh defaulting) are included.
+	ToCoreList(list *kube_core.SecretList, out core_model.ResourceList, mesh string) error
 }
 
 func DefaultConverter() Converter {
@@ -314,17 +318,20 @@ func (c *SimpleConverter) ToCoreResource(secret *kube_core.Secret, out core_mode
 	return nil
 }
 
-func (c *SimpleConverter) ToCoreList(in *kube_core.SecretList, out core_model.ResourceList) error {
+func (c *SimpleConverter) ToCoreList(in *kube_core.SecretList, out core_model.ResourceList, mesh string) error {
 	switch out.GetItemType() {
 	case secret_model.SecretType:
 		secOut := out.(*secret_model.SecretResourceList)
-		secOut.Items = make([]*secret_model.SecretResource, len(in.Items))
+		secOut.Items = make([]*secret_model.SecretResource, 0, len(in.Items))
 		for i := range in.Items {
 			r := secret_model.NewSecretResource()
 			if err := c.ToCoreResource(&in.Items[i], r); err != nil {
 				return err
 			}
-			secOut.Items[i] = r
+			if mesh != "" && r.GetMeta().GetMesh() != mesh {
+				continue
+			}
+			secOut.Items = append(secOut.Items, r)
 		}
 	case secret_model.GlobalSecretType:
 		secOut := out.(*secret_model.GlobalSecretResourceList)

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -768,6 +768,37 @@ var _ = Describe("KubernetesStore", func() {
 				Expect(secrets.Items[0].Spec.Data.Value).To(Equal([]byte("another")))
 			})
 
+			It("should include a secret with no mesh label when listing the default mesh", func() {
+				// given a secret with no "kuma.io/mesh" label at all, e.g. created directly via kubectl
+				noLabel := backend.ParseYAML(fmt.Sprintf(`
+                apiVersion: v1
+                kind: Secret
+                type: system.kuma.io/secret
+                metadata:
+                  namespace: %s
+                  name: %s
+                data:
+                  value: c2l4 # base64(six)
+`, ns, "six"))
+				backend.Create(noLabel)
+
+				// given
+				secrets := &core_system.SecretResourceList{}
+
+				// when: Get() and the "default mesh" predicate elsewhere in this codebase both treat a
+				// missing kuma.io/mesh label as implicitly belonging to the default mesh (see the
+				// "implicit default mesh" Get() test above), so List() should be consistent with that.
+				err := rs.List(context.Background(), secrets, store.ListByMesh("default"))
+
+				// then
+				Expect(err).ToNot(HaveOccurred())
+				names := []string{}
+				for _, item := range secrets.Items {
+					names = append(names, item.Meta.GetName())
+				}
+				Expect(names).To(ContainElement("six"))
+			})
+
 			It("should return a list of global secrets sorted", func() {
 				// given
 				secrets := &core_system.GlobalSecretResourceList{}


### PR DESCRIPTION
## Motivation

Fixes #9188.

A `Secret`/`GlobalSecret` created directly on Kubernetes (e.g. with `kubectl apply`,
without going through `kumactl` or anything that sets the `kuma.io/mesh` label) is
silently dropped from `KubernetesStore.List()` results when listing secrets for the
default mesh, even though the same store treats a missing label as implicitly meaning
"default mesh" everywhere else.

Reported symptom from the issue: a user creates a `system.kuma.io/secret` for a
MeshGateway TLS certificate without a `kuma.io/mesh` label. `kubectl get secret -oyaml`
shows no label. The control plane then fails to find it:

```
config rejected {"proxyName": ..., "mesh": "default", "type": "RouteConfiguration", ...}
...error: "could not reconcile: failed to generate a snapshot: ... could not load data:
Resource not found: type=\"Secret\" name=\"my-gateway-certificate\" mesh=\"default\""
```

## Root cause

`pkg/plugins/secrets/k8s/store.go`'s `List()` builds a k8s `MatchingLabels{"kuma.io/mesh":
opts.Mesh}` selector and passes it to the k8s API `List` call *before* any conversion to
the core model happens. A k8s label selector only matches objects that actually carry the
label — it has no notion of "absent label defaults to X". So a Secret with no
`kuma.io/mesh` label is excluded by the k8s API server itself, before Kuma's own
mesh-defaulting logic ever runs on it.

That defaulting logic already exists and is already exercised elsewhere in this same file:

- `KubernetesMetaAdapter.GetMesh()` (used for every `Get()` and conversion) explicitly
  returns `core_model.DefaultMesh` when the label is absent.
- `Secret.GetMesh()` (used by the generic k8s object model) does the same.
- `Get()` has an existing test, `"should return an existing resource with implicit
  default mesh"`, proving a labelless Secret is correctly resolved to mesh `"default"`
  when fetched by name.

`List()` alone did not go through this defaulting logic before filtering, because its
filter ran at the k8s API layer, one step before the defaulting conversion. This
verified as still reproducible on current `master` — `git log` on `store.go` shows no
commit has touched this filtering logic since the mesh-label-based KDS sync work in
#8762 (2024), well before this issue was filed.

This matters in practice because `pkg/xds/context/mesh_context_builder.go` builds the
static per-mesh secret loader used to resolve `DataSource` references (e.g. MeshGateway
TLS certs, MeshHTTPRoute/MeshTLS/MeshTrace secret references) by calling
`secretManager.List(ctx, ..., store.ListByMesh(mesh))` — so any default-mesh secret
missing the label was invisible to every policy that references it by name, with no
indication other than a generic "Resource not found" error deep in the xDS reconcile
log.

## Fix

Moved the mesh filter out of the k8s-API-level label selector and into `ToCoreList`
(the `Converter` interface implemented only by `SimpleConverter` in this same file),
where it runs *after* each item has already gone through the label-defaulting
`ToCoreResource` conversion — consistent with how `Get()` and the generic
`pkg/plugins/resources/k8s/store.go` policy store already filter listed resources by
mesh in Go rather than at the k8s API layer.

`Converter.ToCoreList` now takes an explicit `mesh string` parameter; it is only
implemented by `SimpleConverter` and only called from this file's `List()`, so this is a
narrowly-scoped, self-contained signature change.

## Test plan / verification

Added a new spec to the existing `Describe("List()", ...) / Describe("with resources
loaded", ...)` block in `pkg/plugins/secrets/k8s/store_test.go`:
`"should include a secret with no mesh label when listing the default mesh"` — creates a
`system.kuma.io/secret` with no `kuma.io/mesh` label at all and asserts it's returned by
`List(..., store.ListByMesh("default"))`.

Verified the regression end-to-end:
- With only the test added (fix reverted via `git stash` on `store.go`), the new spec
  fails deterministically:
  ```
  [FAILED] Expected <[]string | len:1, cap:1>: ["two"] to contain element matching <string>: six
  ```
- With the fix restored, `go test ./pkg/plugins/secrets/k8s/...` passes all 23 specs
  (22 pre-existing + 1 new), run against a real `envtest` API server
  (`KUBEBUILDER_ASSETS` via `setup-envtest use 1.33`) so k8s label-selector semantics are
  exercised for real rather than against a fake client's approximation.
- Also ran `./pkg/core/secrets/...`, `./pkg/core/datasource/...`, `./pkg/xds/context/...`
  and `./pkg/plugins/resources/k8s/...` (all touch the same code paths or the converter
  interface) — all pass.
- `go build ./...`, `go vet ./pkg/plugins/secrets/... ./pkg/core/secrets/...
  ./pkg/core/datasource/...`, and `golangci-lint run ./pkg/plugins/secrets/...` are all
  clean (0 issues).

## Supporting documentation

Fixes #9188 — "Secret doesn't auto add `kuma.io/mesh: default` when absent". The
maintainer triage comment on that issue ("let's do the same what we do for policies")
pointed at exactly this generic-policy-store pattern (filter by mesh in Go after
conversion, not via a k8s label selector), which this PR now also applies to the
Secrets-specific store.

> Changelog: Fixed `Secret`/`GlobalSecret` resources on Kubernetes without an explicit
> `kuma.io/mesh` label being silently excluded when listing secrets for the default mesh.