### PR TITLE
fix(api-server): apply maximum TLS version

### DIFF
--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -459,6 +459,10 @@ func configureTLS(cfg api_server.ApiServerConfig, certWatchers *util_tls.Watcher
 	if err != nil {
 		return nil, err
 	}
+	tlsConfig.MaxVersion, err = config_types.TLSVersion(cfg.HTTPS.TlsMaxVersion)
+	if err != nil {
+		return nil, err
+	}
 	tlsConfig.CipherSuites, err = config_types.TLSCiphers(cfg.HTTPS.TlsCipherSuites)
 	if err != nil {
 		return nil, err

--- a/pkg/api-server/tls_test.go
+++ b/pkg/api-server/tls_test.go
@@ -70,3 +70,31 @@ var _ = Describe("HTTPS server certificate", func() {
 		}, "30s", "100ms").Should(Succeed())
 	})
 })
+
+var _ = Describe("HTTPS server TLS version", func() {
+	DescribeTable("applies the configured maximum",
+		func(maxVersion string, expectSuccess bool) {
+			cfg := NewTestApiServerConfigurer().WithConfigMutator(func(cfg *config.ApiServerConfig) {
+				cfg.HTTPS.TlsMaxVersion = maxVersion
+			})
+			apiServer, _, stop := StartApiServer(cfg)
+			DeferCleanup(stop)
+
+			conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", apiServer.Config().HTTPS.Port), &tls.Config{
+				InsecureSkipVerify: true, // #nosec G402 -- the test verifies protocol negotiation
+				MinVersion:         tls.VersionTLS13,
+				MaxVersion:         tls.VersionTLS13,
+			})
+			if !expectSuccess {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(conn.Close)
+			Expect(conn.ConnectionState().Version).To(Equal(uint16(tls.VersionTLS13)))
+		},
+		Entry("keeps an empty maximum unrestricted", "", true),
+		Entry("rejects TLS 1.3 when the maximum is TLS 1.2", "TLSv1_2", false),
+	)
+})


### PR DESCRIPTION
## Motivation

The API server accepts and validates `https.tlsMaxVersion`, but does not apply it to its TLS configuration. As a result, clients can negotiate newer TLS versions than configured.

## Implementation information

Apply the parsed maximum TLS version in `configureTLS`, matching Kuma’s other TLS servers. Add integration coverage proving that a TLS 1.2 maximum rejects a TLS-1.3-only client while an empty maximum preserves Go’s unrestricted default.

## Supporting documentation

N/A

> Changelog: honor the API server maximum TLS version