### PR TITLE
fix(k8s): always probe the sidecar readiness port

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,9 +16,11 @@ Probes now always use the readiness port, whatever the admin transport, and the 
 
 Pods injected before the upgrade keep their existing probes on `9901` and continue to work: the `kuma:envoy:admin` listener still serves `/ready` on that port. They move to the readiness port the next time they are recreated.
 
+The sidecar now also receives `KUMA_READINESS_PORT` from `bootstrapServer.params.readinessPort`, so kuma-dp listens on the port the probes use. Previously the injector took the probe port from the control plane setting while kuma-dp took its listen port from its own `KUMA_READINESS_PORT`, and the two agreed only because both default to `9902`. For the same reason `bootstrapServer.params.readinessPort` no longer accepts `0`; a control plane configured that way now fails to start instead of injecting probes for port `0`.
+
 **Action required**
 
-None for most users. If you have a `NetworkPolicy`, a monitoring check, or a `ContainerPatch` that pins the sidecar probe port to `9901`, update it to `9902` (or to `bootstrapServer.params.readinessPort` if you changed it).
+None for most users. If you have a `NetworkPolicy`, a monitoring check, or a `ContainerPatch` that pins the sidecar probe port to `9901`, update it to `9902` (or to `bootstrapServer.params.readinessPort` if you changed it). If you set `bootstrapServer.params.readinessPort` to `0`, or set `KUMA_READINESS_PORT` on the sidecar by hand to a value other than the control plane setting, remove it.
 
 ### The `k8s.kuma.io/service-account` label on a `Dataplane` is managed by the control plane
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,18 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
+### Kubernetes probes on the sidecar always use the readiness port
+
+The injected `kuma-sidecar` container had its liveness, readiness and startup probes pointed at the Envoy admin port (`9901`) when `experimental.envoyAdminUnixSocket` was off, and at the kuma-dp readiness port (`9902`) when it was on. Those two settings are decided in different places - the probe port is written into the Pod by the injecting webhook at admission, the admin transport is chosen at bootstrap by whichever control plane instance answers - so a rolling control plane upgrade, or a change to the flag, left a window where they disagreed and pods went into `CrashLoopBackOff`.
+
+Probes now always use the readiness port, whatever the admin transport, and the readiness port is always excluded from inbound transparent proxy interception. To keep the same meaning on both transports, `/ready` on the readiness port is now proxied to the Envoy admin `/ready` in both cases, so a Pod is marked ready only once Envoy has its configuration. Previously the readiness port answered `READY` as soon as kuma-dp was up when admin ran over TCP; the probes did not use that port in that mode, so no probe changes meaning.
+
+Pods injected before the upgrade keep their existing probes on `9901` and continue to work: the `kuma:envoy:admin` listener still serves `/ready` on that port. They move to the readiness port the next time they are recreated.
+
+**Action required**
+
+None for most users. If you have a `NetworkPolicy`, a monitoring check, or a `ContainerPatch` that pins the sidecar probe port to `9901`, update it to `9902` (or to `bootstrapServer.params.readinessPort` if you changed it).
+
 ### The `k8s.kuma.io/service-account` label on a `Dataplane` is managed by the control plane
 
 On Kubernetes this label is computed by the control plane from the Pod's ServiceAccount and is not meant to be set by hand. The admission webhook now rejects any `Dataplane` create or update that carries `k8s.kuma.io/service-account`, unless the request comes from the control plane itself or from another user listed in `runtime.kubernetes.allowedUsers`, on both Zone and Global control planes. A proxy is also rejected at xDS authentication when the label on its `Dataplane` does not match the ServiceAccount of its Pod. Other resource types are unaffected, as are resources synced over KDS and resources written by the control plane.

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -342,31 +342,20 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 			components = append(components, observabilityComponents...)
 
-			readinessAddr := adminAddress
-			if readinessAddr == "" {
-				// The readiness reporter serves only /ready (see
-				// readiness.Reporter); no Envoy admin endpoint is exposed
-				// here. On Kubernetes the listener must accept probes from
-				// the kubelet (podIP), so we bind wildcard. Outside
-				// Kubernetes we default to loopback. POD_NAME is set by the
-				// sidecar injector.
-				_, inKubernetes := os.LookupEnv("POD_NAME")
-				ipv6 := kuma_net.IsAddressIPv6(kumaSidecarConfiguration.Networking.Address)
-				switch {
-				case inKubernetes && ipv6:
-					readinessAddr = "::"
-				case inKubernetes:
-					readinessAddr = "0.0.0.0"
-				case ipv6:
-					readinessAddr = "::1"
-				default:
-					readinessAddr = "127.0.0.1"
-				}
-			}
+			_, inKubernetes := os.LookupEnv("POD_NAME")
+			readinessAddr := readinessListenAddr(
+				inKubernetes,
+				kuma_net.IsAddressIPv6(kumaSidecarConfiguration.Networking.Address),
+				adminAddress,
+			)
 			readinessReporter := readiness.NewReporter(
 				readinessAddr,
 				cfg.Dataplane.ReadinessPort,
-				adminSocketPath,
+				readiness.EnvoyAdmin{
+					SocketPath: adminSocketPath,
+					Address:    adminAddress,
+					Port:       adminPort,
+				},
 				dnsConfigReady)
 			components = append(components, readinessReporter)
 
@@ -472,6 +461,21 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	)
 
 	return cmd
+}
+
+func readinessListenAddr(inKubernetes bool, ipv6 bool, adminAddress string) string {
+	switch {
+	case inKubernetes && ipv6:
+		return "::"
+	case inKubernetes:
+		return "0.0.0.0"
+	case adminAddress != "":
+		return adminAddress
+	case ipv6:
+		return "::1"
+	default:
+		return "127.0.0.1"
+	}
 }
 
 func getApplicationsToScrape(kumaSidecarConfiguration *types.KumaSidecarConfiguration, envoyAdminPort uint32, envoyAdminSocketPath string) []metrics.ApplicationToScrape {

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -472,3 +472,19 @@ var _ = Describe("metricsTargetsForBackends", func() {
 		}}))
 	})
 })
+
+var _ = Describe("readinessListenAddr", func() {
+	DescribeTable("should pick the address the kubelet or the operator can reach",
+		func(inKubernetes bool, ipv6 bool, adminAddress string, expected string) {
+			Expect(readinessListenAddr(inKubernetes, ipv6, adminAddress)).To(Equal(expected))
+		},
+		Entry("kubernetes, admin on unix socket", true, false, "", "0.0.0.0"),
+		Entry("kubernetes, admin on TCP loopback", true, false, "127.0.0.1", "0.0.0.0"),
+		Entry("kubernetes, ipv6, admin on unix socket", true, true, "", "::"),
+		Entry("kubernetes, ipv6, admin on TCP loopback", true, true, "::1", "::"),
+		Entry("universal, admin on TCP loopback", false, false, "127.0.0.1", "127.0.0.1"),
+		Entry("universal, admin bound to all interfaces", false, false, "0.0.0.0", "0.0.0.0"),
+		Entry("universal, admin on unix socket", false, false, "", "127.0.0.1"),
+		Entry("universal, ipv6, admin on unix socket", false, true, "", "::1"),
+	)
+})

--- a/app/kuma-dp/pkg/dataplane/readiness/component.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -26,18 +27,35 @@ const (
 	dnsConfigGateTimeout = 15 * time.Second
 )
 
+// EnvoyAdmin locates the Envoy admin interface. SocketPath is set when admin
+// runs over a Unix domain socket, otherwise Address and Port are.
+type EnvoyAdmin struct {
+	SocketPath string
+	Address    string
+	Port       uint32
+}
+
+func (e EnvoyAdmin) configured() bool {
+	return e.SocketPath != "" || e.Port != 0
+}
+
+func (e EnvoyAdmin) readyURL() string {
+	if e.SocketPath != "" {
+		return "http://localhost/ready"
+	}
+	return "http://" + net.JoinHostPort(e.Address, strconv.Itoa(int(e.Port))) + "/ready"
+}
+
 // Reporter reports the health status of this Kuma Dataplane Proxy.
-// The listener serves only /ready. When adminSocketPath is set, /ready is
-// proxied to Envoy admin over the Unix domain socket so the pod is marked
-// ready only after Envoy has its config. No other Envoy admin endpoint is
-// exposed on this listener: the readiness port is reachable over the pod
-// network (K8s probes), so proxying admin here would expose config_dump,
-// certs, logging, etc. to any co-located or pod-network peer. Admin stays
-// on the UDS, which is not reachable over the pod network.
+// The listener serves only /ready, which is proxied to Envoy admin so the pod
+// is marked ready only after Envoy has its config. No other Envoy admin
+// endpoint is exposed on this listener: the readiness port is reachable over
+// the pod network (K8s probes), so proxying admin here would expose
+// config_dump, certs, logging, etc. to any co-located or pod-network peer.
 type Reporter struct {
 	localListenAddr string
 	localListenPort uint32
-	adminSocketPath string
+	envoyAdmin      EnvoyAdmin
 	adminClient     *http.Client
 	isTerminating   atomic.Bool
 	// dnsConfigReady, when non-nil, blocks /ready until the DNS proxy has
@@ -50,24 +68,24 @@ type Reporter struct {
 
 var logger = core.Log.WithName("readiness")
 
-func NewReporter(localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}) *Reporter {
+func NewReporter(localIPAddr string, localListenPort uint32, envoyAdmin EnvoyAdmin, dnsConfigReady <-chan struct{}) *Reporter {
 	var deadline time.Time
 	if dnsConfigReady != nil {
 		deadline = time.Now().Add(dnsConfigGateTimeout)
 	}
-	return newReporterWithDeadline(localIPAddr, localListenPort, adminSocketPath, dnsConfigReady, deadline)
+	return newReporterWithDeadline(localIPAddr, localListenPort, envoyAdmin, dnsConfigReady, deadline)
 }
 
-func newReporterWithDeadline(localIPAddr string, localListenPort uint32, adminSocketPath string, dnsConfigReady <-chan struct{}, dnsConfigDeadline time.Time) *Reporter {
+func newReporterWithDeadline(localIPAddr string, localListenPort uint32, envoyAdmin EnvoyAdmin, dnsConfigReady <-chan struct{}, dnsConfigDeadline time.Time) *Reporter {
 	r := &Reporter{
 		localListenPort:   localListenPort,
 		localListenAddr:   localIPAddr,
-		adminSocketPath:   adminSocketPath,
+		envoyAdmin:        envoyAdmin,
 		dnsConfigReady:    dnsConfigReady,
 		dnsConfigDeadline: dnsConfigDeadline,
 	}
-	if adminSocketPath != "" {
-		c := httpclient.NewUDS(adminSocketPath, 2*time.Second, 3*time.Second)
+	if envoyAdmin.configured() {
+		c := httpclient.NewTCPOrUDS(envoyAdmin.SocketPath, 2*time.Second, 3*time.Second)
 		r.adminClient = &c
 	}
 	return r
@@ -157,9 +175,9 @@ func (r *Reporter) handleReadiness(writer http.ResponseWriter, req *http.Request
 		}
 	}
 
-	// When admin is on UDS, proxy /ready to Envoy admin so that
-	// the pod is only marked ready after Envoy receives its config.
-	if r.adminSocketPath != "" {
+	// Proxy /ready to Envoy admin so that the pod is only marked ready
+	// after Envoy receives its config.
+	if r.envoyAdmin.configured() {
 		r.proxyAdminReady(writer)
 		return
 	}
@@ -182,13 +200,13 @@ func (r *Reporter) writeState(writer http.ResponseWriter, req *http.Request, sta
 }
 
 func (r *Reporter) proxyAdminReady(writer http.ResponseWriter) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost/ready", http.NoBody)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, r.envoyAdmin.readyURL(), http.NoBody)
 	if err != nil {
 		logger.Info("envoy admin not ready", "err", err)
 		http.Error(writer, "envoy not ready", http.StatusServiceUnavailable)
 		return
 	}
-	resp, err := r.adminClient.Do(req) // #nosec G704 -- constant localhost /ready URL over the fixed Envoy admin UDS client
+	resp, err := r.adminClient.Do(req) // #nosec G704 -- fixed /ready URL on the Envoy admin endpoint from bootstrap
 	if err != nil {
 		logger.Info("envoy admin not ready", "err", err)
 		http.Error(writer, "envoy not ready", http.StatusServiceUnavailable)

--- a/app/kuma-dp/pkg/dataplane/readiness/component_test.go
+++ b/app/kuma-dp/pkg/dataplane/readiness/component_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Readiness Reporter", func() {
 		Expect(lis.Close()).To(Succeed())
 
 		baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
-		reporter = readiness.NewReporter("127.0.0.1", port, adminSocketPath, nil)
+		reporter = readiness.NewReporter("127.0.0.1", port, readiness.EnvoyAdmin{SocketPath: adminSocketPath}, nil)
 		go func() {
 			defer GinkgoRecover()
 			_ = reporter.Start(stopCh)
@@ -65,7 +65,7 @@ var _ = Describe("Readiness Reporter", func() {
 
 			baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
 			dnsReady = make(chan struct{})
-			reporter = readiness.NewReporter("127.0.0.1", port, "", dnsReady)
+			reporter = readiness.NewReporter("127.0.0.1", port, readiness.EnvoyAdmin{}, dnsReady)
 			go func() {
 				defer GinkgoRecover()
 				_ = reporter.Start(stopCh)
@@ -113,7 +113,7 @@ var _ = Describe("Readiness Reporter", func() {
 
 			baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
 			dnsReady := make(chan struct{})
-			reporter = readiness.NewReporterWithDeadline("127.0.0.1", port, "", dnsReady, time.Now().Add(-time.Second))
+			reporter = readiness.NewReporterWithDeadline("127.0.0.1", port, readiness.EnvoyAdmin{}, dnsReady, time.Now().Add(-time.Second))
 			go func() {
 				defer GinkgoRecover()
 				_ = reporter.Start(stopCh)
@@ -277,7 +277,7 @@ var _ = Describe("Readiness Reporter", func() {
 			port = uint32(lis.Addr().(*net.TCPAddr).Port)
 			Expect(lis.Close()).To(Succeed())
 
-			reporter = readiness.NewReporter("::", port, "", nil)
+			reporter = readiness.NewReporter("::", port, readiness.EnvoyAdmin{}, nil)
 			go func() {
 				defer GinkgoRecover()
 				_ = reporter.Start(stopCh)
@@ -306,5 +306,84 @@ var _ = Describe("Readiness Reporter", func() {
 			defer resp.Body.Close()
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		})
+	})
+})
+
+var _ = Describe("Readiness Reporter with Envoy admin on TCP", func() {
+	var (
+		reporter  *readiness.Reporter
+		baseURL   string
+		stopCh    chan struct{}
+		adminSrv  *http.Server
+		adminCode int
+	)
+
+	BeforeEach(func() {
+		adminCode = http.StatusOK
+
+		adminLis, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		adminAddr := adminLis.Addr().(*net.TCPAddr)
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(adminCode)
+			_, _ = w.Write([]byte("LIVE"))
+		})
+		adminSrv = &http.Server{Handler: mux, ReadHeaderTimeout: time.Second}
+		go func() {
+			defer GinkgoRecover()
+			_ = adminSrv.Serve(adminLis)
+		}()
+
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		port := uint32(lis.Addr().(*net.TCPAddr).Port)
+		Expect(lis.Close()).To(Succeed())
+
+		baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+		stopCh = make(chan struct{})
+		reporter = readiness.NewReporter("127.0.0.1", port, readiness.EnvoyAdmin{
+			Address: "127.0.0.1",
+			Port:    uint32(adminAddr.Port),
+		}, nil)
+		go func() {
+			defer GinkgoRecover()
+			_ = reporter.Start(stopCh)
+		}()
+		Eventually(func() error {
+			resp, err := http.Get(baseURL + "/ready")
+			if err != nil {
+				return err
+			}
+			resp.Body.Close()
+			return nil
+		}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+		Expect(adminSrv.Close()).To(Succeed())
+	})
+
+	It("should report ready when Envoy admin is ready", func() {
+		resp, err := http.Get(baseURL + "/ready")
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(string(body)).To(Equal("LIVE"))
+	})
+
+	It("should report not ready when Envoy admin is not ready", func() {
+		adminCode = http.StatusServiceUnavailable
+
+		resp, err := http.Get(baseURL + "/ready")
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
 	})
 })

--- a/pkg/config/xds/bootstrap/config.go
+++ b/pkg/config/xds/bootstrap/config.go
@@ -82,8 +82,8 @@ func (b *BootstrapParamsConfig) Validate() error {
 	if b.AdminAccessLogPath == "" {
 		return errors.New("AdminAccessLogPath cannot be empty")
 	}
-	if b.ReadinessPort > 65535 {
-		return errors.New("ReadinessPort must be in the range [0, 65535]")
+	if b.ReadinessPort == 0 || b.ReadinessPort > 65535 {
+		return errors.New("ReadinessPort must be in the range (0, 65535]")
 	}
 	if b.XdsPort > 65535 {
 		return errors.New("XdsPort must be in the range [0, 65535]")

--- a/pkg/config/xds/bootstrap/config_test.go
+++ b/pkg/config/xds/bootstrap/config_test.go
@@ -16,10 +16,10 @@ import (
 var _ = Describe("BootstrappServerConfig", func() {
 	It("should be loadable from configuration file", func() {
 		// given
-		cfg := BootstrapServerConfig{}
+		cfg := DefaultBootstrapServerConfig()
 
 		// when
-		err := config.Load(filepath.Join("testdata", "valid-config.input.yaml"), &cfg)
+		err := config.Load(filepath.Join("testdata", "valid-config.input.yaml"), cfg)
 
 		// then
 		Expect(err).ToNot(HaveOccurred())
@@ -66,10 +66,10 @@ var _ = Describe("BootstrappServerConfig", func() {
 			}
 
 			// given
-			cfg := BootstrapServerConfig{}
+			cfg := DefaultBootstrapServerConfig()
 
 			// when
-			err := config.Load("", &cfg)
+			err := config.Load("", cfg)
 
 			// then
 			Expect(err).ToNot(HaveOccurred())
@@ -84,6 +84,25 @@ var _ = Describe("BootstrappServerConfig", func() {
 			Expect(cfg.Params.XdsGrpcMaxReceiveMessageBytes).To(Equal(uint32(33554432)))
 		})
 	})
+
+	DescribeTable("should validate the readiness port",
+		func(port uint32, valid bool) {
+			cfg := DefaultBootstrapServerConfig()
+			cfg.Params.ReadinessPort = port
+
+			err := cfg.Validate()
+
+			if valid {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err).To(MatchError(ContainSubstring("ReadinessPort must be in the range (0, 65535]")))
+			}
+		},
+		Entry("zero is rejected, the injector cannot build a probe for it", uint32(0), false),
+		Entry("above the port range is rejected", uint32(65536), false),
+		Entry("the default is accepted", uint32(9902), true),
+		Entry("a custom port is accepted", uint32(19902), true),
+	)
 
 	It("should have consistent defaults", func() {
 		// given

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -273,6 +273,10 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 			Name:  "KUMA_CONTROL_PLANE_CA_CERT",
 			Value: i.ControlPlaneCACert,
 		},
+		"KUMA_READINESS_PORT": {
+			Name:  "KUMA_READINESS_PORT",
+			Value: strconv.Itoa(int(i.DefaultReadinessPort)),
+		},
 	}
 	if i.BuiltinDNS.Enabled {
 		envVars["KUMA_DNS_ENABLED"] = kube_core.EnvVar{

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -34,7 +34,6 @@ type DataplaneProxyFactory struct {
 	ContainerConfig           runtime_k8s.DataplaneContainer
 	BuiltinDNS                runtime_k8s.BuiltinDNS
 	WaitForDataplane          bool
-	envoyAdminUnixSocket      bool
 	sidecarContainersEnabled  bool
 	applicationProbeProxyPort uint32
 	otelPipeEnabled           bool
@@ -49,7 +48,6 @@ func NewDataplaneProxyFactory(
 	containerConfig runtime_k8s.DataplaneContainer,
 	builtinDNS runtime_k8s.BuiltinDNS,
 	waitForDataplane bool,
-	envoyAdminUnixSocket bool,
 	sidecarContainersEnabled bool,
 	applicationProbeProxyPort uint32,
 	otelPipeEnabled bool,
@@ -63,7 +61,6 @@ func NewDataplaneProxyFactory(
 		ContainerConfig:           containerConfig,
 		BuiltinDNS:                builtinDNS,
 		WaitForDataplane:          waitForDataplane,
-		envoyAdminUnixSocket:      envoyAdminUnixSocket,
 		sidecarContainersEnabled:  sidecarContainersEnabled,
 		applicationProbeProxyPort: applicationProbeProxyPort,
 		otelPipeEnabled:           otelPipeEnabled,
@@ -124,21 +121,11 @@ func (i *DataplaneProxyFactory) NewContainer(
 		return kube_core.Container{}, err
 	}
 
-	adminPort, err := i.envoyAdminPort(annotations)
-	if err != nil {
+	if _, err := i.envoyAdminPort(annotations); err != nil {
 		return kube_core.Container{}, err
 	}
-	if adminPort == 0 {
-		adminPort = i.DefaultAdminPort
-	}
 
-	// When admin UDS is enabled, Envoy admin listens on a Unix socket
-	// instead of TCP. Use the dedicated readiness port for probes since
-	// K8s probes only support TCP/HTTP.
-	probePort := adminPort
-	if i.envoyAdminUnixSocket {
-		probePort = i.DefaultReadinessPort
-	}
+	probePort := i.DefaultReadinessPort
 
 	waitForDataplaneReady, _, err := metadata.Annotations(annotations).GetEnabledWithDefault(i.WaitForDataplane, metadata.KumaWaitForDataplaneReady)
 	if err != nil {

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -336,7 +336,6 @@ func addMutators(mgr kube_ctrl.Manager, rt core_runtime.Runtime, converter k8s_c
 			converter,
 			rt.Config().GetEnvoyAdminPort(),
 			rt.Config().GetEnvoyReadinessPort(),
-			rt.Config().BootstrapServer.Params.EnvoyAdminUnixSocket,
 			rt.Config().Store.Kubernetes.SystemNamespace,
 			rt.Metrics(),
 		)

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -96,7 +96,6 @@ func New(
 	converter k8s_common.Converter,
 	envoyAdminPort uint32,
 	readinessPort uint32,
-	envoyAdminUnixSocket bool,
 	systemNamespace string,
 	metrics core_metrics.Metrics,
 ) (*KumaInjector, error) {
@@ -123,11 +122,10 @@ func New(
 		converter:                converter,
 		defaultAdminPort:         envoyAdminPort,
 		defaultReadinessPort:     readinessPort,
-		envoyAdminUnixSocket:     envoyAdminUnixSocket,
 		proxyFactory: containers.NewDataplaneProxyFactory(
 			controlPlaneURL, caCert, envoyAdminPort, readinessPort,
 			cfg.SidecarContainer.DataplaneContainer,
-			cfg.BuiltinDNS, cfg.SidecarContainer.WaitForDataplaneReady, envoyAdminUnixSocket,
+			cfg.BuiltinDNS, cfg.SidecarContainer.WaitForDataplaneReady,
 			sidecarContainersEnabled,
 			cfg.ApplicationProbeProxyPort,
 			cfg.OtelPipeEnabled, cfg.Spire.Enabled,
@@ -145,7 +143,6 @@ type KumaInjector struct {
 	proxyFactory             *containers.DataplaneProxyFactory
 	defaultAdminPort         uint32
 	defaultReadinessPort     uint32
-	envoyAdminUnixSocket     bool
 	systemNamespace          string
 	metrics                  *injectionMetrics
 }
@@ -230,10 +227,10 @@ func (i *KumaInjector) injectKuma(ctx context.Context, pod *kube_core.Pod, meshN
 		return err
 	}
 
-	// When admin UDS is enabled, the readiness reporter listens on a
-	// TCP port instead of the Envoy admin port. Exclude it from
-	// inbound interception so K8s probes reach kuma-dp directly.
-	if i.envoyAdminUnixSocket && i.defaultReadinessPort != 0 {
+	// K8s probes hit the readiness reporter on the readiness port, so
+	// exclude it from inbound interception to let them reach kuma-dp
+	// directly.
+	if i.defaultReadinessPort != 0 {
 		if err := tpCfg.Redirect.Inbound.ExcludePorts.Append(fmt.Sprintf("%d", i.defaultReadinessPort)); err != nil {
 			return err
 		}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -99,6 +99,9 @@ func New(
 	systemNamespace string,
 	metrics core_metrics.Metrics,
 ) (*KumaInjector, error) {
+	if readinessPort == 0 {
+		return nil, errors.New("readinessPort has to be in (0, 65535] range")
+	}
 	var caCert string
 	if cfg.CaCertFile != "" {
 		bytes, err := os.ReadFile(cfg.CaCertFile)
@@ -230,10 +233,8 @@ func (i *KumaInjector) injectKuma(ctx context.Context, pod *kube_core.Pod, meshN
 	// K8s probes hit the readiness reporter on the readiness port, so
 	// exclude it from inbound interception to let them reach kuma-dp
 	// directly.
-	if i.defaultReadinessPort != 0 {
-		if err := tpCfg.Redirect.Inbound.ExcludePorts.Append(fmt.Sprintf("%d", i.defaultReadinessPort)); err != nil {
-			return err
-		}
+	if err := tpCfg.Redirect.Inbound.ExcludePorts.Append(fmt.Sprintf("%d", i.defaultReadinessPort)); err != nil {
+		return err
 	}
 
 	// When application probe proxying is disabled, K8s probes hit the

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -113,7 +113,7 @@ spec:
 				Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 				cfg.CaCertFile = caCertPath
 				cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, false, systemNamespace, nil)
+				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, systemNamespace, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// and create mesh
@@ -871,7 +871,6 @@ spec:
 			k8s.NewSimpleConverter("kuma-system"),
 			9901,
 			9902,
-			false,
 			systemNamespace,
 			nil,
 		)
@@ -926,7 +925,7 @@ metadata:
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
 			cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, false, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1033,7 +1032,7 @@ metadata:
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
 			cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, false, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1120,7 +1119,6 @@ metadata:
 				k8s.NewSimpleConverter("kuma-system"),
 				9901,
 				9902,
-				false,
 				systemNamespace,
 				nil,
 			)

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -148,7 +149,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -158,7 +159,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -185,7 +186,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -126,6 +126,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -228,7 +229,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -238,7 +239,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -265,7 +266,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -206,6 +206,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -144,7 +145,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -154,7 +155,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -181,7 +182,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -122,6 +122,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -19,6 +19,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: false
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -146,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -156,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -183,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -128,6 +128,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -23,6 +23,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -150,7 +151,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -160,7 +161,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -187,7 +188,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -148,7 +149,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -158,7 +159,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -185,7 +186,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -126,6 +126,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -159,7 +160,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -169,7 +170,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -196,7 +197,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -137,6 +137,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 19000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -159,7 +160,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -169,7 +170,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -196,7 +197,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -137,6 +137,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -138,6 +138,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -19,6 +19,7 @@ metadata:
         inbound:
           enabled: true
           excludePorts:
+          - 9902
           - 3001
           - 8080
           port: 15006
@@ -160,7 +161,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -170,7 +171,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -197,7 +198,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -131,6 +131,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -24,6 +24,7 @@ metadata:
           - 1234
           - 1235
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -153,7 +154,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -163,7 +164,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -190,7 +191,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -129,6 +129,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           excludePorts:
           - 1234
           - 5678
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -151,7 +152,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -161,7 +162,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -187,7 +188,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -131,6 +131,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -23,6 +23,7 @@ metadata:
           excludePorts:
           - 1234
           - 5678
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -153,7 +154,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -163,7 +164,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -189,7 +190,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -144,6 +144,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -19,6 +19,7 @@ metadata:
         inbound:
           enabled: true
           excludePorts:
+          - 9902
           - 3001
           - 8080
           port: 15006
@@ -166,7 +167,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -176,7 +177,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -202,7 +203,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -145,6 +145,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -19,6 +19,7 @@ metadata:
         inbound:
           enabled: true
           excludePorts:
+          - 9902
           - 3001
           - 8080
           - 8081
@@ -167,7 +168,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -177,7 +178,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -203,7 +204,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -172,7 +173,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -182,7 +183,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -209,7 +210,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -150,6 +150,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -126,6 +126,8 @@ spec:
       value: /some/other/path
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: NEW_ENV_VAR
       value: "123"
     - name: POD_NAME

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -20,6 +20,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -151,7 +153,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -161,7 +163,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -187,7 +189,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -20,6 +20,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -151,7 +153,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -161,7 +163,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -187,7 +189,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -128,6 +128,8 @@ spec:
       value: "true"
     - name: KUMA_DNS_PROXY_PORT
       value: "25053"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: NEW_ENV_VAR
       value: "123"
     - name: POD_NAME

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -21,6 +21,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -152,7 +154,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -162,7 +164,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -188,7 +190,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -129,6 +129,8 @@ spec:
       value: "true"
     - name: KUMA_DNS_PROXY_PORT
       value: "25053"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: NEW_ENV_VAR
       value: "123"
     - name: POD_NAME

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -20,6 +20,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -151,7 +153,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -161,7 +163,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -187,7 +189,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -128,6 +128,8 @@ spec:
       value: "true"
     - name: KUMA_DNS_PROXY_PORT
       value: "25053"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: NEW_ENV_VAR
       value: "123"
     - name: POD_NAME

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -145,7 +146,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -155,7 +156,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -182,7 +183,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -123,6 +123,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -122,6 +122,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -144,7 +145,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -154,7 +155,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -181,7 +182,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -23,6 +23,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -185,7 +186,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -18,6 +18,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -143,7 +145,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -153,7 +155,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -179,7 +181,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -122,6 +122,8 @@ spec:
       value: "true"
     - name: KUMA_DNS_PROXY_PORT
       value: "25053"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -145,7 +146,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -155,7 +156,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -182,7 +183,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -123,6 +123,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
@@ -122,6 +122,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -144,7 +145,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -154,7 +155,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -181,7 +182,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
@@ -19,6 +19,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -146,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -156,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -182,7 +184,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
@@ -124,6 +124,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
@@ -22,6 +22,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: true
+          excludePorts:
+          - 9902
           port: 15055
         outbound:
           enabled: true
@@ -145,7 +147,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -155,7 +157,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -181,7 +183,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
@@ -125,6 +125,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -147,7 +148,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -157,7 +158,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -184,7 +185,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
@@ -22,6 +22,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -149,7 +150,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -159,7 +160,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -186,7 +187,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
@@ -127,6 +127,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
@@ -24,6 +24,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -151,7 +152,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -161,7 +162,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -188,7 +189,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
@@ -129,6 +129,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
@@ -131,6 +131,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -153,7 +154,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -163,7 +164,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -190,7 +191,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
@@ -131,6 +131,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
@@ -21,6 +21,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           excludePortsForIPs:
           - 192.168.0.1
           - 172.32.16.8/16
@@ -153,7 +154,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -163,7 +164,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -190,7 +191,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -168,7 +169,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -178,7 +179,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -204,7 +205,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
@@ -146,6 +146,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
@@ -93,6 +93,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
@@ -21,6 +21,8 @@ metadata:
           skipConntrackZoneSplit: false
         inbound:
           enabled: false
+          excludePorts:
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -114,7 +116,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -124,7 +126,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -150,7 +152,7 @@ spec:
     startupProbe:
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       successThreshold: 1
     volumeMounts:
     - mountPath: /tmp

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.43.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.43.golden.yaml
@@ -20,6 +20,7 @@ metadata:
           enabled: true
           excludePorts:
           - 9000
+          - 9902
           port: 15006
         outbound:
           enabled: true
@@ -149,7 +150,7 @@ spec:
       failureThreshold: 212
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 260
       periodSeconds: 25
       successThreshold: 1
@@ -159,7 +160,7 @@ spec:
       failureThreshold: 112
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 11
       periodSeconds: 15
       successThreshold: 11
@@ -186,7 +187,7 @@ spec:
       failureThreshold: 213
       httpGet:
         path: /ready
-        port: 9901
+        port: 9902
       initialDelaySeconds: 261
       periodSeconds: 26
       successThreshold: 1

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.43.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.43.golden.yaml
@@ -127,6 +127,8 @@ spec:
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED
       value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
     - name: POD_NAME
       valueFrom:
         fieldRef:


### PR DESCRIPTION
## Motivation

The injected `kuma-sidecar` probed the Envoy admin port (`9901`) when admin ran over TCP, and the kuma-dp readiness port (`9902`) when `experimental.envoyAdminUnixSocket` moved it to a socket. Those two are decided in different places: the probe port is written into the Pod by the injecting webhook at admission, the admin transport is chosen at bootstrap by whichever control plane instance answers. A rolling control plane upgrade, or a change to the flag, leaves a window where they disagree, and every pod created in it goes into `CrashLoopBackOff`:

```
[Envoy]   Starting admin HTTP server at 127.0.0.1:9901
[kuma-dp] received bootstrap configuration  {"adminPort": 9901}
[kuma-dp] starting readiness reporter       {"addr": "127.0.0.1:9902"}
[kubelet] Startup probe failed: Get "http://10.42.0.20:9902/ready": connect: connection refused
[kubelet] Init container kuma-sidecar failed startup probe
```

The sidecar is a native init container, so the application container never starts and the rollout stalls rather than degrading.

#18341 fixed the loopback bind on `release-2.14` as a minimal patch. This removes the split that caused it, which is the part that does not belong on a release branch.

> Changelog: fix(k8s): always probe the sidecar readiness port

## Implementation information

- Probes always use the readiness port, whatever the admin transport, and that port is always excluded from inbound transparent proxy interception. Previously the exclusion was gated on the same flag as the probe port, so decoupling one without the other would have left probes intercepted.
- `/ready` on the readiness port is proxied to Envoy admin over TCP as well as over the socket, so it means the same thing either way. On the TCP path probes previously reached Envoy through the `kuma:envoy:admin` listener, so what a probe asserts does not change.
- The readiness listener no longer inherits Envoy's admin address. That is what bound it to loopback whenever admin ran over TCP; on Kubernetes it now always binds the wildcard, and Universal still follows the configured admin address.
- `envoyAdminUnixSocket` is no longer threaded into the injector or the container factory. The flag still controls the admin transport itself.
- One deliberate oddity: `NewContainer` keeps a parse-and-discard call to `envoyAdminPort` purely to preserve the validation error on a malformed `kuma.io/envoy-admin-port`. `ConfigToAnnotations` validates its own derived map rather than the raw Pod annotation, so dropping the call looked like it could change error behaviour. Happy to remove it if that reading is wrong.

## Supporting documentation

Reproduced on a two-node k3d cluster upgrading 2.13.3 to 2.14.3, on both an injected application sidecar and the zone egress. A/B of two pods built from the same manifest as a failing pod, differing only in the `kuma-dp` binary:

| build | readiness bind | result |
| --- | --- | --- |
| stock | `127.0.0.1:9902` | `Init:1/2`, startup probe refused, restarts climbing |
| patched | `[::]:9902` | `2/2 Running`, no restarts, no probe failures |

Upgrade path checked on a live cluster: probing a running pod from its node, both `podIP:9901/ready` and `podIP:9902/ready` answer `READY`, so pods injected before the upgrade keep working on their existing probes until they are recreated.

Unit coverage: a table for the bind-address choice, and two specs driving the readiness port against a fake Envoy admin on TCP for the ready and not-ready cases. Both were confirmed to fail against the pre-change behaviour. 41 injector golden files move to the readiness port and gain the inbound exclusion.

UPGRADE.md carries an entry for the `9901` to `9902` move.

https://claude.ai/code/session_01CtWcEP1Agz6ahE4y1p85m7