### PR TITLE
test(meshmetric): run the OpenTelemetry specs

### DIFF
--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -489,7 +489,7 @@ func MeshMetric() {
 		}, "1m", "1s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry enabled", func() {
+	It("MeshMetric with OpenTelemetry enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryBackend(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -506,7 +506,7 @@ func MeshMetric() {
 		}, "3m", "5s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry and usedonly/filter", func() {
+	It("MeshMetric with OpenTelemetry and usedonly/filter", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		Expect(kubernetes.Cluster.Install(MeshMetricWithOpenTelemetryAndIncludeUnused(mainMesh, openTelemetryCollector.CollectorEndpoint()))).To(Succeed())
@@ -524,7 +524,7 @@ func MeshMetric() {
 		}, "3m", "5s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
+	It("MeshMetric with OpenTelemetry and Prometheus enabled", func() {
 		// given
 		openTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		testServerIp, err := PodIPOfApp(kubernetes.Cluster, "test-server-0", namespace)
@@ -553,7 +553,7 @@ func MeshMetric() {
 		}, "3m", "5s").Should(Succeed())
 	})
 
-	XIt("MeshMetric with multiple OpenTelemetry backends", func() {
+	It("MeshMetric with multiple OpenTelemetry backends", func() {
 		// given
 		primaryOpenTelemetryCollector := otelcollector.From(kubernetes.Cluster, primaryOtelCollectorName)
 		secondaryOpenTelemetryCollector := otelcollector.From(kubernetes.Cluster, secondaryOtelCollectorName)

--- a/test/e2e_env/kubernetes/meshmetric/meshmetric.go
+++ b/test/e2e_env/kubernetes/meshmetric/meshmetric.go
@@ -391,6 +391,18 @@ func MeshMetric() {
 		Expect(kubernetes.Cluster.DeleteMesh(secondaryMesh)).To(Succeed())
 	})
 
+	// The OpenTelemetry specs assert on envoy_cluster_external_upstream_rq_time,
+	// a histogram Envoy only emits once requests actually flow. Nothing else in
+	// this suite sends mesh traffic, so drive some instead of depending on what
+	// another spec happens to leave behind.
+	generateTraffic := func(g Gomega) {
+		_, _, err := client.CollectResponse(
+			kubernetes.Cluster, "test-server-0", "http://test-server-1:80",
+			client.FromKubernetesPod(namespace, "test-server-0"),
+		)
+		g.Expect(err).ToNot(HaveOccurred())
+	}
+
 	It("Basic MeshMetric policy exposes Envoy metrics on correct port", func() {
 		// given
 		Expect(kubernetes.Cluster.Install(BasicMeshMetricForMesh("mesh-policy", mainMesh))).To(Succeed())
@@ -496,6 +508,8 @@ func MeshMetric() {
 
 		// then
 		Eventually(func(g Gomega) {
+			generateTraffic(g)
+
 			stdout, _, err := client.CollectResponse(
 				kubernetes.Cluster, "demo-client", openTelemetryCollector.ExporterEndpoint(),
 				client.FromKubernetesPod(observabilityNamespace, "demo-client"),
@@ -513,6 +527,8 @@ func MeshMetric() {
 
 		// then
 		Eventually(func(g Gomega) {
+			generateTraffic(g)
+
 			stdout, _, err := client.CollectResponse(
 				kubernetes.Cluster, "demo-client", openTelemetryCollector.ExporterEndpoint(),
 				client.FromKubernetesPod(observabilityNamespace, "demo-client"),
@@ -533,6 +549,8 @@ func MeshMetric() {
 
 		// then
 		Eventually(func(g Gomega) {
+			generateTraffic(g)
+
 			// metrics from OpenTelemetry
 			stdout, _, err := client.CollectResponse(
 				kubernetes.Cluster, "demo-client", openTelemetryCollector.ExporterEndpoint(),
@@ -561,6 +579,8 @@ func MeshMetric() {
 
 		// then
 		Eventually(func(g Gomega) {
+			generateTraffic(g)
+
 			// primary collector
 			stdout, _, err := client.CollectResponse(
 				kubernetes.Cluster, "demo-client", primaryOpenTelemetryCollector.ExporterEndpoint(),


### PR DESCRIPTION
## Motivation

> Changelog: skip

Four Kubernetes MeshMetric specs covering the OpenTelemetry backend have been off since March 2024. They were disabled for flakiness, turned back on once, and disabled again the next day, and no issue records what failed. Kuma ships OpenTelemetry metrics export in four shapes, plain, filtered to used metrics, alongside Prometheus, and across multiple backends, and none of them had an end-to-end proof on Kubernetes.

They were not flaky. All four assert on `envoy_cluster_external_upstream_rq_time_bucket`, a histogram Envoy only emits once requests actually flow through a cluster, and nothing in this suite sends mesh traffic. The specs could only pass when some other spec happened to leave that stat behind, which explains a spec that goes green once and red the next day.

Confirmed on a live cluster. With no traffic the collector serves gauges and no `external_upstream_rq_time` at all; after 30 requests between two test servers the same endpoint serves 160 `envoy_cluster_external_upstream_rq_time_bucket` samples plus `_count` and `_sum`. The OpenTelemetry path itself was never broken, and histograms export fine: `envoy_cluster_manager_cds_update_duration` was present throughout.

This is the same failure shape as #17421, where the delegated gateway OpenTelemetry spec depends on a Kong Ingress Controller resync that another spec happens to trigger.

Closes #18023

## Implementation information

Dropped the four pending markers and gave the specs their own traffic. A `generateTraffic` helper sends one request between two in-mesh test servers, called at the top of each polling loop so traffic keeps flowing while the assertion converges, rather than firing once and hoping the export lands in time.

Verified locally on k3d: `4 Passed | 0 Failed`.

`ci/verify-stability` cannot act here because the workflow drives reruns by pushing empty trigger commits and skips PRs whose head is a fork, so the kubernetes e2e job will be re-run on this PR instead to build up the consecutive-green evidence the issue asks for.

## Supporting documentation

Part of #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD