### PR TITLE
fix(kuma-cp): tolerate incomplete default MeshTimeout migration

### DIFF
--- a/pkg/defaults/mesh/mesh.go
+++ b/pkg/defaults/mesh/mesh.go
@@ -62,11 +62,15 @@ func EnsureDefaultMeshResources(
 	} else {
 		logger.Info("Dataplane Token Signing Key already exists")
 	}
-	if err := migrateCombinedMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
-		return errors.Wrap(err, "could not migrate legacy combined default MeshTimeout resources")
+	// A migration that cannot complete is logged and skipped rather than
+	// failing CP startup: DefaultComponent retries EnsureDefaultMeshResources
+	// on a budget, and a persistently-failing migration would otherwise take
+	// the whole control plane down.
+	if err := migrateCombinedMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, cpMode, cpZone, logger); err != nil {
+		logger.Error(err, "could not migrate legacy combined default MeshTimeout resources")
 	}
 	if err := migrateGatewayMeshTimeoutDefaults(ctx, resManager, meshName, k8sStore, systemNamespace, logger); err != nil {
-		return errors.Wrap(err, "could not migrate legacy gateway-specific default MeshTimeout resources")
+		logger.Error(err, "could not migrate legacy gateway-specific default MeshTimeout resources")
 	}
 	if slices.Contains(skippedPolicies, "*") {
 		logger.Info("skipping all default policy creation")
@@ -127,6 +131,8 @@ func migrateCombinedMeshTimeoutDefaults(
 	meshName string,
 	k8sStore bool,
 	systemNamespace string,
+	cpMode config_core.CpMode,
+	cpZone string,
 	logger logr.Logger,
 ) error {
 	for _, prefix := range []string{"mesh-timeout-all"} {
@@ -146,7 +152,29 @@ func migrateCombinedMeshTimeoutDefaults(
 		if len(pointer.Deref(existing.Spec.To)) == 0 {
 			continue // already migrated, or an operator-modified rules-only resource
 		}
+
+		// The outbound half of the legacy combined resource is about to be
+		// stripped: create its replacement first so a crash between the two
+		// writes never leaves the mesh without mesh-wide outbound defaults.
+		toResourceName := fmt.Sprintf("mesh-timeout-to-all-%s", meshName)
+		if k8sStore {
+			toResourceName = fmt.Sprintf("%s.%s", toResourceName, systemNamespace)
+		}
+		toKey := model.ResourceKey{Mesh: meshName, Name: toResourceName}
+		if err, _ := ensureDefaultResource(ctx, resManager, defaultMeshTimeoutToResource(), toKey, cpMode, cpZone, k8sStore, systemNamespace, false); err != nil {
+			return errors.Wrapf(err, "could not create default MeshTimeout %q", toKey.Name)
+		}
+
 		existing.Spec.To = nil
+		// 2.14 and earlier kept the inbound half of the combined default in
+		// 'from', a field the current struct no longer has, so it's silently
+		// dropped on unmarshal. Restore it from the current defaults, whose
+		// values are unchanged, so the migrated resource isn't left with
+		// neither 'to' nor 'rules' (invalid, see validator.go).
+		if len(pointer.Deref(existing.Spec.Rules)) == 0 {
+			rules := defaultMeshTimeoutRules()
+			existing.Spec.Rules = &rules
+		}
 		if err := resManager.Update(ctx, existing); err != nil {
 			return errors.Wrapf(err, "could not migrate default MeshTimeout %q", key.Name)
 		}
@@ -199,14 +227,14 @@ func ensureDefaultResource(
 	systemNamespace string,
 	reconcileExistingOnly bool,
 ) (error, bool) {
-	computeLabels := func(existing map[string]string) (map[string]string, error) {
+	computeLabels := func(spec model.ResourceSpec, existing map[string]string) (map[string]string, error) {
 		namespace := resource_labels.UnsetNamespace
 		if k8sStore {
 			namespace = resource_labels.NewNamespace(systemNamespace, true)
 		}
 		return resource_labels.Compute(
 			res.Descriptor(),
-			res.GetSpec(),
+			spec,
 			existing,
 			resourceKey.Mesh,
 			resourceKey.Name,
@@ -217,17 +245,23 @@ func ensureDefaultResource(
 		)
 	}
 
-	err := resManager.Get(ctx, res, store.GetBy(resourceKey), store.GetConsistent())
+	// Get into a fresh instance rather than the desired 'res': 'res' already
+	// carries the builder's default spec, and unmarshalling merges onto
+	// whatever fields are already set instead of replacing them, so reusing
+	// it here could blend the desired spec with a differently-shaped stored
+	// one (e.g. a legacy resource a migration failed to normalize).
+	existing := res.Descriptor().NewObject()
+	err := resManager.Get(ctx, existing, store.GetBy(resourceKey), store.GetConsistent())
 	if err == nil {
-		desired, err := computeLabels(res.GetMeta().GetLabels())
+		desired, err := computeLabels(existing.GetSpec(), existing.GetMeta().GetLabels())
 		if err != nil {
 			return errors.Wrap(err, "could not compute labels for a default resource"), false
 		}
-		if maps.Equal(res.GetMeta().GetLabels(), desired) {
+		if maps.Equal(existing.GetMeta().GetLabels(), desired) {
 			return nil, false
 		}
 		// Older CP versions persisted these without computed labels. Rewrite them in place.
-		if err := resManager.Update(ctx, res, store.UpdateWithLabels(desired)); err != nil {
+		if err := resManager.Update(ctx, existing, store.UpdateWithLabels(desired)); err != nil {
 			return errors.Wrap(err, "could not reconcile labels of a default resource"), false
 		}
 		return nil, false
@@ -240,7 +274,7 @@ func ensureDefaultResource(
 		// resources; it must not recreate ones an operator deleted.
 		return nil, false
 	}
-	desired, err := computeLabels(nil)
+	desired, err := computeLabels(res.GetSpec(), nil)
 	if err != nil {
 		return errors.Wrap(err, "could not compute labels for a default resource"), false
 	}

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -2,6 +2,7 @@ package mesh_test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -163,15 +164,13 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 		})
 
 		It("should migrate a legacy combined MeshTimeout default that predates the rules/to split", func() {
-			// given a combined default MeshTimeout, as an older CP version stored it,
-			// with both 'rules' and 'to' set (now mutually exclusive)
+			// given a combined default MeshTimeout as CP 2.14 and earlier stored
+			// it: 'to' set, and the inbound half in 'from', a field the current
+			// struct no longer has, so it's absent here (dropped on unmarshal).
 			legacy := meshtimeout.NewMeshTimeoutResource()
 			legacy.Spec = &meshtimeout.MeshTimeout{
 				TargetRef: &common_api.TopLevelTargetRef{
 					Kind: common_api.TopLevelTargetRefKindMesh,
-				},
-				Rules: &[]meshtimeout.Rule{
-					{Default: meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}}},
 				},
 				To: &[]meshtimeout.To{
 					{
@@ -190,7 +189,8 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", false)
 			Expect(err).ToNot(HaveOccurred())
 
-			// then the legacy resource is migrated to 'rules' only
+			// then the legacy resource is migrated to 'rules' only, restored
+			// from the current mesh-wide inbound defaults
 			migrated := meshtimeout.NewMeshTimeoutResource()
 			err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
 			Expect(err).ToNot(HaveOccurred())
@@ -198,6 +198,7 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(migrated.Spec.TargetRef.Kind).To(Equal(common_api.TopLevelTargetRefKindMesh))
 			Expect(migrated.Spec.To).To(BeNil())
 			Expect(migrated.Spec.Rules).ToNot(BeNil())
+			Expect(*migrated.Spec.Rules).To(Equal(currentDefaultMeshTimeoutRules(resManager)))
 
 			// and a separate 'to' resource now carries the outbound defaults
 			toResource := meshtimeout.NewMeshTimeoutResource()
@@ -205,6 +206,71 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(toResource.Spec.To).ToNot(BeNil())
 			Expect(toResource.Spec.Rules).To(BeNil())
+		})
+
+		It("should migrate a legacy combined MeshTimeout default on the boot reconcile path", func() {
+			// given the same legacy combined default as above
+			legacy := meshtimeout.NewMeshTimeoutResource()
+			legacy.Spec = &meshtimeout.MeshTimeout{
+				TargetRef: &common_api.TopLevelTargetRef{
+					Kind: common_api.TopLevelTargetRefKindMesh,
+				},
+				To: &[]meshtimeout.To{
+					{
+						TargetRef: common_api.OutboundTargetRef{Kind: common_api.OutboundTargetRefKindMesh},
+						Default:   meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}},
+					},
+				},
+			}
+			err := rawStore.Create(context.Background(), legacy, core_store.CreateByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+
+			// when EnsureDefaultMeshResources runs with reconcileExistingOnly=true,
+			// the mode used by the boot-time reconciliation loop that crashed in
+			// production
+			err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", true)
+			Expect(err).ToNot(HaveOccurred())
+
+			// then the legacy resource is migrated the same way
+			migrated := meshtimeout.NewMeshTimeoutResource()
+			err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migrated.Spec.To).To(BeNil())
+			Expect(migrated.Spec.Rules).ToNot(BeNil())
+			Expect(*migrated.Spec.Rules).To(Equal(currentDefaultMeshTimeoutRules(resManager)))
+
+			toResource := meshtimeout.NewMeshTimeoutResource()
+			err = resManager.Get(context.Background(), toResource, core_store.GetByKey("mesh-timeout-to-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(toResource.Spec.To).ToNot(BeNil())
+		})
+
+		It("should not fail EnsureDefaultMeshResources when a default-resource migration cannot complete", func() {
+			// given a legacy combined default MeshTimeout that needs migrating
+			legacy := meshtimeout.NewMeshTimeoutResource()
+			legacy.Spec = &meshtimeout.MeshTimeout{
+				TargetRef: &common_api.TopLevelTargetRef{
+					Kind: common_api.TopLevelTargetRefKindMesh,
+				},
+				To: &[]meshtimeout.To{
+					{
+						TargetRef: common_api.OutboundTargetRef{Kind: common_api.OutboundTargetRefKindMesh},
+						Default:   meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}},
+					},
+				},
+			}
+			err := rawStore.Create(context.Background(), legacy, core_store.CreateByKey("mesh-timeout-all-default", model.DefaultMesh))
+			Expect(err).ToNot(HaveOccurred())
+
+			// and a resource manager whose Update always fails, simulating a
+			// migration that can never complete (e.g. a persistently
+			// unreachable store)
+			failingManager := &failingUpdateResourceManager{ResourceManager: resManager}
+
+			// when EnsureDefaultMeshResources runs
+			// then it does not return an error: the migration is logged and skipped
+			err = mesh.EnsureDefaultMeshResources(context.Background(), failingManager, defaultMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", false)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should delete legacy gateway-specific default MeshTimeout resources", func() {
@@ -270,4 +336,38 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
 })
+
+// currentDefaultMeshTimeoutRules returns the inbound rules a freshly-created
+// mesh-timeout-all default carries today, used to assert a migrated legacy
+// resource is restored to the same values.
+func currentDefaultMeshTimeoutRules(resManager manager.ResourceManager) []meshtimeout.Rule {
+	referenceMesh := core_mesh.NewMeshResource()
+	err := resManager.Create(context.Background(), referenceMesh, core_store.CreateByKey("reference-defaults-mesh", model.NoMesh))
+	Expect(err).ToNot(HaveOccurred())
+
+	err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, referenceMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", false)
+	Expect(err).ToNot(HaveOccurred())
+
+	reference := meshtimeout.NewMeshTimeoutResource()
+	err = resManager.Get(context.Background(), reference, core_store.GetByKey("mesh-timeout-all-reference-defaults-mesh", "reference-defaults-mesh"))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(reference.Spec.Rules).ToNot(BeNil())
+	return *reference.Spec.Rules
+}
+
+// failingUpdateResourceManager wraps a ResourceManager whose Update fails
+// whenever it's asked to persist a migrated (rules-only) MeshTimeout,
+// simulating a default-resource migration that can never complete without
+// affecting unrelated Update calls (e.g. label reconciliation).
+type failingUpdateResourceManager struct {
+	manager.ResourceManager
+}
+
+func (f *failingUpdateResourceManager) Update(ctx context.Context, res model.Resource, opts ...core_store.UpdateOptionsFunc) error {
+	if mt, ok := res.(*meshtimeout.MeshTimeoutResource); ok && mt.Spec.To == nil {
+		return errors.New("simulated update failure")
+	}
+	return f.ResourceManager.Update(ctx, res, opts...)
+}

--- a/pkg/defaults/mesh/mesh_test.go
+++ b/pkg/defaults/mesh/mesh_test.go
@@ -343,15 +343,23 @@ var _ = Describe("EnsureDefaultMeshResources", func() {
 // mesh-timeout-all default carries today, used to assert a migrated legacy
 // resource is restored to the same values.
 func currentDefaultMeshTimeoutRules(resManager manager.ResourceManager) []meshtimeout.Rule {
+	return currentDefaultMeshTimeoutRulesForStore(resManager, false, "")
+}
+
+func currentDefaultMeshTimeoutRulesForStore(resManager manager.ResourceManager, k8sStore bool, systemNamespace string) []meshtimeout.Rule {
 	referenceMesh := core_mesh.NewMeshResource()
 	err := resManager.Create(context.Background(), referenceMesh, core_store.CreateByKey("reference-defaults-mesh", model.NoMesh))
 	Expect(err).ToNot(HaveOccurred())
 
-	err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, referenceMesh, []string{}, context.Background(), false, "", config_core.Zone, "zone-1", false)
+	err = mesh.EnsureDefaultMeshResources(context.Background(), resManager, referenceMesh, []string{}, context.Background(), k8sStore, systemNamespace, config_core.Zone, "zone-1", false)
 	Expect(err).ToNot(HaveOccurred())
 
+	resourceName := "mesh-timeout-all-reference-defaults-mesh"
+	if k8sStore {
+		resourceName = resourceName + "." + systemNamespace
+	}
 	reference := meshtimeout.NewMeshTimeoutResource()
-	err = resManager.Get(context.Background(), reference, core_store.GetByKey("mesh-timeout-all-reference-defaults-mesh", "reference-defaults-mesh"))
+	err = resManager.Get(context.Background(), reference, core_store.GetByKey(resourceName, "reference-defaults-mesh"))
 	Expect(err).ToNot(HaveOccurred())
 	Expect(reference.Spec.Rules).ToNot(BeNil())
 	return *reference.Spec.Rules

--- a/pkg/defaults/mesh/meshtimeout.go
+++ b/pkg/defaults/mesh/meshtimeout.go
@@ -14,8 +14,37 @@ import (
 // separate resources: 'rules' (inbound) and 'to' (outbound) are mutually
 // exclusive on a single MeshTimeout (see validator.go), so the mesh-wide
 // inbound and outbound defaults can't be expressed on one resource.
-var defaultMeshTimeoutResource = func() model.Resource {
+// defaultMeshTimeoutRules returns the inbound defaults shared by
+// defaultMeshTimeoutResource and the legacy combined-default migration.
+func defaultMeshTimeoutRules() []v1alpha1.Rule {
 	const factor = 2
+	return []v1alpha1.Rule{
+		{
+			Default: v1alpha1.Conf{
+				ConnectionTimeout: &kube_meta.Duration{
+					Duration: factor * policies_defaults.DefaultConnectTimeout,
+				},
+				IdleTimeout: &kube_meta.Duration{
+					Duration: factor * policies_defaults.DefaultIdleTimeout,
+				},
+				Http: &v1alpha1.Http{
+					RequestTimeout: &kube_meta.Duration{
+						Duration: 0,
+					},
+					StreamIdleTimeout: &kube_meta.Duration{
+						Duration: factor * policies_defaults.DefaultStreamIdleTimeout,
+					},
+					MaxStreamDuration: &kube_meta.Duration{
+						Duration: 0,
+					},
+				},
+			},
+		},
+	}
+}
+
+var defaultMeshTimeoutResource = func() model.Resource {
+	rules := defaultMeshTimeoutRules()
 	return &v1alpha1.MeshTimeoutResource{
 		Spec: &v1alpha1.MeshTimeout{
 			TargetRef: &common_api.TopLevelTargetRef{
@@ -23,29 +52,7 @@ var defaultMeshTimeoutResource = func() model.Resource {
 			},
 
 			// bigger than outbound side timeouts or disabled.
-			Rules: &[]v1alpha1.Rule{
-				{
-					Default: v1alpha1.Conf{
-						ConnectionTimeout: &kube_meta.Duration{
-							Duration: factor * policies_defaults.DefaultConnectTimeout,
-						},
-						IdleTimeout: &kube_meta.Duration{
-							Duration: factor * policies_defaults.DefaultIdleTimeout,
-						},
-						Http: &v1alpha1.Http{
-							RequestTimeout: &kube_meta.Duration{
-								Duration: 0,
-							},
-							StreamIdleTimeout: &kube_meta.Duration{
-								Duration: factor * policies_defaults.DefaultStreamIdleTimeout,
-							},
-							MaxStreamDuration: &kube_meta.Duration{
-								Duration: 0,
-							},
-						},
-					},
-				},
-			},
+			Rules: &rules,
 		},
 	}
 }

--- a/pkg/defaults/mesh/migrations_k8s_test.go
+++ b/pkg/defaults/mesh/migrations_k8s_test.go
@@ -1,0 +1,108 @@
+package mesh
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
+	core_store "github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
+)
+
+// These exercise the MeshTimeout default migrations directly against a
+// Kubernetes-backed store, bypassing EnsureDefaultMeshResources (and its
+// Dataplane Token Signing Key step, which needs a Secret-aware store not
+// set up here) to isolate the migration logic itself.
+var _ = Describe("MeshTimeout default migrations on Kubernetes", func() {
+	var resManager manager.ResourceManager
+
+	BeforeEach(func() {
+		scheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+		kubeClient := kube_client_fake.NewClientBuilder().WithScheme(scheme).Build()
+		k8sStore, err := k8s.NewStore(kubeClient, scheme, k8s.NewSimpleConverter("kuma-system"))
+		Expect(err).ToNot(HaveOccurred())
+		resManager = manager.NewResourceManager(k8sStore)
+	})
+
+	It("should migrate a legacy combined MeshTimeout default", func() {
+		// given a combined default MeshTimeout stored the way CP 2.14 and
+		// earlier wrote it on Kubernetes: 'to' set, no 'rules'
+		legacy := v1alpha1.NewMeshTimeoutResource()
+		legacy.Spec = &v1alpha1.MeshTimeout{
+			TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
+			To: &[]v1alpha1.To{
+				{
+					TargetRef: common_api.OutboundTargetRef{Kind: common_api.OutboundTargetRefKindMesh},
+					Default:   v1alpha1.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}},
+				},
+			},
+		}
+		err := resManager.Create(context.Background(), legacy, core_store.CreateByKey("mesh-timeout-all-default.kuma-system", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		err = migrateCombinedMeshTimeoutDefaults(context.Background(), resManager, "default", true, "kuma-system", config_core.Zone, "zone-1", logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the legacy resource is migrated to 'rules' only
+		migrated := v1alpha1.NewMeshTimeoutResource()
+		err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default.kuma-system", "default"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(migrated.Spec.To).To(BeNil())
+		Expect(migrated.Spec.Rules).ToNot(BeNil())
+
+		// and a separate 'to' resource now carries the outbound defaults
+		toResource := v1alpha1.NewMeshTimeoutResource()
+		err = resManager.Get(context.Background(), toResource, core_store.GetByKey("mesh-timeout-to-all-default.kuma-system", "default"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(toResource.Spec.To).ToNot(BeNil())
+	})
+
+	It("should delete legacy gateway-specific default MeshTimeout resources", func() {
+		// given gateway-specific default MeshTimeout resources, as an older
+		// CP version stored them on Kubernetes
+		gatewayRules := v1alpha1.NewMeshTimeoutResource()
+		gatewayRules.Spec = &v1alpha1.MeshTimeout{
+			TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
+			Rules: &[]v1alpha1.Rule{
+				{Default: v1alpha1.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}}},
+			},
+		}
+		err := resManager.Create(context.Background(), gatewayRules, core_store.CreateByKey("mesh-gateways-timeout-all-default.kuma-system", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		gatewayTo := v1alpha1.NewMeshTimeoutResource()
+		gatewayTo.Spec = &v1alpha1.MeshTimeout{
+			TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
+			To: &[]v1alpha1.To{
+				{
+					TargetRef: common_api.OutboundTargetRef{Kind: common_api.OutboundTargetRefKindMesh},
+					Default:   v1alpha1.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}},
+				},
+			},
+		}
+		err = resManager.Create(context.Background(), gatewayTo, core_store.CreateByKey("mesh-gateways-timeout-to-all-default.kuma-system", "default"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		err = migrateGatewayMeshTimeoutDefaults(context.Background(), resManager, "default", true, "kuma-system", logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		// then the legacy gateway-specific defaults are gone
+		err = resManager.Get(context.Background(), v1alpha1.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default.kuma-system", "default"))
+		Expect(core_store.IsNotFound(err)).To(BeTrue())
+		err = resManager.Get(context.Background(), v1alpha1.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-to-all-default.kuma-system", "default"))
+		Expect(core_store.IsNotFound(err)).To(BeTrue())
+	})
+})

--- a/pkg/defaults/mesh/migrations_k8s_test.go
+++ b/pkg/defaults/mesh/migrations_k8s_test.go
@@ -1,108 +1,135 @@
-package mesh
+package mesh_test
 
 import (
 	"context"
 	"time"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	kube_core "k8s.io/api/core/v1"
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 	kube_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
-	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
+	resources_manager "github.com/kumahq/kuma/v3/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	secret_cipher "github.com/kumahq/kuma/v3/pkg/core/secrets/cipher"
+	secret_manager "github.com/kumahq/kuma/v3/pkg/core/secrets/manager"
+	defaults_mesh "github.com/kumahq/kuma/v3/pkg/defaults/mesh"
 	bootstrap_k8s "github.com/kumahq/kuma/v3/pkg/plugins/bootstrap/k8s"
-	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	meshtimeout "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
+	secrets_k8s "github.com/kumahq/kuma/v3/pkg/plugins/secrets/k8s"
 )
 
-// These exercise the MeshTimeout default migrations directly against a
-// Kubernetes-backed store, bypassing EnsureDefaultMeshResources (and its
-// Dataplane Token Signing Key step, which needs a Secret-aware store not
-// set up here) to isolate the migration logic itself.
-var _ = Describe("MeshTimeout default migrations on Kubernetes", func() {
-	var resManager manager.ResourceManager
+var _ = Describe("EnsureDefaultMeshResources on Kubernetes", func() {
+	const systemNamespace = "kuma-system"
+
+	var (
+		rawStore    core_store.ResourceStore
+		resManager  resources_manager.ResourceManager
+		defaultMesh *core_mesh.MeshResource
+	)
 
 	BeforeEach(func() {
+		k8sScheme, err := bootstrap_k8s.NewScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		kubeClient := kube_client_fake.NewClientBuilder().
+			WithScheme(k8sScheme).
+			WithIndex(&kube_core.Secret{}, "type", func(object kube_client.Object) []string {
+				secret := object.(*kube_core.Secret)
+				return []string{string(secret.Type)}
+			}).
+			Build()
+
+		rawStore, err = k8s.NewStore(kubeClient, k8sScheme, k8s.NewSimpleConverter(systemNamespace))
+		Expect(err).ToNot(HaveOccurred())
+
 		scheme, err := bootstrap_k8s.NewScheme()
 		Expect(err).ToNot(HaveOccurred())
-		kubeClient := kube_client_fake.NewClientBuilder().WithScheme(scheme).Build()
-		k8sStore, err := k8s.NewStore(kubeClient, scheme, k8s.NewSimpleConverter("kuma-system"))
+		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, scheme, "default")
 		Expect(err).ToNot(HaveOccurred())
-		resManager = manager.NewResourceManager(k8sStore)
+
+		baseManager := resources_manager.NewResourceManager(rawStore)
+		customizableManager := resources_manager.NewCustomizableResourceManager(baseManager, nil)
+		customizableManager.Customize(
+			system.SecretType,
+			secret_manager.NewSecretManager(secretStore, secret_cipher.None()),
+		)
+		resManager = customizableManager
+
+		defaultMesh = core_mesh.NewMeshResource()
+		err = resManager.Create(context.Background(), defaultMesh, core_store.CreateByKey(core_model.DefaultMesh, core_model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should migrate a legacy combined MeshTimeout default", func() {
-		// given a combined default MeshTimeout stored the way CP 2.14 and
-		// earlier wrote it on Kubernetes: 'to' set, no 'rules'
-		legacy := v1alpha1.NewMeshTimeoutResource()
-		legacy.Spec = &v1alpha1.MeshTimeout{
+		legacy := meshtimeout.NewMeshTimeoutResource()
+		legacy.Spec = &meshtimeout.MeshTimeout{
 			TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
-			To: &[]v1alpha1.To{
+			To: &[]meshtimeout.To{
 				{
 					TargetRef: common_api.OutboundTargetRef{Kind: common_api.OutboundTargetRefKindMesh},
-					Default:   v1alpha1.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}},
+					Default:   meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Hour}},
 				},
 			},
 		}
-		err := resManager.Create(context.Background(), legacy, core_store.CreateByKey("mesh-timeout-all-default.kuma-system", "default"))
+		err := rawStore.Create(context.Background(), legacy, core_store.CreateByKey("mesh-timeout-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
 
-		// when
-		err = migrateCombinedMeshTimeoutDefaults(context.Background(), resManager, "default", true, "kuma-system", config_core.Zone, "zone-1", logr.Discard())
+		err = defaults_mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, nil, context.Background(), true, systemNamespace, config_core.Zone, "zone-1", false)
 		Expect(err).ToNot(HaveOccurred())
 
-		// then the legacy resource is migrated to 'rules' only
-		migrated := v1alpha1.NewMeshTimeoutResource()
-		err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default.kuma-system", "default"))
+		migrated := meshtimeout.NewMeshTimeoutResource()
+		err = resManager.Get(context.Background(), migrated, core_store.GetByKey("mesh-timeout-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(migrated.Spec.To).To(BeNil())
 		Expect(migrated.Spec.Rules).ToNot(BeNil())
+		Expect(*migrated.Spec.Rules).To(Equal(currentDefaultMeshTimeoutRulesForStore(resManager, true, systemNamespace)))
 
-		// and a separate 'to' resource now carries the outbound defaults
-		toResource := v1alpha1.NewMeshTimeoutResource()
-		err = resManager.Get(context.Background(), toResource, core_store.GetByKey("mesh-timeout-to-all-default.kuma-system", "default"))
+		toResource := meshtimeout.NewMeshTimeoutResource()
+		err = resManager.Get(context.Background(), toResource, core_store.GetByKey("mesh-timeout-to-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(toResource.Spec.To).ToNot(BeNil())
+		Expect(toResource.Spec.Rules).To(BeNil())
 	})
 
 	It("should delete legacy gateway-specific default MeshTimeout resources", func() {
-		// given gateway-specific default MeshTimeout resources, as an older
-		// CP version stored them on Kubernetes
-		gatewayRules := v1alpha1.NewMeshTimeoutResource()
-		gatewayRules.Spec = &v1alpha1.MeshTimeout{
+		gatewayRules := meshtimeout.NewMeshTimeoutResource()
+		gatewayRules.Spec = &meshtimeout.MeshTimeout{
 			TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
-			Rules: &[]v1alpha1.Rule{
-				{Default: v1alpha1.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}}},
+			Rules: &[]meshtimeout.Rule{
+				{Default: meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}}},
 			},
 		}
-		err := resManager.Create(context.Background(), gatewayRules, core_store.CreateByKey("mesh-gateways-timeout-all-default.kuma-system", "default"))
+		err := rawStore.Create(context.Background(), gatewayRules, core_store.CreateByKey("mesh-gateways-timeout-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
 
-		gatewayTo := v1alpha1.NewMeshTimeoutResource()
-		gatewayTo.Spec = &v1alpha1.MeshTimeout{
+		gatewayTo := meshtimeout.NewMeshTimeoutResource()
+		gatewayTo.Spec = &meshtimeout.MeshTimeout{
 			TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
-			To: &[]v1alpha1.To{
+			To: &[]meshtimeout.To{
 				{
 					TargetRef: common_api.OutboundTargetRef{Kind: common_api.OutboundTargetRefKindMesh},
-					Default:   v1alpha1.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}},
+					Default:   meshtimeout.Conf{IdleTimeout: &kube_meta.Duration{Duration: time.Minute}},
 				},
 			},
 		}
-		err = resManager.Create(context.Background(), gatewayTo, core_store.CreateByKey("mesh-gateways-timeout-to-all-default.kuma-system", "default"))
+		err = rawStore.Create(context.Background(), gatewayTo, core_store.CreateByKey("mesh-gateways-timeout-to-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(err).ToNot(HaveOccurred())
 
-		// when
-		err = migrateGatewayMeshTimeoutDefaults(context.Background(), resManager, "default", true, "kuma-system", logr.Discard())
+		err = defaults_mesh.EnsureDefaultMeshResources(context.Background(), resManager, defaultMesh, nil, context.Background(), true, systemNamespace, config_core.Zone, "zone-1", false)
 		Expect(err).ToNot(HaveOccurred())
 
-		// then the legacy gateway-specific defaults are gone
-		err = resManager.Get(context.Background(), v1alpha1.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default.kuma-system", "default"))
+		err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(core_store.IsNotFound(err)).To(BeTrue())
-		err = resManager.Get(context.Background(), v1alpha1.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-to-all-default.kuma-system", "default"))
+		err = resManager.Get(context.Background(), meshtimeout.NewMeshTimeoutResource(), core_store.GetByKey("mesh-gateways-timeout-to-all-default.kuma-system", core_model.DefaultMesh))
 		Expect(core_store.IsNotFound(err)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
## Motivation

Prevent the control plane from exiting when migrating legacy default MeshTimeout resources whose fields are rejected by validation, allowing upgraded Universal deployments with Postgres stores to remain running.

## Implementation information

- Updated the default MeshTimeout migration handling to tolerate the incomplete legacy resource shape.
- Corrected and expanded migration coverage for default MeshTimeout resources.

Closes https://github.com/kumahq/kuma/issues/18328

_Generated by Sybra harness_