### PR TITLE
refactor(api-server): simplify route registration

### DIFF
--- a/pkg/api-server/resource_routes_test.go
+++ b/pkg/api-server/resource_routes_test.go
@@ -1,0 +1,159 @@
+package api_server
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+)
+
+func TestResourceRoutes(t *testing.T) {
+	tests := []struct {
+		name       string
+		descriptor core_model.ResourceTypeDescriptor
+		expected   []resourceRoute
+	}{
+		{
+			name: "mesh primary path",
+			descriptor: core_model.ResourceTypeDescriptor{
+				Scope:  core_model.ScopeMesh,
+				WsPath: "resources",
+			},
+			expected: []resourceRoute{
+				{role: meshCRUDListRoute, pathRole: primaryResourcePath},
+				{role: crossMeshListRoute, pathRole: primaryResourcePath},
+			},
+		},
+		{
+			name: "mesh primary and alias paths",
+			descriptor: core_model.ResourceTypeDescriptor{
+				Scope:             core_model.ScopeMesh,
+				WsPath:            "resources",
+				AlternativeWsPath: "resource-aliases",
+			},
+			expected: []resourceRoute{
+				{role: meshCRUDListRoute, pathRole: primaryResourcePath},
+				{role: crossMeshListRoute, pathRole: primaryResourcePath},
+				{role: meshCRUDListRoute, pathRole: aliasResourcePath},
+				{role: crossMeshListRoute, pathRole: aliasResourcePath},
+			},
+		},
+		{
+			name:       "global primary and alias paths",
+			descriptor: system.GlobalSecretResourceTypeDescriptor,
+			expected: []resourceRoute{
+				{role: globalCRUDListRoute, pathRole: primaryResourcePath},
+				{role: globalCRUDListRoute, pathRole: aliasResourcePath},
+			},
+		},
+		{
+			name: "unknown scope",
+			descriptor: core_model.ResourceTypeDescriptor{
+				Scope:  "Unknown",
+				WsPath: "resources",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(resourceRoutes(test.descriptor)).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestRegisterResourceRoutes(t *testing.T) {
+	t.Run("preserves mesh route and metadata order", func(t *testing.T) {
+		for _, readOnly := range []bool{false, true} {
+			t.Run(fmt.Sprintf("read-only=%t", readOnly), func(t *testing.T) {
+				g := NewWithT(t)
+				descriptor := core_model.ResourceTypeDescriptor{
+					Name:              "Resource",
+					Scope:             core_model.ScopeMesh,
+					WsPath:            "resources",
+					AlternativeWsPath: "resource-aliases",
+					ReadOnly:          readOnly,
+				}
+				var metadataCalls []string
+				endpoints := resourceEndpoints{
+					resourceCrudHandler: &resourceCrudHandler{
+						descriptor: descriptor,
+						routeMetadataProvider: func(actual core_model.ResourceTypeDescriptor, method string) map[string]string {
+							g.Expect(actual).To(Equal(descriptor))
+							metadataCalls = append(metadataCalls, method)
+							return nil
+						},
+					},
+				}
+				ws := new(restful.WebService)
+
+				registerResourceRoutes(ws, endpoints)
+
+				g.Expect(routeMethodPaths(ws)).To(Equal([]string{
+					http.MethodPut + " /meshes/{mesh}/resources/{name}",
+					http.MethodDelete + " /meshes/{mesh}/resources/{name}",
+					http.MethodGet + " /meshes/{mesh}/resources/{name}",
+					http.MethodGet + " /meshes/{mesh}/resources",
+					http.MethodGet + " /resources",
+					http.MethodPut + " /meshes/{mesh}/resource-aliases/{name}",
+					http.MethodDelete + " /meshes/{mesh}/resource-aliases/{name}",
+					http.MethodGet + " /meshes/{mesh}/resource-aliases/{name}",
+					http.MethodGet + " /meshes/{mesh}/resource-aliases",
+					http.MethodGet + " /resource-aliases",
+				}))
+				g.Expect(metadataCalls).To(Equal([]string{
+					http.MethodPut,
+					http.MethodDelete,
+					http.MethodGet,
+					http.MethodGet,
+					http.MethodGet,
+					http.MethodPut,
+					http.MethodDelete,
+					http.MethodGet,
+					http.MethodGet,
+					http.MethodGet,
+				}))
+			})
+		}
+	})
+
+	t.Run("preserves GlobalSecret primary and alias paths", func(t *testing.T) {
+		g := NewWithT(t)
+		endpoints := resourceEndpoints{
+			resourceCrudHandler: &resourceCrudHandler{
+				descriptor: system.GlobalSecretResourceTypeDescriptor,
+			},
+		}
+		ws := new(restful.WebService)
+
+		registerResourceRoutes(ws, endpoints)
+
+		g.Expect(routeMethodPaths(ws)).To(Equal([]string{
+			http.MethodPut + " /globalsecrets/{name}",
+			http.MethodDelete + " /globalsecrets/{name}",
+			http.MethodGet + " /globalsecrets/{name}",
+			http.MethodGet + " /globalsecrets",
+			http.MethodPut + " /global-secrets/{name}",
+			http.MethodDelete + " /global-secrets/{name}",
+			http.MethodGet + " /global-secrets/{name}",
+			http.MethodGet + " /global-secrets",
+		}))
+	})
+}
+
+func routeMethodPaths(ws *restful.WebService) []string {
+	routes := ws.Routes()
+	result := make([]string, len(routes))
+	for i, route := range routes {
+		result[i] = route.Method + " " + route.Path
+	}
+	return result
+}

--- a/pkg/api-server/server.go
+++ b/pkg/api-server/server.go
@@ -268,6 +268,73 @@ func NewApiServer(
 	return newApiServer, nil
 }
 
+type resourceRouteRole int
+
+const (
+	meshCRUDListRoute resourceRouteRole = iota
+	crossMeshListRoute
+	globalCRUDListRoute
+)
+
+type resourcePathRole int
+
+const (
+	primaryResourcePath resourcePathRole = iota
+	aliasResourcePath
+)
+
+type resourceRoute struct {
+	role     resourceRouteRole
+	pathRole resourcePathRole
+}
+
+func resourceRoutes(descriptor model.ResourceTypeDescriptor) []resourceRoute {
+	pathRoles := []resourcePathRole{primaryResourcePath}
+	if descriptor.AlternativeWsPath != "" {
+		pathRoles = append(pathRoles, aliasResourcePath)
+	}
+
+	var routes []resourceRoute
+	for _, pathRole := range pathRoles {
+		switch descriptor.Scope {
+		case model.ScopeMesh:
+			routes = append(routes,
+				resourceRoute{role: meshCRUDListRoute, pathRole: pathRole},
+				resourceRoute{role: crossMeshListRoute, pathRole: pathRole},
+			)
+		case model.ScopeGlobal:
+			routes = append(routes, resourceRoute{role: globalCRUDListRoute, pathRole: pathRole})
+		}
+	}
+	return routes
+}
+
+func (r resourceRoute) pathPrefix(descriptor model.ResourceTypeDescriptor) string {
+	path := descriptor.WsPath
+	if r.pathRole == aliasResourcePath {
+		path = descriptor.AlternativeWsPath
+	}
+	if r.role == meshCRUDListRoute {
+		return "/meshes/{mesh}/" + path
+	}
+	return "/" + path
+}
+
+func registerResourceRoutes(ws *restful.WebService, endpoints resourceEndpoints) {
+	for _, route := range resourceRoutes(endpoints.descriptor) {
+		pathPrefix := route.pathPrefix(endpoints.descriptor)
+		switch route.role {
+		case meshCRUDListRoute, globalCRUDListRoute:
+			endpoints.addCreateOrUpdateEndpoint(ws, pathPrefix)
+			endpoints.addDeleteEndpoint(ws, pathPrefix)
+			endpoints.addFindEndpoint(ws, pathPrefix)
+			endpoints.addListEndpoint(ws, pathPrefix)
+		case crossMeshListRoute:
+			endpoints.addListEndpoint(ws, pathPrefix)
+		}
+	}
+}
+
 func addResourcesEndpoints(
 	ws *restful.WebService,
 	defs []model.ResourceTypeDescriptor,
@@ -336,32 +403,7 @@ func addResourcesEndpoints(
 				knownInternalAddresses:   cfg.IPAM.KnownInternalCIDRs,
 			},
 		}
-		switch definition.Scope {
-		case model.ScopeMesh:
-			endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.WsPath)
-			endpoints.addListEndpoint(ws, "/"+definition.WsPath) // listing all resources in all meshes
-			if definition.AlternativeWsPath != "" {
-				endpoints.addCreateOrUpdateEndpoint(ws, "/meshes/{mesh}/"+definition.AlternativeWsPath)
-				endpoints.addDeleteEndpoint(ws, "/meshes/{mesh}/"+definition.AlternativeWsPath)
-				endpoints.addFindEndpoint(ws, "/meshes/{mesh}/"+definition.AlternativeWsPath)
-				endpoints.addListEndpoint(ws, "/meshes/{mesh}/"+definition.AlternativeWsPath)
-				endpoints.addListEndpoint(ws, "/"+definition.AlternativeWsPath) // listing all resources in all meshes
-			}
-		case model.ScopeGlobal:
-			endpoints.addCreateOrUpdateEndpoint(ws, "/"+definition.WsPath)
-			endpoints.addDeleteEndpoint(ws, "/"+definition.WsPath)
-			endpoints.addFindEndpoint(ws, "/"+definition.WsPath)
-			endpoints.addListEndpoint(ws, "/"+definition.WsPath)
-			if definition.AlternativeWsPath != "" {
-				endpoints.addCreateOrUpdateEndpoint(ws, "/"+definition.AlternativeWsPath)
-				endpoints.addDeleteEndpoint(ws, "/"+definition.AlternativeWsPath)
-				endpoints.addFindEndpoint(ws, "/"+definition.AlternativeWsPath)
-				endpoints.addListEndpoint(ws, "/"+definition.AlternativeWsPath)
-			}
-		}
+		registerResourceRoutes(ws, endpoints)
 	}
 
 	kriEndpoints := kriEndpoint{


### PR DESCRIPTION
## Motivation

Resource route registration duplicates scope and alias branches, obscuring the distinct mesh CRUD/list, cross-mesh list, and global CRUD/list roles.

## Implementation information

- Project resource descriptors into explicit ordered route and path roles.
- Register every projected role through one path while retaining the existing endpoint builders.
- Preserve primary-before-alias order, metadata-provider calls, read-only PUT/DELETE routes, unsupported-scope behavior, and cross-mesh lists.
- Add focused tests for route projection, exact method/path order, metadata order, read-only descriptors, and the `GlobalSecret` alias.

## Supporting documentation

Follows #18437.

> Changelog: skip