### PR TITLE
refactor(api-server): share policy inspection

### DIFF
--- a/pkg/api-server/resource_inspect_endpoints.go
+++ b/pkg/api-server/resource_inspect_endpoints.go
@@ -218,49 +218,68 @@ func (r *resourceInspectHandler) configForProxyParams(request *restful.Request) 
 	return params, nil
 }
 
+func (r *resourceInspectHandler) loadDataplaneForInspection(request *restful.Request) (*core_mesh.DataplaneResource, *xds_context.BaseMeshContext, error) {
+	dataplaneName := request.PathParameter("name")
+	meshName, err := r.meshFromRequest(request)
+	if err != nil {
+		return nil, nil, withTitle(err, "Failed to retrieve Mesh")
+	}
+
+	if err := r.resourceAccess.ValidateGet(
+		request.Request.Context(),
+		core_model.ResourceKey{Mesh: meshName, Name: dataplaneName},
+		r.descriptor,
+		user.FromCtx(request.Request.Context()),
+	); err != nil {
+		return nil, nil, withTitle(err, "Access Denied")
+	}
+
+	resource := r.descriptor.NewObject()
+	if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(dataplaneName, meshName)); err != nil {
+		return nil, nil, withTitle(err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
+	}
+	if r.descriptor.Name != core_mesh.DataplaneType {
+		return nil, nil, withTitle(fmt.Errorf("rules not supported for type %s", r.descriptor.Name), "Unsupported resource type")
+	}
+	dataplane := resource.(*core_mesh.DataplaneResource)
+
+	baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
+	if err != nil {
+		return nil, nil, withTitle(err, "Failed to build Mesh context")
+	}
+
+	return dataplane, baseMeshContext, nil
+}
+
+func matchPolicies(plugins []core_plugins.RegisteredPolicyPlugin, dataplane *core_mesh.DataplaneResource, resources xds_context.Resources) ([]core_xds.TypedMatchingPolicies, error) {
+	var matchedPolicies []core_xds.TypedMatchingPolicies
+	for _, policyPlugin := range plugins {
+		matched, err := policyPlugin.Plugin.MatchedPolicies(dataplane, resources)
+		if err != nil {
+			return nil, withTitle(err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
+		}
+		if matched.Type == "" {
+			return nil, withTitle(fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
+		}
+
+		matchedPolicies = append(matchedPolicies, matched)
+	}
+	return matchedPolicies, nil
+}
+
 func (r *resourceInspectHandler) getPoliciesConf(plugins []core_plugins.RegisteredPolicyPlugin, mapToResponse matchedPoliciesToResponse) handlerFunc {
 	return func(request *restful.Request) (any, error) {
-		dataplaneName := request.PathParameter("name")
-		meshName, err := r.meshFromRequest(request)
+		dataplane, baseMeshContext, err := r.loadDataplaneForInspection(request)
 		if err != nil {
-			return nil, withTitle(err, "Failed to retrieve Mesh")
+			return nil, err
 		}
-
-		if err := r.resourceAccess.ValidateGet(
-			request.Request.Context(),
-			core_model.ResourceKey{Mesh: meshName, Name: dataplaneName},
-			r.descriptor,
-			user.FromCtx(request.Request.Context()),
-		); err != nil {
-			return nil, withTitle(err, "Access Denied")
-		}
-
-		resource := r.descriptor.NewObject()
-		if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(dataplaneName, meshName)); err != nil {
-			return nil, withTitle(err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
-		}
-		dataplane := resource.(*core_mesh.DataplaneResource)
-
-		baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
+		resources := baseMeshContext.Resources()
+		matchedPolicies, err := matchPolicies(plugins, dataplane, resources)
 		if err != nil {
-			return nil, withTitle(err, "Failed to build Mesh context")
+			return nil, err
 		}
 
-		var matchedPolicies []core_xds.TypedMatchingPolicies
-		allPlugins := plugins
-		for _, policyPlugin := range allPlugins {
-			res, err := policyPlugin.Plugin.MatchedPolicies(dataplane, baseMeshContext.Resources())
-			if err != nil {
-				return nil, withTitle(err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
-			}
-			if res.Type == "" {
-				return nil, withTitle(fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
-			}
-
-			matchedPolicies = append(matchedPolicies, res)
-		}
-
-		out, err := mapToResponse(matchedPolicies, request, baseMeshContext.Mesh, dataplane, baseMeshContext.Resources())
+		out, err := mapToResponse(matchedPolicies, request, baseMeshContext.Mesh, dataplane, resources)
 		if err != nil {
 			return nil, withTitle(err, "Failed building response")
 		}
@@ -451,151 +470,120 @@ func originToKRI(origin core_model.ResourceMeta, policyType core_model.ResourceT
 
 func (r *resourceInspectHandler) rulesForResource() handlerFunc {
 	return func(request *restful.Request) (any, error) {
-		resourceName := request.PathParameter("name")
-		meshName, err := r.meshFromRequest(request)
+		dataplane, baseMeshContext, err := r.loadDataplaneForInspection(request)
 		if err != nil {
-			return nil, withTitle(err, "Failed to retrieve Mesh")
+			return nil, err
 		}
-
-		if err := r.resourceAccess.ValidateGet(
-			request.Request.Context(),
-			core_model.ResourceKey{Mesh: meshName, Name: resourceName},
-			r.descriptor,
-			user.FromCtx(request.Request.Context()),
-		); err != nil {
-			return nil, withTitle(err, "Access Denied")
-		}
-
-		resource := r.descriptor.NewObject()
-		if err := r.resManager.Get(request.Request.Context(), resource, store.GetByKey(resourceName, meshName)); err != nil {
-			return nil, withTitle(err, fmt.Sprintf("Could not retrieve %s", r.descriptor.Name))
-		}
-		var dp *core_mesh.DataplaneResource
-		switch r.descriptor.Name {
-		case core_mesh.DataplaneType:
-			dp = resource.(*core_mesh.DataplaneResource)
-		default:
-			return nil, withTitle(fmt.Errorf("rules not supported for type %s", r.descriptor.Name), "Unsupported resource type")
-		}
-		baseMeshContext, err := r.meshContextBuilder.BuildBaseMeshContextIfChanged(request.Request.Context(), meshName, nil)
+		resources := baseMeshContext.Resources()
+		matchedPolicies, err := matchPolicies(core_plugins.Plugins().PolicyPlugins(), dataplane, resources)
 		if err != nil {
-			return nil, withTitle(err, "Failed to build Mesh context")
+			return nil, err
 		}
+		return matchedPoliciesToRulesResponse(matchedPolicies, dataplane), nil
+	}
+}
 
-		resources := xds_context.Resources{
-			MeshLocalResources: baseMeshContext.ResourceMap,
-		}
-		matchesByHash := map[common_api.MatchesHash][]meshhttproute_api.Match{}
-		// Get all the matching policies
-		allPlugins := core_plugins.Plugins().PolicyPlugins()
-		rules := []api_common.InspectRule{}
-		for _, policyPlugin := range allPlugins {
-			res, err := policyPlugin.Plugin.MatchedPolicies(dp, resources)
-			if err != nil {
-				return nil, withTitle(err, fmt.Sprintf("could not apply policy plugin %s", policyPlugin.Name))
-			}
-			if res.Type == "" {
-				return nil, withTitle(fmt.Errorf("matched policy didn't set type for policy plugin %s", policyPlugin.Name), "could not apply policy plugin")
-			}
-			if res.Type == meshhttproute_api.MeshHTTPRouteType {
-				for _, resourceRule := range res.ToRules.ResourceRules {
-					for _, conf := range resourceRule.Conf {
-						if pd, ok := conf.(meshhttproute_api.PolicyDefault); ok {
-							for _, r := range pd.Rules {
-								matchesByHash[meshhttproute_api.HashMatches(r.Matches)] = r.Matches
-							}
+func matchedPoliciesToRulesResponse(matchedPolicies []core_xds.TypedMatchingPolicies, dataplane *core_mesh.DataplaneResource) api_types.InspectRulesResponse {
+	matchesByHash := map[common_api.MatchesHash][]meshhttproute_api.Match{}
+	rules := []api_common.InspectRule{}
+	for _, matched := range matchedPolicies {
+		if matched.Type == meshhttproute_api.MeshHTTPRouteType {
+			for _, resourceRule := range matched.ToRules.ResourceRules {
+				for _, conf := range resourceRule.Conf {
+					if policyDefault, ok := conf.(meshhttproute_api.PolicyDefault); ok {
+						for _, rule := range policyDefault.Rules {
+							matchesByHash[meshhttproute_api.HashMatches(rule.Matches)] = rule.Matches
 						}
 					}
 				}
 			}
+		}
 
-			if len(res.ToRules.ResourceRules) == 0 && len(res.FromRules.InboundRules) == 0 && res.ProxyConf == nil {
+		if len(matched.ToRules.ResourceRules) == 0 && len(matched.FromRules.InboundRules) == 0 && matched.ProxyConf == nil {
+			continue
+		}
+		var proxyRule *api_common.ProxyRule
+		if matched.ProxyConf != nil {
+			proxyRule = &api_common.ProxyRule{
+				Conf:   matched.ProxyConf.Conf,
+				Origin: oapi_helpers.ResourceMetaListToMetaList(matched.Type, matched.ProxyConf.Origin),
+			}
+		}
+
+		getInboundPortName := func(port uint32) *string {
+			if name := dataplane.Spec.GetNetworking().GetInboundForPort(port).GetName(); name != "" {
+				return &name
+			}
+			return nil
+		}
+
+		inboundRules := []api_common.InboundRulesEntry{}
+		for inbound, rulesForInbound := range matched.FromRules.InboundRules {
+			if len(rulesForInbound) == 0 {
 				continue
 			}
-			var proxyRule *api_common.ProxyRule
-			if res.ProxyConf != nil {
-				proxyRule = &api_common.ProxyRule{
-					Conf:   res.ProxyConf.Conf,
-					Origin: oapi_helpers.ResourceMetaListToMetaList(res.Type, res.ProxyConf.Origin),
+			rs := make([]api_common.InboundRule, len(rulesForInbound))
+			for i := range rulesForInbound {
+				rs[i] = api_common.InboundRule{
+					Conf:   []any{rulesForInbound[i].Conf},
+					Match:  rulesForInbound[i].Match,
+					Origin: oapi_helpers.OriginListToResourceRuleOrigin(matched.Type, []common.Origin{rulesForInbound[i].Origin}),
 				}
 			}
-
-			getInboundPortName := func(port uint32) *string {
-				if name := dp.Spec.GetNetworking().GetInboundForPort(port).GetName(); name != "" {
-					return &name
-				}
-				return nil
-			}
-
-			inboundRules := []api_common.InboundRulesEntry{}
-			for inbound, rulesForInbound := range res.FromRules.InboundRules {
-				if len(rulesForInbound) == 0 {
-					continue
-				}
-				rs := make([]api_common.InboundRule, len(rulesForInbound))
-				for i := range rulesForInbound {
-					rs[i] = api_common.InboundRule{
-						Conf:   []any{rulesForInbound[i].Conf},
-						Match:  rulesForInbound[i].Match,
-						Origin: oapi_helpers.OriginListToResourceRuleOrigin(res.Type, []common.Origin{rulesForInbound[i].Origin}),
-					}
-				}
-				inboundRules = append(inboundRules, api_common.InboundRulesEntry{
-					Inbound: api_common.Inbound{
-						Name: getInboundPortName(inbound.Port),
-						Port: int(inbound.Port),
-					},
-					Rules: rs,
-				})
-			}
-			sort.SliceStable(inboundRules, func(i, j int) bool {
-				return inboundRules[i].Inbound.Port < inboundRules[j].Inbound.Port
-			})
-
-			toResourceRules := []api_common.ResourceRule{}
-			for itemIdentifier, resourceRuleItem := range res.ToRules.ResourceRules {
-				toResourceRules = append(toResourceRules, api_common.ResourceRule{
-					Conf:                resourceRuleItem.Conf,
-					Origin:              oapi_helpers.OriginListToResourceRuleOrigin(res.Type, resourceRuleItem.Origin),
-					ResourceMeta:        oapi_helpers.ResourceMetaToMeta(itemIdentifier.ResourceType, resourceRuleItem.Resource),
-					ResourceSectionName: &resourceRuleItem.ResourceSectionName,
-				})
-			}
-			sort.Slice(toResourceRules, func(i, j int) bool {
-				return toResourceRules[i].ResourceMeta.Name < toResourceRules[j].ResourceMeta.Name
-			})
-
-			if proxyRule == nil && len(toResourceRules) == 0 && len(inboundRules) == 0 && len(res.Warnings) == 0 {
-				// No matches for this policy, keep going...
-				continue
-			}
-			warnings := res.Warnings
-			if warnings == nil {
-				warnings = []string{}
-			}
-			rules = append(rules, api_common.InspectRule{
-				Type:            string(res.Type),
-				ToResourceRules: &toResourceRules,
-				InboundRules:    &inboundRules,
-				ProxyRule:       proxyRule,
-				Warnings:        &warnings,
+			inboundRules = append(inboundRules, api_common.InboundRulesEntry{
+				Inbound: api_common.Inbound{
+					Name: getInboundPortName(inbound.Port),
+					Port: int(inbound.Port),
+				},
+				Rules: rs,
 			})
 		}
-		httpMatches := []api_common.HttpMatch{}
-		for k, v := range matchesByHash {
-			httpMatches = append(httpMatches, api_common.HttpMatch{
-				Match: v,
-				Hash:  string(k),
-			})
-		}
-		sort.Slice(httpMatches, func(i, j int) bool {
-			return httpMatches[i].Hash < httpMatches[j].Hash
+		sort.SliceStable(inboundRules, func(i, j int) bool {
+			return inboundRules[i].Inbound.Port < inboundRules[j].Inbound.Port
 		})
-		out := api_types.InspectRulesResponse{
-			HttpMatches: httpMatches,
-			Resource:    oapi_helpers.ResourceToMeta(resource),
-			Rules:       rules,
+
+		toResourceRules := []api_common.ResourceRule{}
+		for itemIdentifier, resourceRuleItem := range matched.ToRules.ResourceRules {
+			toResourceRules = append(toResourceRules, api_common.ResourceRule{
+				Conf:                resourceRuleItem.Conf,
+				Origin:              oapi_helpers.OriginListToResourceRuleOrigin(matched.Type, resourceRuleItem.Origin),
+				ResourceMeta:        oapi_helpers.ResourceMetaToMeta(itemIdentifier.ResourceType, resourceRuleItem.Resource),
+				ResourceSectionName: &resourceRuleItem.ResourceSectionName,
+			})
 		}
-		return out, nil
+		sort.Slice(toResourceRules, func(i, j int) bool {
+			return toResourceRules[i].ResourceMeta.Name < toResourceRules[j].ResourceMeta.Name
+		})
+
+		if proxyRule == nil && len(toResourceRules) == 0 && len(inboundRules) == 0 && len(matched.Warnings) == 0 {
+			// No matches for this policy, keep going...
+			continue
+		}
+		warnings := matched.Warnings
+		if warnings == nil {
+			warnings = []string{}
+		}
+		rules = append(rules, api_common.InspectRule{
+			Type:            string(matched.Type),
+			ToResourceRules: &toResourceRules,
+			InboundRules:    &inboundRules,
+			ProxyRule:       proxyRule,
+			Warnings:        &warnings,
+		})
+	}
+	httpMatches := []api_common.HttpMatch{}
+	for hash, matches := range matchesByHash {
+		httpMatches = append(httpMatches, api_common.HttpMatch{
+			Match: matches,
+			Hash:  string(hash),
+		})
+	}
+	sort.Slice(httpMatches, func(i, j int) bool {
+		return httpMatches[i].Hash < httpMatches[j].Hash
+	})
+	return api_types.InspectRulesResponse{
+		HttpMatches: httpMatches,
+		Resource:    oapi_helpers.ResourceToMeta(dataplane),
+		Rules:       rules,
 	}
 }

--- a/pkg/api-server/resource_inspect_endpoints_test.go
+++ b/pkg/api-server/resource_inspect_endpoints_test.go
@@ -1,0 +1,295 @@
+package api_server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/access"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	core_user "github.com/kumahq/kuma/v3/pkg/core/user"
+	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
+	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
+	rules_common "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/common"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/inbound"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/outbound"
+	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
+)
+
+func TestLoadDataplaneForInspection(t *testing.T) {
+	t.Run("loads Mesh, authorizes, loads Dataplane, and builds context in order", func(t *testing.T) {
+		g := NewWithT(t)
+		events := []string{}
+		dataplane := builders.Dataplane().WithName("dp-1").WithMesh("default").Build()
+		baseMeshContext := &xds_context.BaseMeshContext{
+			Mesh:        builders.Mesh().WithName("default").Build(),
+			ResourceMap: xds_context.ResourceMap{},
+		}
+		handler := newInspectionHandler(
+			&inspectionResourceManager{events: &events, dataplane: dataplane},
+			&inspectionResourceAccess{events: &events},
+			&inspectionMeshContextBuilder{events: &events, baseMeshContext: baseMeshContext},
+		)
+		request := newCrudRequest(http.MethodGet, "/meshes/default/dataplanes/dp-1/_rules", "dp-1", "")
+		request.PathParameters()["mesh"] = "default"
+
+		loadedDataplane, loadedContext, err := handler.loadDataplaneForInspection(request)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(loadedDataplane.GetMeta()).To(Equal(dataplane.GetMeta()))
+		g.Expect(loadedContext).To(BeIdenticalTo(baseMeshContext))
+		g.Expect(events).To(Equal([]string{"mesh", "authorize", "dataplane", "context"}))
+	})
+
+	t.Run("authorization failure stops before Dataplane and context loading", func(t *testing.T) {
+		g := NewWithT(t)
+		events := []string{}
+		accessErr := errors.New("access denied")
+		handler := newInspectionHandler(
+			&inspectionResourceManager{events: &events},
+			&inspectionResourceAccess{events: &events, err: accessErr},
+			&inspectionMeshContextBuilder{events: &events},
+		)
+		request := newCrudRequest(http.MethodGet, "/meshes/default/dataplanes/dp-1/_rules", "dp-1", "")
+		request.PathParameters()["mesh"] = "default"
+
+		_, _, err := handler.loadDataplaneForInspection(request)
+
+		expectTitledError(g, err, "Access Denied")
+		g.Expect(errors.Is(err, accessErr)).To(BeTrue())
+		g.Expect(events).To(Equal([]string{"mesh", "authorize"}))
+	})
+}
+
+func TestMatchPolicies(t *testing.T) {
+	t.Run("preserves plugin order and inputs", func(t *testing.T) {
+		g := NewWithT(t)
+		events := []string{}
+		dataplane := builders.Dataplane().Build()
+		resources := xds_context.NewResources()
+		plugins := []core_plugins.RegisteredPolicyPlugin{
+			inspectionRegisteredPlugin("z-plugin", "MeshZ", &events),
+			inspectionRegisteredPlugin("a-plugin", "MeshA", &events),
+		}
+
+		matched, err := matchPolicies(plugins, dataplane, resources)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(events).To(Equal([]string{"z-plugin", "a-plugin"}))
+		g.Expect(matched).To(HaveLen(2))
+		g.Expect(matched[0].Type).To(Equal(core_model.ResourceType("MeshZ")))
+		g.Expect(matched[1].Type).To(Equal(core_model.ResourceType("MeshA")))
+		for _, plugin := range plugins {
+			recording := plugin.Plugin.(*inspectionPolicyPlugin)
+			g.Expect(recording.dataplane).To(BeIdenticalTo(dataplane))
+			g.Expect(recording.resources).To(Equal(resources))
+			g.Expect(recording.options).To(BeZero())
+		}
+	})
+
+	t.Run("stops on the first plugin error", func(t *testing.T) {
+		g := NewWithT(t)
+		events := []string{}
+		pluginErr := errors.New("match failed")
+		plugins := []core_plugins.RegisteredPolicyPlugin{
+			{
+				Name: "broken",
+				Plugin: &inspectionPolicyPlugin{
+					name:   "broken",
+					events: &events,
+					err:    pluginErr,
+				},
+			},
+			inspectionRegisteredPlugin("not-called", "MeshA", &events),
+		}
+
+		_, err := matchPolicies(plugins, builders.Dataplane().Build(), xds_context.NewResources())
+
+		expectTitledError(g, err, "could not apply policy plugin broken")
+		g.Expect(errors.Is(err, pluginErr)).To(BeTrue())
+		g.Expect(events).To(Equal([]string{"broken"}))
+	})
+
+	t.Run("rejects an empty policy type before calling the next plugin", func(t *testing.T) {
+		g := NewWithT(t)
+		events := []string{}
+		plugins := []core_plugins.RegisteredPolicyPlugin{
+			inspectionRegisteredPlugin("empty", "", &events),
+			inspectionRegisteredPlugin("not-called", "MeshA", &events),
+		}
+
+		_, err := matchPolicies(plugins, builders.Dataplane().Build(), xds_context.NewResources())
+
+		expectTitledError(g, err, "could not apply policy plugin")
+		g.Expect(err.Error()).To(ContainSubstring("matched policy didn't set type for policy plugin empty"))
+		g.Expect(events).To(Equal([]string{"empty"}))
+	})
+}
+
+func TestMatchedPoliciesToRulesResponse(t *testing.T) {
+	g := NewWithT(t)
+	dataplane := builders.Dataplane().
+		WithName("dp-1").
+		WithoutInbounds().
+		AddInbound(builders.Inbound().WithPort(9090).WithName("inbound-9090")).
+		AddInbound(builders.Inbound().WithPort(7070).WithName("inbound-7070")).
+		AddInbound(builders.Inbound().WithPort(8080).WithName("inbound-8080")).
+		Build()
+	policyMeta := &test_model.ResourceMeta{Name: "route-policy", Mesh: "default"}
+	matchesA := []meshhttproute_api.Match{{Path: &meshhttproute_api.PathMatch{Type: meshhttproute_api.Exact, Value: "/a"}}}
+	matchesZ := []meshhttproute_api.Match{{Path: &meshhttproute_api.PathMatch{Type: meshhttproute_api.Exact, Value: "/z"}}}
+	matched := []core_xds.TypedMatchingPolicies{{
+		Type: meshhttproute_api.MeshHTTPRouteType,
+		FromRules: core_rules.FromRules{InboundRules: map[core_rules.InboundListener][]*inbound.Rule{
+			{Port: 9090}: {{Conf: "9090", Origin: rules_common.Origin{Resource: policyMeta}}},
+			{Port: 7070}: {{Conf: "7070", Origin: rules_common.Origin{Resource: policyMeta}}},
+			{Port: 8080}: {{Conf: "8080", Origin: rules_common.Origin{Resource: policyMeta}}},
+		}},
+		ToRules: core_rules.ToRules{ResourceRules: outbound.ResourceRules{
+			{ResourceType: meshservice_api.MeshServiceType, Mesh: "default", Name: "backend-2"}: {
+				Resource: &test_model.ResourceMeta{Name: "backend-2", Mesh: "default"},
+				Conf: []any{meshhttproute_api.PolicyDefault{Rules: []meshhttproute_api.Rule{{
+					Matches: matchesZ,
+				}}}},
+			},
+			{ResourceType: meshservice_api.MeshServiceType, Mesh: "default", Name: "backend-1"}: {
+				Resource: &test_model.ResourceMeta{Name: "backend-1", Mesh: "default"},
+				Conf: []any{meshhttproute_api.PolicyDefault{Rules: []meshhttproute_api.Rule{{
+					Matches: matchesA,
+				}}}},
+			},
+		}},
+	}}
+
+	response := matchedPoliciesToRulesResponse(matched, dataplane)
+
+	g.Expect(response.Resource.Name).To(Equal("dp-1"))
+	g.Expect(response.Rules).To(HaveLen(1))
+	rule := response.Rules[0]
+	g.Expect(rule.InboundRules).NotTo(BeNil())
+	g.Expect(*rule.InboundRules).To(HaveLen(3))
+	g.Expect([]int{
+		(*rule.InboundRules)[0].Inbound.Port,
+		(*rule.InboundRules)[1].Inbound.Port,
+		(*rule.InboundRules)[2].Inbound.Port,
+	}).To(Equal([]int{7070, 8080, 9090}))
+	g.Expect(rule.ToResourceRules).NotTo(BeNil())
+	g.Expect(*rule.ToResourceRules).To(HaveLen(2))
+	g.Expect([]string{
+		(*rule.ToResourceRules)[0].ResourceMeta.Name,
+		(*rule.ToResourceRules)[1].ResourceMeta.Name,
+	}).To(Equal([]string{"backend-1", "backend-2"}))
+	g.Expect(rule.Warnings).NotTo(BeNil())
+	g.Expect(*rule.Warnings).To(BeEmpty())
+	g.Expect(response.HttpMatches).To(HaveLen(2))
+	hashes := []string{response.HttpMatches[0].Hash, response.HttpMatches[1].Hash}
+	expectedHashes := []string{string(meshhttproute_api.HashMatches(matchesA)), string(meshhttproute_api.HashMatches(matchesZ))}
+	slices.Sort(expectedHashes)
+	g.Expect(hashes).To(Equal(expectedHashes))
+
+	emptyResponse := matchedPoliciesToRulesResponse(nil, dataplane)
+	g.Expect(emptyResponse.Rules).NotTo(BeNil())
+	g.Expect(emptyResponse.Rules).To(BeEmpty())
+	g.Expect(emptyResponse.HttpMatches).NotTo(BeNil())
+	g.Expect(emptyResponse.HttpMatches).To(BeEmpty())
+}
+
+type inspectionResourceManager struct {
+	manager.ResourceManager
+	events    *[]string
+	dataplane *core_mesh.DataplaneResource
+}
+
+func (r *inspectionResourceManager) Get(_ context.Context, resource core_model.Resource, _ ...store.GetOptionsFunc) error {
+	switch typed := resource.(type) {
+	case *core_mesh.MeshResource:
+		*r.events = append(*r.events, "mesh")
+	case *core_mesh.DataplaneResource:
+		*r.events = append(*r.events, "dataplane")
+		if r.dataplane != nil {
+			typed.SetMeta(r.dataplane.GetMeta())
+			return typed.SetSpec(r.dataplane.GetSpec())
+		}
+	}
+	return nil
+}
+
+type inspectionResourceAccess struct {
+	access.ResourceAccess
+	events *[]string
+	err    error
+}
+
+func (r *inspectionResourceAccess) ValidateGet(context.Context, core_model.ResourceKey, core_model.ResourceTypeDescriptor, core_user.User) error {
+	*r.events = append(*r.events, "authorize")
+	return r.err
+}
+
+type inspectionMeshContextBuilder struct {
+	xds_context.MeshContextBuilder
+	events          *[]string
+	baseMeshContext *xds_context.BaseMeshContext
+}
+
+func (b *inspectionMeshContextBuilder) BuildBaseMeshContextIfChanged(context.Context, string, *xds_context.BaseMeshContext) (*xds_context.BaseMeshContext, error) {
+	*b.events = append(*b.events, "context")
+	return b.baseMeshContext, nil
+}
+
+func newInspectionHandler(resManager manager.ResourceManager, resourceAccess access.ResourceAccess, meshContextBuilder xds_context.MeshContextBuilder) *resourceInspectHandler {
+	return &resourceInspectHandler{
+		resManager:         resManager,
+		descriptor:         core_mesh.DataplaneResourceTypeDescriptor,
+		resourceAccess:     resourceAccess,
+		meshContextBuilder: meshContextBuilder,
+	}
+}
+
+type inspectionPolicyPlugin struct {
+	name      string
+	events    *[]string
+	result    core_xds.TypedMatchingPolicies
+	err       error
+	dataplane *core_mesh.DataplaneResource
+	resources xds_context.Resources
+	options   int
+}
+
+func (p *inspectionPolicyPlugin) Order() int {
+	return 0
+}
+
+func (p *inspectionPolicyPlugin) MatchedPolicies(dataplane *core_mesh.DataplaneResource, resources xds_context.Resources, opts ...core_plugins.MatchedPoliciesOption) (core_xds.TypedMatchingPolicies, error) {
+	*p.events = append(*p.events, p.name)
+	p.dataplane = dataplane
+	p.resources = resources
+	p.options = len(opts)
+	return p.result, p.err
+}
+
+func (p *inspectionPolicyPlugin) Apply(*core_xds.ResourceSet, xds_context.Context, *core_xds.Proxy) error {
+	return nil
+}
+
+func inspectionRegisteredPlugin(name string, resourceType core_model.ResourceType, events *[]string) core_plugins.RegisteredPolicyPlugin {
+	return core_plugins.RegisteredPolicyPlugin{
+		Name: core_plugins.PluginName(name),
+		Plugin: &inspectionPolicyPlugin{
+			name:   name,
+			events: events,
+			result: core_xds.TypedMatchingPolicies{Type: resourceType},
+		},
+	}
+}


### PR DESCRIPTION
## Motivation

Dataplane policy inspection endpoints duplicate authorization, resource loading, mesh context construction, and policy matching. Keeping these paths separate risks contract drift.

## Implementation information

- Share authorized Dataplane and base mesh context loading across policy inspection handlers.
- Share policy plugin matching while preserving plugin lookup timing and order.
- Extract `_rules` response mapping and retain deterministic sorting and initialized empty collections.
- Use the complete base mesh context resources consistently.
- Add focused tests for operation order, fail-fast errors, plugin inputs, sorting, and empty responses.

## Supporting documentation

Follows #18429.

> Changelog: skip