### PR TITLE
fix(api-server): make startup transactional

### DIFF
--- a/pkg/api-server/api_server_suite_test.go
+++ b/pkg/api-server/api_server_suite_test.go
@@ -145,6 +145,47 @@ func tryStartApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, kuma_
 		return nil, kuma_cp.Config{}, stop, err
 	}
 	t.config.HTTPS.Port = uint32(port)
+
+	apiServer, cfg, err := newTestApiServer(t)
+	if err != nil {
+		return nil, cfg, stop, err
+	}
+	errChan := make(chan error, 1)
+	go func() {
+		err := apiServer.Start(ctx.Done()) //nolint:contextcheck
+		errChan <- err
+	}()
+
+	tick := time.NewTicker(time.Millisecond * 500)
+	defer tick.Stop()
+	leftTicks := 10
+	for {
+		if leftTicks == 0 {
+			stop()
+			return nil, cfg, stop, errors.New("no more ticks left")
+		}
+		select {
+		case err = <-errChan:
+			return nil, cfg, stop, err
+		case <-tick.C:
+			leftTicks--
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+apiServer.Address()+"/config", http.NoBody)
+			if err != nil {
+				return nil, cfg, stop, err
+			}
+			r, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return nil, cfg, stop, err
+			}
+			r.Body.Close()
+			if r.StatusCode == http.StatusOK {
+				return apiServer, cfg, stop, nil
+			}
+		}
+	}
+}
+
+func newTestApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, kuma_cp.Config, error) {
 	if t.config.HTTPS.TlsKeyFile == "" {
 		t.config.HTTPS.TlsKeyFile = filepath.Join("..", "..", "test", "certs", "server-key.pem")
 		t.config.HTTPS.TlsCertFile = filepath.Join("..", "..", "test", "certs", "server-cert.pem")
@@ -199,40 +240,9 @@ func tryStartApiServer(t *testApiServerConfigurer) (*api_server.ApiServer, kuma_
 		nil,
 	)
 	if err != nil {
-		return nil, cfg, stop, err
+		return nil, cfg, err
 	}
-	errChan := make(chan error)
-	go func() {
-		err := apiServer.Start(ctx.Done()) //nolint:contextcheck
-		errChan <- err
-	}()
-
-	tick := time.NewTicker(time.Millisecond * 500)
-	leftTicks := 10
-	for {
-		if leftTicks == 0 {
-			stop()
-			return nil, cfg, stop, errors.New("no more ticks left")
-		}
-		select {
-		case err = <-errChan:
-			return nil, cfg, stop, err
-		case <-tick.C:
-			leftTicks--
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+apiServer.Address()+"/config", http.NoBody)
-			if err != nil {
-				return nil, cfg, stop, err
-			}
-			r, err := http.DefaultClient.Do(req)
-			if err != nil {
-				return nil, cfg, stop, err
-			}
-			r.Body.Close()
-			if r.StatusCode == http.StatusOK {
-				return apiServer, cfg, stop, nil
-			}
-		}
-	}
+	return apiServer, cfg, nil
 }
 
 type action struct {

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/bakito/go-log-logr-adapter/adapter"
 	"github.com/emicklei/go-restful/v3"
@@ -53,6 +54,8 @@ import (
 )
 
 var log = core.Log.WithName("api-server")
+
+const apiServerShutdownTimeout = 2 * time.Second
 
 type ApiServer struct {
 	mux          *http.ServeMux
@@ -383,8 +386,37 @@ func (a *ApiServer) Ready() bool {
 	return a.httpReady.Load() && a.httpsReady.Load()
 }
 
-func (a *ApiServer) Start(stop <-chan struct{}) error {
-	errChan := make(chan error)
+func (a *ApiServer) Start(stop <-chan struct{}) (result error) {
+	a.httpReady.Store(false)
+	a.httpsReady.Store(false)
+	errChan := make(chan error, 2)
+
+	startedServers := make([]*http.Server, 0, 2)
+	doneChannels := make([]<-chan struct{}, 0, 2)
+	defer func() {
+		a.httpReady.Store(false)
+		a.httpsReady.Store(false)
+		ctx, cancel := context.WithTimeout(context.Background(), apiServerShutdownTimeout)
+		defer cancel()
+		shutdownErrs := make(chan error, len(startedServers))
+		for _, server := range startedServers {
+			go func() {
+				err := server.Shutdown(ctx)
+				if err != nil {
+					err = multierr.Append(err, server.Close())
+				}
+				shutdownErrs <- err
+			}()
+		}
+		for range startedServers {
+			if err := <-shutdownErrs; err != nil {
+				result = multierr.Append(result, err)
+			}
+		}
+		for _, done := range doneChannels {
+			<-done
+		}
+	}()
 
 	var httpServer, httpsServer *http.Server
 	if a.config.HTTP.Enabled {
@@ -397,11 +429,6 @@ func (a *ApiServer) Start(stop <-chan struct{}) error {
 			Handler:           a.mux,
 			ErrorLog:          adapter.ToStd(log),
 		}
-		if err := kuma_srv.StartServer(log, httpServer, &a.httpReady, errChan); err != nil {
-			return err
-		}
-	} else {
-		a.httpReady.Store(true)
 	}
 	if a.config.HTTPS.Enabled {
 		tlsConfig, err := configureTLS(a.config, a.certWatchers)
@@ -418,29 +445,43 @@ func (a *ApiServer) Start(stop <-chan struct{}) error {
 			TLSConfig:         tlsConfig,
 			ErrorLog:          adapter.ToStd(log),
 		}
-		if err := kuma_srv.StartServer(log, httpsServer, &a.httpsReady, errChan); err != nil {
+	}
+
+	var httpListener, httpsListener net.Listener
+	if httpServer != nil {
+		listener, err := kuma_srv.NewListener(httpServer)
+		if err != nil {
 			return err
 		}
+		httpListener = listener
+	}
+	if httpsServer != nil {
+		listener, err := kuma_srv.NewListener(httpsServer)
+		if err != nil {
+			if httpListener != nil {
+				err = multierr.Append(err, httpListener.Close())
+			}
+			return err
+		}
+		httpsListener = listener
+	}
+
+	if httpServer != nil {
+		startedServers = append(startedServers, httpServer)
+		doneChannels = append(doneChannels, kuma_srv.ServeServer(log, httpServer, httpListener, &a.httpReady, errChan))
+	} else {
+		a.httpReady.Store(true)
+	}
+	if httpsServer != nil {
+		startedServers = append(startedServers, httpsServer)
+		doneChannels = append(doneChannels, kuma_srv.ServeServer(log, httpsServer, httpsListener, &a.httpsReady, errChan))
 	} else {
 		a.httpsReady.Store(true)
 	}
 	select {
 	case <-stop:
 		log.Info("stopping down API Server")
-		a.httpReady.Store(false)
-		a.httpsReady.Store(false)
-		var errs error
-		if httpServer != nil {
-			if err := httpServer.Shutdown(context.Background()); err != nil {
-				errs = multierr.Append(errs, err)
-			}
-		}
-		if httpsServer != nil {
-			if err := httpsServer.Shutdown(context.Background()); err != nil {
-				errs = multierr.Append(errs, err)
-			}
-		}
-		return errs
+		return nil
 	case err := <-errChan:
 		return err
 	}

--- a/pkg/api-server/server_test.go
+++ b/pkg/api-server/server_test.go
@@ -1,0 +1,42 @@
+package api_server_test
+
+import (
+	"net"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	config_api_server "github.com/kumahq/kuma/v3/pkg/config/api-server"
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+var _ = Describe("API Server startup", func() {
+	It("closes HTTP when HTTPS cannot start", func() {
+		httpsListener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(httpsListener.Close)
+		httpsPort := httpsListener.Addr().(*net.TCPAddr).Port
+
+		httpPort, err := test.GetFreePort()
+		Expect(err).ToNot(HaveOccurred())
+		configurer := NewTestApiServerConfigurer().WithConfigMutator(func(cfg *config_api_server.ApiServerConfig) {
+			cfg.HTTP.Port = uint32(httpPort)
+			cfg.HTTPS.Port = uint32(httpsPort)
+		})
+		apiServer, _, err := newTestApiServer(configurer)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = apiServer.Start(make(chan struct{}))
+		Expect(err).To(MatchError(ContainSubstring(httpsListener.Addr().String())))
+		Expect(apiServer.Ready()).To(BeFalse())
+
+		httpAddress := net.JoinHostPort("127.0.0.1", strconv.Itoa(httpPort))
+		conn, err := net.DialTimeout("tcp", httpAddress, 100*time.Millisecond)
+		if conn != nil {
+			DeferCleanup(conn.Close)
+		}
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/diagnostics/server.go
+++ b/pkg/diagnostics/server.go
@@ -95,7 +95,7 @@ func (s *diagnosticsServer) Start(stop <-chan struct{}) error {
 		ReadHeaderTimeout: time.Second,
 		ErrorLog:          adapter.ToStd(diagnosticsServerLog),
 	}
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	if err := kuma_srv.StartServer(diagnosticsServerLog, httpServer, &s.ready, errChan); err != nil {
 		return err
 	}

--- a/pkg/mads/server/server.go
+++ b/pkg/mads/server/server.go
@@ -91,7 +91,7 @@ func (s *muxServer) Start(stop <-chan struct{}) error {
 
 	container := restful.NewContainer()
 	container.Add(ws)
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	httpS := &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.config.Port),
 		ReadHeaderTimeout: time.Second,

--- a/pkg/util/http/server/server.go
+++ b/pkg/util/http/server/server.go
@@ -12,18 +12,34 @@ import (
 )
 
 func StartServer(log logr.Logger, server *http.Server, ready *atomic.Bool, errChan chan error) error {
-	l := log.WithValues("tls", server.TLSConfig != nil, "interface", server.Addr)
-	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", server.Addr)
+	ready.Store(false)
+	listener, err := NewListener(server)
 	if err != nil {
 		return err
+	}
+	ServeServer(log, server, listener, ready, errChan)
+	return nil
+}
+
+func NewListener(server *http.Server) (net.Listener, error) {
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", server.Addr)
+	if err != nil {
+		return nil, err
 	}
 	if server.TLSConfig != nil {
 		listener = tls.NewListener(listener, server.TLSConfig)
 	}
+	return listener, nil
+}
 
+func ServeServer(log logr.Logger, server *http.Server, listener net.Listener, ready *atomic.Bool, errChan chan error) <-chan struct{} {
+	l := log.WithValues("tls", server.TLSConfig != nil, "interface", server.Addr)
 	l.Info("starting server")
+	ready.Store(true)
+	done := make(chan struct{})
 	go func() {
-		ready.Store(true)
+		defer close(done)
+		defer ready.Store(false)
 		if err := server.Serve(listener); err != nil {
 			if errors.Is(err, http.ErrServerClosed) {
 				l.Info("shutting down server")
@@ -33,5 +49,5 @@ func StartServer(log logr.Logger, server *http.Server, ready *atomic.Bool, errCh
 			}
 		}
 	}()
-	return nil
+	return done
 }


### PR DESCRIPTION
## Motivation

If HTTPS fails to bind after HTTP starts, the API server currently returns an error while leaving HTTP available. Server goroutines can also block while reporting lifecycle errors.

## Implementation information

Pre-bind every configured listener before serving traffic, close previously opened listeners on setup failure, and shut down all started servers through one bounded cleanup path. Track Serve completion and reset readiness when servers stop. Buffer lifecycle error channels for every shared HTTP server helper caller.

Adds a regression test that occupies the HTTPS port and verifies HTTP is not left reachable.

## Supporting documentation

API server refactoring roadmap follow-up.

## Testing

- `make test TEST_PKG_LIST='./pkg/api-server/... ./pkg/diagnostics/... ./pkg/mads/server/... ./pkg/util/http/server/...' RACE=true`
- startup regression repeated 20 times with the race detector
- `make check`