### PR TITLE
ci(release): verify chart resolves via helm index

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,9 @@ on:
         description: "check that everything is published correctly"
 env:
   CHARTS_REPO: "kumahq/charts"
+  HELM_REPO_NAME: "kuma"
+  HELM_REPO_URL: "https://kumahq.github.io/charts"
+  HELM_CHARTS: "kuma"
   BINARIES: "darwin-amd64,darwin-arm64,linux-amd64,linux-arm64"
   DOCKER_REPO: "kumahq"
   DOCKER_IMAGES: "kumactl,kuma-cp,kuma-dp,kuma-init,kuma-cni"
@@ -82,6 +85,17 @@ jobs:
           retry_wait_seconds: 60
           timeout_minutes: 1
           command: release-tool release helm-chart --repo "$GITHUB_REPOSITORY" --charts-repo "$CHARTS_REPO" --release "$RELEASE"
+      # The check above only proves the charts repo cut a release. The index.yaml users
+      # install from is published separately, so also verify the chart is resolvable and
+      # pullable through `helm repo update`.
+      - name: check-helm-repo
+        if: env.RELEASE != '0.0.0' && fromJSON(env.CHECK)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 60
+          timeout_minutes: 2
+          command: .github/workflows/scripts/check-helm-repo.sh
       - name: check-binaries
         if: fromJSON(env.CHECK)
         env:

--- a/.github/workflows/scripts/check-helm-repo.sh
+++ b/.github/workflows/scripts/check-helm-repo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# `release-tool release helm-chart` only checks the charts repo's GitHub release.
+# `helm install` resolves charts from the index.yaml served by GitHub Pages, which is
+# regenerated separately and can lag behind (or miss) that release, so the chart can be
+# released and still not be installable. Verify it from a consumer's point of view:
+# add the repo, refresh the index, and pull the released version.
+
+set -euo pipefail
+
+repo_name="${HELM_REPO_NAME:?}"
+repo_url="${HELM_REPO_URL:?}"
+charts="${HELM_CHARTS:?}"
+release="${RELEASE:?}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+helm repo add "$repo_name" "$repo_url" --force-update
+helm repo update "$repo_name"
+
+failed=0
+IFS=',' read -ra chart_names <<<"$charts"
+for chart in "${chart_names[@]}"; do
+  ref="${repo_name}/${chart}"
+
+  # `helm search repo` matches substrings and keywords, so filter on the exact chart ref.
+  if ! helm search repo "$ref" --version "$release" --devel --output json |
+    jq -e --arg ref "$ref" --arg version "$release" \
+      'map(select(.name == $ref and .version == $version)) | length > 0' >/dev/null; then
+    echo "::error::${ref} ${release} is missing from ${repo_url} index" >&2
+    failed=1
+    continue
+  fi
+
+  if ! helm pull "$ref" --version "$release" --devel --destination "$workdir"; then
+    echo "::error::${ref} ${release} is indexed by ${repo_url} but cannot be pulled" >&2
+    failed=1
+    continue
+  fi
+
+  echo "${ref} ${release} is installable from ${repo_url}"
+done
+
+exit "$failed"


### PR DESCRIPTION
> Changelog: skip

## Motivation

The release workflow's `check-helm` step only confirms the `kumahq/charts` repo cut a GitHub release for the chart. The `index.yaml` served from GitHub Pages, which is what `helm repo update`/`helm install` actually resolve against, is regenerated separately and can lag behind or miss that release. A chart can therefore be marked released while still being uninstallable.

## Implementation information

Adds a `check-helm-repo` step to `release.yaml`, right after `check-helm`, reusing the same retry wrapper for GitHub Pages propagation lag. A new script, `check-helm-repo.sh`, adds the chart repo, runs `helm repo update`, and confirms the release version is both listed (`helm search repo`) and pullable (`helm pull`). Chart repo/name are set via `HELM_REPO_NAME`/`HELM_REPO_URL`/`HELM_CHARTS` env vars so a downstream fork only needs to change those three values.
