### PR TITLE
chore(k8s): remove unused deprecation helpers

### DIFF
--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -1,7 +1,6 @@
 package metadata
 
 import (
-	"fmt"
 	"maps"
 	"strconv"
 	"strings"
@@ -103,28 +102,6 @@ var PodAnnotationDeprecations = []Deprecation{
 type Deprecation struct {
 	Key     string
 	Message string
-}
-
-func NewReplaceByDeprecation(old, n string, removed bool) Deprecation {
-	msg := fmt.Sprintf("'%s' is being replaced by: '%s'", old, n)
-	if removed {
-		msg = fmt.Sprintf("'%s' is no longer supported and it will be ignored, use '%s' instead", old, n)
-	}
-	return Deprecation{
-		Key:     old,
-		Message: msg,
-	}
-}
-
-func NewDeprecation(old string, removed bool) Deprecation {
-	msg := fmt.Sprintf("'%s' will be removed in a future release", old)
-	if removed {
-		msg = fmt.Sprintf("'%s' is no longer supported and it will be ignored, please see documentation on how to migrate", old)
-	}
-	return Deprecation{
-		Key:     old,
-		Message: msg,
-	}
 }
 
 // Annotations that are being automatically set by the Kuma Sidecar Injector.


### PR DESCRIPTION
## Motivation

> Changelog: chore(k8s): remove unused deprecation helpers

`NewReplaceByDeprecation` and `NewDeprecation` in `pkg/plugins/runtime/k8s/metadata/annotations.go` have no remaining call sites anywhere in the repo — dead code.

## Implementation information

Verified via `grep -rn "NewReplaceByDeprecation\|NewDeprecation(" --include="*.go" .` that only their own definitions matched. The `Deprecation` struct type and `PodAnnotationDeprecations` var they sit next to are still used (consumed in `pkg/plugins/runtime/k8s/webhooks/injector/precheck.go`) and are untouched.

## Supporting documentation

N/A

https://claude.ai/code/session_01MShFdzPmWTKa7em2A7xznh