### PR TITLE
refactor(api-server): page-size errors to core

### DIFF
--- a/pkg/api-server/pagination.go
+++ b/pkg/api-server/pagination.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 
-	"github.com/kumahq/kuma/v3/pkg/api-server/types"
+	"github.com/kumahq/kuma/v3/pkg/core/rest/errors/types"
 )
 
 const (

--- a/pkg/core/rest/errors/error_handler.go
+++ b/pkg/core/rest/errors/error_handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/trace"
 
-	api_server_types "github.com/kumahq/kuma/v3/pkg/api-server/types"
 	"github.com/kumahq/kuma/v3/pkg/core/access"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest"
@@ -71,7 +70,7 @@ func HandleError(ctx context.Context, response *restful.Response, err error, tit
 			Title:  title,
 			Detail: err.Error(),
 		}
-	case errors.Is(err, &api_server_types.InvalidPageSizeError{}):
+	case errors.Is(err, &types.InvalidPageSizeError{}):
 		kumaErr = &types.Error{
 			Status: 400,
 			Title:  title,

--- a/pkg/core/rest/errors/types/page_size.go
+++ b/pkg/core/rest/errors/types/page_size.go
@@ -1,8 +1,8 @@
 package types
 
 import (
+	"errors"
 	"fmt"
-	"reflect"
 )
 
 type InvalidPageSizeError struct {
@@ -14,7 +14,8 @@ func (a *InvalidPageSizeError) Error() string {
 }
 
 func (a *InvalidPageSizeError) Is(err error) bool {
-	return reflect.TypeOf(a) == reflect.TypeOf(err)
+	var target *InvalidPageSizeError
+	return errors.As(err, &target)
 }
 
 func NewMaxPageSizeExceeded(pageSize, limit int) error {


### PR DESCRIPTION
## Motivation

`pkg/core/rest/errors/error_handler.go` imported `pkg/api-server/types` for `InvalidPageSizeError` — a layering inversion (`core` depending on `api-server`).

## Implementation information

- Move `InvalidPageSizeError`, `NewMaxPageSizeExceeded`, `InvalidPageSize` to `pkg/core/rest/errors/types` (next to the `Error` response type they feed into).
- Replace the `reflect.TypeOf`-based `Is` with `errors.As`.
- Update the two importers (`error_handler.go`, `pagination.go`).

No behavior change; error responses identical.

## Supporting documentation

- [x] There is no user-facing change

> Changelog: skip