### PR TITLE
fix(api-server): header order, dead branch

### DIFF
--- a/pkg/api-server/filters/filtering.go
+++ b/pkg/api-server/filters/filtering.go
@@ -93,11 +93,6 @@ func labelFilter(request *restful.Request) (store.ListFilterFunc, error) {
 		labels := rs.GetMeta().GetLabels()
 		for _, filter := range filters {
 			v, ok := labels[filter.Key]
-			if filter.Op == FilterOpEq {
-				if !ok || v != filter.Value {
-					return false
-				}
-			}
 			if !ok || v != filter.Value {
 				return false
 			}

--- a/pkg/api-server/gui_handler.go
+++ b/pkg/api-server/gui_handler.go
@@ -40,8 +40,8 @@ func NewGuiHandler(guiPath string, disableGui bool, guiConfig GuiConfig) (http.H
 			http.FileServer(http.FS(guiFs)).ServeHTTP(writer, request)
 			return
 		}
-		writer.WriteHeader(http.StatusOK)
 		writer.Header().Set("Content-Type", "text/html")
+		writer.WriteHeader(http.StatusOK)
 		_, _ = writer.Write(buf.Bytes())
 	})), nil
 }


### PR DESCRIPTION
## Motivation

Two small bugs found while researching `pkg/api-server` refactoring:

1. `gui_handler.go`: `Content-Type: text/html` was set **after** `WriteHeader`, so it was never sent for the SPA fallback response.
2. `filters/filtering.go`: `labelFilter`'s closure had a duplicated unconditional check after the `FilterOpEq` branch — dead code (only the `eq` op exists).

## Implementation information

- Set `Content-Type` before `WriteHeader`.
- Collapse the duplicated branch into a single check.

## Supporting documentation

- [x] This PR fixes a bug (no issue, found during code review)

> Changelog: fix(api-server): send Content-Type on GUI fallback responses