### PR TITLE
refactor(api-server): add handle() adapter

### DIFF
--- a/pkg/api-server/handler.go
+++ b/pkg/api-server/handler.go
@@ -20,8 +20,7 @@ func handle(fn handlerFunc) restful.RouteFunction {
 		body, err := fn(request)
 		if err != nil {
 			title := ""
-			var terr *titledError
-			if errors.As(err, &terr) {
+			if terr, ok := errors.AsType[*titledError](err); ok {
 				title = terr.title
 				err = terr.err
 			}

--- a/pkg/api-server/handler.go
+++ b/pkg/api-server/handler.go
@@ -1,0 +1,69 @@
+package api_server
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+
+	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
+)
+
+// handlerFunc is an HTTP handler that returns a response body (written as JSON
+// with 200 OK) or an error (rendered by rest_errors.HandleError).
+type handlerFunc func(request *restful.Request) (any, error)
+
+// handle adapts a handlerFunc to restful.RouteFunction, centralizing error
+// rendering and response writing so handlers don't repeat it per call site.
+func handle(fn handlerFunc) restful.RouteFunction {
+	return func(request *restful.Request, response *restful.Response) {
+		body, err := fn(request)
+		if err != nil {
+			title := ""
+			var terr *titledError
+			if errors.As(err, &terr) {
+				title = terr.title
+				err = terr.err
+			}
+			rest_errors.HandleError(request.Request.Context(), response, err, title)
+			return
+		}
+		status := http.StatusOK
+		if sr, ok := body.(statusResponse); ok {
+			status = sr.status
+			body = sr.body
+		}
+		if err := response.WriteHeaderAndJson(status, body, "application/json"); err != nil {
+			log.Error(err, "Could not write the response")
+		}
+	}
+}
+
+// titledError carries the title used in the error response body, preserving
+// the per-call-site titles handlers previously passed to HandleError.
+type titledError struct {
+	err   error
+	title string
+}
+
+func (t *titledError) Error() string { return t.err.Error() }
+func (t *titledError) Unwrap() error { return t.err }
+
+// withTitle annotates err with the title used in the error response body.
+func withTitle(err error, title string) error {
+	if err == nil {
+		return nil
+	}
+	return &titledError{err: err, title: title}
+}
+
+// statusResponse wraps a body with a non-200 status code.
+type statusResponse struct {
+	status int
+	body   any
+}
+
+// created responds with 201 Created.
+func created(body any) any {
+	return statusResponse{status: http.StatusCreated, body: body}
+}

--- a/pkg/api-server/resource_crud_endpoints.go
+++ b/pkg/api-server/resource_crud_endpoints.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -69,13 +68,12 @@ func overviewForResource(
 	return overview.(core_model.Resource), nil
 }
 
-func (r *resourceCrudHandler) findResource(withInsight bool) func(request *restful.Request, response *restful.Response) {
-	return func(request *restful.Request, response *restful.Response) {
+func (r *resourceCrudHandler) findResource(withInsight bool) handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		name := request.PathParameter("name")
 		meshName, err := r.meshFromRequest(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-			return
+			return nil, withTitle(err, "Failed to retrieve Mesh")
 		}
 
 		if err := r.resourceAccess.ValidateGet(
@@ -84,32 +82,25 @@ func (r *resourceCrudHandler) findResource(withInsight bool) func(request *restf
 			r.descriptor,
 			user.FromCtx(request.Request.Context()),
 		); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-			return
+			return nil, withTitle(err, "Access Denied")
 		}
 
 		resource := r.descriptor.NewObject()
 		if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, meshName)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
-			return
+			return nil, withTitle(err, "Could not retrieve a resource")
 		}
 		if withInsight {
 			resource, err = overviewForResource(request.Request.Context(), r.resManager, r.descriptor, resource, name, meshName)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve insights")
-				return
+				return nil, withTitle(err, "Could not retrieve insights")
 			}
 		}
-		var res any
 
-		res, err = formatResource(resource, request.QueryParameter("format"), r.k8sMapper, request.QueryParameter("namespace"))
+		res, err := formatResource(resource, request.QueryParameter("format"), r.k8sMapper, request.QueryParameter("namespace"))
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
-			return
+			return nil, withTitle(err, "Could not retrieve a resource")
 		}
-		if err := response.WriteAsJson(res); err != nil {
-			log.Error(err, "Could not write the find response")
-		}
+		return res, nil
 	}
 }
 
@@ -129,35 +120,30 @@ func formatResource(resource core_model.Resource, format string, k8sMapper k8s.R
 	}
 }
 
-func (r *resourceCrudHandler) listResources(withInsight bool) func(request *restful.Request, response *restful.Response) {
-	return func(request *restful.Request, response *restful.Response) {
+func (r *resourceCrudHandler) listResources(withInsight bool) handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		page, err := pagination(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-			return
+			return nil, withTitle(err, "Could not retrieve resources")
 		}
 		filter, err := r.filter(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-			return
+			return nil, withTitle(err, "Could not retrieve resources")
 		}
 		nameContains := request.QueryParameter("name")
 		status, err := filters.Status(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-			return
+			return nil, withTitle(err, "Could not retrieve resources")
 		}
 		if status != "" {
 			if err := r.validateStatusFilter(withInsight); err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-				return
+				return nil, withTitle(err, "Could not retrieve resources")
 			}
 		}
 
 		meshName, err := r.meshFromRequest(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-			return
+			return nil, withTitle(err, "Failed to retrieve Mesh")
 		}
 
 		if err := r.resourceAccess.ValidateList(
@@ -166,53 +152,52 @@ func (r *resourceCrudHandler) listResources(withInsight bool) func(request *rest
 			r.descriptor,
 			user.FromCtx(request.Request.Context()),
 		); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-			return
+			return nil, withTitle(err, "Access Denied")
 		}
 		list := r.descriptor.NewList()
 		listOpts := []store.ListOptionsFunc{store.ListByMesh(meshName), store.ListByNameContains(nameContains), store.ListByFilterFunc(filter)}
 		if status == "" {
 			listOpts = append(listOpts, store.ListByPage(page.size, page.offset))
 		}
-		// Status lives on the insight, so the page can only be cut once the
-		// overviews are merged. List everything and paginate below instead.
 		if err := r.resManager.List(request.Request.Context(), list, listOpts...); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-			return
+			return nil, withTitle(err, "Could not retrieve resources")
 		}
 		if withInsight {
-			// we cannot paginate insights since there is no guarantee that the insights elements will be the same as regular entities
-			// Extract ResourceKeys from filtered dataplanes
-			resourceKeys := make([]core_model.ResourceKey, 0, len(list.GetItems()))
-			for _, item := range list.GetItems() {
-				resourceKeys = append(resourceKeys, core_model.MetaToResourceKey(item.GetMeta()))
-			}
-
-			// Fetch insights only for filtered dataplanes
-			insights := r.descriptor.NewInsightList()
-			if err := r.resManager.List(request.Request.Context(), insights, store.ListByMesh(meshName), store.ListByResourceKeys(resourceKeys)); err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-				return
-			}
-			list, err = r.MergeInOverview(list, insights)
+			list, err = r.mergeInsights(request.Request.Context(), list, meshName, status, page)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "Failed merging overview and insights")
-				return
-			}
-			if status != "" {
-				list, err = r.pageByStatus(list, status, page)
-				if err != nil {
-					rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve resources")
-					return
-				}
+				return nil, err
 			}
 		}
 		restList := rest.From.ResourceList(list)
 		restList.Next = nextLink(request, list.GetPagination().NextOffset)
-		if err := response.WriteAsJson(restList); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not list resources")
+		return restList, nil
+	}
+}
+
+// mergeInsights merges the list with the insights of its items into overviews.
+// Status lives on the insight, so when a status filter is set the page can only
+// be cut once the overviews are merged: everything is listed and paginated here.
+func (r *resourceCrudHandler) mergeInsights(ctx context.Context, list core_model.ResourceList, meshName string, status core_mesh.Status, page page) (core_model.ResourceList, error) {
+	resourceKeys := make([]core_model.ResourceKey, 0, len(list.GetItems()))
+	for _, item := range list.GetItems() {
+		resourceKeys = append(resourceKeys, core_model.MetaToResourceKey(item.GetMeta()))
+	}
+
+	insights := r.descriptor.NewInsightList()
+	if err := r.resManager.List(ctx, insights, store.ListByMesh(meshName), store.ListByResourceKeys(resourceKeys)); err != nil {
+		return nil, withTitle(err, "Could not retrieve resources")
+	}
+	merged, err := r.MergeInOverview(list, insights)
+	if err != nil {
+		return nil, withTitle(err, "Failed merging overview and insights")
+	}
+	if status != "" {
+		merged, err = r.pageByStatus(merged, status, page)
+		if err != nil {
+			return nil, withTitle(err, "Could not retrieve resources")
 		}
 	}
+	return merged, nil
 }
 
 // statusAware is implemented by overviews exposing a status computed from their
@@ -292,24 +277,21 @@ func (r *resourceCrudHandler) MergeInOverview(resources core_model.ResourceList,
 	return items, nil
 }
 
-func (r *resourceCrudHandler) createOrUpdateResource(request *restful.Request, response *restful.Response) {
+func (r *resourceCrudHandler) createOrUpdateResource(request *restful.Request) (any, error) {
 	name := request.PathParameter("name")
 	meshName, err := r.meshFromRequest(request)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-		return
+		return nil, withTitle(err, "Failed to retrieve Mesh")
 	}
 
 	bodyBytes, err := io.ReadAll(request.Request.Body)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not process a resource")
-		return
+		return nil, withTitle(err, "Could not process a resource")
 	}
 
 	resourceRest, err := rest.JSON.Unmarshal(bodyBytes, r.descriptor)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not process a resource")
-		return
+		return nil, withTitle(err, "Could not process a resource")
 	}
 
 	create := false
@@ -317,20 +299,17 @@ func (r *resourceCrudHandler) createOrUpdateResource(request *restful.Request, r
 	if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, meshName)); err != nil && store.IsNotFound(err) {
 		create = true
 	} else if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to find a resource")
-		return
+		return nil, withTitle(err, "Failed to find a resource")
 	}
 
 	if err := r.validateResourceRequest(name, meshName, resourceRest); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not process a resource")
-		return
+		return nil, withTitle(err, "Could not process a resource")
 	}
 
 	if create {
-		r.createResource(request.Request.Context(), name, meshName, resourceRest, response)
-	} else {
-		r.updateResource(request.Request.Context(), resource, resourceRest, response, meshName)
+		return r.createResource(request.Request.Context(), name, meshName, resourceRest)
 	}
+	return r.updateResource(request.Request.Context(), resource, resourceRest, meshName)
 }
 
 func (r *resourceCrudHandler) clearMeshTrustOrigin(resRest rest.Resource, meshName string, name string) {
@@ -373,8 +352,7 @@ func (r *resourceCrudHandler) createResource(
 	name string,
 	meshName string,
 	resRest rest.Resource,
-	response *restful.Response,
-) {
+) (any, error) {
 	if err := r.resourceAccess.ValidateCreate(
 		ctx,
 		core_model.ResourceKey{Mesh: meshName, Name: name},
@@ -382,8 +360,7 @@ func (r *resourceCrudHandler) createResource(
 		r.descriptor,
 		user.FromCtx(ctx),
 	); err != nil {
-		rest_errors.HandleError(ctx, response, err, "Access Denied")
-		return
+		return nil, withTitle(err, "Access Denied")
 	}
 
 	r.clearMeshTrustOrigin(resRest, meshName, name)
@@ -392,48 +369,53 @@ func (r *resourceCrudHandler) createResource(
 	_ = res.SetSpec(resRest.GetSpec())
 	res.SetMeta(resRest.GetMeta())
 
-	// Validate workload label on Universal Zone dataplanes
-	if r.descriptor.Name == core_mesh.DataplaneType && !r.isK8s {
-		if resLabels := res.GetMeta().GetLabels(); resLabels != nil {
-			if workloadName, ok := resLabels[metadata.KumaWorkload]; ok && workloadName != "" {
-				if r.mode == config_core.Global {
-					err := rest_errors.NewBadRequestError("labels[\"kuma.io/workload\"]: not allowed on Global control plane")
-					rest_errors.HandleError(ctx, response, err, "Invalid workload label")
-					return
-				}
-				if validationErrs := apimachineryvalidation.NameIsDNS1035Label(workloadName, false); len(validationErrs) != 0 {
-					err := rest_errors.NewBadRequestError(fmt.Sprintf("labels[\"kuma.io/workload\"]: must be a valid DNS-1035 label (at most 63 characters, matching regex [a-z]([-a-z0-9]*[a-z0-9])?): %s", strings.Join(validationErrs, "; ")))
-					rest_errors.HandleError(ctx, response, err, "Invalid workload label")
-					return
-				}
-			}
-		}
+	if err := r.validateUniversalDataplaneWorkloadLabel(res); err != nil {
+		return nil, err
 	}
 
 	labels, err := r.computeLabels(res.Descriptor(), res.GetSpec(), res.GetMeta(), meshName, name)
 	if err != nil {
-		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")
-		return
+		return nil, withTitle(err, "Could not compute labels for a resource")
 	}
 
 	if err := r.resManager.Create(ctx, res, store.CreateByKey(name, meshName), store.CreateWithLabels(labels)); err != nil {
-		rest_errors.HandleError(ctx, response, err, "Failed to create a resource")
-		return
+		return nil, withTitle(err, "Failed to create a resource")
 	}
 
-	resp := api_server_types.CreateOrUpdateSuccessResponse{Warnings: core_model.Deprecations(res)}
-	if err := response.WriteHeaderAndJson(http.StatusCreated, resp, "application/json"); err != nil {
-		log.Error(err, "Could not write the create response")
+	return created(api_server_types.CreateOrUpdateSuccessResponse{Warnings: core_model.Deprecations(res)}), nil
+}
+
+// validateUniversalDataplaneWorkloadLabel validates the workload label of
+// Dataplanes created on Universal zones.
+func (r *resourceCrudHandler) validateUniversalDataplaneWorkloadLabel(res core_model.Resource) error {
+	if r.descriptor.Name != core_mesh.DataplaneType || r.isK8s {
+		return nil
 	}
+	workloadName, ok := res.GetMeta().GetLabels()[metadata.KumaWorkload]
+	if !ok || workloadName == "" {
+		return nil
+	}
+	if r.mode == config_core.Global {
+		return withTitle(
+			rest_errors.NewBadRequestError("labels[\"kuma.io/workload\"]: not allowed on Global control plane"),
+			"Invalid workload label",
+		)
+	}
+	if validationErrs := apimachineryvalidation.NameIsDNS1035Label(workloadName, false); len(validationErrs) != 0 {
+		return withTitle(
+			rest_errors.NewBadRequestError(fmt.Sprintf("labels[\"kuma.io/workload\"]: must be a valid DNS-1035 label (at most 63 characters, matching regex [a-z]([-a-z0-9]*[a-z0-9])?): %s", strings.Join(validationErrs, "; "))),
+			"Invalid workload label",
+		)
+	}
+	return nil
 }
 
 func (r *resourceCrudHandler) updateResource(
 	ctx context.Context,
 	currentRes core_model.Resource,
 	newResRest rest.Resource,
-	response *restful.Response,
 	meshName string,
-) {
+) (any, error) {
 	if err := r.resourceAccess.ValidateUpdate(
 		ctx,
 		core_model.ResourceKey{Mesh: currentRes.GetMeta().GetMesh(), Name: currentRes.GetMeta().GetName()},
@@ -442,65 +424,51 @@ func (r *resourceCrudHandler) updateResource(
 		r.descriptor,
 		user.FromCtx(ctx),
 	); err != nil {
-		rest_errors.HandleError(ctx, response, err, "Access Denied")
-		return
+		return nil, withTitle(err, "Access Denied")
 	}
 
 	r.clearMeshTrustOrigin(newResRest, meshName, currentRes.GetMeta().GetName())
 
-	// Compute labels for current state BEFORE modifying spec
 	currentLabels, err := r.computeLabels(currentRes.Descriptor(), currentRes.GetSpec(), currentRes.GetMeta(), meshName, currentRes.GetMeta().GetName())
 	if err != nil {
-		rest_errors.HandleError(ctx, response, err, "Could not compute current labels")
-		return
+		return nil, withTitle(err, "Could not compute current labels")
 	}
 
 	_ = currentRes.SetSpec(newResRest.GetSpec())
 
-	// Compute labels for new request
 	labels, err := r.computeLabels(currentRes.Descriptor(), currentRes.GetSpec(), newResRest.GetMeta(), meshName, currentRes.GetMeta().GetName())
 	if err != nil {
-		rest_errors.HandleError(ctx, response, err, "Could not compute labels for a resource")
-		return
+		return nil, withTitle(err, "Could not compute labels for a resource")
 	}
 
-	// Validate immutable labels by comparing computed results
 	if validationErr := r.validateImmutableLabels(currentLabels, labels); validationErr.HasViolations() {
 		var err validators.ValidationError
 		err.AddError("labels", validationErr)
-		rest_errors.HandleError(ctx, response, &err, "Could not update a resource")
-		return
+		return nil, withTitle(&err, "Could not update a resource")
 	}
 
 	if err := r.resManager.Update(ctx, currentRes, store.UpdateWithLabels(labels)); err != nil {
-		rest_errors.HandleError(ctx, response, err, "Failed to update a resource")
-		return
+		return nil, withTitle(err, "Failed to update a resource")
 	}
 
-	resp := api_server_types.CreateOrUpdateSuccessResponse{Warnings: core_model.Deprecations(currentRes)}
-	if err := response.WriteHeaderAndJson(http.StatusOK, resp, "application/json"); err != nil {
-		log.Error(err, "Could not write the update response")
-	}
+	return api_server_types.CreateOrUpdateSuccessResponse{Warnings: core_model.Deprecations(currentRes)}, nil
 }
 
-func (r *resourceCrudHandler) deleteResource(request *restful.Request, response *restful.Response) {
+func (r *resourceCrudHandler) deleteResource(request *restful.Request) (any, error) {
 	name := request.PathParameter("name")
 	meshName, err := r.meshFromRequest(request)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-		return
+		return nil, withTitle(err, "Failed to retrieve Mesh")
 	}
 
 	resource := r.descriptor.NewObject()
 
 	if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, meshName)); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not delete a resource")
-		return
+		return nil, withTitle(err, "Could not delete a resource")
 	}
 
 	if verr := r.validateOriginForWrite(resource.GetMeta()); verr.HasViolations() {
-		rest_errors.HandleError(request.Request.Context(), response, verr.OrNil(), "Could not delete a resource")
-		return
+		return nil, withTitle(verr.OrNil(), "Could not delete a resource")
 	}
 
 	if err := r.resourceAccess.ValidateDelete(
@@ -510,19 +478,14 @@ func (r *resourceCrudHandler) deleteResource(request *restful.Request, response 
 		resource.Descriptor(),
 		user.FromCtx(request.Request.Context()),
 	); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-		return
+		return nil, withTitle(err, "Access Denied")
 	}
 
 	if err := r.resManager.Delete(request.Request.Context(), resource, store.DeleteByKey(name, meshName)); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not delete a resource")
-		return
+		return nil, withTitle(err, "Could not delete a resource")
 	}
 
-	resp := api_server_types.DeleteSuccessResponse{}
-	if err := response.WriteHeaderAndJson(http.StatusOK, resp, "application/json"); err != nil {
-		log.Error(err, "Could not write the delete response")
-	}
+	return api_server_types.DeleteSuccessResponse{}, nil
 }
 
 func (r *resourceCrudHandler) validateResourceRequest(name string, meshName string, resource rest.Resource) error {

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
-	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v3/pkg/core/rest/errors/types"
 	"github.com/kumahq/kuma/v3/pkg/core/runtime"
 	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
@@ -86,14 +85,14 @@ func (r *resourceEndpoints) route(ws *restful.WebService, method, path string) *
 }
 
 func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix string) {
-	ws.Route(r.route(ws, http.MethodGet, pathPrefix+"/{name}").To(r.findResource(false)).
+	ws.Route(r.route(ws, http.MethodGet, pathPrefix+"/{name}").To(handle(r.findResource(false))).
 		Doc(fmt.Sprintf("Get a %s", r.descriptor.WsPath)).
 		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 		Returns(200, "OK", nil).
 		Returns(404, "Not found", nil))
 	if r.descriptor.HasInsights() {
 		route := r.findResource(true)
-		ws.Route(ws.GET(pathPrefix+"/{name}/_overview").To(route).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_overview").To(handle(route)).
 			Doc(fmt.Sprintf("Get overview of a %s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil).
@@ -114,7 +113,7 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 			Returns(404, "Not found", nil))
 		if r.mode == config_core.Global {
 			msg := "Not allowed on global CP"
-			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(r.methodNotAllowed(msg)).
+			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(handle(r.methodNotAllowed(msg))).
 				Doc(msg).
 				Returns(http.StatusMethodNotAllowed, msg, restful.ServiceError{}))
 		} else {
@@ -169,19 +168,18 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 	}
 }
 
-func (r *resourceEndpoints) methodNotAllowed(detail string) func(request *restful.Request, response *restful.Response) {
-	return func(request *restful.Request, response *restful.Response) {
-		err := &types.Error{
+func (r *resourceEndpoints) methodNotAllowed(detail string) handlerFunc {
+	return func(request *restful.Request) (any, error) {
+		return nil, &types.Error{
 			Status: 405,
 			Title:  "Method not allowed",
 			Detail: detail,
 		}
-		rest_errors.HandleError(request.Request.Context(), response, err, "")
 	}
 }
 
 func (r *resourceEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix string) {
-	ws.Route(r.route(ws, http.MethodGet, pathPrefix).To(r.listResources(false)).
+	ws.Route(r.route(ws, http.MethodGet, pathPrefix).To(handle(r.listResources(false))).
 		Doc(fmt.Sprintf("List of %s", r.descriptor.Name)).
 		Param(ws.QueryParameter("size", "size of page").DataType("int")).
 		Param(ws.QueryParameter("offset", "offset of page to list").DataType("string")).
@@ -189,7 +187,7 @@ func (r *resourceEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix s
 		Returns(200, "OK", nil))
 	if r.descriptor.HasInsights() {
 		route := r.listResources(true)
-		ws.Route(ws.GET(pathPrefix+"/_overview").To(route).
+		ws.Route(ws.GET(pathPrefix+"/_overview").To(handle(route)).
 			Doc(fmt.Sprintf("Get a %s", r.descriptor.WsPath)).
 			Param(ws.QueryParameter("size", "size of page").DataType("int")).
 			Param(ws.QueryParameter("offset", "offset of page to list").DataType("string")).
@@ -202,11 +200,11 @@ func (r *resourceEndpoints) addListEndpoint(ws *restful.WebService, pathPrefix s
 
 func (r *resourceEndpoints) addCreateOrUpdateEndpoint(ws *restful.WebService, pathPrefix string) {
 	if r.descriptor.ReadOnly {
-		ws.Route(r.route(ws, http.MethodPut, pathPrefix+"/{name}").To(r.methodNotAllowed(r.readOnlyMessage())).
+		ws.Route(r.route(ws, http.MethodPut, pathPrefix+"/{name}").To(handle(r.methodNotAllowed(r.readOnlyMessage()))).
 			Doc("Not allowed in read-only mode.").
 			Returns(http.StatusMethodNotAllowed, "Not allowed in read-only mode.", restful.ServiceError{}))
 	} else {
-		ws.Route(r.route(ws, http.MethodPut, pathPrefix+"/{name}").To(r.createOrUpdateResource).
+		ws.Route(r.route(ws, http.MethodPut, pathPrefix+"/{name}").To(handle(r.createOrUpdateResource)).
 			Doc(fmt.Sprintf("Updates a %s", r.descriptor.WsPath)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of the %s", r.descriptor.WsPath)).DataType("string")).
 			Returns(200, "OK", nil).
@@ -216,11 +214,11 @@ func (r *resourceEndpoints) addCreateOrUpdateEndpoint(ws *restful.WebService, pa
 
 func (r *resourceEndpoints) addDeleteEndpoint(ws *restful.WebService, pathPrefix string) {
 	if r.descriptor.ReadOnly {
-		ws.Route(r.route(ws, http.MethodDelete, pathPrefix+"/{name}").To(r.methodNotAllowed(r.readOnlyMessage())).
+		ws.Route(r.route(ws, http.MethodDelete, pathPrefix+"/{name}").To(handle(r.methodNotAllowed(r.readOnlyMessage()))).
 			Doc("Not allowed in read-only mode.").
 			Returns(http.StatusMethodNotAllowed, "Not allowed in read-only mode.", restful.ServiceError{}))
 	} else {
-		ws.Route(r.route(ws, http.MethodDelete, pathPrefix+"/{name}").To(r.deleteResource).
+		ws.Route(r.route(ws, http.MethodDelete, pathPrefix+"/{name}").To(handle(r.deleteResource)).
 			Doc(fmt.Sprintf("Deletes a %s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil))


### PR DESCRIPTION
## Motivation

Every `pkg/api-server` handler repeats the same boilerplate (~90 occurrences package-wide):

```go
x, err := ...
if err != nil {
    rest_errors.HandleError(ctx, response, err, "<free-text title>")
    return
}
```

plus an inconsistent write path (`WriteAsJson` + log vs `WriteHeaderAndJson` + `HandleError`).

## Implementation information

New `handler.go`:

- `handlerFunc func(*restful.Request) (any, error)` — handlers return body or error
- `handle()` adapts it to `restful.RouteFunction`: one place renders errors via `rest_errors.HandleError`, one place writes JSON
- `withTitle()` preserves per-call-site error titles, so **response bodies are byte-identical** (golden files untouched)
- `created()` covers the 201 path

Migrated as proof: resource CRUD handlers (`findResource`, `listResources`, `createOrUpdateResource`, `deleteResource`) and `methodNotAllowed`. Inspect endpoints migrate in a follow-up.

Side benefit: handlers are now plain functions returning `(any, error)` — unit-testable without booting the server. Also extracted `mergeInsights`/`validateUniversalDataplaneWorkloadLabel` from the two longest handlers.

Not middleware on purpose: go-restful's `RouteFunction` returns nothing, so a filter can't see handler errors; a filter+context stash would keep the same per-error line while adding ordering coupling.

## Supporting documentation

- [x] There is no user-facing change (error bodies preserved exactly)

> Changelog: skip