### PR TITLE
docs(oas): document computed labels on resources

### DIFF
--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -74,16 +74,62 @@ components:
           type: object
           additionalProperties:
             type: string
+          patternProperties:
+            # Always computed by the control plane. A value supplied by the user is overwritten.
+            '^kuma\.io/display-name$':
+              type: string
+              readOnly: true
+              description: Display name of the resource. Always computed by the control plane.
+            '^kuma\.io/origin$':
+              type: string
+              readOnly: true
+              description: Whether the resource originated on a zone or on global. Always computed by the control plane, and immutable.
+            '^k8s\.kuma\.io/namespace$':
+              type: string
+              readOnly: true
+              description: Namespace the object lives in. Always computed by the control plane on Kubernetes.
+            '^kuma\.io/policy-role$':
+              type: string
+              readOnly: true
+              description: Role driving namespaced policy matching. Always computed by the control plane for namespaced policies on Kubernetes.
+            '^k8s\.kuma\.io/service-account$':
+              type: string
+              readOnly: true
+              description: Service account of the workload. Always computed by the control plane on Kubernetes.
+            '^kuma\.io/workload$':
+              type: string
+              readOnly: true
+              description: Workload the resource belongs to. Always computed by the control plane.
+            '^kuma\.io/listener-zoneingress$':
+              type: string
+              readOnly: true
+              description: Set to `enabled` when the proxy has a zone ingress listener. Always computed by the control plane.
+            '^kuma\.io/listener-zoneegress$':
+              type: string
+              readOnly: true
+              description: Set to `enabled` when the proxy has a zone egress listener. Always computed by the control plane.
+            # Can be set by the user. The control plane only fills in a default when the label is absent.
+            '^kuma\.io/mesh$':
+              type: string
+              description: Mesh the resource belongs to. Defaults to `default` when unset.
+            '^kuma\.io/zone$':
+              type: string
+              description: Zone the resource originated in. Defaults to the name of the zone it was applied on when unset, and is immutable afterwards.
+            '^kuma\.io/env$':
+              type: string
+              description: Environment the resource was applied in. Defaults to `universal` or `kubernetes` when unset.
           example:
             "k8s.kuma.io/namespace": "kuma-system"
             "kuma.io/display-name": "mtp"
             "kuma.io/mesh": "default"
             "kuma.io/origin": "zone"
           description: |
-            Labels of the resource. Note: certain system labels are immutable after creation:
-            - `kuma.io/origin`: Resource origin (zone/global). Immutable.
-            - `kuma.io/zone`: Zone where resource originated. Immutable.
-            - `kuma.io/display-name`: Display name for the resource. Immutable.
+            Labels of the resource.
+
+            Labels documented as `readOnly` are always computed by the control plane; a value supplied by the
+            user is overwritten. The remaining documented labels can be set by the user, and the control plane
+            only fills in a default when they are absent. `kuma.io/origin` and `kuma.io/zone` are immutable
+            after creation.
     InspectRule:
       type: object
       required: [type]

--- a/api/openapi/types/common/zz_generated.resource.go
+++ b/api/openapi/types/common/zz_generated.resource.go
@@ -157,10 +157,12 @@ type Meta struct {
 	// Example: kri_mtp_default_zone-east_kuma-demo_mypolicy1_
 	KRI *string `json:"kri,omitempty"`
 
-	// Labels Labels of the resource. Note: certain system labels are immutable after creation:
-	// - `kuma.io/origin`: Resource origin (zone/global). Immutable.
-	// - `kuma.io/zone`: Zone where resource originated. Immutable.
-	// - `kuma.io/display-name`: Display name for the resource. Immutable.
+	// Labels Labels of the resource.
+	//
+	// Labels documented as `readOnly` are always computed by the control plane; a value supplied by the
+	// user is overwritten. The remaining documented labels can be set by the user, and the control plane
+	// only fills in a default when they are absent. `kuma.io/origin` and `kuma.io/zone` are immutable
+	// after creation.
 	//
 	//
 	// Example: {"k8s.kuma.io/namespace":"kuma-system","kuma.io/display-name":"mtp","kuma.io/mesh":"default","kuma.io/origin":"zone"}

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -4572,20 +4572,87 @@ components:
           type: object
           additionalProperties:
             type: string
+          patternProperties:
+            ^kuma\.io/display-name$:
+              type: string
+              readOnly: true
+              description: >-
+                Display name of the resource. Always computed by the control
+                plane.
+            ^kuma\.io/origin$:
+              type: string
+              readOnly: true
+              description: >-
+                Whether the resource originated on a zone or on global. Always
+                computed by the control plane, and immutable.
+            ^k8s\.kuma\.io/namespace$:
+              type: string
+              readOnly: true
+              description: >-
+                Namespace the object lives in. Always computed by the control
+                plane on Kubernetes.
+            ^kuma\.io/policy-role$:
+              type: string
+              readOnly: true
+              description: >-
+                Role driving namespaced policy matching. Always computed by the
+                control plane for namespaced policies on Kubernetes.
+            ^k8s\.kuma\.io/service-account$:
+              type: string
+              readOnly: true
+              description: >-
+                Service account of the workload. Always computed by the control
+                plane on Kubernetes.
+            ^kuma\.io/workload$:
+              type: string
+              readOnly: true
+              description: >-
+                Workload the resource belongs to. Always computed by the control
+                plane.
+            ^kuma\.io/listener-zoneingress$:
+              type: string
+              readOnly: true
+              description: >-
+                Set to `enabled` when the proxy has a zone ingress listener.
+                Always computed by the control plane.
+            ^kuma\.io/listener-zoneegress$:
+              type: string
+              readOnly: true
+              description: >-
+                Set to `enabled` when the proxy has a zone egress listener.
+                Always computed by the control plane.
+            ^kuma\.io/mesh$:
+              type: string
+              description: Mesh the resource belongs to. Defaults to `default` when unset.
+            ^kuma\.io/zone$:
+              type: string
+              description: >-
+                Zone the resource originated in. Defaults to the name of the
+                zone it was applied on when unset, and is immutable afterwards.
+            ^kuma\.io/env$:
+              type: string
+              description: >-
+                Environment the resource was applied in. Defaults to `universal`
+                or `kubernetes` when unset.
           example:
             k8s.kuma.io/namespace: kuma-system
             kuma.io/display-name: mtp
             kuma.io/mesh: default
             kuma.io/origin: zone
           description: >
-            Labels of the resource. Note: certain system labels are immutable
-            after creation:
+            Labels of the resource.
 
-            - `kuma.io/origin`: Resource origin (zone/global). Immutable.
 
-            - `kuma.io/zone`: Zone where resource originated. Immutable.
+            Labels documented as `readOnly` are always computed by the control
+            plane; a value supplied by the
 
-            - `kuma.io/display-name`: Display name for the resource. Immutable.
+            user is overwritten. The remaining documented labels can be set by
+            the user, and the control plane
+
+            only fills in a default when they are absent. `kuma.io/origin` and
+            `kuma.io/zone` are immutable
+
+            after creation.
     ProxyRule:
       description: a rule that affects the entire proxy
       type: object

--- a/pkg/core/resources/labels/registry_test.go
+++ b/pkg/core/resources/labels/registry_test.go
@@ -1,0 +1,52 @@
+package labels_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kumahq/kuma/v3/pkg/core/resources/labels"
+)
+
+var _ = Describe("AllComputedLabels", func() {
+	// The OpenAPI spec documents every computed label under Meta.labels. Nothing
+	// forces the two to agree, so they drift silently as labels come and go.
+	It("should match the labels documented in the OpenAPI spec", func() {
+		specPath := filepath.Join("..", "..", "..", "..", "api", "openapi", "specs", "common", "resource.yaml")
+		raw, err := os.ReadFile(specPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		spec := struct {
+			Components struct {
+				Schemas struct {
+					Meta struct {
+						Properties struct {
+							Labels struct {
+								PatternProperties map[string]any `json:"patternProperties"`
+							} `json:"labels"`
+						} `json:"properties"`
+					} `json:"Meta"`
+				} `json:"schemas"`
+			} `json:"components"`
+		}{}
+		Expect(yaml.Unmarshal(raw, &spec)).To(Succeed())
+
+		var documented []string
+		for pattern := range spec.Components.Schemas.Meta.Properties.Labels.PatternProperties {
+			// patterns are anchored exact matches, e.g. `^kuma\.io/zone$`
+			label := strings.NewReplacer("^", "", "$", "", `\.`, ".").Replace(pattern)
+			documented = append(documented, label)
+		}
+
+		var computed []string
+		for label := range labels.AllComputedLabels {
+			computed = append(computed, label)
+		}
+
+		Expect(documented).To(ConsistOf(computed))
+	})
+})


### PR DESCRIPTION
## Motivation

Closes #14878.

Which labels the control plane computes, and which of those a user may still set, lives only in `pkg/core/resources/labels`. Consumers of the OpenAPI spec have no way to tell `kuma.io/zone` apart from any other label, so the information gets rediscovered by hand or copied into other projects and goes stale.

> Changelog: docs(oas): document computed labels on resources

## Implementation information

The description sketched `properties` alongside `additionalProperties` and asked that downstream code generation be verified. I measured both options ([details on the issue](https://github.com/kumahq/kuma/issues/14878#issuecomment-5524177657)) and this PR takes the `patternProperties` route instead:

- `Labels` stays `map[string]string` — nothing downstream has to be regenerated.
- `make docs` bundles it and `make validate/openapi-generated-docs` passes.

`properties` was rejected because it does not just cost a migration. `oapi-codegen` promotes each documented label to a typed field and drops it from `AdditionalProperties`, so `Labels.Get("kuma.io/zone")` starts returning `found=false`. Every label documented is one more that silently disappears from map-style access — the failure gets worse the more of the list we cover.

The honest caveat: tooling that does not implement `patternProperties` will ignore the block rather than act on it, so `readOnly` there documents intent rather than being enforced by a generator. I verified our Go generation and the docs pipeline; I have not verified the TypeScript or Terraform generators.

## The documented set

Taken from `labels.AllComputedLabels` and `labels.Compute` rather than from the description, which has gone stale:

- `kuma.io/proxy-type` is **not** computed any more — `Compute` deletes it and replaced it with `kuma.io/listener-zoneingress` / `kuma.io/listener-zoneegress`. Documenting it would have been wrong.
- The description was also missing `kuma.io/display-name`, `kuma.io/workload` and those two listener labels.

Always computed, marked `readOnly` (`set` in `Compute`, so a user value is overwritten): `kuma.io/display-name`, `kuma.io/origin`, `k8s.kuma.io/namespace`, `kuma.io/policy-role`, `k8s.kuma.io/service-account`, `kuma.io/workload`, `kuma.io/listener-zoneingress`, `kuma.io/listener-zoneegress`.

Defaulted only when absent (`setIfNotExist`): `kuma.io/mesh`, `kuma.io/zone`, `kuma.io/env`.

On `kuma.io/env` the description wondered whether it belongs in the first category. It is `setIfNotExist` today, so it is documented as user-settable. Moving it is a behaviour change and belongs in its own issue.

## Supporting documentation

`pkg/core/resources/labels/registry_test.go` asserts the documented patterns match `AllComputedLabels` exactly. Drift is precisely how the list in the description rotted, and `AllComputedLabels` already has to be kept in sync with a downstream project, so it is worth a guard. I confirmed the test fails when a computed label is left undocumented.

https://claude.ai/code/session_01LC2YPrLoawcS7afNbsn2sd