### PR TITLE
feat(api-server): add clusters to layout listeners

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -173,7 +173,7 @@ components:
           type: string
     DataplaneListener:
       type: object
-      required: [ kri, type, port, proxyResourceName ]
+      required: [ kri, type, port, proxyResourceName, clusters ]
       properties:
         kri:
           type: string
@@ -183,6 +183,24 @@ components:
         port:
           type: integer
           x-go-type: 'int32'
+        proxyResourceName:
+          type: string
+        clusters:
+          description: The destinations this listener proxies traffic to, one entry per destination port.
+          type: array
+          items:
+            $ref: '#/components/schemas/DataplaneListenerCluster'
+    DataplaneListenerCluster:
+      type: object
+      required: [ kri, port, protocol, proxyResourceName ]
+      properties:
+        kri:
+          type: string
+        port:
+          type: integer
+          x-go-type: 'int32'
+        protocol:
+          type: string
         proxyResourceName:
           type: string
     DataplaneOutbound:

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -53,14 +53,24 @@ type DataplaneInbound struct {
 
 // DataplaneListener defines model for DataplaneListener.
 type DataplaneListener struct {
-	Kri               string                `json:"kri"`
-	Port              int32                 `json:"port"`
-	ProxyResourceName string                `json:"proxyResourceName"`
-	Type              DataplaneListenerType `json:"type"`
+	// Clusters The destinations this listener proxies traffic to, one entry per destination port.
+	Clusters          []DataplaneListenerCluster `json:"clusters"`
+	Kri               string                     `json:"kri"`
+	Port              int32                      `json:"port"`
+	ProxyResourceName string                     `json:"proxyResourceName"`
+	Type              DataplaneListenerType      `json:"type"`
 }
 
 // DataplaneListenerType defines model for DataplaneListener.Type.
 type DataplaneListenerType string
+
+// DataplaneListenerCluster defines model for DataplaneListenerCluster.
+type DataplaneListenerCluster struct {
+	Kri               string `json:"kri"`
+	Port              int32  `json:"port"`
+	Protocol          string `json:"protocol"`
+	ProxyResourceName string `json:"proxyResourceName"`
+}
 
 // DataplaneOutbound defines model for DataplaneOutbound.
 type DataplaneOutbound struct {

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4801,6 +4801,23 @@ components:
           type: string
         proxyResourceName:
           type: string
+    DataplaneListenerCluster:
+      type: object
+      required:
+        - kri
+        - port
+        - protocol
+        - proxyResourceName
+      properties:
+        kri:
+          type: string
+        port:
+          type: integer
+          x-go-type: int32
+        protocol:
+          type: string
+        proxyResourceName:
+          type: string
     DataplaneListener:
       type: object
       required:
@@ -4808,6 +4825,7 @@ components:
         - type
         - port
         - proxyResourceName
+        - clusters
       properties:
         kri:
           type: string
@@ -4821,6 +4839,13 @@ components:
           x-go-type: int32
         proxyResourceName:
           type: string
+        clusters:
+          description: >-
+            The destinations this listener proxies traffic to, one entry per
+            destination port.
+          type: array
+          items:
+            $ref: '#/components/schemas/DataplaneListenerCluster'
     PolicyOrigin:
       type: object
       required:

--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	"github.com/kumahq/kuma/v3/pkg/core/naming"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/access"
+	core_resources "github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	meshidentity_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshidentity/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -23,6 +24,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/user"
 	util_slices "github.com/kumahq/kuma/v3/pkg/util/slices"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
+	"github.com/kumahq/kuma/v3/pkg/xds/generator/zoneproxy"
 )
 
 type dataplaneLayoutEndpoint struct {
@@ -94,18 +96,22 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 		}
 	})
 
+	meshResources := baseMeshContext.Resources()
 	listeners := []api_common.DataplaneListener{}
 	for _, listener := range dataplane.Spec.GetNetworking().GetListeners() {
 		sectionName := listener.GetSectionName()
 		var listenerType api_common.DataplaneListenerType
 		var proxyResourceName string
+		var clusters []api_common.DataplaneListenerCluster
 		switch listener.GetType() {
 		case v1alpha1.Dataplane_Networking_Listener_ZoneIngress:
 			listenerType = api_common.ZoneIngress
 			proxyResourceName = naming.ContextualZoneIngressListenerName(sectionName)
+			clusters = clustersForDestinations(zoneproxy.IngressDestinations(meshResources), allPorts)
 		case v1alpha1.Dataplane_Networking_Listener_ZoneEgress:
 			listenerType = api_common.ZoneEgress
 			proxyResourceName = naming.ContextualZoneEgressListenerName(sectionName)
+			clusters = clustersForDestinations(zoneproxy.EgressDestinations(meshResources), firstPort)
 		default:
 			continue
 		}
@@ -114,6 +120,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 			Type:              listenerType,
 			Port:              int32(listener.GetPort()),
 			ProxyResourceName: proxyResourceName,
+			Clusters:          clusters,
 		})
 	}
 
@@ -145,6 +152,45 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 	if err != nil {
 		log.Error(err, "Could not write response")
 	}
+}
+
+func allPorts(destination core_resources.Destination) []core_resources.Port {
+	return destination.GetPorts()
+}
+
+// firstPort matches the egress generator, which builds a single filter chain
+// per MeshExternalService off its first port.
+func firstPort(destination core_resources.Destination) []core_resources.Port {
+	if ports := destination.GetPorts(); len(ports) > 0 {
+		return ports[:1]
+	}
+	return nil
+}
+
+// clustersForDestinations reports the clusters a zone proxy listener serves.
+// Like the outbounds above it describes what is configured, so a destination
+// with no endpoints yet is still listed.
+func clustersForDestinations(
+	destinations []core_resources.Destination,
+	ports func(core_resources.Destination) []core_resources.Port,
+) []api_common.DataplaneListenerCluster {
+	clusters := []api_common.DataplaneListenerCluster{}
+	for _, destination := range destinations {
+		origin := kri.From(destination)
+		for _, port := range ports(destination) {
+			id := kri.WithSectionName(origin, port.GetName()).String()
+			clusters = append(clusters, api_common.DataplaneListenerCluster{
+				Kri:               id,
+				Port:              port.GetValue(),
+				Protocol:          string(port.GetProtocol()),
+				ProxyResourceName: id,
+			})
+		}
+	}
+	slices.SortStableFunc(clusters, func(a, b api_common.DataplaneListenerCluster) int {
+		return strings.Compare(a.Kri, b.Kri)
+	})
+	return clusters
 }
 
 func (dle *dataplaneLayoutEndpoint) computeSpiffeID(request *restful.Request, meshName string, dataplane *core_mesh.DataplaneResource) *string {

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/zone_proxy_listeners.golden.json
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/zone_proxy_listeners.golden.json
@@ -6,17 +6,76 @@
  },
  "listeners": [
   {
+   "clusters": [
+    {
+     "kri": "kri_msvc_default_test-zone__local-server_main-port",
+     "port": 80,
+     "protocol": "http",
+     "proxyResourceName": "kri_msvc_default_test-zone__local-server_main-port"
+    },
+    {
+     "kri": "kri_msvc_default_test-zone__local-server_secondary-port",
+     "port": 8080,
+     "protocol": "tcp",
+     "proxyResourceName": "kri_msvc_default_test-zone__local-server_secondary-port"
+    },
+    {
+     "kri": "kri_mzsvc_default___multizone-server_80",
+     "port": 80,
+     "protocol": "http",
+     "proxyResourceName": "kri_mzsvc_default___multizone-server_80"
+    }
+   ],
    "kri": "kri_dp_default_test-zone__dp-zone-proxy_zi-main",
    "port": 10001,
    "proxyResourceName": "self_zoneingress_dp_zi-main",
    "type": "ZoneIngress"
   },
   {
+   "clusters": [
+    {
+     "kri": "kri_extsvc_default___mes-1_9090",
+     "port": 9090,
+     "protocol": "http",
+     "proxyResourceName": "kri_extsvc_default___mes-1_9090"
+    }
+   ],
    "kri": "kri_dp_default_test-zone__dp-zone-proxy_10002",
    "port": 10002,
    "proxyResourceName": "self_zoneegress_dp_10002",
    "type": "ZoneEgress"
   }
  ],
- "outbounds": []
+ "outbounds": [
+  {
+   "kri": "kri_extsvc_default___mes-1_9090",
+   "port": 9090,
+   "protocol": "http",
+   "proxyResourceName": "kri_extsvc_default___mes-1_9090"
+  },
+  {
+   "kri": "kri_msvc_default_other-zone__remote-server_main-port",
+   "port": 80,
+   "protocol": "http",
+   "proxyResourceName": "kri_msvc_default_other-zone__remote-server_main-port"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__local-server_main-port",
+   "port": 80,
+   "protocol": "http",
+   "proxyResourceName": "kri_msvc_default_test-zone__local-server_main-port"
+  },
+  {
+   "kri": "kri_msvc_default_test-zone__local-server_secondary-port",
+   "port": 8080,
+   "protocol": "tcp",
+   "proxyResourceName": "kri_msvc_default_test-zone__local-server_secondary-port"
+  },
+  {
+   "kri": "kri_mzsvc_default___multizone-server_80",
+   "port": 80,
+   "protocol": "http",
+   "proxyResourceName": "kri_mzsvc_default___multizone-server_80"
+  }
+ ]
 }

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/zone_proxy_listeners.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/zone_proxy_listeners.input.yaml
@@ -17,3 +17,65 @@ networking:
     - address: 127.0.0.1
       port: 10002
       type: ZoneEgress
+---
+type: MeshService
+name: local-server
+mesh: default
+labels:
+  kuma.io/display-name: local-server
+  kuma.io/origin: zone
+  kuma.io/zone: test-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: local-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+    - port: 8080
+      targetPort: 8080
+      appProtocol: tcp
+      name: secondary-port
+---
+type: MeshService
+name: remote-server
+mesh: default
+labels:
+  kuma.io/display-name: remote-server
+  kuma.io/origin: global
+  kuma.io/zone: other-zone
+spec:
+  selector:
+    dataplaneTags:
+      kuma.io/service: remote-server
+  ports:
+    - port: 80
+      targetPort: 80
+      appProtocol: http
+      name: main-port
+---
+type: MeshMultiZoneService
+name: multizone-server
+mesh: default
+spec:
+  selector:
+    meshService:
+      matchLabels:
+        kuma.io/display-name: local-server
+  ports:
+    - port: 80
+      appProtocol: http
+---
+type: MeshExternalService
+name: mes-1
+mesh: default
+spec:
+  match:
+    type: HostnameGenerator
+    port: 9090
+    protocol: http
+  endpoints:
+    - address: 127.0.0.1
+      port: 8080

--- a/pkg/xds/generator/zone_proxy_listener_generator.go
+++ b/pkg/xds/generator/zone_proxy_listener_generator.go
@@ -11,7 +11,6 @@ import (
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
 	"github.com/kumahq/kuma/v3/pkg/core/naming"
 	core_resources "github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
-	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_sni "github.com/kumahq/kuma/v3/pkg/core/resources/sni"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
@@ -21,7 +20,6 @@ import (
 	plugins_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
 	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/xds"
-	util_slices "github.com/kumahq/kuma/v3/pkg/util/slices"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
 	envoy_clusters "github.com/kumahq/kuma/v3/pkg/xds/envoy/clusters"
@@ -72,7 +70,7 @@ func (g ZoneProxyListenerGenerator) Generate(
 			generated, err := g.generateEgressListener(
 				proxy,
 				l,
-				localResources.MeshExternalServices().GetDestinations(),
+				zoneproxy.EgressDestinations(localResources),
 				xdsCtx.Mesh.DataplaneZoneEgressEndpointMap,
 			)
 			if err != nil {
@@ -104,23 +102,7 @@ func (g ZoneProxyListenerGenerator) generateIngressListener(
 
 	meshResources := xds_context.Resources{MeshLocalResources: xdsCtx.Mesh.Resources.MeshLocalResources}
 
-	// Only expose services local to this zone.
-	localMS := &meshservice_api.MeshServiceResourceList{}
-	for _, ms := range meshResources.MeshServices().GetItems() {
-		if !ms.(*meshservice_api.MeshServiceResource).IsLocalMeshService() {
-			continue
-		}
-		if err := localMS.AddItem(ms); err != nil {
-			return nil, err
-		}
-	}
-
-	backendRefs := zoneproxy.BuildRealResourceDestinations(
-		util_slices.FlatMap(
-			[]core_resources.DestinationList{localMS, meshResources.MeshMultiZoneServices()},
-			core_resources.DestinationList.GetDestinations,
-		),
-	)
+	backendRefs := zoneproxy.BuildRealResourceDestinations(zoneproxy.IngressDestinations(meshResources))
 	dest := zoneproxy.MeshDestinations{BackendRefs: backendRefs}
 
 	services := zoneproxy.GetServices(dest)

--- a/pkg/xds/generator/zoneproxy/destinations.go
+++ b/pkg/xds/generator/zoneproxy/destinations.go
@@ -4,8 +4,10 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_resources "github.com/kumahq/kuma/v3/pkg/core/resources/apis/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core/destinationname"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	core_sni "github.com/kumahq/kuma/v3/pkg/core/resources/sni"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
+	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 )
 
 type MeshDestinations struct {
@@ -40,4 +42,21 @@ func BuildRealResourceDestinations(destinations []core_resources.Destination) []
 		}
 	}
 	return result
+}
+
+// IngressDestinations returns the destinations a zone ingress listener exposes:
+// mesh services local to this zone, plus every MeshMultiZoneService.
+func IngressDestinations(resources xds_context.Resources) []core_resources.Destination {
+	var destinations []core_resources.Destination
+	for _, ms := range resources.MeshServices().GetItems() {
+		if ms.(*meshservice_api.MeshServiceResource).IsLocalMeshService() {
+			destinations = append(destinations, ms.(core_resources.Destination))
+		}
+	}
+	return append(destinations, resources.MeshMultiZoneServices().GetDestinations()...)
+}
+
+// EgressDestinations returns the destinations a zone egress listener proxies to.
+func EgressDestinations(resources xds_context.Resources) []core_resources.Destination {
+	return resources.MeshExternalServices().GetDestinations()
 }


### PR DESCRIPTION
## Motivation

Closes #16692.

With mesh-scoped zone proxies, `_layout` reports a `listeners` array, but each entry only carries a contextual `proxyResourceName` (`self_zoneingress_dp_<section>`). The relation from listener to service is one-to-many, so the GUI has no way to work out which services sit behind a listener — which means no per-service traffic stats and no clusters.

> Changelog: feat(api-server): add clusters to layout listeners

## Implementation information

Each `DataplaneListener` now carries a `clusters` array of `{kri, port, protocol, proxyResourceName}`, the same shape `DataplaneOutbound` already uses. On zone proxies the Envoy cluster name *is* the KRI string, so `proxyResourceName` matches `kri` and can be used directly to look up stats.

To keep the endpoint honest, the destination selection is now shared with `ZoneProxyListenerGenerator` rather than reimplemented:

- `zoneproxy.IngressDestinations` — mesh services local to this zone, plus every MeshMultiZoneService, one cluster per port.
- `zoneproxy.EgressDestinations` — MeshExternalServices, first port only, matching the single filter chain per service the egress generator builds.

The generator now calls both, so the endpoint cannot drift from what is actually programmed. The xDS goldens are unchanged, which is the proof that extraction was behaviour-preserving.

One deliberate difference: the generator additionally drops destinations with no endpoints (it consults `DataplaneZoneEgressEndpointMap`, which only hangs off the full `MeshContext`). This endpoint reports what is *configured* and stays on the cached `BaseMeshContext`, so a destination with no endpoints yet is still listed. That matches how `outbounds` on this same endpoint already behave, and avoids making a GUI-polled endpoint pay for a full mesh context build.

## Supporting documentation

The existing `zone_proxy_listeners` fixture had no services at all, so both listeners produced empty sets. It now carries a local MeshService with two ports, a MeshService from another zone, a MeshMultiZoneService and a MeshExternalService. The golden shows the ingress listener picking up the local service (both ports) and the multi-zone service, the remote-zone service correctly excluded, and the egress listener picking up the external service.

https://claude.ai/code/session_01LC2YPrLoawcS7afNbsn2sd