### PR TITLE
ci(actions): add a release-tag workflow

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -77,8 +77,15 @@ jobs:
             exit 1
           fi
 
+          if ! BRANCH_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" 2>/dev/null)"; then
+            echo "::error::branch ${BRANCH} does not exist"
+            exit 1
+          fi
+          SHA="$(jq -r '.object.sha' <<< "${BRANCH_JSON}")"
+
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Tagging ${BRANCH} as ${TAG}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Tagging ${BRANCH} at ${SHA} as ${TAG}"
 
       - name: "Wait for the branch build to finish"
         env:
@@ -108,10 +115,29 @@ jobs:
           echo "::error::a build is still running on ${BRANCH} after 30 minutes; re-run once it finishes"
           exit 1
 
-      - name: "Check out the release branch"
+      - name: "Require a green branch build for the commit being tagged"
+        env:
+          SHA: ${{ steps.tag.outputs.sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          GREEN=$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-test-distribute.yaml/runs" \
+            -f head_sha="${SHA}" -f status=completed -f event=push -f per_page=100 --paginate \
+            --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')
+
+          if [[ "${GREEN}" -eq 0 ]]; then
+            echo "::error::no successful push run of build-test-distribute for ${SHA}. build-test-distribute's release_sha_gate requires one, so the tag build would fail and the tag would have to be moved. Re-run the branch build on this commit, then dispatch again."
+            exit 1
+          fi
+
+          echo "${SHA} has ${GREEN} successful push run(s)."
+
+      - name: "Check out the commit being tagged"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ steps.tag.outputs.sha }}
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
@@ -120,25 +146,29 @@ jobs:
         env:
           BRANCH: ${{ inputs.branch }}
           TAG: ${{ steps.tag.outputs.tag }}
+          SHA: ${{ steps.tag.outputs.sha }}
           DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
-          git fetch origin "${BRANCH}"
-          git reset --hard "origin/${BRANCH}"
+          CURRENT=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" --jq '.object.sha')
+          if [[ "${CURRENT}" != "${SHA}" ]]; then
+            echo "::error::${BRANCH} moved from ${SHA} to ${CURRENT} while this run was validating. The new head needs its own green build; dispatch again."
+            exit 1
+          fi
 
-          COMMIT=$(git rev-parse HEAD)
-          echo "${BRANCH} is at ${COMMIT}"
+          echo "${BRANCH} is at ${SHA}"
           git --no-pager log -1 --oneline
 
           if [[ "${DRY_RUN}" == "true" ]]; then
-            echo "Dry run: would tag ${COMMIT} as ${TAG} and push it." >> "$GITHUB_STEP_SUMMARY"
+            echo "Dry run: would tag ${SHA} as ${TAG} and push it." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           git config user.name "kumahq[bot]"
           git config user.email "110050114+kumahq[bot]@users.noreply.github.com"
           git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "${TAG}"
+          git push origin "refs/tags/${TAG}"
 
-          echo "Pushed \`${TAG}\` at \`${COMMIT}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Pushed \`${TAG}\` at \`${SHA}\`." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,144 @@
+name: "release-tag"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch to tag, e.g. release-2.14"
+        required: true
+        type: string
+      version:
+        description: "Version to release, without a v prefix, e.g. 2.14.4"
+        required: true
+        type: string
+      dry_run:
+        description: "Report the tag that would be pushed without pushing it"
+        required: false
+        type: boolean
+        default: false
+
+run-name: "release-tag · ${{ inputs.branch }} · ${{ inputs.version }}"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    timeout-minutes: 60
+    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    steps:
+      - name: "Generate GitHub app token"
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: "Resolve and validate the tag"
+        id: tag
+        env:
+          BRANCH: ${{ inputs.branch }}
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${BRANCH}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::'${BRANCH}' is not a release branch (expected release-X.Y)"
+            exit 1
+          fi
+          BRANCH_MAJOR="${BASH_REMATCH[1]}"
+          BRANCH_MINOR="${BASH_REMATCH[2]}"
+
+          if [[ ! "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::'${VERSION}' is not a version (expected X.Y.Z, without a v prefix)"
+            exit 1
+          fi
+          VERSION_MAJOR="${BASH_REMATCH[1]}"
+          VERSION_MINOR="${BASH_REMATCH[2]}"
+
+          if [[ "${BRANCH_MAJOR}.${BRANCH_MINOR}" != "${VERSION_MAJOR}.${VERSION_MINOR}" ]]; then
+            echo "::error::version ${VERSION} does not belong on branch ${BRANCH}"
+            exit 1
+          fi
+
+          if [[ "${BRANCH_MAJOR}.${BRANCH_MINOR}" == "2.9" ]]; then
+            TAG="${VERSION}"
+            echo "release-2.9 never received the v-prefix backport (#14810), so this tag stays bare."
+          else
+            TAG="v${VERSION}"
+          fi
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::tag ${TAG} already exists"
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Tagging ${BRANCH} as ${TAG}"
+
+      - name: "Wait for the branch build to finish"
+        env:
+          BRANCH: ${{ inputs.branch }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 60); do
+            IN_FLIGHT=0
+            for STATUS in queued in_progress requested waiting pending; do
+              COUNT=$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/build-test-distribute.yaml/runs?branch=${BRANCH}&status=${STATUS}" \
+                --jq '.total_count')
+              IN_FLIGHT=$((IN_FLIGHT + COUNT))
+            done
+
+            if [[ "${IN_FLIGHT}" -eq 0 ]]; then
+              echo "No build in flight on ${BRANCH}."
+              exit 0
+            fi
+
+            echo "Tagging now would fail that build. ${IN_FLIGHT} in flight on ${BRANCH}; waiting (attempt ${attempt}/60)."
+            sleep 30
+          done
+
+          echo "::error::a build is still running on ${BRANCH} after 30 minutes; re-run once it finishes"
+          exit 1
+
+      - name: "Check out the release branch"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: "Push the tag"
+        env:
+          BRANCH: ${{ inputs.branch }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin "${BRANCH}"
+          git reset --hard "origin/${BRANCH}"
+
+          COMMIT=$(git rev-parse HEAD)
+          echo "${BRANCH} is at ${COMMIT}"
+          git --no-pager log -1 --oneline
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "Dry run: would tag ${COMMIT} as ${TAG} and push it." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git config user.name "kumahq[bot]"
+          git config user.email "110050114+kumahq[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+
+          echo "Pushed \`${TAG}\` at \`${COMMIT}\`." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Motivation

> Changelog: skip

Pushing a release tag is done by hand from a laptop, and the two footguns it carries are prevented only by prose in the release checklist:

* `release-2.9` never received the v-prefix backport (#14810), so it must tag bare. A `v`-prefixed tag there produces images and binaries whose names break consistency with every previously released 2.9.x.
* Pushing a tag while that branch's `build-test-distribute` is still in flight fails the build.

Both depend on the release manager reading a warning at the right moment, on the right branch, having set up the right remotes locally.

## Implementation information

A `workflow_dispatch` workflow taking a branch and a version. It derives the tag by the branch rule, validates, waits, then tags and pushes:

* rejects anything that is not `release-X.Y`, anything that is not a bare `X.Y.Z`, a version whose major.minor does not match the branch, and a tag that already exists,
* applies the `release-2.9` rule, so `2.9.20` stays bare and everything else takes a `v`,
* polls `build-test-distribute` on that branch and waits until nothing is queued or running, failing after 30 minutes rather than tagging into a live build,
* resets hard to the remote branch before tagging, and prints the commit it is about to tag,
* `dry_run` reports the tag and the commit without pushing.

The push uses the App token rather than `GITHUB_TOKEN`, because a `GITHUB_TOKEN` push does not trigger `build-test-distribute` and the whole release chain hangs off that build.

It lives on `master` and operates on any release branch, so no backport to the older release branches is needed.

## Verification

The tag-resolution step was run offline against a stubbed `gh`, covering every guard:

| branch | version | result |
|:--|:--|:--|
| `release-2.14` | `2.14.4` | `v2.14.4` |
| `release-2.9` | `2.9.20` | `2.9.20`, bare |
| `release-2.9` | `2.9.19` | rejected, tag exists |
| `release-2.14` | `v2.14.4` | rejected, v in input |
| `release-2.14` | `2.13.5` | rejected, wrong branch |
| `master` | `2.14.4` | rejected, not a release branch |
| `release-2.14` | `2.14.3` | rejected, tag exists |

Every shell step passes `bash -n`. The workflow has not yet pushed a real tag; the first use should be a `dry_run` on the branch being released.

## Supporting documentation

* Release manual: https://github.com/Kong/team-mesh/blob/main/docs/releasing.md
* v-prefix rule: #14810