### PR TITLE
ci(actions): name release-task runs by version

### DIFF
--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -39,6 +39,8 @@ on:
         type: boolean
         default: true
 
+run-name: "release-tasks · ${{ inputs.version || github.event.workflow_run.head_branch }}"
+
 permissions: {}
 
 concurrency:


### PR DESCRIPTION
## Motivation

> Changelog: skip

Every `trigger-release-tasks` run is titled `trigger-release-tasks`. There are 1300+ of them, so the run list gives no way to tell which version a run belongs to - not by eye, and not through the API either: for a `workflow_run`-triggered run GitHub reports `head_branch: master` and the head SHA of master, neither of which is the release tag.

That matters beyond readability. The release tracking issue is now synced automatically from observed CI signals, and the smoke and artifact workflows can be matched to a version because their run names carry it. The release-task run cannot, so the installer verification it performs has no per-version signal to read.

## Implementation information

Add a `run-name` carrying the version, using the same expression the concurrency group already uses, so nothing new has to be resolved:

```yaml
run-name: "release-tasks · ${{ inputs.version || github.event.workflow_run.head_branch }}"
```

Tag-triggered runs become `release-tasks · v2.14.3`, manual runs take the dispatch input, and the skipped runs from ordinary branch pushes become `release-tasks · master`, which is also easier to scan past.

No behaviour changes: `run-name` only affects the title, and the value is one the workflow already reads.

## Supporting documentation

* Workflow: `.github/workflows/trigger-release-tasks.yaml`
* Convention borrowed from the downstream smoke workflow, whose run names already carry product and version