### PR TITLE
fix(api-server): reject malformed and duplicate label filters

### DIFF
--- a/pkg/api-server/filters/filtering.go
+++ b/pkg/api-server/filters/filtering.go
@@ -69,18 +69,21 @@ func labelFilter(request *restful.Request) (store.ListFilterFunc, error) {
 				validators.RootedAt(request.SelectedRoutePath()).Field(k), "filters are only supported on labels and status")
 			continue
 		}
-		closingBracket := strings.Index(k, "]")
-		key := k[len("filter[labels."):closingBracket]
-		if closingBracket != len(k)-1 {
+		// strings.Index returns -1 when "]" is missing, so this guard must run before slicing
+		if closingBracket := strings.Index(k, "]"); closingBracket != len(k)-1 {
 			verr.AddViolationAt(
 				validators.RootedAt(request.SelectedRoutePath()).Field(k), "advanced filters are not supported")
 			continue
 		}
-		op := FilterOpEq
+		if len(v) > 1 {
+			verr.AddViolationAt(
+				validators.RootedAt(request.SelectedRoutePath()).Field(k), "duplicate filter parameter")
+			continue
+		}
 		filters = append(filters, filterEntry{
-			Op:    op,
-			Key:   key,
-			Value: v[len(v)-1],
+			Op:    FilterOpEq,
+			Key:   strings.TrimSuffix(strings.TrimPrefix(k, "filter[labels."), "]"),
+			Value: v[0],
 		})
 	}
 	if verr.HasViolations() {

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_duplicate.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_duplicate.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Could not retrieve resources",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labels.a]",
+   "reason": "duplicate filter parameter"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labels.a]",
+   "message": "duplicate filter parameter"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_duplicate.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_duplicate.input.yaml
@@ -1,0 +1,3 @@
+#/meshes/default/dataplanes?filter[labels.a]=x&filter[labels.a]=y 400
+type: Mesh
+name: default

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_unclosed.golden.json
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_unclosed.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Could not retrieve resources",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labels.foo",
+   "reason": "advanced filters are not supported"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "/meshes/{mesh}/dataplanes.filter[labels.foo",
+   "message": "advanced filters are not supported"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_unclosed.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/list_dp_with_label_filter_unclosed.input.yaml
@@ -1,0 +1,3 @@
+#/meshes/default/dataplanes?filter%5Blabels.foo=bar 400
+type: Mesh
+name: default


### PR DESCRIPTION
## Motivation

Two input-validation gaps in `filter[labels.<key>]` query parsing on the REST API:

- a key without the closing `]` (e.g. `filter%5Blabels.foo=bar`) sliced the string with a `-1` bound and panicked the handler, dropping the connection instead of returning `400`;
- duplicate `filter[labels.<key>]` params were silently accepted and only the last value applied, while other malformed filters already return `400`.

## Implementation information

`labelFilter` in `pkg/api-server/filters/filtering.go` now checks the closing bracket before slicing (reusing the existing "advanced filters are not supported" violation) and rejects duplicate params with `duplicate filter parameter`. Two REST goldens under `pkg/api-server/testdata/resources/crud/` pin both `400` responses.

## Supporting documentation

Fix #18417

