### PR TITLE
fix(api-server): map KRI secrets correctly

### DIFF
--- a/pkg/api-server/kri_endpoint.go
+++ b/pkg/api-server/kri_endpoint.go
@@ -8,6 +8,7 @@ import (
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/access"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
@@ -22,6 +23,7 @@ import (
 
 type kriEndpoint struct {
 	k8sMapper       k8s.ResourceMapperFunc
+	k8sSecretMapper k8s.ResourceMapperFunc
 	resManager      manager.ResourceManager
 	resourceAccess  access.ResourceAccess
 	cpMode          config_core.CpMode
@@ -82,13 +84,25 @@ func (k *kriEndpoint) findByKriRoute(withInsight bool) handlerFunc {
 			}
 		}
 
-		res, err := formatResource(resource, request.QueryParameter("format"), k.k8sMapper, identifier.Namespace)
+		mapper := k8sMapperForDescriptor(*descriptor, k.k8sMapper, k.k8sSecretMapper)
+		res, err := formatResource(resource, request.QueryParameter("format"), mapper, identifier.Namespace)
 		if err != nil {
 			return nil, withTitle(err, "Could not format a resource")
 		}
 
 		return res, nil
 	}
+}
+
+func k8sMapperForDescriptor(
+	descriptor core_model.ResourceTypeDescriptor,
+	defaultMapper k8s.ResourceMapperFunc,
+	secretMapper k8s.ResourceMapperFunc,
+) k8s.ResourceMapperFunc {
+	if descriptor.Name == system.SecretType || descriptor.Name == system.GlobalSecretType {
+		return secretMapper
+	}
+	return defaultMapper
 }
 
 func (k *kriEndpoint) getCoreName(id kri.Identifier, desc core_model.ResourceTypeDescriptor) string {

--- a/pkg/api-server/kri_endpoint_test.go
+++ b/pkg/api-server/kri_endpoint_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s"
+	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
+	secrets_k8s "github.com/kumahq/kuma/v3/pkg/plugins/secrets/k8s"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 )
 
 func descriptorFor(id kri.Identifier) core_model.ResourceTypeDescriptor {
@@ -17,6 +21,53 @@ func descriptorFor(id kri.Identifier) core_model.ResourceTypeDescriptor {
 }
 
 var _ = Describe("KRI endpoint", func() {
+	DescribeTable("selecting a Kubernetes mapper for secrets",
+		func(resource core_model.Resource, kubernetesStore bool, namespace, expectedNamespace string) {
+			const systemNamespace = "kuma-system"
+			var defaultMapper, secretMapper k8s.ResourceMapperFunc
+			if kubernetesStore {
+				resource.SetMeta(&secrets_k8s.KubernetesMetaAdapter{
+					Name:      resource.GetMeta().GetName(),
+					Namespace: systemNamespace,
+				})
+				defaultMapper = k8s.NewKubernetesMapper(k8s.NewSimpleKubeFactory())
+				secretMapper = secrets_k8s.NewKubernetesMapper()
+			} else {
+				defaultMapper = k8s.NewInferenceMapper(systemNamespace, k8s.NewSimpleKubeFactory())
+				secretMapper = secrets_k8s.NewInferenceMapper(systemNamespace)
+			}
+
+			mapped, err := k8sMapperForDescriptor(resource.Descriptor(), defaultMapper, secretMapper)(resource, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			secret, ok := mapped.(*secrets_k8s.Secret)
+			Expect(ok).To(BeTrue())
+			Expect(secret.GetNamespace()).To(Equal(expectedNamespace))
+		},
+		Entry("Secret from Kubernetes with an explicit namespace", builders.Secret().Build(), true, "other", "other"),
+		Entry("Secret from Kubernetes with its stored namespace", builders.Secret().Build(), true, "", "kuma-system"),
+		Entry("GlobalSecret from Kubernetes with an explicit namespace", builders.GlobalSecret().Build(), true, "other", "other"),
+		Entry("GlobalSecret from Kubernetes with its stored namespace", builders.GlobalSecret().Build(), true, "", "kuma-system"),
+		Entry("inferred Secret with an explicit namespace", builders.Secret().Build(), false, "other", "other"),
+		Entry("inferred Secret with the system namespace", builders.Secret().Build(), false, "", "kuma-system"),
+		Entry("inferred GlobalSecret with an explicit namespace", builders.GlobalSecret().Build(), false, "other", "other"),
+		Entry("inferred GlobalSecret with the system namespace", builders.GlobalSecret().Build(), false, "", "kuma-system"),
+	)
+
+	It("selects the default mapper for other resources", func() {
+		defaultMapperCalled := false
+		defaultMapper := func(core_model.Resource, string) (k8s_model.KubernetesObject, error) {
+			defaultMapperCalled = true
+			return nil, nil
+		}
+
+		mapper := k8sMapperForDescriptor(descriptorFor(kri.MustFromString("kri_m____default_")), defaultMapper, nil)
+		_, err := mapper(nil, "")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(defaultMapperCalled).To(BeTrue())
+	})
+
 	It("should properly generate CoreName on resources synced from different zone", func() {
 		// given
 		cpZone := "kuma-1"

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -33,7 +33,6 @@ import (
 	config_types "github.com/kumahq/kuma/v3/pkg/config/types"
 	"github.com/kumahq/kuma/v3/pkg/core"
 	resources_access "github.com/kumahq/kuma/v3/pkg/core/resources/access"
-	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
@@ -301,8 +300,6 @@ func addResourcesEndpoints(
 		k8sSecretMapper = secrets_k8s.NewInferenceMapper(cfg.Store.Kubernetes.SystemNamespace)
 	}
 	for _, definition := range defs {
-		defType := definition.Name
-
 		switch {
 		case cfg.ApiServer.ReadOnly:
 			definition.ReadOnly = true
@@ -322,7 +319,7 @@ func addResourcesEndpoints(
 		endpoints := resourceEndpoints{
 			resourceCrudHandler: &resourceCrudHandler{
 				resourceEndpointsContext:     endpointsCtx,
-				k8sMapper:                    k8sMapper,
+				k8sMapper:                    k8sMapperForDescriptor(definition, k8sMapper, k8sSecretMapper),
 				federatedZone:                cfg.IsFederatedZoneCP(),
 				filter:                       filters.Resource(definition),
 				disableOriginLabelValidation: cfg.Multizone.Zone.DisableOriginLabelValidation,
@@ -335,9 +332,6 @@ func addResourcesEndpoints(
 				xdsHooks:                 xdsHooks,
 				knownInternalAddresses:   cfg.IPAM.KnownInternalCIDRs,
 			},
-		}
-		if defType == system.SecretType || defType == system.GlobalSecretType {
-			endpoints.k8sMapper = k8sSecretMapper
 		}
 		switch definition.Scope {
 		case model.ScopeMesh:
@@ -369,6 +363,7 @@ func addResourcesEndpoints(
 
 	kriEndpoints := kriEndpoint{
 		k8sMapper:       k8sMapper,
+		k8sSecretMapper: k8sSecretMapper,
 		resManager:      resManager,
 		resourceAccess:  resourceAccess,
 		cpMode:          cfg.Mode,


### PR DESCRIPTION
## Motivation

Ordinary resource reads choose a dedicated Kubernetes mapper for `Secret` and `GlobalSecret`, but KRI formatting always receives the generic mapper. This leaves the KRI path inconsistent and unable to format those descriptors as Kubernetes Secrets.

## Implementation information

Centralize descriptor-aware mapper selection and use it for both ordinary resource endpoints and KRI formatting. Pass the existing Kubernetes-store or inference Secret mapper into the KRI endpoint without changing KRI parsing, lookup names, or resource addressability.

Add focused coverage for `Secret` and `GlobalSecret` across Kubernetes-backed and inferred mappings, including explicit namespaces and default/stored system namespaces.

## Supporting documentation

API server refactoring roadmap follow-up.

## Testing

- `make test TEST_PKG_LIST=./pkg/api-server/...`
- focused mapper specs repeated 21 times with the race detector
- `make check`

> Changelog: skip