### PR TITLE
test(e2e): add display-name to stale goldens

### DIFF
--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.demo-client.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.demo-client.golden.json
@@ -383,6 +383,7 @@
                       "team": "client-owners"
                     },
                     "io.kuma.labels": {
+                      "kuma.io/display-name": "demo-client",
                       "kuma.io/env": "universal",
                       "kuma.io/mesh": "envoyconfig",
                       "kuma.io/origin": "zone",
@@ -431,6 +432,7 @@
                       "version": "v1"
                     },
                     "io.kuma.labels": {
+                      "kuma.io/display-name": "test-server",
                       "kuma.io/env": "universal",
                       "kuma.io/mesh": "envoyconfig",
                       "kuma.io/origin": "zone",

--- a/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.test-server.golden.json
+++ b/test/e2e_env/universal/envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.test-server.golden.json
@@ -396,6 +396,7 @@
                       "team": "client-owners"
                     },
                     "io.kuma.labels": {
+                      "kuma.io/display-name": "demo-client",
                       "kuma.io/env": "universal",
                       "kuma.io/mesh": "envoyconfig",
                       "kuma.io/origin": "zone",
@@ -444,6 +445,7 @@
                       "version": "v1"
                     },
                     "io.kuma.labels": {
+                      "kuma.io/display-name": "test-server",
                       "kuma.io/env": "universal",
                       "kuma.io/mesh": "envoyconfig",
                       "kuma.io/origin": "zone",


### PR DESCRIPTION
## Motivation

`build-test-distribute` on `release-2.14` fails in `test / e2e (universal, kind, amd64)`. `Envoy Config – Sidecars` times out on `envoyconfig/testdata/sidecars/meshproxypatch/circuit-breaker-thresholds.input.yaml`, 252 passed / 1 failed.

`feat(labels): compute kuma.io/display-name for all resources (backport of #17162) (#18161)` adds `kuma.io/display-name` to the `io.kuma.labels` endpoint metadata, and regenerated the e2e goldens — except these two. They are the only files under `test/e2e_env` on this branch that carry `kuma.io/proxy-type` endpoint metadata without the new label, so the generated config no longer matches what is committed.

## Implementation information

Added `kuma.io/display-name` to the `io.kuma.labels` block of each `ClusterLoadAssignment` endpoint in both goldens, value taken from the service in the cluster name. Four lines, no code change.

The demo-client golden is now byte-identical to the config the failing CI run actually produced (extracted from the job log and compared structurally — the two labels were the only difference). The test-server golden takes the same treatment; its assertion never ran because the spec timed out on demo-client first.

Draft until the universal e2e job confirms it green here.

## Supporting documentation

Failing run: https://github.com/kumahq/kuma/actions/runs/33498110476/job/99827129261

> Changelog: skip
