### PR TITLE
test(e2e): gate an external service on egress

### DIFF
--- a/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
+++ b/test/e2e_env/multizone/meshtrafficpermission/meshtrafficpermission.go
@@ -45,6 +45,14 @@ func MeshTrafficPermission() {
 		)
 	}
 
+	zoneEgress := func() InstallFunc {
+		return zoneproxy.Install(
+			zoneproxy.WithMesh(meshName),
+			zoneproxy.WithNamespace(namespace),
+			zoneproxy.WithEgress(),
+		)
+	}
+
 	BeforeAll(func() {
 		// Global. No MeshTrafficPermission is installed: the mesh has to start
 		// out default-deny for the first assertion of the test.
@@ -75,6 +83,7 @@ func MeshTrafficPermission() {
 			Install(Parallel(
 				democlient.Install(democlient.WithNamespace(namespace), democlient.WithMesh(meshName)),
 				zoneIngress(),
+				zoneEgress(),
 			)).
 			SetupInGroup(multizone.KubeZone1, &group)
 		Expect(group.Wait()).To(Succeed())
@@ -149,8 +158,34 @@ spec:
 		trafficAllowed(serverHostname)
 	})
 
-	It("should allow the traffic to the external service through the egress", func() {
-		Skip("MeshTrafficPermission cannot gate a MeshExternalService without Zone Proxy + MeshIdentity (SNI rules); tracked in https://github.com/kumahq/kuma/issues/17160")
-		trafficAllowed("external-service.extsvc.mesh.local")
+	It("should gate the external service on the egress by SNI", func() {
+		esHostname := "external-service.extsvc.mesh.local"
+
+		// the egress denies everything it has no rule for
+		trafficBlocked(esHostname)
+
+		// MeshExternalService access is granted on the egress listener by
+		// matching the SNI the client presents for it, which is the
+		// MeshExternalService's KRI rendered in the SNI format. The resource
+		// is created on Global, so it carries no zone segment.
+		yaml := `
+type: MeshTrafficPermission
+name: mtp-egress
+mesh: mtp-test
+spec:
+ targetRef:
+   kind: Dataplane
+   labels:
+     kuma.io/listener-zoneegress: enabled
+ rules:
+   - default:
+       allow:
+         - sni:
+             type: Exact
+             value: sni.extsvc.mtp-test.external-service.80
+`
+		Expect(YamlUniversal(yaml)(multizone.Global)).To(Succeed())
+
+		trafficAllowed(esHostname)
 	})
 }


### PR DESCRIPTION
## Motivation

> Changelog: skip

The multizone MeshTrafficPermission spec covering a MeshExternalService reached through the egress was skipped when the mesh moved to `meshServices: Exclusive`. The old form, a top-level `targetRef.kind: MeshExternalService` with `from[]`, is rejected on apply, so the spec was parked with a `Skip` and the coverage went away.

Access control for a MeshExternalService now lives on the zone egress: the embedded egress applies MeshTrafficPermission `spec.rules[].matches[].sni` against the SNI the client presents, which needs MeshIdentity and a workload identity.

Closes #17160

## Implementation information

Most of what the issue asks for had already landed. The suite runs on Exclusive with `MeshIdentityBundled`, distributes MeshTrusts across zones and installs a zone proxy, so what was missing was the egress half and the rule itself.

The Kubernetes zone now also gets an egress zone proxy, and the spec asserts the behaviour end to end: with no MeshTrafficPermission the egress denies the request with a 403, and after applying a permission that targets the egress listener with an exact SNI match the same request succeeds.

The SNI is the MeshExternalService's KRI rendered in the SNI format from `pkg/core/resources/sni/sni.go`, `sni.<short>.<mesh>.<name>.<sectionName>`. This resource is created on Global, so it carries no zone segment and the value is `sni.extsvc.mtp-test.external-service.80`. The comment in the spec says so, because the shape is not guessable from the resource alone.

Two claims in the issue are out of date and worth recording. `validateTop` no longer accepts MeshSubset, MeshService or MeshServiceSubset, only Mesh and Dataplane, after #17422. And the legacy standalone ZoneEgress path it contrasts against is gone with #17242, so there is no all-or-nothing flag left to compare with.

Verified locally: `2 Passed | 0 Failed` on the multizone suite.

## Supporting documentation

Part of #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD