### PR TITLE
test(e2e): run mes priority on ipv6 again

### DIFF
--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -669,6 +669,37 @@ spec:
 				g.Expect(stdout).To(ContainSubstring(mesPrimaryName))
 			}, "30s", "1s").Should(Succeed())
 
+			By("Ejecting the primary endpoint once it stops accepting connections")
+			// Priority failover only reacts to host health, and a
+			// MeshExternalService cluster has neither health checks nor outlier
+			// detection by default. Without this the primary stays healthy and
+			// keeps taking traffic, and the spec only passes where DNS happens
+			// to drop the host, which is not the case on every address family.
+			outlierDetection := fmt.Sprintf(`
+type: MeshCircuitBreaker
+name: mes-priority-outlier
+mesh: %s
+spec:
+  targetRef:
+    kind: Mesh
+  to:
+    - targetRef:
+        kind: MeshExternalService
+        labels:
+          kuma.io/display-name: mes-priority
+      default:
+        outlierDetection:
+          interval: 1s
+          baseEjectionTime: 30s
+          maxEjectionPercent: 100
+          healthyPanicThreshold: 0
+          splitExternalAndLocalErrors: true
+          detectors:
+            localOriginFailures:
+              consecutive: 1
+`, meshNameNoDefaults)
+			Expect(universal.Cluster.Install(YamlUniversal(outlierDetection))).To(Succeed())
+
 			By("Removing primary endpoint to trigger failover")
 			Expect(universal.Cluster.DeleteApp(mesPrimaryName)).To(Succeed())
 

--- a/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
+++ b/test/e2e_env/universal/meshexternalservice/meshexternalservice.go
@@ -620,8 +620,7 @@ spec:
 		})
 	})
 
-	// https://github.com/kumahq/kuma/issues/15805
-	Context("MeshExternalService with endpoint priority", Ordered, Label("ipv6-not-supported"), func() {
+	Context("MeshExternalService with endpoint priority", Ordered, func() {
 		mesPrimaryName := "mes-priority-primary"
 		mesPrimaryPort := 83
 		var mesPrimaryContainerName string


### PR DESCRIPTION
## Motivation

> Changelog: skip

The MeshExternalService endpoint priority spec has been excluded from IPv6 since March, when it was labelled `ipv6-not-supported` and #15805 was filed to investigate. The issue body is a link to a failed run and nothing else, and that run's logs have expired, so there was no record of what failed.

Removing the label produced a fresh failure, and the debug artifact shows the spec was passing on IPv4 for the wrong reason.

Both endpoints are in the cluster. What differs is health:

| endpoint | hostname | priority | cx_connect_fail | health_flags |
|---|---|---|---|---|
| `[fd00:fd12:3456::e]:83` | `mes-priority-primary` | 0 | 12 | healthy |
| `[fd00:fd12:3456::9]:80` | `mes-http` | 1 | 0 | healthy |

After the primary's container is deleted Envoy keeps it as a healthy priority 0 host, so every request stays there and returns 503 while priority 1 serves nothing at all.

The cluster has nothing that could demote it: `STRICT_DNS`, `outlier_detection: false`, `health_checks: false`. Priority failover reacts only to host health, so the only thing that can remove the dead host is DNS re-resolution dropping it. That depends on the lookup family, which is the one thing that differs between the environments: `endpoint_cluster_configurer.go:41` picks `V4_ONLY` normally and `AUTO` when IPv6 is enabled. On IPv4 the host disappears and the spec passes; under `AUTO` it survives and the spec fails.

Closes #15805

## Implementation information

The label is gone, so the spec runs on IPv6 again, and the failover is now driven rather than hoped for.

Before removing the primary, the spec applies a MeshCircuitBreaker targeting the MeshExternalService with `splitExternalAndLocalErrors` and `localOriginFailures.consecutive: 1`, so the endpoint is ejected once it stops accepting connections. That works on any address family and does not depend on what DNS does with a deleted container.

`healthyPanicThreshold: 0` goes with it. With one of two hosts ejected the default 50% panic threshold would put Envoy into panic mode and spray traffic across all hosts including the dead one, which would make the spec flaky in a way that is hard to attribute.

This also makes the spec a better test of the feature. It now proves that traffic shifts when the endpoint is detected unhealthy, instead of passing because of a DNS side effect that only happens under one lookup family.

Verified on IPv4 locally: `1 Passed | 0 Failed`. IPv6 is what CI decides, since a local docker network with IPv6 enabled passes even without this change.

## Note

Independent of this spec: a MeshExternalService endpoint that refuses every connection keeps receiving traffic while a lower priority endpoint idles, on any address family, unless the user configures outlier detection. IPv4 masked that by removing the host from DNS. Whether these clusters should get outlier detection by default is left on #15805 rather than decided here.

## Supporting documentation

Part of #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD