### PR TITLE
fix(xds): reject unsupported SOTW streams

### DIFF
--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -80,7 +80,7 @@ type adsServer struct {
 }
 
 func (s *adsServer) StreamAggregatedResources(stream envoy_service_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-	return status.Error(codes.Unimplemented, "unsupported SOTW/state-of-the-world xDS StreamAggregatedResources; use Delta ADS instead")
+	return status.Error(codes.Unimplemented, "unsupported SOTW/state-of-the-world xDS StreamAggregatedResources; restart the proxy with a delta-capable bootstrap to use Delta ADS")
 }
 
 func (s *adsServer) DeltaAggregatedResources(stream envoy_service_discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {

--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -7,7 +7,8 @@ import (
 	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/config"
 	envoy_server_delta "github.com/envoyproxy/go-control-plane/pkg/server/delta/v3"
-	envoy_server_sotw "github.com/envoyproxy/go-control-plane/pkg/server/sotw/v3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kumahq/kuma/v3/pkg/core"
@@ -49,21 +50,6 @@ func RegisterXDS(
 	syncTracker := xds_callbacks.DataplaneCallbacksToXdsCallbacks(xds_callbacks.NewDataplaneSyncTracker(rt.AppContext(), watchdogFactory))
 	dpStatusTracker := DefaultDataplaneStatusTracker(rt, otelStatusCache)
 
-	callbacks := util_xds_v3.CallbacksChain{
-		util_xds_v3.NewControlPlaneIdCallbacks(rt.GetInstanceId()),
-		util_xds_v3.AdaptCallbacks(statsCallbacks),
-		util_xds_v3.AdaptCallbacks(authCallbacks),
-		util_xds_v3.AdaptCallbacks(workloadLabelValidator),
-		util_xds_v3.AdaptCallbacks(dpLifecycle),
-		util_xds_v3.AdaptCallbacks(syncTracker),
-		util_xds_v3.AdaptCallbacks(dpStatusTracker),
-		util_xds_v3.AdaptCallbacks(xds_callbacks.NewNackBackoff(rt.Config().XdsServer.NACKBackoff.Duration)),
-	}
-
-	if cb := rt.XDS().ServerCallbacks; cb != nil {
-		callbacks = append(callbacks, util_xds_v3.AdaptCallbacks(cb))
-	}
-
 	deltaCallbacks := util_xds_v3.CallbacksChain{
 		util_xds_v3.NewControlPlaneIdCallbacks(rt.GetInstanceId()),
 		util_xds_v3.AdaptDeltaCallbacks(statsCallbacks),
@@ -79,24 +65,22 @@ func RegisterXDS(
 		deltaCallbacks = append(deltaCallbacks, util_xds_v3.AdaptDeltaCallbacks(cb))
 	}
 
-	sotw := envoy_server_sotw.NewServer(rt.AppContext(), xdsContext.Cache(), callbacks, envoy_server_sotw.WithOrderedADS())
 	delta := envoy_server_delta.NewServer(rt.AppContext(), xdsContext.Cache(), deltaCallbacks, func(o *config.Opts) {
 		o.Ordered = true
 	})
 
 	xdsServerLog.Info("registering Aggregated Discovery Service V3 in Dataplane Server")
-	envoy_service_discovery.RegisterAggregatedDiscoveryServiceServer(rt.DpServer().GrpcServer(), &adsServer{sotw: sotw, delta: delta})
+	envoy_service_discovery.RegisterAggregatedDiscoveryServiceServer(rt.DpServer().GrpcServer(), &adsServer{delta: delta})
 	return nil
 }
 
 type adsServer struct {
 	envoy_service_discovery.UnimplementedAggregatedDiscoveryServiceServer
-	sotw  envoy_server_sotw.Server
 	delta envoy_server_delta.Server
 }
 
 func (s *adsServer) StreamAggregatedResources(stream envoy_service_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-	return s.sotw.StreamHandler(stream, envoy_resource.AnyType)
+	return status.Error(codes.Unimplemented, "unsupported SOTW/state-of-the-world xDS StreamAggregatedResources; use Delta ADS instead")
 }
 
 func (s *adsServer) DeltaAggregatedResources(stream envoy_service_discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {

--- a/pkg/xds/server/v3/components_test.go
+++ b/pkg/xds/server/v3/components_test.go
@@ -1,0 +1,27 @@
+package v3
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestADSServerRejectsSOTWStream(t *testing.T) {
+	err := (&adsServer{}).StreamAggregatedResources(nil)
+	if err == nil {
+		t.Fatal("expected SOTW stream to be rejected")
+	}
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected %v, got %v", codes.Unimplemented, status.Code(err))
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "unsupported SOTW/state-of-the-world xDS") {
+		t.Fatalf("expected error to mention unsupported SOTW/state-of-the-world xDS, got %q", msg)
+	}
+	if !strings.Contains(msg, "Delta ADS") {
+		t.Fatalf("expected error to mention Delta ADS, got %q", msg)
+	}
+}

--- a/pkg/xds/server/v3/components_test.go
+++ b/pkg/xds/server/v3/components_test.go
@@ -13,13 +13,20 @@ func TestADSServerRejectsSOTWStream(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected SOTW stream to be rejected")
 	}
-	if status.Code(err) != codes.Unimplemented {
-		t.Fatalf("expected %v, got %v", codes.Unimplemented, status.Code(err))
+	st := status.Convert(err)
+	if st.Code() != codes.Unimplemented {
+		t.Fatalf("expected %v, got %v", codes.Unimplemented, st.Code())
 	}
 
-	msg := err.Error()
+	msg := st.Message()
 	if !strings.Contains(msg, "unsupported SOTW/state-of-the-world xDS") {
 		t.Fatalf("expected error to mention unsupported SOTW/state-of-the-world xDS, got %q", msg)
+	}
+	if !strings.Contains(msg, "restart the proxy") {
+		t.Fatalf("expected error to mention restarting the proxy, got %q", msg)
+	}
+	if !strings.Contains(msg, "delta-capable bootstrap") {
+		t.Fatalf("expected error to mention a delta-capable bootstrap, got %q", msg)
 	}
 	if !strings.Contains(msg, "Delta ADS") {
 		t.Fatalf("expected error to mention Delta ADS, got %q", msg)


### PR DESCRIPTION
## Motivation

Prevent older proxies using state-of-the-world ADS from appearing connected while receiving no configuration and continuing to serve stale snapshots. Rejecting these streams makes the unsupported protocol visible and indicates that the proxy must be restarted.

## Implementation information

- Reject SOTW ADS streams in xDS v3 with an error identifying the unsupported protocol.

Closes https://github.com/kumahq/kuma/issues/18329

_Generated by Sybra harness_