### PR TITLE
chore(docs): regenerate proto docs for envoy main

### DIFF
--- a/docs/generated/raw/protos/Message.json
+++ b/docs/generated/raw/protos/Message.json
@@ -581,7 +581,7 @@
                 },
                 "network_namespace_filepath": {
                     "type": "string",
-                    "description": "Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7 network_namespaces``). If this field is set, Envoy will create the socket in the specified network namespace. .. note::    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability. .. attention::     Network namespaces are only configurable on Linux. Otherwise, this field has no effect."
+                    "description": "Filepath that specifies the Linux network namespace this socket will be created in (see ``man 7 network_namespaces``). If this field is set, Envoy will create the socket in the specified network namespace. .. note::    Setting this parameter requires Envoy to run with the ``CAP_SYS_ADMIN`` capability. .. attention::     Network namespaces are only configurable on Linux. Otherwise, this field has no effect."
                 }
             },
             "additionalProperties": true,


### PR DESCRIPTION
## Motivation

`build-test-distribute` on `release-2.11` fails in the `check` job. `make check` regenerates `docs/generated/raw/protos/Message.json` and the result differs from what is committed, so the job exits 2 and `distributions` halts.

The proto docs are generated against `github.com/envoyproxy/data-plane-api@main` (see `PROTO_ENVOY` in `mk/dev.mk`), which is an unpinned moving reference. Envoy changed the `network_namespace_filepath` comment upstream (`CAP_NET_ADMIN` -> `CAP_SYS_ADMIN`), so every run since then regenerates a file that does not match the checked-in one. `master` already carries the regenerated content; the release branches never got it.

## Implementation information

Regenerated `Message.json` — the description of `network_namespace_filepath` now matches the current Envoy proto, byte-identical to `master`. Docs only, no code change.

## Supporting documentation

Failing run: https://github.com/kumahq/kuma/actions/runs/33435269725

> Changelog: skip
