### PR TITLE
fix(helm): reject removed ingress and egress values

### DIFF
--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -177,17 +177,6 @@ var _ = Context("kumactl install control-plane", func() {
 			},
 			goldenFile: "install-control-plane.zone.golden.yaml",
 		}),
-		Entry("should generate Kubernetes resources when controlPlane.ingress is removed", testCase{
-			extraArgs: []string{
-				"--values",
-				"-",
-			},
-			goldenFile: "install-cp-helm/empty.golden.yaml",
-			stdin: `
-controlPlane:
-  ingress: null
-`,
-		}),
 		Entry("should work with --set", testCase{
 			extraArgs: []string{
 				"--set",
@@ -224,6 +213,7 @@ controlPlane:
 	)
 
 	type errTestCase struct {
+		stdin     string
 		extraArgs []string
 		errorMsg  string
 	}
@@ -232,6 +222,11 @@ controlPlane:
 			// given
 			args := append([]string{"install", "control-plane", "--without-kubernetes-connection"}, given.extraArgs...)
 			_, _, rootCmd := test.DefaultTestingRootCmd(args...)
+			if given.stdin != "" {
+				stdin := &bytes.Buffer{}
+				stdin.WriteString(given.stdin)
+				rootCmd.SetIn(stdin)
+			}
 
 			// when
 			err := rootCmd.Execute()
@@ -267,6 +262,22 @@ controlPlane:
 		Entry("--mode standalone is no longer supported", errTestCase{
 			extraArgs: []string{"--kds-global-address", "192.168.0.1:1234", "--mode", "standalone"},
 			errorMsg:  "controlPlane.mode invalid got:'standalone'",
+		}),
+		Entry("removed top-level ingress values are rejected", errTestCase{
+			extraArgs: []string{"--values", "-"},
+			stdin: `
+ingress:
+  enabled: true
+`,
+			errorMsg: "top-level ingress was removed from the Kuma Helm chart",
+		}),
+		Entry("removed top-level egress values are rejected", errTestCase{
+			extraArgs: []string{"--values", "-"},
+			stdin: `
+egress:
+  enabled: true
+`,
+			errorMsg: "top-level egress was removed from the Kuma Helm chart",
 		}),
 		Entry("--tls-general-secret without --tls-general-ca-bundle", errTestCase{
 			extraArgs: []string{"--tls-general-secret", "sec"},

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -177,6 +177,17 @@ var _ = Context("kumactl install control-plane", func() {
 			},
 			goldenFile: "install-control-plane.zone.golden.yaml",
 		}),
+		Entry("should generate Kubernetes resources when controlPlane.ingress is removed", testCase{
+			extraArgs: []string{
+				"--values",
+				"-",
+			},
+			goldenFile: "install-cp-helm/empty.golden.yaml",
+			stdin: `
+controlPlane:
+  ingress: null
+`,
+		}),
 		Entry("should work with --set", testCase{
 			extraArgs: []string{
 				"--set",

--- a/deployments/charts/kuma/templates/cp-ingress.yaml
+++ b/deployments/charts/kuma/templates/cp-ingress.yaml
@@ -1,26 +1,25 @@
-{{- $ingress := .Values.controlPlane.ingress | default dict }}
-{{- if $ingress.enabled }}
+{{- if .Values.controlPlane.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "kuma.controlPlane.serviceName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- with $ingress.annotations }}
+  {{- with .Values.controlPlane.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
-  ingressClassName: {{ $ingress.ingressClassName }}
+  ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName }}
   rules:
-  - host: {{ $ingress.hostname }}
+  - host: {{ .Values.controlPlane.ingress.hostname }}
     http:
       paths:
-      - path: {{ $ingress.path }}
-        pathType: {{ $ingress.pathType }}
+      - path: {{ .Values.controlPlane.ingress.path }}
+        pathType: {{ .Values.controlPlane.ingress.pathType }}
         backend:
           service:
             name: {{ include "kuma.controlPlane.serviceName" . }}
             port:
-              number: {{ $ingress.servicePort }}
+              number: {{ .Values.controlPlane.ingress.servicePort }}
 {{- end }}

--- a/deployments/charts/kuma/templates/cp-ingress.yaml
+++ b/deployments/charts/kuma/templates/cp-ingress.yaml
@@ -1,25 +1,26 @@
-{{- if .Values.controlPlane.ingress.enabled }}
+{{- $ingress := .Values.controlPlane.ingress | default dict }}
+{{- if $ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "kuma.controlPlane.serviceName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.controlPlane.ingress.annotations }}
+  {{- with $ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels: {{ include "kuma.cpLabels" . | nindent 4 }}
 spec:
-  ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName }}
+  ingressClassName: {{ $ingress.ingressClassName }}
   rules:
-  - host: {{ .Values.controlPlane.ingress.hostname }}
+  - host: {{ $ingress.hostname }}
     http:
       paths:
-      - path: {{ .Values.controlPlane.ingress.path }}
-        pathType: {{ .Values.controlPlane.ingress.pathType }}
+      - path: {{ $ingress.path }}
+        pathType: {{ $ingress.pathType }}
         backend:
           service:
             name: {{ include "kuma.controlPlane.serviceName" . }}
             port:
-              number: {{ .Values.controlPlane.ingress.servicePort }}
+              number: {{ $ingress.servicePort }}
 {{- end }}

--- a/deployments/charts/kuma/templates/removed-values-validation.yaml
+++ b/deployments/charts/kuma/templates/removed-values-validation.yaml
@@ -1,0 +1,6 @@
+{{- if hasKey .Values "ingress" }}
+{{- fail "top-level ingress was removed from the Kuma Helm chart; use controlPlane.ingress for the control-plane Ingress or meshes[].ingress / meshZoneProxyDefaults.ingress for zone ingress" }}
+{{- end }}
+{{- if hasKey .Values "egress" }}
+{{- fail "top-level egress was removed from the Kuma Helm chart; use meshes[].egress or meshZoneProxyDefaults.egress for zone egress" }}
+{{- end }}


### PR DESCRIPTION
## Motivation

Top-level `ingress` and `egress` blocks were removed in 3.0. Helm doesn't reject unknown values, so upgrades using the old values silently succeed but delete zone ingress and zone egress Deployments, Services, and RBAC. This breaks cross-zone traffic with no warning.

A validation guard has been added following the existing pattern for the global control plane check. It rejects these removed values and points to mesh-scoped alternatives (`meshes[].ingress.enabled` and `meshes[].egress.enabled`), which are available in 2.14.3 for zero-downtime upgrades.

## Implementation information

Added validation to reject the top-level `ingress` and `egress` values during chart rendering. When detected, the chart fails with a message naming the removed values and pointing to their mesh-scoped replacements.

Closes https://github.com/kumahq/kuma/issues/18332

_Generated by Sybra harness_