### PR TITLE
fix(gatewayapi): reject route filters the mesh cannot apply

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -546,6 +546,93 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		Expect(routes.Items[0].Namespace).To(Equal(routeNamespace))
 	})
 
+	It("keeps an explicit empty backendRefs list and Accepted=False for unsupported filters while valid refs stay resolved", func() {
+		parent := &kube_core.Service{
+			Name: "backend", Namespace: routeNamespace,
+			Spec: kube_core.ServiceSpec{
+				ClusterIP: "10.0.0.1",
+				Ports:     []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		upstream := &kube_core.Service{
+			Name: "upstream", Namespace: routeNamespace,
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+		route := newRoute(withSectionName(serviceParentRef(), "http"))
+		pathPrefix := gatewayapi_v1.PathMatchPathPrefix
+		route.Spec.Rules = []gatewayapi.HTTPRouteRule{
+			{
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  &pathPrefix,
+						Value: pointer.To("/ext"),
+					},
+				}},
+				Filters: []gatewayapi.HTTPRouteFilter{{
+					Type: gatewayapi_v1.HTTPRouteFilterExtensionRef,
+				}},
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
+						Name: gatewayapi.ObjectName("upstream"),
+						Port: pointer.To(gatewayapi.PortNumber(8080)),
+					},
+					Weight: pointer.To(int32(1)),
+				}},
+			},
+			{
+				Matches: []gatewayapi.HTTPRouteMatch{{
+					Path: &gatewayapi.HTTPPathMatch{
+						Type:  &pathPrefix,
+						Value: pointer.To("/backend-filter"),
+					},
+				}},
+				BackendRefs: []gatewayapi.HTTPBackendRef{{
+					BackendObjectReference: gatewayapi.BackendObjectReference{
+						Name: gatewayapi.ObjectName("upstream"),
+						Port: pointer.To(gatewayapi.PortNumber(8080)),
+					},
+					Weight: pointer.To(int32(1)),
+					Filters: []gatewayapi.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi.HTTPHeaderFilter{
+							Add: []gatewayapi.HTTPHeader{{Name: "x-test", Value: "1"}},
+						},
+					}},
+				}},
+			},
+		}
+
+		client := newClientBuilder(parent, upstream, route)
+		reconciler.Client = client
+
+		_, err := reconciler.Reconcile(context.Background(), kube_ctrl.Request{
+			NamespacedName: kube_client.ObjectKeyFromObject(route),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		routes := &meshhttproute_k8s.MeshHTTPRouteList{}
+		Expect(client.List(context.Background(), routes)).To(Succeed())
+		Expect(routes.Items).To(HaveLen(1))
+		generatedRules := (*routes.Items[0].Spec.To)[0].Rules
+		Expect(generatedRules).To(HaveLen(2))
+		Expect(pointer.Deref(generatedRules[0].Default.BackendRefs)).To(BeEmpty())
+		Expect(pointer.Deref(generatedRules[1].Default.BackendRefs)).To(BeEmpty())
+
+		var updatedRoute gatewayapi.HTTPRoute
+		Expect(client.Get(context.Background(), kube_client.ObjectKeyFromObject(route), &updatedRoute)).To(Succeed())
+		Expect(updatedRoute.Status.Parents).To(HaveLen(1))
+		accepted := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi.RouteReasonUnsupportedValue)))
+		Expect(accepted.Message).To(ContainSubstring(string(gatewayapi_v1.HTTPRouteFilterExtensionRef)))
+		resolvedRefs := kube_apimeta.FindStatusCondition(updatedRoute.Status.Parents[0].Conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionTrue))
+	})
+
 	It("replaces a pre-upgrade generated route with a legacy owner label and name", func() {
 		svc := &kube_core.Service{
 			Name: "backend", Namespace: routeNamespace,

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -582,10 +582,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 					},
 				},
 				BackendRefs: []gatewayapi.HTTPBackendRef{{
-					BackendObjectReference: gatewayapi.BackendObjectReference{
-						Name: gatewayapi.ObjectName("upstream"),
-						Port: pointer.To(gatewayapi.PortNumber(8080)),
-					},
+					Name:   gatewayapi.ObjectName("upstream"),
+					Port:   pointer.To(gatewayapi.PortNumber(8080)),
 					Weight: pointer.To(int32(1)),
 				}},
 			},
@@ -597,10 +595,8 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 					},
 				}},
 				BackendRefs: []gatewayapi.HTTPBackendRef{{
-					BackendObjectReference: gatewayapi.BackendObjectReference{
-						Name: gatewayapi.ObjectName("upstream"),
-						Port: pointer.To(gatewayapi.PortNumber(8080)),
-					},
+					Name:   gatewayapi.ObjectName("upstream"),
+					Port:   pointer.To(gatewayapi.PortNumber(8080)),
 					Weight: pointer.To(int32(1)),
 					Filters: []gatewayapi.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_controller_test.go
@@ -570,9 +570,17 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 						Value: pointer.To("/ext"),
 					},
 				}},
-				Filters: []gatewayapi.HTTPRouteFilter{{
-					Type: gatewayapi_v1.HTTPRouteFilterExtensionRef,
-				}},
+				Filters: []gatewayapi.HTTPRouteFilter{
+					{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayapi.HTTPRequestRedirectFilter{
+							Scheme: pointer.To("https"),
+						},
+					},
+					{
+						Type: gatewayapi_v1.HTTPRouteFilterExtensionRef,
+					},
+				},
 				BackendRefs: []gatewayapi.HTTPBackendRef{{
 					BackendObjectReference: gatewayapi.BackendObjectReference{
 						Name: gatewayapi.ObjectName("upstream"),
@@ -618,6 +626,7 @@ var _ = Describe("HTTPRouteReconciler.Reconcile with a Service parentRef", func(
 		generatedRules := (*routes.Items[0].Spec.To)[0].Rules
 		Expect(generatedRules).To(HaveLen(2))
 		Expect(pointer.Deref(generatedRules[0].Default.BackendRefs)).To(BeEmpty())
+		Expect(pointer.Deref(generatedRules[0].Default.Filters)).To(BeEmpty())
 		Expect(pointer.Deref(generatedRules[1].Default.BackendRefs)).To(BeEmpty())
 
 		var updatedRoute gatewayapi.HTTPRoute

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -246,13 +246,12 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 		}
 
 		refCondition.AddIfFalseAndNotPresent(&conditions)
-		if refCondition.preventsBackendTarget() {
-			continue
-		}
-
 		if len(gapiBackendRef.Filters) > 0 {
 			unsupportedFilter = true
 			addIfFalseAndNotPresent(&conditions, unsupportedBackendRefFilterCondition(route.Namespace, gapiBackendRef))
+		}
+		if refCondition.preventsBackendTarget() {
+			continue
 		}
 
 		backendRefs = append(backendRefs, common_api.BackendRef{
@@ -263,6 +262,7 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 
 	if unsupportedFilter {
 		backendRefs = []common_api.BackendRef{}
+		filters = []v1alpha1.Filter{}
 	}
 
 	return v1alpha1.Rule{

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion.go
@@ -205,6 +205,7 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 	var matches []v1alpha1.Match
 	var filters []v1alpha1.Filter
 	var backendRefs []common_api.BackendRef
+	unsupportedFilter := false
 
 	for _, gapiMatch := range rule.Matches {
 		match, ok := r.gapiToKumaMeshMatch(gapiMatch)
@@ -230,6 +231,11 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 
 		if len(filterConditions) == 0 {
 			filters = append(filters, filter)
+			continue
+		}
+
+		if hasAcceptedFalse(filterConditions) {
+			unsupportedFilter = true
 		}
 	}
 
@@ -244,10 +250,19 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshRule(
 			continue
 		}
 
+		if len(gapiBackendRef.Filters) > 0 {
+			unsupportedFilter = true
+			addIfFalseAndNotPresent(&conditions, unsupportedBackendRefFilterCondition(route.Namespace, gapiBackendRef))
+		}
+
 		backendRefs = append(backendRefs, common_api.BackendRef{
 			TargetRef: ref,
 			Weight:    pointer.To(uint(*gapiBackendRef.Weight)),
 		})
+	}
+
+	if unsupportedFilter {
+		backendRefs = []common_api.BackendRef{}
 	}
 
 	return v1alpha1.Rule{
@@ -448,8 +463,48 @@ func (r *HTTPRouteReconciler) gapiToKumaMeshFilter(
 			},
 		}, conditions, true
 	default:
-		return v1alpha1.Filter{}, nil, false
+		return v1alpha1.Filter{}, []kube_meta.Condition{unsupportedHTTPRouteFilterCondition(gapiFilter.Type)}, true
 	}
+}
+
+func unsupportedHTTPRouteFilterCondition(filterType gatewayapi_v1.HTTPRouteFilterType) kube_meta.Condition {
+	return kube_meta.Condition{
+		Type:    string(gatewayapi.RouteConditionAccepted),
+		Status:  kube_meta.ConditionFalse,
+		Reason:  string(gatewayapi.RouteReasonUnsupportedValue),
+		Message: fmt.Sprintf("HTTPRoute filter type %q is not supported", filterType),
+	}
+}
+
+func addIfFalseAndNotPresent(conditions *[]kube_meta.Condition, condition kube_meta.Condition) {
+	if kube_apimeta.FindStatusCondition(*conditions, condition.Type) == nil {
+		kube_apimeta.SetStatusCondition(conditions, condition)
+	}
+}
+
+func unsupportedBackendRefFilterCondition(routeNamespace string, backendRef gatewayapi.HTTPBackendRef) kube_meta.Condition {
+	if len(backendRef.Filters) == 0 {
+		return kube_meta.Condition{}
+	}
+
+	return kube_meta.Condition{
+		Type:   string(gatewayapi.RouteConditionAccepted),
+		Status: kube_meta.ConditionFalse,
+		Reason: string(gatewayapi.RouteReasonUnsupportedValue),
+		Message: fmt.Sprintf(
+			"HTTPBackendRef filter type %q is not supported for backendRef %q",
+			backendRef.Filters[0].Type,
+			backendObjectReferenceString(routeNamespace, backendRef.BackendObjectReference),
+		),
+	}
+}
+
+func backendObjectReferenceString(routeNamespace string, ref gatewayapi.BackendObjectReference) string {
+	namespace := routeNamespace
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+	return kube_types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}.String()
 }
 
 type ResolvedRefsConditionFalse struct {

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -540,7 +540,7 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		Expect(resolvedRefs).To(BeNil())
 	})
 
-		It("reports Accepted=False for backendRef RequestHeaderModifier Filters without adding ResolvedRefs for valid backends", func() {
+	It("reports Accepted=False for backendRef RequestHeaderModifier Filters without adding ResolvedRefs for valid backends", func() {
 		frontend := &kube_core.Service{
 			Name:      "frontend",
 			Namespace: "route-ns",

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -8,6 +8,7 @@ import (
 	kube_core "k8s.io/api/core/v1"
 	kube_apimeta "k8s.io/apimachinery/pkg/api/meta"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -390,10 +391,16 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		}
 	}
 
-	It("keeps an explicit empty BackendRefs list when a denied cross-namespace backendRef is filtered out", func() {
+	newReconciler := func(objs ...kube_client.Object) *HTTPRouteReconciler {
 		scheme, err := bootstrap_k8s.NewScheme()
 		Expect(err).ToNot(HaveOccurred())
 
+		return &HTTPRouteReconciler{
+			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		}
+	}
+
+	It("keeps an explicit empty BackendRefs list when a denied cross-namespace backendRef is filtered out", func() {
 		frontend := &kube_core.Service{
 			Name:      "frontend",
 			Namespace: "route-ns",
@@ -409,9 +416,7 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 			},
 		}
 
-		reconciler := &HTTPRouteReconciler{
-			Client: kube_client_fake.NewClientBuilder().WithScheme(scheme).WithObjects(frontend, backend).Build(),
-		}
+		reconciler := newReconciler(frontend, backend)
 
 		route := &gatewayapi.HTTPRoute{
 			Name: "my-route", Namespace: "route-ns",
@@ -431,6 +436,102 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		Expect(resolvedRefs).ToNot(BeNil())
 		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionFalse))
 		Expect(resolvedRefs.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
+	})
+
+	It("reports Accepted=False and clears backendRefs for an unsupported rule-level ExtensionRef filter", func() {
+		frontend := &kube_core.Service{
+			Name:      "frontend",
+			Namespace: "route-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		backend := &kube_core.Service{
+			Name:      "backend",
+			Namespace: "route-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+
+		reconciler := newReconciler(frontend, backend)
+
+		route := &gatewayapi.HTTPRoute{
+			Name: "my-route", Namespace: "route-ns",
+		}
+		rule := gatewayapi.HTTPRouteRule{
+			Filters: []gatewayapi.HTTPRouteFilter{{
+				Type: gatewayapi_v1.HTTPRouteFilterExtensionRef,
+			}},
+			BackendRefs: []gatewayapi.HTTPBackendRef{
+				serviceBackendRef("route-ns", "backend", 8080),
+			},
+		}
+
+		kumaRule, conditions, err := reconciler.gapiToKumaMeshRule(context.Background(), route, rule)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kumaRule.Default.BackendRefs).ToNot(BeNil())
+		Expect(pointer.Deref(kumaRule.Default.BackendRefs)).To(BeEmpty())
+		accepted := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi.RouteReasonUnsupportedValue)))
+		Expect(accepted.Message).To(ContainSubstring(string(gatewayapi_v1.HTTPRouteFilterExtensionRef)))
+		resolvedRefs := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).To(BeNil())
+	})
+
+	It("reports Accepted=False for backendRef RequestHeaderModifier Filters while keeping ResolvedRefs=True for valid backends", func() {
+		frontend := &kube_core.Service{
+			Name:      "frontend",
+			Namespace: "route-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		backend := &kube_core.Service{
+			Name:      "backend",
+			Namespace: "route-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+
+		reconciler := newReconciler(frontend, backend)
+
+		route := &gatewayapi.HTTPRoute{
+			Name: "my-route", Namespace: "route-ns",
+		}
+		rule := gatewayapi.HTTPRouteRule{
+			BackendRefs: []gatewayapi.HTTPBackendRef{func() gatewayapi.HTTPBackendRef {
+				ref := serviceBackendRef("route-ns", "backend", 8080)
+				ref.Filters = []gatewayapi.HTTPRouteFilter{{
+					Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayapi.HTTPHeaderFilter{
+						Add: []gatewayapi.HTTPHeader{{
+							Name:  "x-test",
+							Value: "1",
+						}},
+					},
+				}}
+				return ref
+			}()},
+		}
+
+		kumaRule, conditions, err := reconciler.gapiToKumaMeshRule(context.Background(), route, rule)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kumaRule.Default.BackendRefs).ToNot(BeNil())
+		Expect(pointer.Deref(kumaRule.Default.BackendRefs)).To(BeEmpty())
+		accepted := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi.RouteReasonUnsupportedValue)))
+		Expect(accepted.Message).To(ContainSubstring(string(gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier)))
+		Expect(accepted.Message).To(ContainSubstring("route-ns/backend"))
+		resolvedRefs := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).To(BeNil())
 	})
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -540,7 +540,7 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		Expect(resolvedRefs).To(BeNil())
 	})
 
-	It("reports Accepted=False for backendRef RequestHeaderModifier Filters while keeping ResolvedRefs=True for valid backends", func() {
+		It("reports Accepted=False for backendRef RequestHeaderModifier Filters without adding ResolvedRefs for valid backends", func() {
 		frontend := &kube_core.Service{
 			Name:      "frontend",
 			Namespace: "route-ns",

--- a/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/gatewayapi/http_route_conversion_test.go
@@ -438,7 +438,55 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		Expect(resolvedRefs.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
 	})
 
-	It("reports Accepted=False and clears backendRefs for an unsupported rule-level ExtensionRef filter", func() {
+	It("reports Accepted=False when a denied cross-namespace backendRef has filters", func() {
+		frontend := &kube_core.Service{
+			Name:      "frontend",
+			Namespace: "route-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 80}},
+			},
+		}
+		backend := &kube_core.Service{
+			Name:      "backend",
+			Namespace: "backend-ns",
+			Spec: kube_core.ServiceSpec{
+				Ports: []kube_core.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+
+		reconciler := newReconciler(frontend, backend)
+
+		route := &gatewayapi.HTTPRoute{
+			Name: "my-route", Namespace: "route-ns",
+		}
+		backendRef := serviceBackendRef("backend-ns", "backend", 8080)
+		backendRef.Filters = []gatewayapi.HTTPRouteFilter{{
+			Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+			RequestHeaderModifier: &gatewayapi.HTTPHeaderFilter{
+				Add: []gatewayapi.HTTPHeader{{Name: "x-test", Value: "1"}},
+			},
+		}}
+		rule := gatewayapi.HTTPRouteRule{
+			BackendRefs: []gatewayapi.HTTPBackendRef{backendRef},
+		}
+
+		kumaRule, conditions, err := reconciler.gapiToKumaMeshRule(context.Background(), route, rule)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kumaRule.Default.BackendRefs).ToNot(BeNil())
+		Expect(pointer.Deref(kumaRule.Default.BackendRefs)).To(BeEmpty())
+		accepted := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionAccepted))
+		Expect(accepted).ToNot(BeNil())
+		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(accepted.Reason).To(Equal(string(gatewayapi.RouteReasonUnsupportedValue)))
+		Expect(accepted.Message).To(ContainSubstring(string(gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier)))
+		resolvedRefs := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionResolvedRefs))
+		Expect(resolvedRefs).ToNot(BeNil())
+		Expect(resolvedRefs.Status).To(Equal(kube_meta.ConditionFalse))
+		Expect(resolvedRefs.Reason).To(Equal(string(gatewayapi.RouteReasonRefNotPermitted)))
+	})
+
+	It("reports Accepted=False and clears backendRefs and filters for an unsupported rule-level ExtensionRef filter", func() {
 		frontend := &kube_core.Service{
 			Name:      "frontend",
 			Namespace: "route-ns",
@@ -460,9 +508,17 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 			Name: "my-route", Namespace: "route-ns",
 		}
 		rule := gatewayapi.HTTPRouteRule{
-			Filters: []gatewayapi.HTTPRouteFilter{{
-				Type: gatewayapi_v1.HTTPRouteFilterExtensionRef,
-			}},
+			Filters: []gatewayapi.HTTPRouteFilter{
+				{
+					Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+					RequestRedirect: &gatewayapi.HTTPRequestRedirectFilter{
+						Scheme: pointer.To("https"),
+					},
+				},
+				{
+					Type: gatewayapi_v1.HTTPRouteFilterExtensionRef,
+				},
+			},
 			BackendRefs: []gatewayapi.HTTPBackendRef{
 				serviceBackendRef("route-ns", "backend", 8080),
 			},
@@ -473,6 +529,8 @@ var _ = Describe("gapiToKumaMeshRule", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(kumaRule.Default.BackendRefs).ToNot(BeNil())
 		Expect(pointer.Deref(kumaRule.Default.BackendRefs)).To(BeEmpty())
+		Expect(kumaRule.Default.Filters).ToNot(BeNil())
+		Expect(pointer.Deref(kumaRule.Default.Filters)).To(BeEmpty())
 		accepted := kube_apimeta.FindStatusCondition(conditions, string(gatewayapi.RouteConditionAccepted))
 		Expect(accepted).ToNot(BeNil())
 		Expect(accepted.Status).To(Equal(kube_meta.ConditionFalse))


### PR DESCRIPTION
## Motivation

Kuma was silently dropping route filters during Gateway API conversion that it could not translate, while still reporting the route as Accepted with ResolvedRefs true. This silent failure allowed invalid configuration to pass through: users writing filters to strip or set headers would see traffic served without the filter applied. The issue affected ExtensionRef filters naming unsupported kinds and filters attached to backendRefs.

## Implementation information

The conversion now fails closed when encountering unsupported HTTPRoute filters: routes with unsupported filters report a false condition identifying the unsupported value, and matching requests fail with 500 instead of silently accepting broken configuration.

Closes https://github.com/kumahq/kuma/issues/18265

_Generated by Sybra harness_