### PR TITLE
chore(xds): remove dead legacy listener match

### DIFF
--- a/pkg/plugins/policies/core/xds/listeners.go
+++ b/pkg/plugins/policies/core/xds/listeners.go
@@ -61,10 +61,6 @@ func GatherListeners(rs *xds.ResourceSet) Listeners {
 			}
 		case generator_meta.OriginTransparent:
 			switch listener.Name {
-			case generator_meta.TransparentOutboundNameIPv4:
-				listeners.Ipv4Passthrough = listener
-			case generator_meta.TransparentOutboundNameIPv6:
-				listeners.Ipv6Passthrough = listener
 			case naming.ContextualTransparentProxyName("outbound", 4):
 				listeners.Ipv4Passthrough = listener
 			case naming.ContextualTransparentProxyName("outbound", 6):


### PR DESCRIPTION
## Motivation

> Changelog: chore(xds): remove dead legacy listener match

`GatherListeners` matched transparent-proxy listener names against both the legacy `generator_meta.TransparentOutboundNameIPv4/IPv6` format and the current `naming.ContextualTransparentProxyName` format. The transparent proxy generator only ever emits the contextual name now, so the legacy-name branches can never match and are dead code.

## Implementation information

Removed the two dead `case` branches in `pkg/plugins/policies/core/xds/listeners.go`. The `generator_meta.TransparentOutboundNameIPv4/IPv6` constants themselves are kept, since `pkg/plugins/policies/meshproxypatch/plugin/v1alpha1/network_filter_mod.go` still matches `MeshProxyPatch` policies against both name formats for backward compatibility.

## Supporting documentation

N/A

https://claude.ai/code/session_01MShFdzPmWTKa7em2A7xznh