### PR TITLE
test(gateway): run the delegated OTel metrics spec

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshmetric.go
@@ -87,13 +87,25 @@ spec:
 			)).To(Succeed())
 		})
 
-		XIt("MeshMetric with OpenTelemetry enabled", func() {
+		It("MeshMetric with OpenTelemetry enabled", func() {
 			// given
 			collector := otelcollector.From(kubernetes.Cluster, otelcollector.DefaultDeploymentName)
 			Expect(kubernetes.Cluster.Install(meshMetric(collector.CollectorEndpoint()))).To(Succeed())
 
 			// then
 			Eventually(func(g Gomega) {
+				// The counter below only exists once requests flow through
+				// the gateway. Drive them here rather than asserting on a
+				// cluster that only sees traffic when the Kong Ingress
+				// Controller happens to sync its config.
+				_, err := client.CollectEchoResponse(
+					kubernetes.Cluster,
+					"demo-client",
+					fmt.Sprintf("http://%s/test-server", config.KicIP),
+					client.FromKubernetesPod(config.NamespaceOutsideMesh, "demo-client"),
+				)
+				g.Expect(err).ToNot(HaveOccurred())
+
 				stdout, _, err := client.CollectResponse(
 					kubernetes.Cluster,
 					"demo-client",
@@ -107,8 +119,7 @@ spec:
 						return strings.Split(stdout, "\n")
 					},
 					ContainElement(MatchRegexp(
-						`envoy_cluster_external_upstream_rq_time_bucket\{.*service="%[1]s-gateway-admin_%[1]s_svc_8444"`,
-						config.Mesh,
+						`envoy_cluster_upstream_rq_total\{envoy_cluster_name="[^"]*test-server[^"]*".*kuma_workload="gateway"`,
 					)),
 				))
 			}, "3m", "5s").Should(Succeed())


### PR DESCRIPTION
## Motivation

> Changelog: skip

The delegated gateway's OpenTelemetry metrics spec has been disabled since it was found to time out unreliably, even at 300s in CI. #17421 traced that to the stat it waits for: `envoy_cluster_external_upstream_rq_time_bucket` on the gateway's own Kong Admin API cluster, which only sees traffic when the Kong Ingress Controller pushes a config sync. That sync is event driven, so the spec was really waiting for another spec to churn a watched resource, and converged anywhere from 15 seconds to over 10 minutes.

Reading the live collector while driving traffic through the gateway turned up two more reasons it could not pass reliably:

The assertion matches a `service="..."` label that no longer exists. Metrics now carry `envoy_cluster_name`, `kuma_workload`, `kuma_proxy_role`, `mesh` and `zone`.

`external_upstream_rq_time` is never produced for user traffic here at all. Requests the gateway forwards to the backend are classified as internal: after 20 requests through the gateway the collector serves `envoy_cluster_internal_upstream_rq_total{envoy_cluster_name="kri_msvc_..._test-server_main",kuma_workload="gateway"} 54`, while the only `external_upstream_rq_time` samples belong to `envoy_cluster_name="system_envoy_admin"`.

Closes #17421

## Implementation information

The spec now drives its own traffic. Each poll sends a request through the gateway to the backend, so the metric it asserts on is produced by this spec rather than by whatever the ingress controller or a neighbouring spec happened to do.

The assertion moved to `envoy_cluster_upstream_rq_total` for a cluster whose name contains `test-server`, exported by `kuma_workload="gateway"`. That is the plain counter, so it does not depend on how Envoy classifies the request as internal or external, nor on histogram bucketing, and matching the cluster name loosely keeps it working through unified-naming changes. It still proves the specific thing the spec is for: the delegated gateway's own proxy exporting metrics over OpenTelemetry for traffic it handled.

Same root cause as #18434, where four sidecar OpenTelemetry specs assert on a traffic-dependent metric without generating traffic.

## Supporting documentation

Part of #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD