### PR TITLE
refactor(api-server): migrate handlers to handle()

### DIFF
--- a/pkg/api-server/config_ws.go
+++ b/pkg/api-server/config_ws.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kumahq/kuma/v3/pkg/config"
 	"github.com/kumahq/kuma/v3/pkg/core/access"
-	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v3/pkg/core/user"
 )
 
@@ -14,16 +13,12 @@ func addConfigEndpoints(ws *restful.WebService, access access.ControlPlaneMetada
 	if err != nil {
 		return err
 	}
-	ws.Route(ws.GET("/config").To(func(req *restful.Request, resp *restful.Response) {
+	ws.Route(ws.GET("/config").To(handle(func(req *restful.Request) (any, error) {
 		ctx := req.Request.Context()
 		if err := access.ValidateView(ctx, user.FromCtx(ctx)); err != nil {
-			rest_errors.HandleError(ctx, resp, err, "Access denied")
-			return
+			return nil, withTitle(err, "Access denied")
 		}
-		resp.AddHeader("content-type", "application/json")
-		if _, err := resp.Write([]byte(cfgForDisplay)); err != nil {
-			log.Error(err, "Could not write the index response")
-		}
-	}))
+		return rawResponse{contentType: "application/json", body: []byte(cfgForDisplay)}, nil
+	})))
 	return nil
 }

--- a/pkg/api-server/dataplane_layout_endpoint.go
+++ b/pkg/api-server/dataplane_layout_endpoint.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
-	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v3/pkg/core/user"
 	util_slices "github.com/kumahq/kuma/v3/pkg/util/slices"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
@@ -54,13 +53,13 @@ func newDataplaneLayoutEndpoint(
 func (dle *dataplaneLayoutEndpoint) addEndpoint(ws *restful.WebService) {
 	ws.Route(
 		ws.GET("/meshes/{mesh}/dataplanes/{name}/_layout").
-			To(dle.getLayout).
+			To(handle(dle.getLayout)).
 			Doc("Get Dataplane Layout").
 			Returns(http.StatusOK, "OK", nil),
 	)
 }
 
-func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response *restful.Response) {
+func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request) (any, error) {
 	meshName := request.PathParameter("mesh")
 	dataplaneName := request.PathParameter("name")
 
@@ -70,21 +69,18 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 		core_mesh.DataplaneResourceTypeDescriptor,
 		user.FromCtx(request.Request.Context()),
 	); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-		return
+		return nil, withTitle(err, "Access Denied")
 	}
 
 	baseMeshContext, err := dle.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build MeshContext")
-		return
+		return nil, withTitle(err, "Failed to build MeshContext")
 	}
 
 	dataplane := core_mesh.NewDataplaneResource()
 	err = dle.resManager.Get(request.Request.Context(), dataplane, store.GetByKey(dataplaneName, meshName))
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Dataplane")
-		return
+		return nil, withTitle(err, "Failed to retrieve Dataplane")
 	}
 
 	inbounds := util_slices.Map(dataplane.Spec.GetNetworking().GetInbound(), func(inbound *v1alpha1.Dataplane_Networking_Inbound) api_common.DataplaneInbound {
@@ -148,10 +144,7 @@ func (dle *dataplaneLayoutEndpoint) getLayout(request *restful.Request, response
 		SpiffeId:  dle.computeSpiffeID(request, meshName, dataplane),
 	}
 
-	err = response.WriteHeaderAndJson(http.StatusOK, networkingLayout, "application/json")
-	if err != nil {
-		log.Error(err, "Could not write response")
-	}
+	return networkingLayout, nil
 }
 
 func allPorts(destination core_resources.Destination) []core_resources.Port {

--- a/pkg/api-server/global_insight_endpoint.go
+++ b/pkg/api-server/global_insight_endpoint.go
@@ -3,7 +3,6 @@ package api_server
 import (
 	"github.com/emicklei/go-restful/v3"
 
-	"github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v3/pkg/insights/globalinsight"
 )
 
@@ -15,22 +14,16 @@ type globalInsightEndpoint struct {
 
 func (ge *globalInsightEndpoint) addEndpoint(ws *restful.WebService) {
 	ws.Route(
-		ws.GET(GlobalInsightPath).To(ge.getGlobalInsight).
+		ws.GET(GlobalInsightPath).To(handle(ge.getGlobalInsight)).
 			Doc("Get Global Insight").
 			Returns(200, "OK", nil),
 	)
 }
 
-func (ge *globalInsightEndpoint) getGlobalInsight(request *restful.Request, response *restful.Response) {
-	ctx := request.Request.Context()
-	globalInsight, err := ge.globalInsightService.GetGlobalInsight(ctx)
+func (ge *globalInsightEndpoint) getGlobalInsight(request *restful.Request) (any, error) {
+	globalInsight, err := ge.globalInsightService.GetGlobalInsight(request.Request.Context())
 	if err != nil {
-		errors.HandleError(ctx, response, err, "Could not retrieve GlobalInsight")
-		return
+		return nil, withTitle(err, "Could not retrieve GlobalInsight")
 	}
-
-	if err = response.WriteAsJson(globalInsight); err != nil {
-		errors.HandleError(ctx, response, err, "Could not write response")
-		return
-	}
+	return globalInsight, nil
 }

--- a/pkg/api-server/global_insights_endpoints.go
+++ b/pkg/api-server/global_insights_endpoints.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
-	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 )
 
 type globalInsightsEndpoints struct {
@@ -39,12 +38,12 @@ func newGlobalInsightsResponse(resources map[string]globalInsightsStat) *globalI
 }
 
 func (r *globalInsightsEndpoints) addEndpoint(ws *restful.WebService) {
-	ws.Route(ws.GET("/global-insights").To(r.inspectGlobalResources).
+	ws.Route(ws.GET("/global-insights").To(handle(r.inspectGlobalResources)).
 		Doc("Inspect all global resources").
 		Returns(200, "OK", nil))
 }
 
-func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Request, response *restful.Response) {
+func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Request) (any, error) {
 	resources := map[string]globalInsightsStat{}
 
 	for _, descriptor := range registry.Global().ObjectDescriptors() {
@@ -56,8 +55,7 @@ func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Reques
 
 		list := descriptor.NewList()
 		if err := r.resManager.List(request.Request.Context(), list); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve global insights")
-			return
+			return nil, withTitle(err, "Could not retrieve global insights")
 		}
 
 		resources[string(descriptor.Name)] = globalInsightsStat{
@@ -65,9 +63,5 @@ func (r *globalInsightsEndpoints) inspectGlobalResources(request *restful.Reques
 		}
 	}
 
-	insights := newGlobalInsightsResponse(resources)
-
-	if err := response.WriteAsJson(insights); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve global insights")
-	}
+	return newGlobalInsightsResponse(resources), nil
 }

--- a/pkg/api-server/handler.go
+++ b/pkg/api-server/handler.go
@@ -32,6 +32,13 @@ func handle(fn handlerFunc) restful.RouteFunction {
 			status = sr.status
 			body = sr.body
 		}
+		if raw, ok := body.(rawResponse); ok {
+			response.AddHeader(restful.HEADER_ContentType, raw.contentType)
+			if _, err := response.Write(raw.body); err != nil {
+				log.Error(err, "Could not write the response")
+			}
+			return
+		}
 		if err := response.WriteHeaderAndJson(status, body, "application/json"); err != nil {
 			log.Error(err, "Could not write the response")
 		}
@@ -65,4 +72,11 @@ type statusResponse struct {
 // created responds with 201 Created.
 func created(body any) any {
 	return statusResponse{status: http.StatusCreated, body: body}
+}
+
+// rawResponse is a response body written as-is with the given Content-Type,
+// for endpoints that don't serve JSON (e.g. Envoy admin output).
+type rawResponse struct {
+	contentType string
+	body        []byte
 }

--- a/pkg/api-server/inspect_endpoints.go
+++ b/pkg/api-server/inspect_endpoints.go
@@ -16,7 +16,6 @@ import (
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
-	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	"github.com/kumahq/kuma/v3/pkg/core/xds/inspect"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
@@ -48,7 +47,7 @@ func addInspectEndpoints(
 ) {
 	for _, desc := range registry.Global().ObjectDescriptors(core_model.AllowedToInspect()) {
 		ws.Route(
-			ws.GET(fmt.Sprintf("/meshes/{mesh}/%s/{name}/dataplanes", desc.WsPath)).To(inspectPolicies(desc.Name, builder, cfg)).
+			ws.GET(fmt.Sprintf("/meshes/{mesh}/%s/{name}/dataplanes", desc.WsPath)).To(handle(inspectPolicies(desc.Name, builder, cfg))).
 				Doc("inspect policies").
 				Param(ws.PathParameter("mesh", "mesh name").DataType("string")).
 				Param(ws.PathParameter("name", "resource name").DataType("string")).
@@ -57,7 +56,7 @@ func addInspectEndpoints(
 	}
 
 	ws.Route(
-		ws.GET("/meshes/{mesh}/meshservices/{name}/_dataplanes").To(inspectMeshServiceDataplanes(rm, resourceAccess)).
+		ws.GET("/meshes/{mesh}/meshservices/{name}/_dataplanes").To(handle(inspectMeshServiceDataplanes(rm, resourceAccess))).
 			Doc("inspect MeshService").
 			Param(ws.PathParameter("mesh", "mesh name").DataType("string")).
 			Param(ws.PathParameter("name", "resource name").DataType("string")).
@@ -70,11 +69,10 @@ func addInspectEndpoints(
 func inspectMeshServiceDataplanes(
 	rm manager.ResourceManager,
 	resourceAccess access.ResourceAccess,
-) restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
-		matchingDataplanesForFilter(
+) handlerFunc {
+	return func(request *restful.Request) (any, error) {
+		return matchingDataplanesForFilter(
 			request,
-			response,
 			meshservice_api.MeshServiceResourceTypeDescriptor,
 			rm,
 			resourceAccess,
@@ -92,16 +90,15 @@ func inspectPolicies(
 	resType core_model.ResourceType,
 	builder xds_context.MeshContextBuilder,
 	cfg *kuma_cp.Config,
-) restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+) handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		ctx := request.Request.Context()
 		meshName := request.PathParameter("mesh")
 		policyName := request.PathParameter("name")
 
 		meshContext, err := builder.Build(ctx, meshName)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not list Dataplanes")
-			return
+			return nil, withTitle(err, "Could not list Dataplanes")
 		}
 
 		result := api_server_types.NewPolicyInspectEntryList()
@@ -114,8 +111,7 @@ func inspectPolicies(
 			}
 			proxy, err := getMatchedPolicies(request.Request.Context(), cfg, meshContext, dpKey)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("Could not get MatchedPolicies for %v", dpKey))
-				return
+				return nil, withTitle(err, fmt.Sprintf("Could not get MatchedPolicies for %v", dpKey))
 			}
 			for policy, attachments := range inspect.GroupByPolicy(&proxy.Policies) {
 				if policy.Type != resType || policy.Key.Name != policyName || policy.Key.Mesh != meshName {
@@ -137,9 +133,6 @@ func inspectPolicies(
 
 		result.Total = uint32(len(result.Items))
 
-		if err := response.WriteAsJson(result); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not write response")
-			return
-		}
+		return result, nil
 	}
 }

--- a/pkg/api-server/inspect_envoy_admin_endpoints.go
+++ b/pkg/api-server/inspect_envoy_admin_endpoints.go
@@ -41,7 +41,7 @@ func addInspectEnvoyAdminEndpoints(
 	}
 	ws.Route(
 		ws.GET("/meshes/{mesh}/dataplanes/{dataplane}/{type}").
-			To(cl.inspectDataplaneAdmin()).
+			To(handle(cl.inspectDataplaneAdmin())).
 			Doc("inspect dataplane configuration and stats").
 			Param(ws.PathParameter("mesh", "mesh name").DataType("string")).
 			Param(ws.PathParameter("dataplane", "dataplane name").DataType("string")).
@@ -57,23 +57,21 @@ const (
 	adminTypeStats      adminType = "stats"
 )
 
-func (cl *inspectClient) inspectDataplaneAdmin() restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+func (cl *inspectClient) inspectDataplaneAdmin() handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		ctx := request.Request.Context()
 		meshName := request.PathParameter("mesh")
 		dataplaneName := request.PathParameter("dataplane")
 		aType, err := cl.adminType(ctx, request.PathParameter("type"))
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not execute admin operation")
-			return
+			return nil, withTitle(err, "Could not execute admin operation")
 		}
 
 		dp := core_mesh.NewDataplaneResource()
 		if err := cl.rm.Get(request.Request.Context(), dp, store.GetByKey(dataplaneName, meshName)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not get dataplane resource")
-			return
+			return nil, withTitle(err, "Could not get dataplane resource")
 		}
-		cl.inspectProxy(request, response, aType, dp)
+		return cl.inspectProxy(request, aType, dp)
 	}
 }
 
@@ -98,7 +96,7 @@ func (cl *inspectClient) adminType(ctx context.Context, adType string) (adminTyp
 	return res, nil
 }
 
-func (cl *inspectClient) inspectProxy(request *restful.Request, response *restful.Response, adType adminType, proxy core_model.ResourceWithAddress) {
+func (cl *inspectClient) inspectProxy(request *restful.Request, adType adminType, proxy core_model.ResourceWithAddress) (any, error) {
 	ctx := request.Request.Context()
 	contentType := contentTypeText
 
@@ -130,13 +128,8 @@ func (cl *inspectClient) inspectProxy(request *restful.Request, response *restfu
 		res, err = cl.adminClient.Stats(ctx, proxy, format, usedOnly)
 	}
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not execute admin operation")
-		return
+		return nil, withTitle(err, "Could not execute admin operation")
 	}
 
-	response.AddHeader(restful.HEADER_ContentType, contentType)
-	if _, err := response.Write(res); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not write response")
-		return
-	}
+	return rawResponse{contentType: contentType, body: res}, nil
 }

--- a/pkg/api-server/inspect_mesh_service.go
+++ b/pkg/api-server/inspect_mesh_service.go
@@ -119,9 +119,9 @@ func matchingHostnames(resManager manager.ResourceManager, isGlobal bool) handle
 				}
 				svc.SetMeta(overridden)
 
-			if err := generateAndRecord(svc, svcType, svcZone, hg, byHostname); err != nil {
-				return nil, withTitle(err, "could not generate hostname")
-			}
+				if err := generateAndRecord(svc, svcType, svcZone, hg, byHostname); err != nil {
+					return nil, withTitle(err, "could not generate hostname")
+				}
 			}
 		}
 

--- a/pkg/api-server/inspect_mesh_service.go
+++ b/pkg/api-server/inspect_mesh_service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
-	rest_errors "github.com/kumahq/kuma/v3/pkg/core/rest/errors"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	util_maps "github.com/kumahq/kuma/v3/pkg/util/maps"
 )
@@ -33,7 +32,7 @@ func addInspectMeshServiceEndpoints(
 ) {
 	ws.Route(
 		ws.GET("/meshes/{mesh}/{serviceType}/{name}/_hostnames").
-			To(matchingHostnames(rm, isGlobal)).
+			To(handle(matchingHostnames(rm, isGlobal))).
 			Doc("inspect service hostnames").
 			Param(ws.PathParameter("name", "mesh service name").DataType("string")).
 			Param(ws.PathParameter("mesh", "mesh name").DataType("string")),
@@ -46,7 +45,7 @@ var availableServiceTypes = []string{
 	string(types.Meshmultizoneservices),
 }
 
-func matchingHostnames(resManager manager.ResourceManager, isGlobal bool) restful.RouteFunction {
+func matchingHostnames(resManager manager.ResourceManager, isGlobal bool) handlerFunc {
 	generatorsForType := map[types.InspectHostnamesParamsServiceType]hostname.HostnameGenerator{
 		types.Meshservices:          meshservice_hostname.NewMeshServiceHostnameGenerator(resManager),
 		types.Meshexternalservices:  mes_hostname.NewMeshExternalServiceHostnameGenerator(resManager),
@@ -75,32 +74,27 @@ func matchingHostnames(resManager manager.ResourceManager, isGlobal bool) restfu
 		return nil
 	}
 
-	return func(request *restful.Request, response *restful.Response) {
+	return func(request *restful.Request) (any, error) {
 		svcName := request.PathParameter("name")
 		svcMesh := request.PathParameter("mesh")
 		svcType := types.InspectHostnamesParamsServiceType(request.PathParameter("serviceType"))
 
 		desc, ok := typeDescForType[svcType]
 		if !ok {
-			rest_errors.HandleError(
-				request.Request.Context(),
-				response,
+			return nil, withTitle(
 				&validators.ValidationError{},
 				fmt.Sprintf("only %q are available for inspection", strings.Join(availableServiceTypes, ",")),
 			)
-			return
 		}
 
 		svc := desc.NewObject()
 		if err := resManager.Get(request.Request.Context(), svc, store.GetByKey(svcName, svcMesh)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "could not retrieve service")
-			return
+			return nil, withTitle(err, "could not retrieve service")
 		}
 
 		hostnameGenerators := hostnamegenerator_api.HostnameGeneratorResourceList{}
 		if err := resManager.List(request.Request.Context(), &hostnameGenerators); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "could not retrieve hostname generators")
-			return
+			return nil, withTitle(err, "could not retrieve hostname generators")
 		}
 
 		byHostname := map[string]map[string]struct{}{}
@@ -125,10 +119,9 @@ func matchingHostnames(resManager manager.ResourceManager, isGlobal bool) restfu
 				}
 				svc.SetMeta(overridden)
 
-				if err := generateAndRecord(svc, svcType, svcZone, hg, byHostname); err != nil {
-					rest_errors.HandleError(request.Request.Context(), response, err, "could not generate hostname")
-					return
-				}
+			if err := generateAndRecord(svc, svcType, svcZone, hg, byHostname); err != nil {
+				return nil, withTitle(err, "could not generate hostname")
+			}
 			}
 		}
 
@@ -150,9 +143,7 @@ func matchingHostnames(resManager manager.ResourceManager, isGlobal bool) restfu
 			})
 		}
 		resp.Total = len(resp.Items)
-		if err := response.WriteAsJson(resp); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed writing response")
-		}
+		return resp, nil
 	}
 }
 

--- a/pkg/api-server/kri_endpoint.go
+++ b/pkg/api-server/kri_endpoint.go
@@ -31,36 +31,33 @@ type kriEndpoint struct {
 }
 
 func (k *kriEndpoint) addFindByKriEndpoint(ws *restful.WebService) {
-	ws.Route(ws.GET("/_kri/{kri}").To(k.findByKriRoute(false)).Doc("Returns a resource by KRI").
+	ws.Route(ws.GET("/_kri/{kri}").To(handle(k.findByKriRoute(false))).Doc("Returns a resource by KRI").
 		Param(ws.PathParameter("kri", "KRI of the resource").DataType("string")).
 		Returns(200, "OK", nil).
 		Returns(400, "Bad request", nil).
 		Returns(404, "Not found", nil))
-	ws.Route(ws.GET("/_kri/{kri}/_overview").To(k.findByKriRoute(true)).Doc("Returns an overview of a resource by KRI").
+	ws.Route(ws.GET("/_kri/{kri}/_overview").To(handle(k.findByKriRoute(true))).Doc("Returns an overview of a resource by KRI").
 		Param(ws.PathParameter("kri", "KRI of the resource").DataType("string")).
 		Returns(200, "OK", nil).
 		Returns(400, "Bad request", nil).
 		Returns(404, "Not found", nil))
 }
 
-func (k *kriEndpoint) findByKriRoute(withInsight bool) restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+func (k *kriEndpoint) findByKriRoute(withInsight bool) handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		kriParam := request.PathParameter("kri")
 		identifier, err := kri.FromString(kriParam)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError(err.Error()), "Could not parse KRI")
-			return
+			return nil, withTitle(rest_errors.NewBadRequestError(err.Error()), "Could not parse KRI")
 		}
 
 		descriptor, err := getDescriptor(identifier.ResourceType)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
-			return
+			return nil, withTitle(err, "Could not retrieve a resource")
 		}
 
 		if withInsight && !descriptor.HasInsights() {
-			rest_errors.HandleError(request.Request.Context(), response, rest_errors.NewBadRequestError(fmt.Sprintf("resource type %s does not have an overview", identifier.ResourceType)), "Could not retrieve an overview")
-			return
+			return nil, withTitle(rest_errors.NewBadRequestError(fmt.Sprintf("resource type %s does not have an overview", identifier.ResourceType)), "Could not retrieve an overview")
 		}
 
 		name := k.getCoreName(identifier, *descriptor)
@@ -70,34 +67,27 @@ func (k *kriEndpoint) findByKriRoute(withInsight bool) restful.RouteFunction {
 			*descriptor,
 			user.FromCtx(request.Request.Context()),
 		); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-			return
+			return nil, withTitle(err, "Access Denied")
 		}
 
 		resource := descriptor.NewObject()
 		if err := k.resManager.Get(request.Request.Context(), resource, store.GetByKey(name, identifier.Mesh)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve a resource")
-			return
+			return nil, withTitle(err, "Could not retrieve a resource")
 		}
 
 		if withInsight {
 			resource, err = overviewForResource(request.Request.Context(), k.resManager, *descriptor, resource, name, identifier.Mesh)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve insights")
-				return
+				return nil, withTitle(err, "Could not retrieve insights")
 			}
 		}
 
 		res, err := formatResource(resource, request.QueryParameter("format"), k.k8sMapper, identifier.Namespace)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Could not format a resource")
-			return
+			return nil, withTitle(err, "Could not format a resource")
 		}
 
-		if err := response.WriteAsJson(res); err != nil {
-			log.Error(err, "Could not write the find response")
-			return
-		}
+		return res, nil
 	}
 }
 

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -99,14 +99,14 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 			Returns(404, "Not found", nil))
 	}
 	if r.descriptor.IsPolicy {
-		ws.Route(ws.GET(pathPrefix+"/{name}/_resources/dataplanes").To(r.inspect.matchingDataplanesForPolicy()).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_resources/dataplanes").To(handle(r.inspect.matchingDataplanesForPolicy())).
 			Doc(fmt.Sprintf("Get matching dataplanes of a %s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
 	}
 	if r.descriptor.Name == core_mesh.DataplaneType {
-		ws.Route(ws.GET(pathPrefix+"/{name}/_rules").To(r.inspect.rulesForResource()).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_rules").To(handle(r.inspect.rulesForResource())).
 			Doc(fmt.Sprintf("Get matching rules %s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil).
@@ -117,7 +117,7 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 				Doc(msg).
 				Returns(http.StatusMethodNotAllowed, msg, restful.ServiceError{}))
 		} else {
-			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(r.inspect.configForProxy()).
+			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(handle(r.inspect.configForProxy())).
 				Doc(fmt.Sprintf("Get proxy config%s", r.descriptor.Name)).
 				Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 				Returns(200, "OK", nil).
@@ -125,40 +125,40 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 		}
 	}
 	if r.descriptor.Name == core_mesh.DataplaneType {
-		ws.Route(ws.GET(pathPrefix+"/{name}/_policies").To(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToProxyPolicy)).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToProxyPolicy))).
 			Doc(fmt.Sprintf("Get policy config %s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_inbounds/{inbound_kri}/_policies").To(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToInboundConfig)).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_inbounds/{inbound_kri}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToInboundConfig))).
 			Doc("Get policy config for inbound").
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Param(ws.PathParameter("inbound_kri", "KRI of a inbound").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_policies").To(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToOutboundPolicy)).
+		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToOutboundPolicy))).
 			Doc("Get policy config for outbound").
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes").To(r.inspect.getPoliciesConf(
+		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes").To(handle(r.inspect.getPoliciesConf(
 			util_slices.Filter(core_plugins.Plugins().PolicyPlugins(), func(p core_plugins.RegisteredPolicyPlugin) bool {
 				return p.Name == core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) ||
 					p.Name == core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
 			}),
 			matchedPoliciesToRoutes,
-		)).
+		))).
 			Doc("Get policy config for outbound").
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes/{route_kri}/_policies").To(r.inspect.getPoliciesConf(
+		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes/{route_kri}/_policies").To(handle(r.inspect.getPoliciesConf(
 			util_slices.Filter(core_plugins.Plugins().PolicyPlugins(), func(p core_plugins.RegisteredPolicyPlugin) bool {
 				return p.Name != core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) &&
 					p.Name != core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
-			}), matchedPoliciesToRouteConfig)).
+			}), matchedPoliciesToRouteConfig))).
 			Doc("Get policy config for route").
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
 			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).

--- a/pkg/api-server/resource_inspect_endpoints.go
+++ b/pkg/api-server/resource_inspect_endpoints.go
@@ -48,12 +48,11 @@ type resourceInspectHandler struct {
 	knownInternalAddresses []string
 }
 
-func (r *resourceInspectHandler) matchingDataplanesForPolicy() restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+func (r *resourceInspectHandler) matchingDataplanesForPolicy() handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		meshName, err := r.meshFromRequest(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-			return
+			return nil, withTitle(err, "Failed to retrieve Mesh")
 		}
 
 		var dependentTypes []core_model.ResourceType
@@ -64,18 +63,15 @@ func (r *resourceInspectHandler) matchingDataplanesForPolicy() restful.RouteFunc
 		for _, dependentType := range dependentTypes {
 			hl, err := registry.Global().NewList(dependentType)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "failed inspect")
-				return
+				return nil, withTitle(err, "failed inspect")
 			}
 			if err := r.resManager.List(request.Request.Context(), hl, store.ListByMesh(meshName)); err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, "failed inspect")
-				return
+				return nil, withTitle(err, "failed inspect")
 			}
 			dependentResources.MeshLocalResources[dependentType] = hl
 		}
-		matchingDataplanesForFilter(
+		return matchingDataplanesForFilter(
 			request,
-			response,
 			r.descriptor,
 			r.resManager,
 			r.resourceAccess,
@@ -92,17 +88,15 @@ func (r *resourceInspectHandler) matchingDataplanesForPolicy() restful.RouteFunc
 
 func matchingDataplanesForFilter(
 	request *restful.Request,
-	response *restful.Response,
 	descriptor core_model.ResourceTypeDescriptor,
 	resManager manager.ResourceManager,
 	resourceAccess access.ResourceAccess,
 	dpFilterForResource func(resource core_model.Resource) store.ListFilterFunc,
-) {
+) (any, error) {
 	policyName := request.PathParameter("name")
 	page, err := pagination(request)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve policy")
-		return
+		return nil, withTitle(err, "Could not retrieve policy")
 	}
 	nameContains := request.QueryParameter("name")
 	meshName := request.PathParameter("mesh")
@@ -113,13 +107,11 @@ func matchingDataplanesForFilter(
 		descriptor,
 		user.FromCtx(request.Request.Context()),
 	); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-		return
+		return nil, withTitle(err, "Access Denied")
 	}
 	policyResource := descriptor.NewObject()
 	if err := resManager.Get(request.Request.Context(), policyResource, store.GetByKey(policyName, meshName)); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Could not retrieve policy")
-		return
+		return nil, withTitle(err, "Could not retrieve policy")
 	}
 
 	dppList := registry.Global().MustNewList(core_mesh.DataplaneType)
@@ -130,62 +122,52 @@ func matchingDataplanesForFilter(
 		store.ListByPage(page.size, page.offset),
 	)
 	if err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "failed inspect")
-		return
+		return nil, withTitle(err, "failed inspect")
 	}
 	items := make([]api_common.Meta, len(dppList.GetItems()))
 	for i, elt := range dppList.GetItems() {
 		items[i] = oapi_helpers.ResourceToMeta(elt)
 	}
-	out := api_types.InspectDataplanesForPolicyResponse{
+	return api_types.InspectDataplanesForPolicyResponse{
 		Total: int(dppList.GetPagination().Total),
 		Items: items,
 		Next:  nextLink(request, dppList.GetPagination().NextOffset),
-	}
-	if err := response.WriteAsJson(out); err != nil {
-		rest_errors.HandleError(request.Request.Context(), response, err, "Failed writing response")
-	}
+	}, nil
 }
 
-func (r *resourceInspectHandler) configForProxy() restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+func (r *resourceInspectHandler) configForProxy() handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		ctx := request.Request.Context()
 
 		name := request.PathParameter("name")
 		mesh, err := r.meshFromRequest(request)
 		if err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed to retrieve Mesh")
-			return
+			return nil, withTitle(err, "Failed to retrieve Mesh")
 		}
 		qparams, err := r.configForProxyParams(request)
 		if err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed to parse query parameters")
-			return
+			return nil, withTitle(err, "Failed to parse query parameters")
 		}
 
 		mc, err := r.meshContextBuilder.Build(ctx, mesh)
 		if err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed to build mesh context")
-			return
+			return nil, withTitle(err, "Failed to build mesh context")
 		}
 
 		dataplaneInsight := core_mesh.NewDataplaneInsightResource()
 		err = r.resManager.Get(ctx, dataplaneInsight, store.GetByKey(name, mesh))
 		if err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed to fetch dataplane insight")
-			return
+			return nil, withTitle(err, "Failed to fetch dataplane insight")
 		}
 
 		inspector, err := inspect.NewProxyConfigInspector(mc, core_xds.DataplaneMetadataFromXdsMetadata(dataplaneInsight.Spec.Metadata), r.zoneName, r.knownInternalAddresses, r.xdsHooks...)
 		if err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed to create proxy config inspector")
-			return
+			return nil, withTitle(err, "Failed to create proxy config inspector")
 		}
 
 		config, err := inspector.Get(ctx, name, *qparams.Shadow)
 		if err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed to inspect proxy config")
-			return
+			return nil, withTitle(err, "Failed to inspect proxy config")
 		}
 
 		out := &api_types.GetDataplaneXDSConfigResponse{
@@ -195,20 +177,16 @@ func (r *resourceInspectHandler) configForProxy() restful.RouteFunction {
 		if slices.Contains(*qparams.Include, api_types.Diff) {
 			currentConfig, err := inspector.Get(ctx, name, false)
 			if err != nil {
-				rest_errors.HandleError(ctx, response, err, "Failed to inspect current proxy config")
-				return
+				return nil, withTitle(err, "Failed to inspect current proxy config")
 			}
 			diff, err := inspect.Diff(currentConfig, config)
 			if err != nil {
-				rest_errors.HandleError(ctx, response, err, "Failed to compute diff")
-				return
+				return nil, withTitle(err, "Failed to compute diff")
 			}
 			out.Diff = &diff
 		}
 
-		if err := response.WriteAsJson(out); err != nil {
-			rest_errors.HandleError(ctx, response, err, "Failed writing response")
-		}
+		return out, nil
 	}
 }
 
@@ -240,13 +218,12 @@ func (r *resourceInspectHandler) configForProxyParams(request *restful.Request) 
 	return params, nil
 }
 
-func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.RegisteredPolicyPlugin, mapToResponse matchedPoliciesToResponse) restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.RegisteredPolicyPlugin, mapToResponse matchedPoliciesToResponse) handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		dataplaneName := request.PathParameter("name")
 		meshName, err := r.meshFromRequest(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-			return
+			return nil, withTitle(err, "Failed to retrieve Mesh")
 		}
 
 		if err := r.resourceAccess.ValidateGet(
@@ -255,21 +232,18 @@ func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.Register
 			r.descriptor,
 			user.FromCtx(request.Request.Context()),
 		); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-			return
+			return nil, withTitle(err, "Access Denied")
 		}
 
 		resource := r.descriptor.NewObject()
 		if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(dataplaneName, meshName)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
-			return
+			return nil, withTitle(err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
 		}
 		dataplane := resource.(*core_mesh.DataplaneResource)
 
 		baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build Mesh context")
-			return
+			return nil, withTitle(err, "Failed to build Mesh context")
 		}
 
 		var matchedPolicies []core_xds.TypedMatchingPolicies
@@ -277,12 +251,10 @@ func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.Register
 		for _, policyPlugin := range allPlugins {
 			res, err := policyPlugin.Plugin.MatchedPolicies(dataplane, baseMeshContext.Resources())
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
-				return
+				return nil, withTitle(err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
 			}
 			if res.Type == "" {
-				rest_errors.HandleError(request.Request.Context(), response, fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
-				return
+				return nil, withTitle(fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
 			}
 
 			matchedPolicies = append(matchedPolicies, res)
@@ -290,13 +262,10 @@ func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.Register
 
 		out, err := mapToResponse(matchedPolicies, request, baseMeshContext.Mesh, dataplane, baseMeshContext.Resources())
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed building response")
-			return
+			return nil, withTitle(err, "Failed building response")
 		}
 
-		if err := response.WriteAsJson(out); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed writing response")
-		}
+		return out, nil
 	}
 }
 
@@ -480,13 +449,12 @@ func originToKRI(origin core_model.ResourceMeta, policyType core_model.ResourceT
 	return api_common.PolicyOrigin{Kri: kri.FromResourceMeta(origin, policyType).String()}
 }
 
-func (r *resourceInspectHandler) rulesForResource() restful.RouteFunction {
-	return func(request *restful.Request, response *restful.Response) {
+func (r *resourceInspectHandler) rulesForResource() handlerFunc {
+	return func(request *restful.Request) (any, error) {
 		resourceName := request.PathParameter("name")
 		meshName, err := r.meshFromRequest(request)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to retrieve Mesh")
-			return
+			return nil, withTitle(err, "Failed to retrieve Mesh")
 		}
 
 		if err := r.resourceAccess.ValidateGet(
@@ -495,28 +463,23 @@ func (r *resourceInspectHandler) rulesForResource() restful.RouteFunction {
 			r.descriptor,
 			user.FromCtx(request.Request.Context()),
 		); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Access Denied")
-			return
+			return nil, withTitle(err, "Access Denied")
 		}
 
 		resource := r.descriptor.NewObject()
 		if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(resourceName, meshName)); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
-			return
+			return nil, withTitle(err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
 		}
 		var dp *core_mesh.DataplaneResource
 		switch r.descriptor.Name {
 		case core_mesh.DataplaneType:
 			dp = resource.(*core_mesh.DataplaneResource)
-		// In the future we will probably add externalService
 		default:
-			rest_errors.HandleError(request.Request.Context(), response, fmt.Errorf("rules not supported for type %s", r.descriptor.Name), "Unsupported resource type")
-			return
+			return nil, withTitle(fmt.Errorf("rules not supported for type %s", r.descriptor.Name), "Unsupported resource type")
 		}
 		baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
 		if err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed to build Mesh context")
-			return
+			return nil, withTitle(err, "Failed to build Mesh context")
 		}
 
 		resources := xds_context.Resources{
@@ -529,12 +492,10 @@ func (r *resourceInspectHandler) rulesForResource() restful.RouteFunction {
 		for _, policyPlugin := range allPlugins {
 			res, err := policyPlugin.Plugin.MatchedPolicies(dp, resources)
 			if err != nil {
-				rest_errors.HandleError(request.Request.Context(), response, err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
-				return
+				return nil, withTitle(err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
 			}
 			if res.Type == "" {
-				rest_errors.HandleError(request.Request.Context(), response, fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
-				return
+				return nil, withTitle(fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
 			}
 			if res.Type == meshhttproute_api.MeshHTTPRouteType {
 				for _, resourceRule := range res.ToRules.ResourceRules {
@@ -635,8 +596,6 @@ func (r *resourceInspectHandler) rulesForResource() restful.RouteFunction {
 			Resource:    oapi_helpers.ResourceToMeta(resource),
 			Rules:       rules,
 		}
-		if err := response.WriteAsJson(out); err != nil {
-			rest_errors.HandleError(request.Request.Context(), response, err, "Failed writing response")
-		}
+		return out, nil
 	}
 }


### PR DESCRIPTION
## Motivation

Follow-up to #18400, which introduced the `handle()` adapter and migrated the resource CRUD endpoints. The remaining ~60 `rest_errors.HandleError` call sites across 9 files still repeated the same write-or-render-error boilerplate per call site.

## Implementation information

All remaining handlers in `pkg/api-server` now return `(any, error)` and are wrapped in `handle()` at registration:

- inspect endpoints (`resource_inspect_endpoints.go`, `inspect_endpoints.go`, `inspect_mesh_service.go`, `inspect_envoy_admin_endpoints.go`)
- KRI, layout, config, and global insight(s) endpoints

Error titles passed to `HandleError` are preserved via `withTitle()`, so error response bodies are unchanged (golden files untouched, full `pkg/api-server` suite passes).

Two handlers write raw bytes instead of JSON (`/config`, Envoy admin output). `handle()` gained a `rawResponse{contentType, body}` case for these, so they use the same path as everything else.

After this PR the only `HandleError` call in `pkg/api-server` is inside `handle()` itself.

## Supporting documentation

> Changelog: skip