### PR TITLE
ci(actions): name the build workflow once

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -23,6 +23,8 @@ permissions: {}
 
 env:
   BUILD_WORKFLOW: "build-test-distribute.yaml"
+  GIT_USER: "kumahq[bot]"
+  GIT_EMAIL: "110050114+kumahq[bot]@users.noreply.github.com"
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.branch }}
@@ -169,8 +171,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "kumahq[bot]"
-          git config user.email "110050114+kumahq[bot]@users.noreply.github.com"
+          git config user.name "${GIT_USER}"
+          git config user.email "${GIT_EMAIL}"
           git tag -a "${TAG}" -m "Release ${TAG}"
           git push origin "refs/tags/${TAG}"
 

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -21,6 +21,9 @@ run-name: "release-tag · ${{ inputs.branch }} · ${{ inputs.version }}"
 
 permissions: {}
 
+env:
+  BUILD_WORKFLOW: "build-test-distribute.yaml"
+
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.branch }}
   cancel-in-progress: false
@@ -98,7 +101,7 @@ jobs:
             IN_FLIGHT=0
             for STATUS in queued in_progress requested waiting pending; do
               COUNT=$(gh api \
-                "repos/${GITHUB_REPOSITORY}/actions/workflows/build-test-distribute.yaml/runs?branch=${BRANCH}&status=${STATUS}" \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/${BUILD_WORKFLOW}/runs?branch=${BRANCH}&status=${STATUS}" \
                 --jq '.total_count')
               IN_FLIGHT=$((IN_FLIGHT + COUNT))
             done
@@ -123,12 +126,12 @@ jobs:
           set -euo pipefail
 
           GREEN=$(gh api --method GET \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-test-distribute.yaml/runs" \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${BUILD_WORKFLOW}/runs" \
             -f head_sha="${SHA}" -f status=completed -f event=push -f per_page=100 --paginate \
             --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')
 
           if [[ "${GREEN}" -eq 0 ]]; then
-            echo "::error::no successful push run of build-test-distribute for ${SHA}. build-test-distribute's release_sha_gate requires one, so the tag build would fail and the tag would have to be moved. Re-run the branch build on this commit, then dispatch again."
+            echo "::error::no successful push run of ${BUILD_WORKFLOW} for ${SHA}. its release_sha_gate requires one, so the tag build would fail and the tag would have to be moved. Re-run the branch build on this commit, then dispatch again."
             exit 1
           fi
 


### PR DESCRIPTION
## Motivation

> Changelog: skip

The downstream sync copies workflows into the enterprise fork and rewrites references to `build-test-distribute.yaml`, which is prefixed there. `release-tag.yaml` named that file inline in two separate `gh api` URLs, so the sync would have to rewrite each one separately and would silently miss a third if one were added.

## Implementation information

Hold the name in a single `BUILD_WORKFLOW` env var and use it in both queries and in the error message. No behaviour change in this repository.

## Supporting documentation

* `.github/workflows/release-tag.yaml`, added in #18294