### PR TITLE
build(e2e): import images on DEBUG reruns

### DIFF
--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -153,6 +153,8 @@ ifdef DEBUG
 	done; \
 	if [ $$need_start -eq 1 ]; then \
 		$(MAKE) test/e2e/k8s/start; \
+	else \
+		$(MAKE) $(K8SCLUSTERS_LOAD_IMAGES_TARGETS); \
 	fi
 	$(E2E_ENV_VARS) $(GINKGO_TEST_E2E) $(KUBE_E2E_PKG_LIST)
 else


### PR DESCRIPTION
## Motivation

> Changelog: skip

`make test/e2e-kubernetes DEBUG=1` exists so you can iterate against a cluster you already have. It checks whether the clusters answer `cluster-info` and, if they do, skips `test/e2e/k8s/start` — which is also the only place that imports the freshly built images into k3d.

So the first run of the day starts a cluster and imports images, and every run after that, on every new commit, silently tests against the images from the previous version. What you see is the app pod stuck in `Pending` with `ErrImagePull` on a tag that exists locally but was never imported, and the failure looks like a broken test rather than a stale cluster.

## Implementation information

When the clusters are already up, import the images instead of doing nothing. `test/e2e/k8s/start` already runs the same load targets after starting, so the two paths now agree.

Costs one `k3d image import` per rerun, which is the price of the images actually matching the code under test.

## Supporting documentation

Hit while iterating on #18430.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD