### PR TITLE
fix(kuma-dp): bind readiness wildcard on k8s

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -417,27 +417,12 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 			components = append(components, observabilityComponents...)
 
-			readinessAddr := adminAddress
-			if readinessAddr == "" {
-				// The readiness reporter serves only /ready (see
-				// readiness.Reporter); no Envoy admin endpoint is exposed
-				// here. On Kubernetes the listener must accept probes from
-				// the kubelet (podIP), so we bind wildcard. Outside
-				// Kubernetes we default to loopback. POD_NAME is set by the
-				// sidecar injector.
-				_, inKubernetes := os.LookupEnv("POD_NAME")
-				ipv6 := kuma_net.IsAddressIPv6(kumaSidecarConfiguration.Networking.Address)
-				switch {
-				case inKubernetes && ipv6:
-					readinessAddr = "::"
-				case inKubernetes:
-					readinessAddr = "0.0.0.0"
-				case ipv6:
-					readinessAddr = "::1"
-				default:
-					readinessAddr = "127.0.0.1"
-				}
-			}
+			_, inKubernetes := os.LookupEnv("POD_NAME")
+			readinessAddr := readinessListenAddr(
+				inKubernetes,
+				kuma_net.IsAddressIPv6(kumaSidecarConfiguration.Networking.Address),
+				adminAddress,
+			)
 			readinessReporter := readiness.NewReporter(
 				readinessAddr,
 				cfg.Dataplane.ReadinessPort,
@@ -559,6 +544,21 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	}
 
 	return cmd
+}
+
+func readinessListenAddr(inKubernetes bool, ipv6 bool, adminAddress string) string {
+	switch {
+	case inKubernetes && ipv6:
+		return "::"
+	case inKubernetes:
+		return "0.0.0.0"
+	case adminAddress != "":
+		return adminAddress
+	case ipv6:
+		return "::1"
+	default:
+		return "127.0.0.1"
+	}
 }
 
 func getApplicationsToScrape(kumaSidecarConfiguration *types.KumaSidecarConfiguration, envoyAdminPort uint32, envoyAdminSocketPath string) []metrics.ApplicationToScrape {

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -529,3 +529,19 @@ var _ = Describe("metricsTargetsForBackends", func() {
 		}}))
 	})
 })
+
+var _ = Describe("readinessListenAddr", func() {
+	DescribeTable("should pick the address the kubelet or the operator can reach",
+		func(inKubernetes bool, ipv6 bool, adminAddress string, expected string) {
+			Expect(readinessListenAddr(inKubernetes, ipv6, adminAddress)).To(Equal(expected))
+		},
+		Entry("kubernetes, admin on unix socket", true, false, "", "0.0.0.0"),
+		Entry("kubernetes, admin on TCP loopback", true, false, "127.0.0.1", "0.0.0.0"),
+		Entry("kubernetes, ipv6, admin on unix socket", true, true, "", "::"),
+		Entry("kubernetes, ipv6, admin on TCP loopback", true, true, "::1", "::"),
+		Entry("universal, admin on TCP loopback", false, false, "127.0.0.1", "127.0.0.1"),
+		Entry("universal, admin bound to all interfaces", false, false, "0.0.0.0", "0.0.0.0"),
+		Entry("universal, admin on unix socket", false, false, "", "127.0.0.1"),
+		Entry("universal, ipv6, admin on unix socket", false, true, "", "::1"),
+	)
+})


### PR DESCRIPTION
## Motivation

The readiness reporter seeds its listen address from Envoy's admin address and only falls through to the wildcard bind when that address is empty — which is true only when admin runs over a Unix socket. Whenever admin runs over TCP the reporter binds `127.0.0.1`, so kubelet probes to the pod IP are refused and the sidecar is killed on its startup probe.

The probe port and the admin transport are decided in two different places: the port is written into the pod by the injecting webhook at admission, while the transport is chosen at bootstrap by whichever control plane instance answers the request. Any window where the two disagree ends in `CrashLoopBackOff`. Two ways to open that window on a stock chart:

- A rolling control plane upgrade from 2.13.x. A pod admitted by the new webhook gets probes on 9902; if it bootstraps against an outgoing 2.13.x instance it gets a TCP admin address.
- Flipping `experimental.envoyAdminUnixSocket`. The value reaches the egress and ingress probe ports at render time and the control plane at rollout time.

Seen on both an injected application sidecar and the standalone zone egress:

```
[Envoy]   Starting admin HTTP server at 127.0.0.1:9901
[kuma-dp] received bootstrap configuration  {"adminPort": 9901}
[kuma-dp] starting readiness reporter       {"addr": "127.0.0.1:9902"}
[kubelet] Startup probe failed: Get "http://10.42.0.20:9902/ready": connect: connection refused
[kubelet] Init container kuma-sidecar failed startup probe
```

Because the sidecar is a native init container, the application container never starts either, so the rollout stalls instead of degrading.

> Changelog: fix(kuma-dp): bind readiness wildcard on k8s

## Implementation information

Address selection moves into `readinessListenAddr`. On Kubernetes it now returns the wildcard address whatever the admin transport is; outside Kubernetes the configured admin address is still honored, then loopback.

The reporter serves only `/ready` and exposes no Envoy admin endpoint, so this is the same reachability the probes already had on the Unix socket path. Nothing new is reachable over the pod network.

## Supporting documentation

Verified with an A/B on a two-node k3d cluster: two pods built from the same manifest as a failing pod, differing only in the `kuma-dp` binary inside the stock 2.14.3 image, both bootstrapping against a 2.13.3 control plane.

| build | readiness bind | result |
| --- | --- | --- |
| 2.14.3 | `127.0.0.1:9902` | `Init:1/2`, startup probe refused, restarts climbing |
| patched | `[::]:9902` | `2/2 Running`, no restarts, no probe failures |

Unit coverage is a table in `run_test.go`. Reinstating the old precedence fails exactly the two Kubernetes-with-TCP-admin entries and no others.

Regression check on the default 2.14.3 path, admin on the Unix socket: readiness still binds the wildcard, every workload ready, traffic unaffected.

A master PR follows, where the underlying split between probe port and admin transport can be removed rather than patched.

https://claude.ai/code/session_01CtWcEP1Agz6ahE4y1p85m7