### PR TITLE
docs(oas): document name rules and zone overviews

### DIFF
--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -61,6 +61,8 @@ components:
             type: string
           type: object
         mesh:
+          maxLength: 253
+          pattern: ^[0-9a-z-_.]*$
           type: string
         modificationTime:
           description: Time at which the resource was updated
@@ -68,6 +70,8 @@ components:
           readOnly: true
           type: string
         name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
         networking:
           description: |-

--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -66,6 +66,8 @@ components:
           readOnly: true
           type: string
         name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
         skipCreatingInitialPolicies:
           description: |-

--- a/api/mesh/v1alpha1/zoneoverview/rest.yaml
+++ b/api/mesh/v1alpha1/zoneoverview/rest.yaml
@@ -1,0 +1,66 @@
+openapi: 3.1.0
+info:
+  version: v1alpha1
+  title: Kuma API
+  description: Kuma API
+  x-ref-schema-name: "ZoneOverview"
+
+paths:
+  /zones/{name}/_overview:
+    get:
+      operationId: getZoneOverview
+      parameters:
+        - in: path
+          name: name
+          required: true
+          description: The name of the zone to get the overview for.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/GetZoneOverviewResponse'
+        '400':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/Internal'
+  /zones/_overview:
+    get:
+      operationId: getZoneOverviewList
+      responses:
+        '200':
+          $ref: '#/components/responses/GetZoneOverviewListResponse'
+        '400':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/Internal'
+
+components:
+  schemas:
+    ZoneOverviewWithMeta:
+      allOf:
+        - $ref: '/specs/base/specs/common/resource.yaml#/components/schemas/Meta'
+        - $ref: '/specs/protoresources/zoneoverview/schema.yaml#/components/schemas/ZoneOverview'
+
+  responses:
+    GetZoneOverviewResponse:
+      description: A response containing the overview of a zone.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ZoneOverviewWithMeta'
+    GetZoneOverviewListResponse:
+      description: A response containing a list of zone overviews.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              total:
+                type: integer
+                example: 200
+              next:
+                type: string
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZoneOverviewWithMeta'

--- a/api/mesh/v1alpha1/zoneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/zoneoverview/schema.yaml
@@ -1,0 +1,242 @@
+components:
+  schemas:
+    ZoneOverview:
+      description: ZoneOverview defines the projected state of a Zone.
+      properties:
+        zone:
+          properties:
+            enabled:
+              description: |-
+                enable allows to turn the zone on/off and exclude the whole zone from
+                balancing traffic on it
+              type: boolean
+          type: object
+        zoneInsight:
+          properties:
+            envoyAdminStreams:
+              description: |-
+                Statistics about Envoy Admin Streams
+                Deprecated: use kds_streams instead.
+              properties:
+                clustersGlobalInstanceId:
+                  description: Global instance ID that handles Clusters streams.
+                  type: string
+                configDumpGlobalInstanceId:
+                  description: Global instance ID that handles XDS Config Dump streams.
+                  type: string
+                statsGlobalInstanceId:
+                  description: Global instance ID that handles Stats streams.
+                  type: string
+              type: object
+            healthCheck:
+              properties:
+                time:
+                  description: Time last health check received
+                  properties:
+                    nanos:
+                      type: integer
+                    seconds:
+                      type: integer
+                  type: object
+              type: object
+            kdsStreams:
+              description: Information about kds streams that are estabilished between
+                global and zone
+              properties:
+                clusters:
+                  description: Details of stream that handles Clusters stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                configDump:
+                  description: Details of stream that handles XDS Config Dump stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                globalToZone:
+                  description: Details of stream that handles global to zone resource
+                    sync stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                stats:
+                  description: Details of stream that handles Stats stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                zoneToGlobal:
+                  description: Details of stream that handles zone to global resource
+                    sync stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+              type: object
+            subscriptions:
+              description: List of KDS subscriptions created by a given Zone Kuma
+                CP.
+              items:
+                description: KDSSubscription describes a single KDS subscription created
+                  by a Zone to the Global.
+                properties:
+                  authTokenProvided:
+                    description: Indicates if subscription provided auth token
+                    type: boolean
+                  config:
+                    description: Config of Zone Kuma CP
+                    type: string
+                  connectTime:
+                    description: Time when a given Zone connected to the Global.
+                    properties:
+                      nanos:
+                        type: integer
+                      seconds:
+                        type: integer
+                    type: object
+                  disconnectTime:
+                    description: Time when a given Zone disconnected from the Global.
+                    properties:
+                      nanos:
+                        type: integer
+                      seconds:
+                        type: integer
+                    type: object
+                  generation:
+                    description: |-
+                      Generation is an integer number which is periodically increased by the
+                      status sink
+                    type: integer
+                  globalInstanceId:
+                    description: Global CP instance that handled given subscription.
+                    type: string
+                  id:
+                    description: Unique id per KDS subscription.
+                    type: string
+                  status:
+                    description: Status of the KDS subscription.
+                    properties:
+                      lastUpdateTime:
+                        description: Time when status of a given KDS subscription
+                          was most recently updated.
+                        properties:
+                          nanos:
+                            type: integer
+                          seconds:
+                            type: integer
+                        type: object
+                      stat:
+                        additionalProperties:
+                          description: DiscoveryServiceStats defines all stats over
+                            a single xDS service.
+                          properties:
+                            responsesAcknowledged:
+                              description: Number of xDS responses ACKed by the Dataplane.
+                              type: integer
+                            responsesRejected:
+                              description: Number of xDS responses NACKed by the Dataplane.
+                              type: integer
+                            responsesSent:
+                              description: Number of xDS responses sent to the Dataplane.
+                              type: integer
+                          type: object
+                        type: object
+                      total:
+                        description: Total defines an aggregate over individual KDS
+                          stats.
+                        properties:
+                          responsesAcknowledged:
+                            description: Number of xDS responses ACKed by the Dataplane.
+                            type: integer
+                          responsesRejected:
+                            description: Number of xDS responses NACKed by the Dataplane.
+                            type: integer
+                          responsesSent:
+                            description: Number of xDS responses sent to the Dataplane.
+                            type: integer
+                        type: object
+                    type: object
+                  version:
+                    description: Version of Zone Kuma CP.
+                    properties:
+                      kumaCp:
+                        description: Version of Zone Kuma CP
+                        properties:
+                          buildDate:
+                            description: Build date of Kuma ControlPlane version
+                            type: string
+                          gitCommit:
+                            description: Git commit of Kuma ControlPlane version
+                            type: string
+                          gitTag:
+                            description: Git tag of Kuma ControlPlane version
+                            type: string
+                          kumaCpGlobalCompatible:
+                            description: True iff this Zone CP version is compatible
+                              with Global CP
+                            type: boolean
+                          version:
+                            description: Version number of Kuma ControlPlane
+                            type: string
+                        type: object
+                    type: object
+                  zoneInstanceId:
+                    description: |-
+                      Zone CP instance that handled the given subscription (This is the leader at
+                      time of connection).
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+info:
+  x-ref-schema-name: ZoneOverview
+openapi: 3.1.0

--- a/api/openapi/specs/common/resource.yaml
+++ b/api/openapi/specs/common/resource.yaml
@@ -60,10 +60,16 @@ components:
           type: string
           example: default
           description: the mesh this resource is part of
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         name:
           type: string
           example: my-resource
           description: the name of the resource
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         kri:
           type: string
           readOnly: true

--- a/api/system/v1alpha1/secret/rest.yaml
+++ b/api/system/v1alpha1/secret/rest.yaml
@@ -61,6 +61,8 @@ components:
             type: string
           type: object
         mesh:
+          maxLength: 253
+          pattern: ^[0-9a-z-_.]*$
           type: string
         modificationTime:
           description: Time at which the resource was updated
@@ -68,6 +70,8 @@ components:
           readOnly: true
           type: string
         name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
         type:
           type: string

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Kuma API
   description: Kuma API
   version: v1alpha1
-  x-ref-schema-name: MeshOverview
+  x-ref-schema-name: ZoneOverview
 security:
   - BasicAuth: []
   - BearerAuth: []
@@ -2919,6 +2919,33 @@ paths:
       summary: Creates or Updates Secret entity
       tags:
         - Secret
+  /zones/{name}/_overview:
+    get:
+      operationId: getZoneOverview
+      parameters:
+        - in: path
+          name: name
+          required: true
+          description: The name of the zone to get the overview for.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/GetZoneOverviewResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
+  /zones/_overview:
+    get:
+      operationId: getZoneOverviewList
+      responses:
+        '200':
+          $ref: '#/components/responses/GetZoneOverviewListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
   /hostnamegenerators/{name}:
     get:
       operationId: getHostnameGenerator
@@ -4558,10 +4585,14 @@ components:
           type: string
           example: default
           description: the mesh this resource is part of
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         name:
           type: string
           example: my-resource
           description: the name of the resource
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         kri:
           type: string
           readOnly: true
@@ -5057,6 +5088,8 @@ components:
             type: string
           type: object
         mesh:
+          maxLength: 253
+          pattern: ^[0-9a-z-_.]*$
           type: string
         modificationTime:
           description: Time at which the resource was updated
@@ -5064,6 +5097,8 @@ components:
           readOnly: true
           type: string
         name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
         networking:
           description: >-
@@ -5526,6 +5561,8 @@ components:
           readOnly: true
           type: string
         name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
         skipCreatingInitialPolicies:
           description: >-
@@ -5568,6 +5605,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -5579,6 +5618,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -6223,6 +6264,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -6234,6 +6277,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -7309,6 +7354,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -7320,6 +7367,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -7720,6 +7769,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -7731,6 +7782,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -8655,6 +8708,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -8666,6 +8721,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -9057,6 +9114,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -9068,6 +9127,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -9621,6 +9682,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -9632,6 +9695,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -9987,6 +10052,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -9998,6 +10065,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -10139,6 +10208,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -10150,6 +10221,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -10826,6 +10899,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -10837,6 +10912,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -11299,6 +11376,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -11310,6 +11389,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -11883,6 +11964,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -11894,6 +11977,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -12102,6 +12187,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -12113,6 +12200,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -12260,6 +12349,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -12271,6 +12362,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -12631,6 +12724,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -12642,6 +12737,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -13017,6 +13114,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -13028,6 +13127,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -14168,6 +14269,8 @@ components:
             type: string
           type: object
         mesh:
+          maxLength: 253
+          pattern: ^[0-9a-z-_.]*$
           type: string
         modificationTime:
           description: Time at which the resource was updated
@@ -14175,6 +14278,8 @@ components:
           readOnly: true
           type: string
         name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
         type:
           type: string
@@ -14182,6 +14287,258 @@ components:
         - type
         - name
         - mesh
+      type: object
+    ZoneOverviewWithMeta:
+      allOf:
+        - $ref: '#/components/schemas/Meta'
+        - $ref: '#/components/schemas/ZoneOverview'
+    ZoneOverview:
+      description: ZoneOverview defines the projected state of a Zone.
+      properties:
+        zone:
+          properties:
+            enabled:
+              description: >-
+                enable allows to turn the zone on/off and exclude the whole zone
+                from
+
+                balancing traffic on it
+              type: boolean
+          type: object
+        zoneInsight:
+          properties:
+            envoyAdminStreams:
+              description: |-
+                Statistics about Envoy Admin Streams
+                Deprecated: use kds_streams instead.
+              properties:
+                clustersGlobalInstanceId:
+                  description: Global instance ID that handles Clusters streams.
+                  type: string
+                configDumpGlobalInstanceId:
+                  description: Global instance ID that handles XDS Config Dump streams.
+                  type: string
+                statsGlobalInstanceId:
+                  description: Global instance ID that handles Stats streams.
+                  type: string
+              type: object
+            healthCheck:
+              properties:
+                time:
+                  description: Time last health check received
+                  properties:
+                    nanos:
+                      type: integer
+                    seconds:
+                      type: integer
+                  type: object
+              type: object
+            kdsStreams:
+              description: >-
+                Information about kds streams that are estabilished between
+                global and zone
+              properties:
+                clusters:
+                  description: Details of stream that handles Clusters stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                configDump:
+                  description: Details of stream that handles XDS Config Dump stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                globalToZone:
+                  description: >-
+                    Details of stream that handles global to zone resource sync
+                    stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                stats:
+                  description: Details of stream that handles Stats stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+                zoneToGlobal:
+                  description: >-
+                    Details of stream that handles zone to global resource sync
+                    stream.
+                  properties:
+                    connectTime:
+                      description: Time when the stream was open.
+                      properties:
+                        nanos:
+                          type: integer
+                        seconds:
+                          type: integer
+                      type: object
+                    globalInstanceId:
+                      description: Global instance ID that handles the stream.
+                      type: string
+                  type: object
+              type: object
+            subscriptions:
+              description: List of KDS subscriptions created by a given Zone Kuma CP.
+              items:
+                description: >-
+                  KDSSubscription describes a single KDS subscription created by
+                  a Zone to the Global.
+                properties:
+                  authTokenProvided:
+                    description: Indicates if subscription provided auth token
+                    type: boolean
+                  config:
+                    description: Config of Zone Kuma CP
+                    type: string
+                  connectTime:
+                    description: Time when a given Zone connected to the Global.
+                    properties:
+                      nanos:
+                        type: integer
+                      seconds:
+                        type: integer
+                    type: object
+                  disconnectTime:
+                    description: Time when a given Zone disconnected from the Global.
+                    properties:
+                      nanos:
+                        type: integer
+                      seconds:
+                        type: integer
+                    type: object
+                  generation:
+                    description: >-
+                      Generation is an integer number which is periodically
+                      increased by the
+
+                      status sink
+                    type: integer
+                  globalInstanceId:
+                    description: Global CP instance that handled given subscription.
+                    type: string
+                  id:
+                    description: Unique id per KDS subscription.
+                    type: string
+                  status:
+                    description: Status of the KDS subscription.
+                    properties:
+                      lastUpdateTime:
+                        description: >-
+                          Time when status of a given KDS subscription was most
+                          recently updated.
+                        properties:
+                          nanos:
+                            type: integer
+                          seconds:
+                            type: integer
+                        type: object
+                      stat:
+                        additionalProperties:
+                          description: >-
+                            DiscoveryServiceStats defines all stats over a
+                            single xDS service.
+                          properties:
+                            responsesAcknowledged:
+                              description: Number of xDS responses ACKed by the Dataplane.
+                              type: integer
+                            responsesRejected:
+                              description: Number of xDS responses NACKed by the Dataplane.
+                              type: integer
+                            responsesSent:
+                              description: Number of xDS responses sent to the Dataplane.
+                              type: integer
+                          type: object
+                        type: object
+                      total:
+                        description: Total defines an aggregate over individual KDS stats.
+                        properties:
+                          responsesAcknowledged:
+                            description: Number of xDS responses ACKed by the Dataplane.
+                            type: integer
+                          responsesRejected:
+                            description: Number of xDS responses NACKed by the Dataplane.
+                            type: integer
+                          responsesSent:
+                            description: Number of xDS responses sent to the Dataplane.
+                            type: integer
+                        type: object
+                    type: object
+                  version:
+                    description: Version of Zone Kuma CP.
+                    properties:
+                      kumaCp:
+                        description: Version of Zone Kuma CP
+                        properties:
+                          buildDate:
+                            description: Build date of Kuma ControlPlane version
+                            type: string
+                          gitCommit:
+                            description: Git commit of Kuma ControlPlane version
+                            type: string
+                          gitTag:
+                            description: Git tag of Kuma ControlPlane version
+                            type: string
+                          kumaCpGlobalCompatible:
+                            description: >-
+                              True iff this Zone CP version is compatible with
+                              Global CP
+                            type: boolean
+                          version:
+                            description: Version number of Kuma ControlPlane
+                            type: string
+                        type: object
+                    type: object
+                  zoneInstanceId:
+                    description: >-
+                      Zone CP instance that handled the given subscription (This
+                      is the leader at
+
+                      time of connection).
+                    type: string
+                type: object
+              type: array
+          type: object
       type: object
     HostnameGeneratorItem:
       type: object
@@ -14212,6 +14569,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -14297,6 +14656,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -14331,6 +14692,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -14793,6 +15156,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -14804,6 +15169,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -15106,6 +15473,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -15140,6 +15509,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -15396,6 +15767,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -15407,6 +15780,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -15639,6 +16014,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -15673,6 +16050,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -15910,6 +16289,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -15921,6 +16302,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -16013,6 +16396,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -16024,6 +16409,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -16084,6 +16471,8 @@ components:
             be omitted for cluster-scoped resources.
           type: string
           default: default
+          pattern: ^[0-9a-z-_.]*$
+          maxLength: 253
         kri:
           description: >-
             A unique identifier for this resource instance used by internal
@@ -16095,6 +16484,8 @@ components:
         name:
           description: Name of the Kuma resource
           type: string
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          maxLength: 253
         labels:
           additionalProperties:
             type: string
@@ -17189,6 +17580,28 @@ components:
                 type: number
             type: object
       description: List
+    GetZoneOverviewResponse:
+      description: A response containing the overview of a zone.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ZoneOverviewWithMeta'
+    GetZoneOverviewListResponse:
+      description: A response containing a list of zone overviews.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              total:
+                type: integer
+                example: 200
+              next:
+                type: string
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ZoneOverviewWithMeta'
     HostnameGeneratorItem:
       description: Successful response
       content:

--- a/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/hostnamegenerator/api/v1alpha1/rest.yaml
@@ -118,6 +118,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/mesh/meta_validator.go
+++ b/pkg/core/resources/apis/mesh/meta_validator.go
@@ -1,19 +1,32 @@
 package mesh
 
 import (
+	"fmt"
 	"regexp"
 
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 )
 
+const (
+	// NamePattern is the pattern every resource name must match. Exported so the
+	// OpenAPI specs advertise the same constraint the API enforces.
+	NamePattern = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// MeshNamePattern is laxer than NamePattern: a Mesh created before the
+	// stricter rule may still contain '_', and mesh-scoped resources have to keep
+	// referring to it.
+	MeshNamePattern = `^[0-9a-z-_.]*$`
+	// MaxNameLength is the maximum length of a resource name or mesh reference.
+	MaxNameLength = 253
+)
+
 var (
-	backwardCompatRegexp = regexp.MustCompile(`^[0-9a-z-_.]*$`)
+	backwardCompatRegexp = regexp.MustCompile(MeshNamePattern)
 	backwardCompatErrMsg = "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_', '.' symbols."
 )
 
 var (
-	identifierRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+	identifierRegexp = regexp.MustCompile(NamePattern)
 	identifierErrMsg = "invalid characters. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric " +
 		"characters, '-' or '.', and must start and end with an alphanumeric character"
 )
@@ -41,8 +54,8 @@ func validateIdentifier(identifier string, r *regexp.Regexp, errMsg string) vali
 	switch {
 	case identifier == "":
 		err.AddViolation("", "cannot be empty")
-	case len(identifier) > 253:
-		err.AddViolation("", "value length must less or equal 253")
+	case len(identifier) > MaxNameLength:
+		err.AddViolation("", fmt.Sprintf("value length must less or equal %d", MaxNameLength))
 	case !r.MatchString(identifier):
 		err.AddViolation("", errMsg)
 	}

--- a/pkg/core/resources/apis/mesh/meta_validator.go
+++ b/pkg/core/resources/apis/mesh/meta_validator.go
@@ -8,25 +8,13 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 )
 
-const (
-	// NamePattern is the pattern every resource name must match. Exported so the
-	// OpenAPI specs advertise the same constraint the API enforces.
-	NamePattern = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	// MeshNamePattern is laxer than NamePattern: a Mesh created before the
-	// stricter rule may still contain '_', and mesh-scoped resources have to keep
-	// referring to it.
-	MeshNamePattern = `^[0-9a-z-_.]*$`
-	// MaxNameLength is the maximum length of a resource name or mesh reference.
-	MaxNameLength = 253
-)
-
 var (
-	backwardCompatRegexp = regexp.MustCompile(MeshNamePattern)
+	backwardCompatRegexp = regexp.MustCompile(core_model.MeshNamePattern)
 	backwardCompatErrMsg = "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_', '.' symbols."
 )
 
 var (
-	identifierRegexp = regexp.MustCompile(NamePattern)
+	identifierRegexp = regexp.MustCompile(core_model.NamePattern)
 	identifierErrMsg = "invalid characters. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric " +
 		"characters, '-' or '.', and must start and end with an alphanumeric character"
 )
@@ -54,8 +42,8 @@ func validateIdentifier(identifier string, r *regexp.Regexp, errMsg string) vali
 	switch {
 	case identifier == "":
 		err.AddViolation("", "cannot be empty")
-	case len(identifier) > MaxNameLength:
-		err.AddViolation("", fmt.Sprintf("value length must less or equal %d", MaxNameLength))
+	case len(identifier) > core_model.MaxNameLength:
+		err.AddViolation("", fmt.Sprintf("value length must less or equal %d", core_model.MaxNameLength))
 	case !r.MatchString(identifier):
 		err.AddViolation("", errMsg)
 	}

--- a/pkg/core/resources/apis/mesh/meta_validator_spec_test.go
+++ b/pkg/core/resources/apis/mesh/meta_validator_spec_test.go
@@ -1,0 +1,29 @@
+package mesh_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+)
+
+// The OpenAPI specs advertise the name and mesh constraints the API enforces.
+// Two of the three places that carry them are YAML, so nothing but this test
+// stops them drifting from the validator.
+var _ = Describe("name constraints in the OpenAPI specs", func() {
+	repoRoot := filepath.Join("..", "..", "..", "..", "..")
+
+	DescribeTable("should match the validator",
+		func(path string) {
+			raw, err := os.ReadFile(filepath.Join(repoRoot, path))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(raw)).To(ContainSubstring(core_mesh.NamePattern))
+			Expect(string(raw)).To(ContainSubstring(core_mesh.MeshNamePattern))
+		},
+		Entry("policy schema template", filepath.Join("tools", "openapi", "templates", "schema.yaml")),
+		Entry("shared metadata schema", filepath.Join("api", "openapi", "specs", "common", "resource.yaml")),
+	)
+})

--- a/pkg/core/resources/apis/mesh/meta_validator_spec_test.go
+++ b/pkg/core/resources/apis/mesh/meta_validator_spec_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 )
 
 // The OpenAPI specs advertise the name and mesh constraints the API enforces.
@@ -20,8 +20,8 @@ var _ = Describe("name constraints in the OpenAPI specs", func() {
 		func(path string) {
 			raw, err := os.ReadFile(filepath.Join(repoRoot, path))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(raw)).To(ContainSubstring(core_mesh.NamePattern))
-			Expect(string(raw)).To(ContainSubstring(core_mesh.MeshNamePattern))
+			Expect(string(raw)).To(ContainSubstring(core_model.NamePattern))
+			Expect(string(raw)).To(ContainSubstring(core_model.MeshNamePattern))
 		},
 		Entry("policy schema template", filepath.Join("tools", "openapi", "templates", "schema.yaml")),
 		Entry("shared metadata schema", filepath.Join("api", "openapi", "specs", "common", "resource.yaml")),

--- a/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshexternalservice/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -164,6 +167,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshmultizoneservice/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -164,6 +167,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -164,6 +167,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/meshtrust/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshtrust/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshzoneaddress/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/apis/workload/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/workload/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/core/resources/model/names.go
+++ b/pkg/core/resources/model/names.go
@@ -1,0 +1,14 @@
+package model
+
+const (
+	// NamePattern is the pattern every resource name must match. It lives here
+	// rather than next to the validator so code generators can read it without
+	// depending on the packages they generate.
+	NamePattern = `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// MeshNamePattern is laxer than NamePattern: a Mesh created before the
+	// stricter rule may still contain '_', and mesh-scoped resources have to keep
+	// referring to it.
+	MeshNamePattern = `^[0-9a-z-_.]*$`
+	// MaxNameLength is the maximum length of a resource name or mesh reference.
+	MaxNameLength = 253
+)

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshfaultinjection/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhealthcheck/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshpassthrough/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshproxypatch/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshratelimit/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshretry/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtcproute/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtimeout/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtls/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrafficpermission/api/v1alpha1/rest.yaml
@@ -138,6 +138,9 @@ components:
           description: 'Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.'
           type: string
           default: default
+          # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+          pattern: '^[0-9a-z-_.]*$'
+          maxLength: 253
         kri:
           description: 'A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing'
           type: string
@@ -146,6 +149,9 @@ components:
         name:
           description: 'Name of the Kuma resource'
           type: string
+          # keep in sync with core_mesh.NamePattern / MaxNameLength
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+          maxLength: 253
         labels:
           additionalProperties:
             type: string

--- a/tools/openapi/templates/schema.yaml
+++ b/tools/openapi/templates/schema.yaml
@@ -11,6 +11,9 @@ properties:
       It may be omitted for cluster-scoped resources.'
     type: string
     default: default
+    # keep in sync with core_mesh.MeshNamePattern / MaxNameLength
+    pattern: '^[0-9a-z-_.]*$'
+    maxLength: 253
   {{- end }}
   {{- if ne .ShortName "" }}
   {{- $kind := ternary .IsPolicy "policy" "resource" }}
@@ -51,6 +54,9 @@ properties:
   name:
     description: 'Name of the Kuma resource'
     type: string
+    # keep in sync with core_mesh.NamePattern / MaxNameLength
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+    maxLength: 253
   labels:
     additionalProperties:
       type: string

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -27,7 +27,9 @@ import (
 
 	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	"github.com/kumahq/kuma/v3/pkg/util/maps"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	commontemplate "github.com/kumahq/kuma/v3/tools/common/template"
 	"github.com/kumahq/kuma/v3/tools/common/types"
 	. "github.com/kumahq/kuma/v3/tools/resource-gen/genutils"
@@ -457,6 +459,7 @@ var AdditionalProtoTypes = []reflect.Type{
 	reflect.TypeFor[v1alpha1.DataplaneOverview](),
 	reflect.TypeFor[v1alpha1.MeshOverview](),
 	reflect.TypeFor[system_proto.Zone](),
+	reflect.TypeFor[system_proto.ZoneOverview](),
 }
 
 func openApiGenerator(pkg string, resources []ResourceInfo) error {
@@ -471,9 +474,17 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 		}
 		schemaMap := jsonschema.NewProperties()
 		schemaMap.Set("type", &jsonschema.Schema{Type: "string"})
-		schemaMap.Set("name", &jsonschema.Schema{Type: "string"})
+		schemaMap.Set("name", &jsonschema.Schema{
+			Type:      "string",
+			Pattern:   core_mesh.NamePattern,
+			MaxLength: pointer.To[uint64](core_mesh.MaxNameLength),
+		})
 		if !r.Global {
-			schemaMap.Set("mesh", &jsonschema.Schema{Type: "string"})
+			schemaMap.Set("mesh", &jsonschema.Schema{
+				Type:      "string",
+				Pattern:   core_mesh.MeshNamePattern,
+				MaxLength: pointer.To[uint64](core_mesh.MaxNameLength),
+			})
 		}
 		schemaMap.Set("labels", &jsonschema.Schema{Type: "object", AdditionalProperties: &jsonschema.Schema{Type: "string"}})
 		// kri is only emitted at runtime for resources that have a ShortName

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
-	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/util/maps"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	commontemplate "github.com/kumahq/kuma/v3/tools/common/template"
@@ -478,14 +478,14 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 		schemaMap.Set("type", &jsonschema.Schema{Type: "string"})
 		schemaMap.Set("name", &jsonschema.Schema{
 			Type:      "string",
-			Pattern:   core_mesh.NamePattern,
-			MaxLength: pointer.To[uint64](core_mesh.MaxNameLength),
+			Pattern:   core_model.NamePattern,
+			MaxLength: pointer.To[uint64](core_model.MaxNameLength),
 		})
 		if !r.Global {
 			schemaMap.Set("mesh", &jsonschema.Schema{
 				Type:      "string",
-				Pattern:   core_mesh.MeshNamePattern,
-				MaxLength: pointer.To[uint64](core_mesh.MaxNameLength),
+				Pattern:   core_model.MeshNamePattern,
+				MaxLength: pointer.To[uint64](core_model.MaxNameLength),
 			})
 		}
 		schemaMap.Set("labels", &jsonschema.Schema{Type: "object", AdditionalProperties: &jsonschema.Schema{Type: "string"}})


### PR DESCRIPTION
## Motivation

The goal is that the GUI needs no overlay on our spec at all. Every overlay entry is something the control plane already knows but the spec fails to say. Two of them are pure omissions, and this closes both.

**Names are validated but undocumented.** `ValidateMeta` runs on every create and update through the generic CRUD handler, checking `name` against an RFC 1123 subdomain pattern and `mesh` against a laxer one, both capped at 253 characters. The specs described each as a bare `type: string`, so the overlay re-adds the same `name` regex by hand for every policy.

**Zone overviews are served but undocumented.** `/zones/_overview` and `/zones/{name}/_overview` are generic routes registered off `HasInsights()`, exactly like the mesh overviews added in #18349 — they just never got a spec, so the overlay has to declare them.

> Changelog: docs(oas): document name rules and zone overviews

## Implementation information

### Name and mesh constraints

`NamePattern`, `MeshNamePattern` and `MaxNameLength` are now exported from `meta_validator.go` and used to build the regexes, so the validator itself is the single source. `resource-gen` reads them directly. The two YAML templates cannot import Go, so they carry a copy with a `keep in sync` comment plus a test.

`mesh` deliberately keeps the laxer `^[0-9a-z-_.]*$`: a Mesh created before the stricter rule may still contain `_`, and mesh-scoped resources have to keep referring to it. That asymmetry is intentional and is why this documents two patterns rather than one.

Applied in all three places metadata is described — the policy schema template, the proto-resource generator, and the shared `Meta` schema — so it covers policies, core resources and inspect responses alike.

### Zone overviews

`ZoneOverview` is added to `AdditionalProtoTypes` for schema generation, with a hand-written `rest.yaml` for the two paths, mirroring `meshoverview`. Note the generated schema lands under `api/mesh/v1alpha1/zoneoverview/` rather than `api/system/...` — that is existing behaviour of the `pkg == "mesh"` guard in the generator, which already puts `Zone` there. The `$ref` prefix is path-independent so it bundles correctly; I left the quirk alone rather than widening this change.

The deprecated `zones+insights` alias is intentionally left undocumented.

## Supporting documentation

`pkg/core/resources/apis/mesh/meta_validator_spec_test.go` asserts both YAML copies still contain the validator patterns. I confirmed it fails when a pattern is edited — the copies are the drift risk, so an assertion that only passes vacuously would be worse than none.

## Still needed before the overlay can go away

Out of scope here, happy to file:

1. Discriminated unions are flattened — `+kuma:discriminator` fields emit as sibling optional properties instead of a `oneOf` keyed on `type`, so the overlay rebuilds the union for `MeshLoadBalancingStrategy` `loadBalancer` and `hashPolicies`, `MeshHTTPRoute` `filters`, and `MeshAccessLog` `backends`. This is the largest remaining chunk.
2. `backendRefs.kind` reuses the full `TargetRef` kind enum instead of the three kinds valid there; may resolve via #17721.
3. Endpoints still undocumented: `/config`, `/mesh-insights`, `/meshes/{mesh}/service-insights`, and `/meshes/{mesh}/dataplanes/{name}/{xds,stats,clusters,policies}`.

https://claude.ai/code/session_01LC2YPrLoawcS7afNbsn2sd