### PR TITLE
ci(cache): stop falling back to master cache

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -130,6 +130,15 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           fetch-depth: 0
+      - name: Cache Go build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
         with:
           # protoc-gen-go-grpc@1.1.0 fails to resolve on mise 2026.7.17+ (jdx/mise#11469); pin until this branch moves past that version.


### PR DESCRIPTION
> Changelog: skip

## Motivation

`build-binaries` and `build-images` in `_build_publish.yaml` restore the Go build cache with `actions/cache/restore` under key `go-build-\<os\>-\<go.sum hash\>`, falling back to the `go-build-\<os\>-` prefix. Nothing on this branch ever saves that key, so the exact key can never hit and the branch-scoped prefix can never hit either. The restore therefore falls through to the default branch scope and unpacks master's Go build cache into a release-branch build. Those objects were compiled against master's dependency graph, so they cost disk and restore time on the runner and produce no usable cache hits.

`release-2.13` and `release-2.14` do not have this problem: their `check` job saves the key, so the exact or branch-scoped match always wins and the default branch scope is never reached.

## Implementation information

Add the `Cache Go build` step (`actions/cache`, save and restore) to the `check` job in `build-test-distribute.yaml`, matching what `release-2.13` and `release-2.14` already run. The action SHA is the one already pinned for `actions/cache/restore` in `_build_publish.yaml` on this branch, and the `with:` block is identical to the `release-2.13` step.

## Supporting documentation

Cache scope and restore-key search order are documented in [actions/cache](https://github.com/actions/cache#cache-scopes): a run can restore caches from its own branch and from the default branch, and the default branch is searched only after the current branch yields no match.