### PR TITLE
test(gatewayapi): skip flaky MeshGRPCRouteWeight

### DIFF
--- a/test/e2e_env/gatewayapi/conformance_test.go
+++ b/test/e2e_env/gatewayapi/conformance_test.go
@@ -128,6 +128,16 @@ metadata:
 		},
 		SkipTests: []string{
 			"HTTPRouteNoBackendRefs",
+			// The upstream mesh weight tests sample the traffic distribution
+			// without waiting for the route to be programmed: the only gate is
+			// three consecutive 200s, which the parent Service already answers
+			// before any route exists. The distribution check then retries a
+			// fixed 10 times with no delay, so the whole budget is under two
+			// seconds and Kuma loses the race roughly half the time, reporting
+			// the routeless 50/50 split across the echo-v1 and echo-v2 pods.
+			// Re-enable once the upstream fix that bounds the retries by
+			// TimeoutConfig lands and we bump the conformance module.
+			"MeshGRPCRouteWeight",
 		},
 		// Left undeclared, with what Kuma does not do:
 		//   - SupportMeshHTTPRouteNamedRouteRule: the upstream test is Provisional and


### PR DESCRIPTION
## Motivation

> Changelog: skip

`MeshGRPCRouteWeight` fails on master about half the time. It started when [#18280](https://github.com/kumahq/kuma/pull/18280) enabled `features.SupportGRPCRoute` and switched the test on. The race is in the upstream test, not in Kuma.

The test applies the GRPCRoute, then samples the traffic split without ever checking that the route is programmed. Its only gate is `MakeRequestAndExpectEventuallyConsistentResponse`, which wants three consecutive 200s, and `echo:7070` answers 200 with no route at all: the parent `echo` Service selects `app: echo` and already fronts both echo-v1 and echo-v2. In the failing runs that gate cleared 164ms after the route was created. The split check then retries a fixed 10 times with no sleep, so the whole propagation budget is under two seconds. Lose the race and every attempt reports the routeless 50/50 instead of the configured 70/30.

Timing, not function: the same test passed on the first attempt in [run 33549436075](https://github.com/kumahq/kuma/actions/runs/33549436075). `MeshHTTPRouteWeight` carries the identical defect and needed 9 of its 10 retries in a recent run, so it is next in line.

## Implementation information

Skip `MeshGRPCRouteWeight`, with a comment recording why and what has to happen before it comes back.

The real fix belongs upstream: bound the retries by `TimeoutConfig` instead of a fixed count, the way [gateway-api#5040](https://github.com/kubernetes-sigs/gateway-api/pull/5040) and [gateway-api#5122](https://github.com/kubernetes-sigs/gateway-api/pull/5122) already did for the L4 weight tests. Raised as [gateway-api#5214](https://github.com/kubernetes-sigs/gateway-api/pull/5214). The skip comes out once that lands and we bump the conformance module.

Bumping `sigs.k8s.io/gateway-api/conformance` on its own will not help. Our pin is 2026-06-03, and [`tests/mesh/grpcroute-weight.go`](https://github.com/kubernetes-sigs/gateway-api/blob/8f69037cd891/conformance/tests/mesh/grpcroute-weight.go) has not changed upstream since 2026-05-11.

## Supporting documentation

- Failing job: https://github.com/kumahq/kuma/actions/runs/33613167790/job/100193746075
- Passing run showing the feature works: https://github.com/kumahq/kuma/actions/runs/33549436075

https://claude.ai/code/session_014tscnFJQ4AwC4CDdsz6P1m

