### PR TITLE
feat(oas): describe union types with oneOf

### DIFF
--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -5966,6 +5966,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                                 path:
                                   description: Path to a file that logs will be written to
                                   example: /tmp/access.log
@@ -6093,6 +6104,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                               required:
                                 - address
                               type: object
@@ -6105,6 +6127,22 @@ components:
                           required:
                             - type
                           type: object
+                          oneOf:
+                            - properties:
+                                tcp: {}
+                                type:
+                                  enum:
+                                    - Tcp
+                            - properties:
+                                file: {}
+                                type:
+                                  enum:
+                                    - File
+                            - properties:
+                                openTelemetry: {}
+                                type:
+                                  enum:
+                                    - OpenTelemetry
                         type: array
                     type: object
                   matches:
@@ -6268,6 +6306,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                                 path:
                                   description: Path to a file that logs will be written to
                                   example: /tmp/access.log
@@ -6395,6 +6444,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                               required:
                                 - address
                               type: object
@@ -6407,6 +6467,22 @@ components:
                           required:
                             - type
                           type: object
+                          oneOf:
+                            - properties:
+                                tcp: {}
+                                type:
+                                  enum:
+                                    - Tcp
+                            - properties:
+                                file: {}
+                                type:
+                                  enum:
+                                    - File
+                            - properties:
+                                openTelemetry: {}
+                                type:
+                                  enum:
+                                    - OpenTelemetry
                         type: array
                     type: object
                   targetRef:
@@ -8312,6 +8388,17 @@ components:
                                               required:
                                                 - type
                                               type: object
+                                              oneOf:
+                                                - properties:
+                                                    replaceFullPath: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplaceFullPath
+                                                - properties:
+                                                    replacePrefixMatch: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplacePrefixMatch
                                             port:
                                               description: >-
                                                 Port is the port to be used in the value
@@ -8438,10 +8525,47 @@ components:
                                               required:
                                                 - type
                                               type: object
+                                              oneOf:
+                                                - properties:
+                                                    replaceFullPath: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplaceFullPath
+                                                - properties:
+                                                    replacePrefixMatch: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplacePrefixMatch
                                           type: object
                                       required:
                                         - type
                                       type: object
+                                      oneOf:
+                                        - properties:
+                                            requestHeaderModifier: {}
+                                            type:
+                                              enum:
+                                                - RequestHeaderModifier
+                                        - properties:
+                                            responseHeaderModifier: {}
+                                            type:
+                                              enum:
+                                                - ResponseHeaderModifier
+                                        - properties:
+                                            requestRedirect: {}
+                                            type:
+                                              enum:
+                                                - RequestRedirect
+                                        - properties:
+                                            type:
+                                              enum:
+                                                - URLRewrite
+                                            urlRewrite: {}
+                                        - properties:
+                                            requestMirror: {}
+                                            type:
+                                              enum:
+                                                - RequestMirror
                                     type: array
                                   kind:
                                     description: Kind of the referenced resource
@@ -8661,6 +8785,17 @@ components:
                                         required:
                                           - type
                                         type: object
+                                        oneOf:
+                                          - properties:
+                                              replaceFullPath: {}
+                                              type:
+                                                enum:
+                                                  - ReplaceFullPath
+                                          - properties:
+                                              replacePrefixMatch: {}
+                                              type:
+                                                enum:
+                                                  - ReplacePrefixMatch
                                       port:
                                         description: >-
                                           Port is the port to be used in the value
@@ -8787,10 +8922,47 @@ components:
                                         required:
                                           - type
                                         type: object
+                                        oneOf:
+                                          - properties:
+                                              replaceFullPath: {}
+                                              type:
+                                                enum:
+                                                  - ReplaceFullPath
+                                          - properties:
+                                              replacePrefixMatch: {}
+                                              type:
+                                                enum:
+                                                  - ReplacePrefixMatch
                                     type: object
                                 required:
                                   - type
                                 type: object
+                                oneOf:
+                                  - properties:
+                                      requestHeaderModifier: {}
+                                      type:
+                                        enum:
+                                          - RequestHeaderModifier
+                                  - properties:
+                                      responseHeaderModifier: {}
+                                      type:
+                                        enum:
+                                          - ResponseHeaderModifier
+                                  - properties:
+                                      requestRedirect: {}
+                                      type:
+                                        enum:
+                                          - RequestRedirect
+                                  - properties:
+                                      type:
+                                        enum:
+                                          - URLRewrite
+                                      urlRewrite: {}
+                                  - properties:
+                                      requestMirror: {}
+                                      type:
+                                        enum:
+                                          - RequestMirror
                               type: array
                           type: object
                         matches:
@@ -9579,6 +9751,32 @@ components:
                           required:
                             - type
                           type: object
+                          oneOf:
+                            - properties:
+                                header: {}
+                                type:
+                                  enum:
+                                    - Header
+                            - properties:
+                                cookie: {}
+                                type:
+                                  enum:
+                                    - Cookie
+                            - properties:
+                                connection: {}
+                                type:
+                                  enum:
+                                    - Connection
+                            - properties:
+                                queryParameter: {}
+                                type:
+                                  enum:
+                                    - QueryParameter
+                            - properties:
+                                filterState: {}
+                                type:
+                                  enum:
+                                    - FilterState
                         type: array
                       loadBalancer:
                         description: >-
@@ -9738,6 +9936,32 @@ components:
                         required:
                           - type
                         type: object
+                        oneOf:
+                          - properties:
+                              roundRobin: {}
+                              type:
+                                enum:
+                                  - RoundRobin
+                          - properties:
+                              leastRequest: {}
+                              type:
+                                enum:
+                                  - LeastRequest
+                          - properties:
+                              ringHash: {}
+                              type:
+                                enum:
+                                  - RingHash
+                          - properties:
+                              random: {}
+                              type:
+                                enum:
+                                  - Random
+                          - properties:
+                              maglev: {}
+                              type:
+                                enum:
+                                  - Maglev
                       localityAwareness:
                         description: >-
                           LocalityAwareness contains configuration for locality
@@ -10103,6 +10327,17 @@ components:
                     required:
                       - type
                     type: object
+                    oneOf:
+                      - properties:
+                          prometheus: {}
+                          type:
+                            enum:
+                              - Prometheus
+                      - properties:
+                          openTelemetry: {}
+                          type:
+                            enum:
+                              - OpenTelemetry
                   type: array
                 sidecar:
                   description: Sidecar metrics collection configuration
@@ -13148,6 +13383,22 @@ components:
                     required:
                       - type
                     type: object
+                    oneOf:
+                      - properties:
+                          type:
+                            enum:
+                              - Zipkin
+                          zipkin: {}
+                      - properties:
+                          datadog: {}
+                          type:
+                            enum:
+                              - Datadog
+                      - properties:
+                          openTelemetry: {}
+                          type:
+                            enum:
+                              - OpenTelemetry
                   maxItems: 1
                   type: array
                 sampling:
@@ -15776,6 +16027,22 @@ components:
               required:
                 - type
               type: object
+              oneOf:
+                - properties:
+                    bundled: {}
+                    type:
+                      enum:
+                        - Bundled
+                - properties:
+                    spire: {}
+                    type:
+                      enum:
+                        - Spire
+                - properties:
+                    extension: {}
+                    type:
+                      enum:
+                        - Extension
             selector:
               properties:
                 dataplane:

--- a/pkg/core/resources/apis/meshidentity/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshidentity/api/v1alpha1/rest.yaml
@@ -322,6 +322,22 @@ components:
               required:
                 - type
               type: object
+              oneOf:
+                - properties:
+                    bundled: {}
+                    type:
+                      enum:
+                        - Bundled
+                - properties:
+                    spire: {}
+                    type:
+                      enum:
+                        - Spire
+                - properties:
+                    extension: {}
+                    type:
+                      enum:
+                        - Extension
             selector:
               properties:
                 dataplane:

--- a/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshaccesslog/api/v1alpha1/rest.yaml
@@ -209,6 +209,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                                 path:
                                   description: Path to a file that logs will be written to
                                   example: /tmp/access.log
@@ -320,6 +331,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                               required:
                                 - address
                               type: object
@@ -332,6 +354,22 @@ components:
                           required:
                             - type
                           type: object
+                          oneOf:
+                            - properties:
+                                tcp: {}
+                                type:
+                                  enum:
+                                    - Tcp
+                            - properties:
+                                file: {}
+                                type:
+                                  enum:
+                                    - File
+                            - properties:
+                                openTelemetry: {}
+                                type:
+                                  enum:
+                                    - OpenTelemetry
                         type: array
                     type: object
                   matches:
@@ -457,6 +495,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                                 path:
                                   description: Path to a file that logs will be written to
                                   example: /tmp/access.log
@@ -568,6 +617,17 @@ components:
                                   required:
                                     - type
                                   type: object
+                                  oneOf:
+                                    - properties:
+                                        plain: {}
+                                        type:
+                                          enum:
+                                            - Plain
+                                    - properties:
+                                        json: {}
+                                        type:
+                                          enum:
+                                            - Json
                               required:
                                 - address
                               type: object
@@ -580,6 +640,22 @@ components:
                           required:
                             - type
                           type: object
+                          oneOf:
+                            - properties:
+                                tcp: {}
+                                type:
+                                  enum:
+                                    - Tcp
+                            - properties:
+                                file: {}
+                                type:
+                                  enum:
+                                    - File
+                            - properties:
+                                openTelemetry: {}
+                                type:
+                                  enum:
+                                    - OpenTelemetry
                         type: array
                     type: object
                   targetRef:

--- a/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshhttproute/api/v1alpha1/rest.yaml
@@ -348,6 +348,17 @@ components:
                                               required:
                                                 - type
                                               type: object
+                                              oneOf:
+                                                - properties:
+                                                    replaceFullPath: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplaceFullPath
+                                                - properties:
+                                                    replacePrefixMatch: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplacePrefixMatch
                                             port:
                                               description: |-
                                                 Port is the port to be used in the value of the `Location`
@@ -457,10 +468,47 @@ components:
                                               required:
                                                 - type
                                               type: object
+                                              oneOf:
+                                                - properties:
+                                                    replaceFullPath: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplaceFullPath
+                                                - properties:
+                                                    replacePrefixMatch: {}
+                                                    type:
+                                                      enum:
+                                                        - ReplacePrefixMatch
                                           type: object
                                       required:
                                         - type
                                       type: object
+                                      oneOf:
+                                        - properties:
+                                            requestHeaderModifier: {}
+                                            type:
+                                              enum:
+                                                - RequestHeaderModifier
+                                        - properties:
+                                            responseHeaderModifier: {}
+                                            type:
+                                              enum:
+                                                - ResponseHeaderModifier
+                                        - properties:
+                                            requestRedirect: {}
+                                            type:
+                                              enum:
+                                                - RequestRedirect
+                                        - properties:
+                                            type:
+                                              enum:
+                                                - URLRewrite
+                                            urlRewrite: {}
+                                        - properties:
+                                            requestMirror: {}
+                                            type:
+                                              enum:
+                                                - RequestMirror
                                     type: array
                                   kind:
                                     description: Kind of the referenced resource
@@ -635,6 +683,17 @@ components:
                                         required:
                                           - type
                                         type: object
+                                        oneOf:
+                                          - properties:
+                                              replaceFullPath: {}
+                                              type:
+                                                enum:
+                                                  - ReplaceFullPath
+                                          - properties:
+                                              replacePrefixMatch: {}
+                                              type:
+                                                enum:
+                                                  - ReplacePrefixMatch
                                       port:
                                         description: |-
                                           Port is the port to be used in the value of the `Location`
@@ -744,10 +803,47 @@ components:
                                         required:
                                           - type
                                         type: object
+                                        oneOf:
+                                          - properties:
+                                              replaceFullPath: {}
+                                              type:
+                                                enum:
+                                                  - ReplaceFullPath
+                                          - properties:
+                                              replacePrefixMatch: {}
+                                              type:
+                                                enum:
+                                                  - ReplacePrefixMatch
                                     type: object
                                 required:
                                   - type
                                 type: object
+                                oneOf:
+                                  - properties:
+                                      requestHeaderModifier: {}
+                                      type:
+                                        enum:
+                                          - RequestHeaderModifier
+                                  - properties:
+                                      responseHeaderModifier: {}
+                                      type:
+                                        enum:
+                                          - ResponseHeaderModifier
+                                  - properties:
+                                      requestRedirect: {}
+                                      type:
+                                        enum:
+                                          - RequestRedirect
+                                  - properties:
+                                      type:
+                                        enum:
+                                          - URLRewrite
+                                      urlRewrite: {}
+                                  - properties:
+                                      requestMirror: {}
+                                      type:
+                                        enum:
+                                          - RequestMirror
                               type: array
                           type: object
                         matches:

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/rest.yaml
@@ -277,6 +277,32 @@ components:
                           required:
                             - type
                           type: object
+                          oneOf:
+                            - properties:
+                                header: {}
+                                type:
+                                  enum:
+                                    - Header
+                            - properties:
+                                cookie: {}
+                                type:
+                                  enum:
+                                    - Cookie
+                            - properties:
+                                connection: {}
+                                type:
+                                  enum:
+                                    - Connection
+                            - properties:
+                                queryParameter: {}
+                                type:
+                                  enum:
+                                    - QueryParameter
+                            - properties:
+                                filterState: {}
+                                type:
+                                  enum:
+                                    - FilterState
                         type: array
                       loadBalancer:
                         description: LoadBalancer allows to specify load balancing algorithm.
@@ -380,6 +406,32 @@ components:
                         required:
                           - type
                         type: object
+                        oneOf:
+                          - properties:
+                              roundRobin: {}
+                              type:
+                                enum:
+                                  - RoundRobin
+                          - properties:
+                              leastRequest: {}
+                              type:
+                                enum:
+                                  - LeastRequest
+                          - properties:
+                              ringHash: {}
+                              type:
+                                enum:
+                                  - RingHash
+                          - properties:
+                              random: {}
+                              type:
+                                enum:
+                                  - Random
+                          - properties:
+                              maglev: {}
+                              type:
+                                enum:
+                                  - Maglev
                       localityAwareness:
                         description: LocalityAwareness contains configuration for locality aware load balancing.
                         properties:

--- a/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
+++ b/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1/validator_test.go
@@ -1,12 +1,26 @@
 package v1alpha1_test
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshloadbalancingstrategy/api/v1alpha1"
 	. "github.com/kumahq/kuma/v3/pkg/test/resources/validators"
 )
+
+var _ = Describe("generated schema", func() {
+	It("should describe the loadBalancer union with a oneOf", func() {
+		contents, err := os.ReadFile("rest.yaml")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Each branch pairs a type with the property it selects, so consumers do
+		// not have to infer the mapping.
+		Expect(string(contents)).To(MatchRegexp(`(?s)oneOf:.*roundRobin: \{\}.*- RoundRobin`))
+	})
+})
 
 var _ = Describe("validation", func() {
 	DescribeErrorCases(

--- a/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshmetric/api/v1alpha1/rest.yaml
@@ -255,6 +255,17 @@ components:
                     required:
                       - type
                     type: object
+                    oneOf:
+                      - properties:
+                          prometheus: {}
+                          type:
+                            enum:
+                              - Prometheus
+                      - properties:
+                          openTelemetry: {}
+                          type:
+                            enum:
+                              - OpenTelemetry
                   type: array
                 sidecar:
                   description: Sidecar metrics collection configuration

--- a/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
+++ b/pkg/plugins/policies/meshtrace/api/v1alpha1/rest.yaml
@@ -255,6 +255,22 @@ components:
                     required:
                       - type
                     type: object
+                    oneOf:
+                      - properties:
+                          type:
+                            enum:
+                              - Zipkin
+                          zipkin: {}
+                      - properties:
+                          datadog: {}
+                          type:
+                            enum:
+                              - Datadog
+                      - properties:
+                          openTelemetry: {}
+                          type:
+                            enum:
+                              - OpenTelemetry
                   maxItems: 1
                   type: array
                 sampling:

--- a/tools/policy-gen/generator/cmd/openapi.go
+++ b/tools/policy-gen/generator/cmd/openapi.go
@@ -58,6 +58,18 @@ func newOpenAPI(rootArgs *args) *cobra.Command {
 				return err
 			}
 
+			// Describe discriminated unions with a oneOf, which controller-gen
+			// cannot express, so consumers do not have to infer which property a
+			// given `type` selects. Appended to the enrichment expression so the
+			// generated file keeps its key order.
+			unions, err := unionAssignments(crdPath)
+			if err != nil {
+				return err
+			}
+			if unions != "" {
+				unions = "\n  | " + unions
+			}
+
 			// Enrich schema with CRD information
 			yqEnrichSchema := exec.CommandContext(cmd.Context(), //nolint:gosec
 				localArgs.yqBin, "e", "-i",
@@ -67,7 +79,7 @@ func newOpenAPI(rootArgs *args) *cobra.Command {
       | del(.apiVersion, .metadata, .kind)
     ) * {"type": {"enum": [$crd.spec.names.kind]}}
   | .description = $crd.spec.versions[0].schema.openAPIV3Schema.description
-  | (.properties | select(has("status")).status) |= . + {"readOnly": true}`, crdPath),
+  | (.properties | select(has("status")).status) |= . + {"readOnly": true}%s`, crdPath, unions),
 				tmpSchemaPath,
 			)
 			yqEnrichSchema.Stderr = cmd.ErrOrStderr()

--- a/tools/policy-gen/generator/cmd/suite_test.go
+++ b/tools/policy-gen/generator/cmd/suite_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestGenerator(t *testing.T) {
+	test.RunSpecs(t, "Generator Suite")
+}

--- a/tools/policy-gen/generator/cmd/unions.go
+++ b/tools/policy-gen/generator/cmd/unions.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+
+	"sigs.k8s.io/yaml"
+)
+
+// unionSite is a schema node that models a discriminated union: an object with a
+// `type` enum where every value has a matching sibling property holding that
+// variant's configuration.
+type unionSite struct {
+	// path is the sequence of map keys leading to the node, for a yq assignment.
+	path []string
+	// oneOf pairs each discriminator value with the property it selects.
+	oneOf []any
+}
+
+// findUnionSites walks a generated schema and reports every discriminated union.
+//
+// Kuma models unions as a `type` discriminator plus one optional property per
+// variant. controller-gen emits those variants as unrelated siblings, so nothing
+// in the spec says which property a given `type` selects and consumers have to
+// hardcode the mapping. A node qualifies only when *every* enum value resolves to
+// a sibling property, which is a tight enough fingerprint to avoid dragging in
+// plain enums that happen to sit next to similarly named fields.
+func findUnionSites(node any, path []string) []unionSite {
+	obj, ok := node.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var sites []unionSite
+	if oneOf, ok := unionOneOf(obj); ok {
+		sites = append(sites, unionSite{path: append([]string{}, path...), oneOf: oneOf})
+	}
+	for key, child := range obj {
+		sites = append(sites, findUnionSites(child, append(path, key))...)
+	}
+	return sites
+}
+
+func unionOneOf(obj map[string]any) ([]any, bool) {
+	properties, ok := obj["properties"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	discriminator, ok := properties["type"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	values, ok := discriminator["enum"].([]any)
+	if !ok || len(values) < 2 {
+		return nil, false
+	}
+
+	oneOf := make([]any, 0, len(values))
+	for _, value := range values {
+		name, ok := value.(string)
+		if !ok {
+			return nil, false
+		}
+		variant, ok := variantProperty(properties, name)
+		if !ok {
+			return nil, false
+		}
+		// The variant is matched as an unconstrained schema: the branch records
+		// which property the value selects without making it required, so a
+		// variant that carries no configuration can still be written as just
+		// `type: <value>`.
+		oneOf = append(oneOf, map[string]any{
+			"properties": map[string]any{
+				"type":  map[string]any{"enum": []any{name}},
+				variant: map[string]any{},
+			},
+		})
+	}
+	return oneOf, true
+}
+
+// variantProperty resolves a discriminator value to the sibling property holding
+// that variant, e.g. `RoundRobin` to `roundRobin` and `URLRewrite` to `urlRewrite`.
+func variantProperty(properties map[string]any, value string) (string, bool) {
+	for _, candidate := range []string{lowerFirst(value), lowerAcronym(value)} {
+		if candidate == "" || candidate == "type" {
+			continue
+		}
+		if _, ok := properties[candidate]; ok {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToLower(r[0])
+	return string(r)
+}
+
+// lowerAcronym lowercases a leading run of capitals, so `URLRewrite` becomes
+// `urlRewrite` the way encoding/json names it.
+func lowerAcronym(s string) string {
+	r := []rune(s)
+	i := 0
+	for i < len(r) && unicode.IsUpper(r[i]) {
+		i++
+	}
+	if i <= 1 {
+		return lowerFirst(s)
+	}
+	if i < len(r) {
+		i-- // the last capital starts the next word
+	}
+	return strings.ToLower(string(r[:i])) + string(r[i:])
+}
+
+// unionAssignments reads the CRD and renders a yq expression adding a oneOf to
+// every discriminated union it declares.
+//
+// The unions are found in the CRD rather than in the enriched schema so the
+// assignments can be appended to the yq call that does the enrichment: that keeps
+// the generated file's key order intact, which marshaling the whole document
+// through Go would not.
+func unionAssignments(crdPath string) (string, error) {
+	raw, err := os.ReadFile(crdPath)
+	if err != nil {
+		return "", err
+	}
+	var crd struct {
+		Spec struct {
+			Versions []struct {
+				Schema struct {
+					OpenAPIV3Schema struct {
+						Properties map[string]any `json:"properties"`
+					} `json:"openAPIV3Schema"`
+				} `json:"schema"`
+			} `json:"versions"`
+		} `json:"spec"`
+	}
+	if err := yaml.Unmarshal(raw, &crd); err != nil {
+		return "", err
+	}
+	if len(crd.Spec.Versions) == 0 {
+		return "", nil
+	}
+
+	// The enrichment merges the CRD properties into `.properties`, so a union at
+	// `spec.foo` in the CRD lands at `.properties.spec.foo` in the schema.
+	sites := findUnionSites(crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties, []string{"properties"})
+	if len(sites) == 0 {
+		return "", nil
+	}
+	sort.Slice(sites, func(i, j int) bool {
+		return strings.Join(sites[i].path, ".") < strings.Join(sites[j].path, ".")
+	})
+
+	assignments := make([]string, 0, len(sites))
+	for _, site := range sites {
+		encoded, err := json.Marshal(site.oneOf)
+		if err != nil {
+			return "", err
+		}
+		assignments = append(assignments, fmt.Sprintf("%s.oneOf = %s", yqPath(site.path), encoded))
+	}
+	return strings.Join(assignments, "\n  | "), nil
+}
+
+func yqPath(path []string) string {
+	var sb strings.Builder
+	for _, key := range path {
+		fmt.Fprintf(&sb, ".%q", key)
+	}
+	return sb.String()
+}

--- a/tools/policy-gen/generator/cmd/unions_test.go
+++ b/tools/policy-gen/generator/cmd/unions_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("findUnionSites", func() {
+	loadBalancer := func(variants ...string) map[string]any {
+		properties := map[string]any{
+			"type": map[string]any{"enum": []any{"RoundRobin", "URLRewrite"}},
+		}
+		for _, v := range variants {
+			properties[v] = map[string]any{"type": "object"}
+		}
+		return map[string]any{"properties": properties}
+	}
+
+	It("should pair every discriminator value with the property it selects", func() {
+		sites := findUnionSites(loadBalancer("roundRobin", "urlRewrite"), nil)
+
+		Expect(sites).To(HaveLen(1))
+		Expect(sites[0].oneOf).To(Equal([]any{
+			map[string]any{"properties": map[string]any{
+				"type":       map[string]any{"enum": []any{"RoundRobin"}},
+				"roundRobin": map[string]any{},
+			}},
+			map[string]any{"properties": map[string]any{
+				"type":       map[string]any{"enum": []any{"URLRewrite"}},
+				"urlRewrite": map[string]any{},
+			}},
+		}))
+	})
+
+	It("should ignore an enum whose values do not all name a sibling property", func() {
+		// A plain status/mode enum must not be mistaken for a union.
+		Expect(findUnionSites(loadBalancer("roundRobin"), nil)).To(BeEmpty())
+	})
+
+	It("should find nested unions and report their path", func() {
+		schema := map[string]any{
+			"properties": map[string]any{
+				"spec": loadBalancer("roundRobin", "urlRewrite"),
+			},
+		}
+
+		sites := findUnionSites(schema, []string{"properties"})
+
+		Expect(sites).To(HaveLen(1))
+		Expect(sites[0].path).To(Equal([]string{"properties", "properties", "spec"}))
+	})
+})
+
+var _ = Describe("variantProperty", func() {
+	DescribeTable("should resolve a discriminator value to its property",
+		func(value string, expected string) {
+			properties := map[string]any{expected: map[string]any{}}
+
+			actual, ok := variantProperty(properties, value)
+
+			Expect(ok).To(BeTrue())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("simple", "RoundRobin", "roundRobin"),
+		Entry("single leading capital", "Tcp", "tcp"),
+		Entry("acronym prefix", "URLRewrite", "urlRewrite"),
+		Entry("mixed caps", "OpenTelemetry", "openTelemetry"),
+	)
+
+	It("should not resolve to the discriminator itself", func() {
+		_, ok := variantProperty(map[string]any{"type": map[string]any{}}, "Type")
+		Expect(ok).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## Motivation

Closes #13667.

The last schema-correctness gap keeping the GUI on an overlay for 3.0.

Kuma models a union as a `type` discriminator plus one optional property per variant. controller-gen has no way to express that, so it emits the variants as unrelated siblings: nothing in the spec says that `type: RoundRobin` selects `roundRobin`. Consumers have to hardcode the mapping, which is exactly what the GUI overlay does for `loadBalancer`, `hashPolicies`, `filters` and `backends`.

> Changelog: feat(oas): describe union types with oneOf

## Implementation information

A generation step now adds a `oneOf` to every union, pairing each discriminator value with the property it selects:

```yaml
loadBalancer:
  properties: { type: {...}, roundRobin: {...}, leastRequest: {...}, ... }
  required: [type]
  oneOf:
    - properties: { type: { enum: [RoundRobin] }, roundRobin: {} }
    - properties: { type: { enum: [LeastRequest] }, leastRequest: {} }
```

**The variant is matched as an unconstrained schema rather than being `required`, and that is deliberate.** `rest.yaml` is not only documentation — `core_resource.go` embeds it and builds the runtime REST validator from it, so the shape here decides what the API accepts. The natural encoding, `oneOf: [{required: [roundRobin]}, ...]`, would reject

```yaml
loadBalancer:
  type: RoundRobin
```

because `RoundRobin` is `struct{}` and nobody writes `roundRobin: {}`. That exact config is asserted valid in `validator_test.go`. Every branch is still selected by exactly one `type` value, so validation is unchanged while the mapping becomes machine readable.

Unions are found by fingerprint — an object whose `type` enum has a sibling property for *every* value — rather than from the `+kuma:discriminator` marker. The marker is read only by the api-linter today, and three of the four unions the GUI overlays do not carry it, so it is not a usable source. The fingerprint is tight enough that a plain status enum sitting next to similarly named fields is not picked up.

The assignments are folded into the existing `yq` enrichment call rather than marshalling the document in Go, so the generated files keep their key order and the diff is only the added `oneOf`.

## What it found

Beyond the four the GUI overlays, the same pass picked up unions in `MeshMetric` backends, `MeshTrace` backends, `MeshIdentity` providers, and a nested one under `MeshHTTPRoute` `urlRewrite` (`replaceFullPath` / `replacePrefixMatch`) — 17 sites across 6 specs. Core resources share the generator, so they are covered too.

## Supporting documentation

`tools/policy-gen/generator/cmd/unions_test.go` covers the discriminator-to-property mapping, including the cases a naive lowercase-first breaks on (`Tcp`, `URLRewrite`, `OpenTelemetry`), and asserts a near-miss enum is not treated as a union. `meshloadbalancingstrategy` gains an assertion that the generated `rest.yaml` really carries the union, so the generator wiring is guarded end to end.

All policy validator suites pass unchanged, which is the evidence that no currently valid policy became invalid.

`pkg/version` fails locally for me both on this branch and on clean master (`invalid semantic version`), and the k8s suites need envtest binaries I do not have; neither is related.

https://claude.ai/code/session_01LC2YPrLoawcS7afNbsn2sd