### PR TITLE
chore(lint): fix whitespace lint failures

### DIFF
--- a/pkg/core/xds/inspect/rules.go
+++ b/pkg/core/xds/inspect/rules.go
@@ -45,7 +45,6 @@ func BuildRulesAttachments(matchedPoliciesByType map[core_model.ResourceType]cor
 	var attachments []RuleAttachment
 
 	for typ, matched := range matchedPoliciesByType {
-
 		attachments = append(attachments, getInboundRuleAttachments(matched.FromRules.Rules, networking, typ)...)
 		attachments = append(attachments, getOutboundRuleAttachments(matched.ToRules.Rules, networking, typ, domainsByAddress)...)
 		if len(matched.SingleItemRules.Rules) > 0 {

--- a/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go
@@ -87,7 +87,6 @@ func applyToInbounds(
 
 		inboundRules, ok := fromRules.InboundRules[listenerKey]
 		if !ok || len(inboundRules) == 0 {
-
 			rules, ok := fromRules.Rules[listenerKey]
 			if !ok {
 				continue


### PR DESCRIPTION
## Motivation

`build-test-distribute` on `release-2.13` fails in the `check` job: golangci-lint reports 2 `whitespace` issues (unnecessary leading newline) in `pkg/core/xds/inspect/rules.go` and `pkg/plugins/policies/meshfaultinjection/plugin/v1alpha1/plugin.go`. The `distributions` job then halts on the previous failure, so the whole branch is red.

The blank lines were introduced by backports that did not go through the master lint gate; the same code on master does not have them.

## Implementation information

Removed the two leading blank lines at the start of the affected blocks. No behavior change.

## Supporting documentation

Failing run: https://github.com/kumahq/kuma/actions/runs/32865221930/job/97859149413

> Changelog: skip
