### PR TITLE
docs(oas): document config and admin endpoints

### DIFF
--- a/api/openapi/specs/api.yaml
+++ b/api/openapi/specs/api.yaml
@@ -121,6 +121,146 @@ paths:
           $ref: './common/error_schema.yaml#/components/responses/BadRequest'
         '500':
           $ref: './common/error_schema.yaml#/components/responses/Internal'
+  /config:
+    get:
+      operationId: get-config
+      summary: Get the control plane configuration
+      description: Returns the configuration of the control plane, with sensitive values redacted.
+      tags: ["System"]
+      responses:
+        '200':
+          $ref: '#/components/responses/ConfigResponse'
+        '400':
+          $ref: './common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: './common/error_schema.yaml#/components/responses/Internal'
+  /meshes/{mesh}/dataplanes/{dataplane}/xds:
+    get:
+      operationId: get-dataplane-xds
+      summary: Get the Envoy config dump of this dataplane
+      description: Proxies the Envoy admin config dump of the DPP.
+      tags: ["Inspect"]
+      parameters:
+        - in: path
+          name: mesh
+          required: true
+          description: The mesh of the DPP.
+          schema:
+            type: string
+        - in: path
+          name: dataplane
+          required: true
+          description: The name of the DPP within the mesh.
+          schema:
+            type: string
+        - in: query
+          name: include_eds
+          required: false
+          description: Include endpoint discovery data in the config dump.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: The Envoy config dump.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: './common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: './common/error_schema.yaml#/components/responses/Internal'
+  /meshes/{mesh}/dataplanes/{dataplane}/clusters:
+    get:
+      operationId: get-dataplane-clusters
+      summary: Get the Envoy clusters of this dataplane
+      description: Proxies the Envoy admin clusters output of the DPP. Returns plain text unless `format=json` is requested.
+      tags: ["Inspect"]
+      parameters:
+        - in: path
+          name: mesh
+          required: true
+          description: The mesh of the DPP.
+          schema:
+            type: string
+        - in: path
+          name: dataplane
+          required: true
+          description: The name of the DPP within the mesh.
+          schema:
+            type: string
+        - in: query
+          name: format
+          required: false
+          description: Set to `json` to receive the Envoy admin output as JSON instead of plain text.
+          schema:
+            type: string
+            enum: [json]
+      responses:
+        '200':
+          description: The Envoy clusters output.
+          content:
+            text/plain:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: './common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: './common/error_schema.yaml#/components/responses/Internal'
+  /meshes/{mesh}/dataplanes/{dataplane}/stats:
+    get:
+      operationId: get-dataplane-stats
+      summary: Get the Envoy stats of this dataplane
+      description: Proxies the Envoy admin stats output of the DPP. Returns plain text unless `format=json` is requested.
+      tags: ["Inspect"]
+      parameters:
+        - in: path
+          name: mesh
+          required: true
+          description: The mesh of the DPP.
+          schema:
+            type: string
+        - in: path
+          name: dataplane
+          required: true
+          description: The name of the DPP within the mesh.
+          schema:
+            type: string
+        - in: query
+          name: format
+          required: false
+          description: Set to `json` to receive the Envoy admin output as JSON instead of plain text.
+          schema:
+            type: string
+            enum: [json]
+        - in: query
+          name: usedonly
+          required: false
+          description: Only return stats Envoy has actually updated.
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          description: The Envoy stats output.
+          content:
+            text/plain:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: './common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: './common/error_schema.yaml#/components/responses/Internal'
   /meshes/{mesh}/dataplanes/{name}/_layout:
     get:
       operationId: get-dataplanes-layout
@@ -770,6 +910,13 @@ components:
           type: string
           description: SPIFFE ID of the dataplane's workload identity certificate
   responses:
+    ConfigResponse:
+      description: The control plane configuration.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
     IndexResponse:
       description: A response for the index endpoint
       content:

--- a/api/openapi/types/zz_generated.api.go
+++ b/api/openapi/types/zz_generated.api.go
@@ -9,6 +9,36 @@ import (
 	externalRef0 "github.com/kumahq/kuma/v3/api/openapi/types/common"
 )
 
+// Defines values for GetDataplaneClustersParamsFormat.
+const (
+	GetDataplaneClustersParamsFormatJson GetDataplaneClustersParamsFormat = "json"
+)
+
+// Valid indicates whether the value is a known member of the GetDataplaneClustersParamsFormat enum.
+func (e GetDataplaneClustersParamsFormat) Valid() bool {
+	switch e {
+	case GetDataplaneClustersParamsFormatJson:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetDataplaneStatsParamsFormat.
+const (
+	GetDataplaneStatsParamsFormatJson GetDataplaneStatsParamsFormat = "json"
+)
+
+// Valid indicates whether the value is a known member of the GetDataplaneStatsParamsFormat enum.
+func (e GetDataplaneStatsParamsFormat) Valid() bool {
+	switch e {
+	case GetDataplaneStatsParamsFormatJson:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetDataplanesXdsConfigParamsInclude.
 const (
 	Diff GetDataplanesXdsConfigParamsInclude = "diff"
@@ -232,6 +262,9 @@ type ZonesStats struct {
 	ZoneIngresses BaseStatus `json:"zoneIngresses"`
 }
 
+// ConfigResponse defines model for ConfigResponse.
+type ConfigResponse map[string]interface{}
+
 // DataplaneNetworkingLayoutResponse Dataplane networking layout. It contains the most important information about the dataplane and lists the available inbounds, outbounds, and zone proxy listeners
 type DataplaneNetworkingLayoutResponse = DataplaneNetworkingLayout
 
@@ -270,6 +303,33 @@ type RoutePolicyConfResponse = externalRef0.PoliciesList
 
 // RoutesListResponse defines model for RoutesListResponse.
 type RoutesListResponse = externalRef0.RoutesList
+
+// GetDataplaneClustersParams defines parameters for GetDataplaneClusters.
+type GetDataplaneClustersParams struct {
+	// Format Set to `json` to receive the Envoy admin output as JSON instead of plain text.
+	Format *GetDataplaneClustersParamsFormat `form:"format,omitempty" json:"format,omitempty"`
+}
+
+// GetDataplaneClustersParamsFormat defines parameters for GetDataplaneClusters.
+type GetDataplaneClustersParamsFormat string
+
+// GetDataplaneStatsParams defines parameters for GetDataplaneStats.
+type GetDataplaneStatsParams struct {
+	// Format Set to `json` to receive the Envoy admin output as JSON instead of plain text.
+	Format *GetDataplaneStatsParamsFormat `form:"format,omitempty" json:"format,omitempty"`
+
+	// Usedonly Only return stats Envoy has actually updated.
+	Usedonly *bool `form:"usedonly,omitempty" json:"usedonly,omitempty"`
+}
+
+// GetDataplaneStatsParamsFormat defines parameters for GetDataplaneStats.
+type GetDataplaneStatsParamsFormat string
+
+// GetDataplaneXdsParams defines parameters for GetDataplaneXds.
+type GetDataplaneXdsParams struct {
+	// IncludeEds Include endpoint discovery data in the config dump.
+	IncludeEds *bool `form:"include_eds,omitempty" json:"include_eds,omitempty"`
+}
 
 // GetDataplanesXdsConfigParams defines parameters for GetDataplanesXdsConfig.
 type GetDataplanesXdsConfigParams struct {

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -141,6 +141,162 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/Internal'
+  /config:
+    get:
+      operationId: get-config
+      summary: Get the control plane configuration
+      description: >-
+        Returns the configuration of the control plane, with sensitive values
+        redacted.
+      tags:
+        - System
+      responses:
+        '200':
+          $ref: '#/components/responses/ConfigResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
+  /meshes/{mesh}/dataplanes/{dataplane}/xds:
+    get:
+      operationId: get-dataplane-xds
+      summary: Get the Envoy config dump of this dataplane
+      description: Proxies the Envoy admin config dump of the DPP.
+      tags:
+        - Inspect
+      parameters:
+        - in: path
+          name: mesh
+          required: true
+          description: The mesh of the DPP.
+          schema:
+            type: string
+        - in: path
+          name: dataplane
+          required: true
+          description: The name of the DPP within the mesh.
+          schema:
+            type: string
+        - in: query
+          name: include_eds
+          required: false
+          description: Include endpoint discovery data in the config dump.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: The Envoy config dump.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
+  /meshes/{mesh}/dataplanes/{dataplane}/clusters:
+    get:
+      operationId: get-dataplane-clusters
+      summary: Get the Envoy clusters of this dataplane
+      description: >-
+        Proxies the Envoy admin clusters output of the DPP. Returns plain text
+        unless `format=json` is requested.
+      tags:
+        - Inspect
+      parameters:
+        - in: path
+          name: mesh
+          required: true
+          description: The mesh of the DPP.
+          schema:
+            type: string
+        - in: path
+          name: dataplane
+          required: true
+          description: The name of the DPP within the mesh.
+          schema:
+            type: string
+        - in: query
+          name: format
+          required: false
+          description: >-
+            Set to `json` to receive the Envoy admin output as JSON instead of
+            plain text.
+          schema:
+            type: string
+            enum:
+              - json
+      responses:
+        '200':
+          description: The Envoy clusters output.
+          content:
+            text/plain:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
+  /meshes/{mesh}/dataplanes/{dataplane}/stats:
+    get:
+      operationId: get-dataplane-stats
+      summary: Get the Envoy stats of this dataplane
+      description: >-
+        Proxies the Envoy admin stats output of the DPP. Returns plain text
+        unless `format=json` is requested.
+      tags:
+        - Inspect
+      parameters:
+        - in: path
+          name: mesh
+          required: true
+          description: The mesh of the DPP.
+          schema:
+            type: string
+        - in: path
+          name: dataplane
+          required: true
+          description: The name of the DPP within the mesh.
+          schema:
+            type: string
+        - in: query
+          name: format
+          required: false
+          description: >-
+            Set to `json` to receive the Envoy admin output as JSON instead of
+            plain text.
+          schema:
+            type: string
+            enum:
+              - json
+        - in: query
+          name: usedonly
+          required: false
+          description: Only return stats Envoy has actually updated.
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          description: The Envoy stats output.
+          content:
+            text/plain:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
   /meshes/{mesh}/dataplanes/{name}/_layout:
     get:
       operationId: get-dataplanes-layout
@@ -16230,6 +16386,13 @@ components:
           type: object
           readOnly: true
   responses:
+    ConfigResponse:
+      description: The control plane configuration.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
     IndexResponse:
       description: A response for the index endpoint
       content:


### PR DESCRIPTION
## Motivation

Working towards the GUI needing no overlay on our spec at all. These four paths are served by the control plane but were never described, so the overlay has to declare them itself.

> Changelog: docs(oas): document config and admin endpoints

## Implementation information

Added to `api/openapi/specs/api.yaml`, no generator changes:

| path | notes |
|---|---|
| `/config` | The control plane config, sensitive values redacted. Free-form object — the shape is the whole `kuma-cp` config and pinning it here would rot immediately. |
| `/meshes/{mesh}/dataplanes/{dataplane}/xds` | Envoy config dump. `include_eds` query param. |
| `/meshes/{mesh}/dataplanes/{dataplane}/clusters` | Envoy clusters. Plain text, or JSON with `format=json`. |
| `/meshes/{mesh}/dataplanes/{dataplane}/stats` | Envoy stats. Plain text, or JSON with `format=json`; `usedonly` defaults to `true`. |

The server routes the three admin endpoints through a single `{type}` path parameter. They are documented as three concrete paths instead, since each takes different query parameters and returns a different content type — a `{type}` wildcard would be accurate but useless to a client.

Both content types are declared on `clusters` and `stats` because the handler really does switch between `text/plain` and `application/json` on the `format` parameter.

## Deliberately not included

`/meshes/{mesh}/dataplanes/{dataplane}/policies` is also missing from the spec and also overlaid by the GUI, but it is marked deprecated in `inspect_endpoints.go` — superseded by `_policies`, and kept only because the vendored GUI bundle still calls it. Documenting an endpoint that is on its way out would work against the goal, so that overlay entry should disappear when the GUI moves to `_policies` rather than by us describing the old path.

## Still needed before the overlay can go away

1. Discriminated unions are flattened — `+kuma:discriminator` fields emit as sibling optional properties rather than a `oneOf` keyed on `type`, so the overlay rebuilds the union for `MeshLoadBalancingStrategy` `loadBalancer` and `hashPolicies`, `MeshHTTPRoute` `filters`, and `MeshAccessLog` `backends`. This is the largest remaining piece.
2. `/mesh-insights` and `/meshes/{mesh}/service-insights` are undocumented. These are generic CRUD routes, so the fix is in the generator rather than hand-written spec, and needs care not to advertise writes on read-only insight types.
3. `backendRefs.kind` reuses the full `TargetRef` kind enum instead of the three kinds valid there; may resolve via #17721.

## Supporting documentation

`make check` is clean; the generated `docs/generated/openapi.yaml` and `api/openapi/types/zz_generated.api.go` are regenerated in the commit.

https://claude.ai/code/session_01LC2YPrLoawcS7afNbsn2sd