### PR TITLE
fix(api-server): retain config validation errors

### DIFF
--- a/pkg/config/api-server/config.go
+++ b/pkg/config/api-server/config.go
@@ -195,17 +195,17 @@ func (t TokensValidator) Validate() error {
 func (a *ApiServerConfig) Validate() error {
 	var errs error
 	if err := a.HTTP.Validate(); err != nil {
-		errs = multierr.Append(err, errors.Wrap(err, ".HTTP not valid"))
+		errs = multierr.Append(errs, errors.Wrap(err, ".HTTP not valid"))
 	}
 	if err := a.HTTPS.Validate(); err != nil {
-		errs = multierr.Append(err, errors.Wrap(err, ".HTTPS not valid"))
+		errs = multierr.Append(errs, errors.Wrap(err, ".HTTPS not valid"))
 	}
 	if err := a.GUI.Validate(); err != nil {
-		errs = multierr.Append(err, errors.Wrap(err, ".GUI not valid"))
+		errs = multierr.Append(errs, errors.Wrap(err, ".GUI not valid"))
 	}
 	if a.RootUrl != "" {
 		if _, err := url.Parse(a.RootUrl); err != nil {
-			errs = multierr.Append(err, errors.New("RootUrl is not a valid URL"))
+			errs = multierr.Append(errs, errors.New("RootUrl is not a valid URL"))
 		}
 	}
 	if a.BasePath != "" {
@@ -215,7 +215,7 @@ func (a *ApiServerConfig) Validate() error {
 		}
 	}
 	if err := a.Authn.Validate(); err != nil {
-		errs = multierr.Append(err, errors.Wrap(err, ".Authn is not valid"))
+		errs = multierr.Append(errs, errors.Wrap(err, ".Authn is not valid"))
 	}
 	if a.ReadHeaderTimeout.Duration < 0 {
 		errs = multierr.Append(errs, errors.New(".ReadHeaderTimeout must be greater or equal 0s"))

--- a/pkg/config/api-server/config_test.go
+++ b/pkg/config/api-server/config_test.go
@@ -1,0 +1,44 @@
+package api_server_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	api_server "github.com/kumahq/kuma/v3/pkg/config/api-server"
+	config_types "github.com/kumahq/kuma/v3/pkg/config/types"
+)
+
+var _ = Describe("ApiServerConfig", func() {
+	It("accumulates validation errors in configuration order", func() {
+		cfg := api_server.DefaultApiServerConfig()
+		cfg.HTTP.Interface = ""
+		cfg.HTTPS.Interface = ""
+		cfg.GUI.RootUrl = "%"
+		cfg.RootUrl = "%"
+		cfg.BasePath = "%"
+		cfg.Authn.Tokens.Validator.PublicKeys = []config_types.PublicKey{{}}
+		cfg.ReadHeaderTimeout.Duration = -time.Second
+		cfg.ReadTimeout.Duration = -time.Second
+		cfg.WriteTimeout.Duration = -time.Second
+		cfg.IdleTimeout.Duration = -time.Second
+
+		Expect(cfg.Validate()).To(MatchError(
+			".HTTP not valid: Interface cannot be empty; " +
+				".HTTPS not valid: .Interface cannot be empty; " +
+				".GUI not valid: RootUrl is not a valid url; " +
+				"RootUrl is not a valid URL; " +
+				"BaseGuiPath is not a valid url; " +
+				".Authn is not valid: .Tokens is not valid: .Validator is not valid: .PublicKeys[0] is not valid: .KID is required; " +
+				".ReadHeaderTimeout must be greater or equal 0s; " +
+				".ReadTimeout must be greater or equal 0s; " +
+				".WriteTimeout must be greater or equal 0s; " +
+				".IdleTimeout must be greater or equal 0s",
+		))
+	})
+
+	It("accepts the default configuration", func() {
+		Expect(api_server.DefaultApiServerConfig().Validate()).To(Succeed())
+	})
+})

--- a/pkg/config/api-server/suite_test.go
+++ b/pkg/config/api-server/suite_test.go
@@ -1,0 +1,11 @@
+package api_server_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestApiServerConfig(t *testing.T) {
+	test.RunSpecs(t, "API Server Config Suite")
+}


### PR DESCRIPTION
## Motivation

API server validation replaces previously collected errors at several parent configuration boundaries and duplicates the latest nested error. This hides useful startup diagnostics.

## Implementation information

Append HTTP, HTTPS, GUI, root URL, and authentication failures to the existing accumulator. Add a deterministic test covering all parent sections and timeout validation. HTTPS port validation remains unchanged.

## Supporting documentation

Follow-up to #18420.

> Changelog: fix API server configuration error aggregation