### PR TITLE
chore(deps): bump coredns to v1.14.7

### DIFF
--- a/mk/build.mk
+++ b/mk/build.mk
@@ -21,7 +21,7 @@ export PATH := $(BUILD_KUMACTL_DIR):$(PATH)
 # An optional extension to the coredns packages
 COREDNS_EXT ?=
 # renovate: datasource=github-tags depName=coredns packageName=kumahq/coredns-builds versioning=semver
-COREDNS_VERSION = v1.14.6
+COREDNS_VERSION = v1.14.7
 
 # List of binaries that we have build/release build rules for.
 BUILD_RELEASE_BINARIES := kuma-cp kuma-dp kumactl coredns kuma-cni install-cni envoy


### PR DESCRIPTION
## Motivation

kumahq/coredns-builds published v1.14.7. This branch still ships the bundled CoreDNS binary in the release tarball and the `kuma-dp` image, so the pin has to move to pick the new build up.

## Implementation information

Bump `COREDNS_VERSION` in `mk/build.mk` from `v1.14.6` to `v1.14.7`. The upstream release carries every artifact the distribution matrix downloads: linux/darwin amd64 and arm64, windows amd64, plus the `+fips` variants.

## Supporting documentation

https://github.com/kumahq/coredns-builds/releases/tag/v1.14.7