### PR TITLE
ci(actions): stop persisting the tag push token

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -144,7 +144,7 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.sha }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
       - name: "Push the tag"
@@ -174,6 +174,6 @@ jobs:
           git config user.name "${GIT_USER}"
           git config user.email "${GIT_EMAIL}"
           git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "refs/tags/${TAG}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${TAG}"
 
           echo "Pushed \`${TAG}\` at \`${SHA}\`." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Motivation

`release-tag.yaml` checks the release commit out with `persist-credentials: true` so the next step can run `git push origin`. That leaves the app token in the job's local git config, where any later step or third-party action in the same job can read it.

Every other workflow in this repository checks out with `persist-credentials: false`. A secret scanner flagged this one on the Kong Mesh copy, which is synced from here, so the fix belongs upstream.

> Changelog: skip

## Implementation information

Check out with `persist-credentials: false` and push the tag over an explicit remote URL built from the app token, which the step already has in `GH_TOKEN`. The token is masked in logs, and it now reaches only the step that needs it.

Nothing else changes: the same token, the same permissions, the same tag.

## Supporting documentation

Follow-up to #18294.

https://claude.ai/code/session_01VjTLVyEoKHT9FGntbFmrT2
