### PR TITLE
docs(oas): document mesh insight endpoints

### DIFF
--- a/api/mesh/v1alpha1/meshinsight/rest.yaml
+++ b/api/mesh/v1alpha1/meshinsight/rest.yaml
@@ -1,0 +1,85 @@
+openapi: 3.1.0
+info:
+  version: v1alpha1
+  title: Kuma API
+  description: Kuma API
+  x-ref-schema-name: "MeshInsight"
+
+paths:
+  /mesh-insights/{name}:
+    get:
+      operationId: getMeshInsight
+      summary: Get the insight of a mesh
+      description: Returns the observed state of a mesh, computed by the control plane. Read only.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetMeshInsightResponse'
+        '400':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/BadRequest'
+        '404':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/NotFound'
+        '500':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/Internal'
+      parameters:
+        - in: path
+          name: name
+          required: true
+          description: The name of the mesh to get the insight for.
+          schema:
+            type: string
+  /mesh-insights:
+    get:
+      operationId: getMeshInsightList
+      summary: List mesh insights
+      description: Returns the observed state of every mesh, computed by the control plane. Read only.
+      parameters:
+        - in: query
+          name: size
+          required: false
+          description: Size of the page.
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          required: false
+          description: Offset of the page to list.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/GetMeshInsightListResponse'
+        '400':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/BadRequest'
+        '500':
+          $ref: '/specs/base/specs/common/error_schema.yaml#/components/responses/Internal'
+
+components:
+  schemas:
+    MeshInsightWithMeta:
+      allOf:
+        - $ref: '/specs/base/specs/common/resource.yaml#/components/schemas/Meta'
+        - $ref: '/specs/protoresources/meshinsight/schema.yaml#/components/schemas/MeshInsight'
+
+  responses:
+    GetMeshInsightResponse:
+      description: A response containing the insight of a mesh.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshInsightWithMeta'
+    GetMeshInsightListResponse:
+      description: A response containing a list of mesh insights.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              total:
+                type: integer
+                example: 200
+              next:
+                type: string
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MeshInsightWithMeta'

--- a/api/mesh/v1alpha1/meshinsight/schema.yaml
+++ b/api/mesh/v1alpha1/meshinsight/schema.yaml
@@ -1,0 +1,130 @@
+components:
+  schemas:
+    MeshInsight:
+      description: MeshInsight defines the observed state of a Mesh.
+      properties:
+        dataplanes:
+          properties:
+            offline:
+              type: integer
+            online:
+              type: integer
+            partiallyDegraded:
+              type: integer
+            total:
+              type: integer
+          type: object
+        dataplanesByType:
+          properties:
+            gateway:
+              properties:
+                offline:
+                  type: integer
+                online:
+                  type: integer
+                partiallyDegraded:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+            gatewayDelegated:
+              properties:
+                offline:
+                  type: integer
+                online:
+                  type: integer
+                partiallyDegraded:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+            standard:
+              properties:
+                offline:
+                  type: integer
+                online:
+                  type: integer
+                partiallyDegraded:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+          type: object
+        dpVersions:
+          properties:
+            envoy:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplane stats grouped by Envoy version
+              type: object
+            kumaDp:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplane stats grouped by KumaDP version
+              type: object
+          type: object
+        mTLS:
+          description: mTLS statistics
+          properties:
+            issuedBackends:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplanes grouped by issued backends.
+              type: object
+            supportedBackends:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplanes grouped by supported backends.
+              type: object
+          type: object
+        resources:
+          additionalProperties:
+            properties:
+              total:
+                type: integer
+            type: object
+          type: object
+      type: object
+info:
+  x-ref-schema-name: MeshInsight
+openapi: 3.1.0

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -2926,6 +2926,56 @@ paths:
       summary: Creates or Updates Mesh entity
       tags:
         - Mesh
+  /mesh-insights/{name}:
+    get:
+      operationId: getMeshInsight
+      summary: Get the insight of a mesh
+      description: >-
+        Returns the observed state of a mesh, computed by the control plane.
+        Read only.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetMeshInsightResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/Internal'
+      parameters:
+        - in: path
+          name: name
+          required: true
+          description: The name of the mesh to get the insight for.
+          schema:
+            type: string
+  /mesh-insights:
+    get:
+      operationId: getMeshInsightList
+      summary: List mesh insights
+      description: >-
+        Returns the observed state of every mesh, computed by the control plane.
+        Read only.
+      parameters:
+        - in: query
+          name: size
+          required: false
+          description: Size of the page.
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          required: false
+          description: Offset of the page to list.
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/GetMeshInsightListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/Internal'
   /meshes/{name}/_overview:
     get:
       operationId: getMeshOverview
@@ -14492,6 +14542,135 @@ components:
       allOf:
         - $ref: '#/components/schemas/Meta'
         - $ref: '#/components/schemas/MeshOverview'
+    MeshInsightWithMeta:
+      allOf:
+        - $ref: '#/components/schemas/Meta'
+        - $ref: '#/components/schemas/MeshInsight'
+    MeshInsight:
+      description: MeshInsight defines the observed state of a Mesh.
+      properties:
+        dataplanes:
+          properties:
+            offline:
+              type: integer
+            online:
+              type: integer
+            partiallyDegraded:
+              type: integer
+            total:
+              type: integer
+          type: object
+        dataplanesByType:
+          properties:
+            gateway:
+              properties:
+                offline:
+                  type: integer
+                online:
+                  type: integer
+                partiallyDegraded:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+            gatewayDelegated:
+              properties:
+                offline:
+                  type: integer
+                online:
+                  type: integer
+                partiallyDegraded:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+            standard:
+              properties:
+                offline:
+                  type: integer
+                online:
+                  type: integer
+                partiallyDegraded:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+          type: object
+        dpVersions:
+          properties:
+            envoy:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplane stats grouped by Envoy version
+              type: object
+            kumaDp:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplane stats grouped by KumaDP version
+              type: object
+          type: object
+        mTLS:
+          description: mTLS statistics
+          properties:
+            issuedBackends:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplanes grouped by issued backends.
+              type: object
+            supportedBackends:
+              additionalProperties:
+                description: DataplaneStat defines statistic specifically for Dataplane
+                properties:
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  partiallyDegraded:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              description: Dataplanes grouped by supported backends.
+              type: object
+          type: object
+        resources:
+          additionalProperties:
+            properties:
+              total:
+                type: integer
+            type: object
+          type: object
+      type: object
     SecretItem:
       properties:
         creationTime:
@@ -17757,6 +17936,28 @@ components:
                 type: number
             type: object
       description: List
+    GetMeshInsightResponse:
+      description: A response containing the insight of a mesh.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshInsightWithMeta'
+    GetMeshInsightListResponse:
+      description: A response containing a list of mesh insights.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              total:
+                type: integer
+                example: 200
+              next:
+                type: string
+              items:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MeshInsightWithMeta'
     GetMeshOverviewResponse:
       description: A response containing the overview of a mesh.
       content:

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -459,6 +459,7 @@ var protoEnumType = reflect.TypeFor[protoreflect.Enum]()
 
 var AdditionalProtoTypes = []reflect.Type{
 	reflect.TypeFor[v1alpha1.DataplaneOverview](),
+	reflect.TypeFor[v1alpha1.MeshInsight](),
 	reflect.TypeFor[v1alpha1.MeshOverview](),
 	reflect.TypeFor[system_proto.Zone](),
 	reflect.TypeFor[system_proto.ZoneOverview](),


### PR DESCRIPTION
## Motivation

`/mesh-insights` and `/mesh-insights/{name}` are served by the control plane but absent from the spec, so the GUI overlay has to declare them. Part of getting the overlay down to nothing.

> Changelog: docs(oas): document mesh insight endpoints

## Implementation information

`MeshInsight` is added to `AdditionalProtoTypes` so its schema is generated, with a hand-written `rest.yaml` for the two paths. Same split as `meshoverview` and `zoneoverview`.

Only `GET` is documented. `MeshInsight` is `ws.read_only`, so the write routes exist solely to answer `405`, and describing them would suggest the resource is writable.

Unlike `ServiceInsight` — which I am removing in a separate PR because nothing writes it any more — `MeshInsight` is live: `pkg/insights/resyncer.go` still calls `createOrUpdateMeshInsight`, so these endpoints return real data and are worth documenting.

## Supporting documentation

`make check` clean; the generated schema and bundled spec are regenerated in the commit.

https://claude.ai/code/session_01LC2YPrLoawcS7afNbsn2sd