### PR TITLE
refactor(api-server): per-type resource hooks

### DIFF
--- a/pkg/api-server/resource_crud_endpoints.go
+++ b/pkg/api-server/resource_crud_endpoints.go
@@ -312,14 +312,24 @@ func (r *resourceCrudHandler) createOrUpdateResource(request *restful.Request) (
 	return r.updateResource(request.Request.Context(), resource, resourceRest, meshName)
 }
 
-func (r *resourceCrudHandler) clearMeshTrustOrigin(resRest rest.Resource, meshName string, name string) {
-	if r.descriptor.Name == meshtrust_api.MeshTrustType {
-		if resRest.GetStatus() != nil {
-			status, ok := resRest.GetStatus().(*meshtrust_api.MeshTrustStatus)
-			if ok && status != nil && status.Origin != nil {
-				log.Info("ignoring status.origin as it is read-only", "mesh", meshName, "name", name)
-				status.Origin = nil
-			}
+// beforeWriteHooks mutate the REST representation of a resource of the given
+// type before it is persisted on create or update.
+var beforeWriteHooks = map[core_model.ResourceType]func(resRest rest.Resource, meshName string, name string){
+	meshtrust_api.MeshTrustType: clearMeshTrustOrigin,
+}
+
+// validateCreateHooks run extra validation on create for the given resource
+// type.
+var validateCreateHooks = map[core_model.ResourceType]func(r *resourceCrudHandler, res core_model.Resource) error{
+	core_mesh.DataplaneType: (*resourceCrudHandler).validateUniversalDataplaneWorkloadLabel,
+}
+
+func clearMeshTrustOrigin(resRest rest.Resource, meshName string, name string) {
+	if resRest.GetStatus() != nil {
+		status, ok := resRest.GetStatus().(*meshtrust_api.MeshTrustStatus)
+		if ok && status != nil && status.Origin != nil {
+			log.Info("ignoring status.origin as it is read-only", "mesh", meshName, "name", name)
+			status.Origin = nil
 		}
 	}
 }
@@ -363,14 +373,18 @@ func (r *resourceCrudHandler) createResource(
 		return nil, withTitle(err, "Access Denied")
 	}
 
-	r.clearMeshTrustOrigin(resRest, meshName, name)
+	if hook, ok := beforeWriteHooks[r.descriptor.Name]; ok {
+		hook(resRest, meshName, name)
+	}
 
 	res := r.descriptor.NewObject()
 	_ = res.SetSpec(resRest.GetSpec())
 	res.SetMeta(resRest.GetMeta())
 
-	if err := r.validateUniversalDataplaneWorkloadLabel(res); err != nil {
-		return nil, err
+	if hook, ok := validateCreateHooks[r.descriptor.Name]; ok {
+		if err := hook(r, res); err != nil {
+			return nil, err
+		}
 	}
 
 	labels, err := r.computeLabels(res.Descriptor(), res.GetSpec(), res.GetMeta(), meshName, name)
@@ -388,7 +402,7 @@ func (r *resourceCrudHandler) createResource(
 // validateUniversalDataplaneWorkloadLabel validates the workload label of
 // Dataplanes created on Universal zones.
 func (r *resourceCrudHandler) validateUniversalDataplaneWorkloadLabel(res core_model.Resource) error {
-	if r.descriptor.Name != core_mesh.DataplaneType || r.isK8s {
+	if r.isK8s {
 		return nil
 	}
 	workloadName, ok := res.GetMeta().GetLabels()[metadata.KumaWorkload]
@@ -427,7 +441,9 @@ func (r *resourceCrudHandler) updateResource(
 		return nil, withTitle(err, "Access Denied")
 	}
 
-	r.clearMeshTrustOrigin(newResRest, meshName, currentRes.GetMeta().GetName())
+	if hook, ok := beforeWriteHooks[r.descriptor.Name]; ok {
+		hook(newResRest, meshName, currentRes.GetMeta().GetName())
+	}
 
 	currentLabels, err := r.computeLabels(currentRes.Descriptor(), currentRes.GetSpec(), currentRes.GetMeta(), meshName, currentRes.GetMeta().GetName())
 	if err != nil {

--- a/pkg/api-server/resource_endpoints.go
+++ b/pkg/api-server/resource_endpoints.go
@@ -105,67 +105,76 @@ func (r *resourceEndpoints) addFindEndpoint(ws *restful.WebService, pathPrefix s
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
 	}
-	if r.descriptor.Name == core_mesh.DataplaneType {
-		ws.Route(ws.GET(pathPrefix+"/{name}/_rules").To(handle(r.inspect.rulesForResource())).
-			Doc(fmt.Sprintf("Get matching rules %s", r.descriptor.Name)).
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-			Returns(200, "OK", nil).
-			Returns(404, "Not found", nil))
-		if r.mode == config_core.Global {
-			msg := "Not allowed on global CP"
-			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(handle(r.methodNotAllowed(msg))).
-				Doc(msg).
-				Returns(http.StatusMethodNotAllowed, msg, restful.ServiceError{}))
-		} else {
-			ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(handle(r.inspect.configForProxy())).
-				Doc(fmt.Sprintf("Get proxy config%s", r.descriptor.Name)).
-				Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-				Returns(200, "OK", nil).
-				Returns(404, "Not found", nil))
-		}
+	if extra, ok := extraInspectRoutes[r.descriptor.Name]; ok {
+		extra(r, ws, pathPrefix)
 	}
-	if r.descriptor.Name == core_mesh.DataplaneType {
-		ws.Route(ws.GET(pathPrefix+"/{name}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToProxyPolicy))).
-			Doc(fmt.Sprintf("Get policy config %s", r.descriptor.Name)).
+}
+
+// extraInspectRoutes registers type-specific GET routes under
+// pathPrefix+"/{name}" for resource types that expose proxy inspect
+// endpoints, keeping addFindEndpoint free of per-type branches.
+var extraInspectRoutes = map[core_model.ResourceType]func(*resourceEndpoints, *restful.WebService, string){
+	core_mesh.DataplaneType: (*resourceEndpoints).addDataplaneInspectRoutes,
+}
+
+func (r *resourceEndpoints) addDataplaneInspectRoutes(ws *restful.WebService, pathPrefix string) {
+	ws.Route(ws.GET(pathPrefix+"/{name}/_rules").To(handle(r.inspect.rulesForResource())).
+		Doc(fmt.Sprintf("Get matching rules %s", r.descriptor.Name)).
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
+		Returns(200, "OK", nil).
+		Returns(404, "Not found", nil))
+	if r.mode == config_core.Global {
+		msg := "Not allowed on global CP"
+		ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(handle(r.methodNotAllowed(msg))).
+			Doc(msg).
+			Returns(http.StatusMethodNotAllowed, msg, restful.ServiceError{}))
+	} else {
+		ws.Route(ws.GET(pathPrefix+"/{name}/_config").To(handle(r.inspect.configForProxy())).
+			Doc(fmt.Sprintf("Get proxy config%s", r.descriptor.Name)).
 			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-			Returns(200, "OK", nil).
-			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_inbounds/{inbound_kri}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToInboundConfig))).
-			Doc("Get policy config for inbound").
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-			Param(ws.PathParameter("inbound_kri", "KRI of a inbound").DataType("string")).
-			Returns(200, "OK", nil).
-			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToOutboundPolicy))).
-			Doc("Get policy config for outbound").
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
-			Returns(200, "OK", nil).
-			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes").To(handle(r.inspect.getPoliciesConf(
-			util_slices.Filter(core_plugins.Plugins().PolicyPlugins(), func(p core_plugins.RegisteredPolicyPlugin) bool {
-				return p.Name == core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) ||
-					p.Name == core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
-			}),
-			matchedPoliciesToRoutes,
-		))).
-			Doc("Get policy config for outbound").
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
-			Returns(200, "OK", nil).
-			Returns(404, "Not found", nil))
-		ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes/{route_kri}/_policies").To(handle(r.inspect.getPoliciesConf(
-			util_slices.Filter(core_plugins.Plugins().PolicyPlugins(), func(p core_plugins.RegisteredPolicyPlugin) bool {
-				return p.Name != core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) &&
-					p.Name != core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
-			}), matchedPoliciesToRouteConfig))).
-			Doc("Get policy config for route").
-			Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
-			Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
-			Param(ws.PathParameter("route_kri", "KRI of a route").DataType("string")).
 			Returns(200, "OK", nil).
 			Returns(404, "Not found", nil))
 	}
+	ws.Route(ws.GET(pathPrefix+"/{name}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToProxyPolicy))).
+		Doc(fmt.Sprintf("Get policy config %s", r.descriptor.Name)).
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
+		Returns(200, "OK", nil).
+		Returns(404, "Not found", nil))
+	ws.Route(ws.GET(pathPrefix+"/{name}/_inbounds/{inbound_kri}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToInboundConfig))).
+		Doc("Get policy config for inbound").
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
+		Param(ws.PathParameter("inbound_kri", "KRI of a inbound").DataType("string")).
+		Returns(200, "OK", nil).
+		Returns(404, "Not found", nil))
+	ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_policies").To(handle(r.inspect.getPoliciesConf(core_plugins.Plugins().PolicyPlugins(), matchedPoliciesToOutboundPolicy))).
+		Doc("Get policy config for outbound").
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
+		Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
+		Returns(200, "OK", nil).
+		Returns(404, "Not found", nil))
+	ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes").To(handle(r.inspect.getPoliciesConf(
+		util_slices.Filter(core_plugins.Plugins().PolicyPlugins(), func(p core_plugins.RegisteredPolicyPlugin) bool {
+			return p.Name == core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) ||
+				p.Name == core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
+		}),
+		matchedPoliciesToRoutes,
+	))).
+		Doc("Get policy config for outbound").
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
+		Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
+		Returns(200, "OK", nil).
+		Returns(404, "Not found", nil))
+	ws.Route(ws.GET(pathPrefix+"/{name}/_outbounds/{outbound_kri}/_routes/{route_kri}/_policies").To(handle(r.inspect.getPoliciesConf(
+		util_slices.Filter(core_plugins.Plugins().PolicyPlugins(), func(p core_plugins.RegisteredPolicyPlugin) bool {
+			return p.Name != core_plugins.PluginName(meshhttproute_api.MeshHTTPRouteResourceTypeDescriptor.KumactlArg) &&
+				p.Name != core_plugins.PluginName(meshtcproute_api.MeshTCPRouteResourceTypeDescriptor.KumactlArg)
+		}), matchedPoliciesToRouteConfig))).
+		Doc("Get policy config for route").
+		Param(ws.PathParameter("name", fmt.Sprintf("Name of a %s", r.descriptor.Name)).DataType("string")).
+		Param(ws.PathParameter("outbound_kri", "KRI of a outbound").DataType("string")).
+		Param(ws.PathParameter("route_kri", "KRI of a route").DataType("string")).
+		Returns(200, "OK", nil).
+		Returns(404, "Not found", nil))
 }
 
 func (r *resourceEndpoints) methodNotAllowed(detail string) handlerFunc {


### PR DESCRIPTION
## Motivation

Part of the api-server simplification series (#18399–#18406). The generic CRUD/inspect registration still branched on `descriptor.Name` for special resources, so adding a special-cased type meant editing the shared code path.

## Implementation

Replace the branches with hook registries keyed by `core_model.ResourceType`:

- `extraInspectRoutes` — Dataplane's `_rules`/`_config`/`_policies`/`_inbounds`/`_outbounds` routes move into `addDataplaneInspectRoutes`, dispatched from `addFindEndpoint` via map lookup (also merges the two separate `if Dataplane` blocks into one function)
- `beforeWriteHooks` — MeshTrust `status.origin` clearing on create/update
- `validateCreateHooks` — Dataplane workload label validation on create

No behavior change: same routes, same handlers, same validation. Full `pkg/api-server` suite passes.

## Supporting information

> Changelog: skip