### PR TITLE
test(gateway): run the delegated MeshTLS spec

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -204,7 +204,6 @@ spec:
 		"MeshLoadBalancingStrategy": delegated.MeshLoadBalancingStrategy(&config),
 		"MeshAccessLog":             delegated.MeshAccessLog(&config),
 		"MeshPassthrough":           delegated.MeshPassthrough(&config),
-		// Matcher for from policy doesn't work for delegated gateway https://github.com/kumahq/kuma/issues/12107
-		// "MeshTLS":                   delegated.MeshTLS(&config),
+		"MeshTLS":                   delegated.MeshTLS(&config),
 	})
 }

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
@@ -45,7 +45,7 @@ spec:
 			)).To(Succeed())
 		})
 
-		XIt("should not break communication once switched to TLS 1.3", func() {
+		It("should not break communication once switched to TLS 1.3", func() {
 			// check that communication to test-server works
 			Eventually(func(g Gomega) {
 				_, err := client.CollectEchoResponse(

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
@@ -60,6 +60,21 @@ spec:
 			// change TLS version to 1.3
 			Expect(framework.YamlK8s(meshTls)(kubernetes.Cluster)).To(Succeed())
 
+			// check that the policy reached the data path the gateway uses.
+			// The gateway proxy has no inbounds of its own, so mesh traffic
+			// entering through it is secured by the backend's inbound.
+			Eventually(func(g Gomega) {
+				stdout, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput(
+					"inspect", "dataplane",
+					"-m", config.Mesh,
+					fmt.Sprintf("test-server-0.%s", config.Namespace),
+					"--type=config-dump",
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(stdout).To(ContainSubstring(`"tls_minimum_protocol_version": "TLSv1_3"`))
+				g.Expect(stdout).To(ContainSubstring(`"tls_maximum_protocol_version": "TLSv1_3"`))
+			}, "30s", "1s").Should(Succeed())
+
 			// check that communication to test-server works
 			Eventually(func(g Gomega) {
 				_, err := client.CollectEchoResponse(


### PR DESCRIPTION
## Motivation

> Changelog: skip

The delegated gateway MeshTLS spec has been dark since November 2024, first behind a pending marker and then by being dropped from the suite listing. The registration comment parks it on #12107, "Matcher for from policy doesn't work for delegated gateway", and that issue was closed as not planned in March on the grounds that delegated gateways were going away. 3.0 then removed the built-in gateway and pointed users at delegated, so the gap sat on the only gateway mode Kuma supports.

The blocker no longer exists. `from[]` was removed from targetRef policies in #17238, and the spec targets the Mesh with `rules`. The plugin applies over inbound `FromRules` for any proxy that has a workload identity, and the delegated suite already installs MeshIdentity and an allow-all workload-identity MeshTrafficPermission. Enabling the spec is enough, no MeshTLS change is needed.

Closes #18022

## Implementation information

Dropped the pending marker and restored the suite registration.

Also added the assertion the issue actually asks for. The spec only proved that traffic survives the switch to TLS 1.3; it never checked the version took effect, so it would have passed even if the policy did nothing. It now reads the config dump of the backend the gateway routes to and requires both `tls_minimum_protocol_version` and `tls_maximum_protocol_version` to be `TLSv1_3`.

The backend, not the gateway, is the right place to assert. The delegated gateway's Dataplane is `{networking: {address, admin}}` with no inbounds at all — its listeners are the outbound `kri_msvc_*` ones, the passthroughs, dynamicconfig and admin — because KIC's own Services carry no `kuma.io/mesh` label, so no MeshService is generated for them. MeshTLS is an inbound policy, so mesh traffic entering through the gateway is secured where it terminates, on the backend's `self_inbound_dp_*` listeners, and those do honour the mesh-wide pin. Whether the gateway's own listening ports should be modelled as mesh inbounds is a separate design question.

The assertion is not vacuous: with the MeshTLS policy deleted, the same config dump carries no `tls_*_protocol_version` keys at all.

Verified locally on k3d: `1 Passed | 0 Failed`.

## Supporting documentation

Part of #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD