### PR TITLE
chore(tools): keep buf envoy dep in sync

### DIFF
--- a/mk/check.mk
+++ b/mk/check.mk
@@ -2,6 +2,14 @@
 fmt/proto: ## Dev: Run buf format on .proto files
 	$(BUF) format -w
 
+# Keeps the Envoy proto dependency on the same release as ENVOY_VERSION, so an
+# Envoy bump can't leave buf lint resolving a different API than codegen does.
+.PHONY: fmt/proto-deps
+fmt/proto-deps: ## Dev: Pin the buf Envoy dependency to ENVOY_PROTO_VERSION
+	@COMMIT=$$($(BUF) registry module label info buf.build/envoyproxy/envoy:$(ENVOY_PROTO_VERSION) --format json | $(YQ) -p json -r '.commit') && \
+		$(YQ) -i '(.deps[] | select(test("^buf\.build/envoyproxy/envoy"))) = "buf.build/envoyproxy/envoy:'"$$COMMIT"'" | (.deps[] | select(test("^buf\.build/envoyproxy/envoy"))) line_comment = "$(ENVOY_PROTO_VERSION)"' buf.yaml
+	$(BUF) dep update
+
 .PHONY: tidy
 tidy:
 	@TOP=$(shell pwd) && \
@@ -38,7 +46,7 @@ ginkgo/lint:
 	$(GO) run $(TOOLS_DIR)/ci/check_test_files.go
 
 .PHONY: format
-format: fmt/proto generate tidy ginkgo/unfocus fmt/ci docs
+format: fmt/proto fmt/proto-deps generate tidy ginkgo/unfocus fmt/ci docs
 
 .PHONY: kube-lint
 kube-lint:


### PR DESCRIPTION
## Motivation

#18290 derived the Envoy proto export from `ENVOY_VERSION` but left the `buf.yaml` Envoy dependency pinned by hand. `buf lint` resolves imports through that pin while codegen resolves them through `ENVOY_PROTO_VERSION`, so an Envoy bump that forgets `buf.yaml` puts the two on different Envoy APIs — the same drift #18290 removed, moved one file over.

## Implementation information

`fmt/proto-deps` resolves the BSR commit for `ENVOY_PROTO_VERSION`, writes it into `buf.yaml` with the release as the line comment, and runs `buf dep update` to refresh `buf.lock`. It joins `format`, so `make check` goes red on drift exactly as it already does for the Kubernetes versions `fmt/ci` writes: a Renovate bump of `ENVOY_VERSION` fails until `make format` is run, and there is no second pin to remember.

The BSR response is read with `yq -p json` rather than `jq` because `release-2.13` has no `JQ` variable in `mk/dev.mk`, and this needs to backport unchanged.

Nothing changes on master today. `v1.39.0` already resolves to the committed `d939ad7a9f30490c81fafe49844c4007`, so the target is a no-op here and first bites on the next Envoy bump.

## Supporting documentation

Follows up on #18290.

> Changelog: skip