### PR TITLE
fix(k8s): enqueue pods behind ignored labels

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_controller.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"maps"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -248,13 +249,19 @@ func (r *PodReconciler) SetupWithManager(mgr kube_ctrl.Manager, maxConcurrentRec
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&kube_core.Pod{}).
 		// on Service update reconcile affected Pods (all Pods selected by this service)
-		Watches(&kube_core.Service{}, kube_handler.EnqueueRequestsFromMapFunc(ServiceToPodsMapper(r.Log, mgr.GetClient()))).
+		Watches(&kube_core.Service{}, kube_handler.EnqueueRequestsFromMapFunc(ServiceToPodsMapper(r.Log, mgr.GetClient(), r.IgnoredServiceSelectorLabels))).
 		Watches(&kube_discovery.EndpointSlice{}, kube_handler.EnqueueRequestsFromMapFunc(EndpointSliceToPodsMapper(r.Log, mgr.GetClient()))).
 		Watches(&mesh_k8s.Mesh{}, kube_handler.EnqueueRequestsFromMapFunc(MeshToPodsMapper(r.Log, mgr.GetClient())), builder.WithPredicates(MeshUpdateIgnoredPredicate{})).
 		Complete(r)
 }
 
-func ServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.MapFunc {
+// ServiceToPodsMapper enqueues the Pods a Service change can affect. Ignored
+// selector labels are stripped before listing, mirroring what the reconciler
+// itself matches on: a Pod that only matches once those labels are dropped
+// still owns an inbound for this Service, an Ignored one, and has to be
+// reconciled to gain or lose it. Listing on the full selector would skip the
+// Pods a selector change moves traffic away from or towards.
+func ServiceToPodsMapper(l logr.Logger, client kube_client.Client, ignoredSelectorLabels []string) kube_handler.MapFunc {
 	l = l.WithName("service-to-pods-mapper")
 	return func(ctx context.Context, obj kube_client.Object) []kube_reconcile.Request {
 		svc := obj.(*kube_core.Service)
@@ -291,7 +298,12 @@ func ServiceToPodsMapper(l logr.Logger, client kube_client.Client) kube_handler.
 			return req
 		}
 
-		if err := client.List(ctx, pods, kube_client.InNamespace(obj.GetNamespace()), kube_client.MatchingLabels(svc.Spec.Selector)); err != nil {
+		selector := maps.Clone(svc.Spec.Selector)
+		for _, ignored := range ignoredSelectorLabels {
+			delete(selector, ignored)
+		}
+
+		if err := client.List(ctx, pods, kube_client.InNamespace(obj.GetNamespace()), kube_client.MatchingLabels(selector)); err != nil {
 			l.Error(err, "failed to fetch Pods matching selector")
 			return nil
 		}

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -841,3 +841,48 @@ var _ = Describe("MeshUpdateIgnoredPredicate", func() {
 		Expect(predicate.Generic(event.GenericEvent{Object: mesh})).To(BeTrue())
 	})
 })
+
+var _ = Describe("ServiceToPodsMapper", func() {
+	newPod := func(name, colour string) *kube_core.Pod {
+		return &kube_core.Pod{
+			Namespace: "demo",
+			Name:      name,
+			Labels: map[string]string{
+				"app":    "test-server",
+				"colour": colour,
+			},
+		}
+	}
+
+	svc := &kube_core.Service{
+		Namespace: "demo",
+		Name:      "test-server",
+		Spec: kube_core.ServiceSpec{
+			Selector: map[string]string{
+				"app":    "test-server",
+				"colour": "blue",
+			},
+		},
+	}
+
+	enqueued := func(ignoredLabels []string) []string {
+		client := kube_client_fake.NewClientBuilder().
+			WithScheme(k8sClientScheme).
+			WithObjects(newPod("blue", "blue"), newPod("green", "green")).
+			Build()
+
+		var names []string
+		for _, req := range ServiceToPodsMapper(core.Log, client, ignoredLabels)(context.Background(), svc) {
+			names = append(names, req.Name)
+		}
+		return names
+	}
+
+	It("should enqueue only the Pods the selector matches", func() {
+		Expect(enqueued(nil)).To(ConsistOf("blue"))
+	})
+
+	It("should enqueue Pods that match once ignored labels are stripped", func() {
+		Expect(enqueued([]string{"colour"})).To(ConsistOf("blue", "green"))
+	})
+})

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -843,13 +843,13 @@ var _ = Describe("MeshUpdateIgnoredPredicate", func() {
 })
 
 var _ = Describe("ServiceToPodsMapper", func() {
-	newPod := func(name, colour string) *kube_core.Pod {
+	newPod := func(name, color string) *kube_core.Pod {
 		return &kube_core.Pod{
 			Namespace: "demo",
 			Name:      name,
 			Labels: map[string]string{
-				"app":    "test-server",
-				"colour": colour,
+				"app":   "test-server",
+				"color": color,
 			},
 		}
 	}
@@ -859,8 +859,8 @@ var _ = Describe("ServiceToPodsMapper", func() {
 		Name:      "test-server",
 		Spec: kube_core.ServiceSpec{
 			Selector: map[string]string{
-				"app":    "test-server",
-				"colour": "blue",
+				"app":   "test-server",
+				"color": "blue",
 			},
 		},
 	}
@@ -883,6 +883,6 @@ var _ = Describe("ServiceToPodsMapper", func() {
 	})
 
 	It("should enqueue Pods that match once ignored labels are stripped", func() {
-		Expect(enqueued([]string{"colour"})).To(ConsistOf("blue", "green"))
+		Expect(enqueued([]string{"color"})).To(ConsistOf("blue", "green"))
 	})
 })

--- a/test/e2e_env/kubernetes/graceful/change_service.go
+++ b/test/e2e_env/kubernetes/graceful/change_service.go
@@ -134,9 +134,7 @@ func ChangeService() {
 		return resp.Instance, err
 	}
 
-	// Pending: one request is dropped while the selector moves, tracked in
-	// https://github.com/kumahq/kuma/issues/18432
-	XIt("should gracefully switch to other service", func() {
+	It("should gracefully switch to other service", func() {
 		// given traffic to the first server
 		Eventually(func(g Gomega) {
 			instance, err := doRequest()


### PR DESCRIPTION
## Motivation

> Changelog: fix(k8s): reconcile pods that match a Service only once ignoredServiceSelectorLabels are stripped

`ignoredServiceSelectorLabels` exists so that a Service selector can move between two sets of Pods without traffic noticing. A Pod that matches a Service only once those labels are stripped keeps an inbound for it in the `Ignored` state, so the listener is already there when the selector arrives, which is what the config comment means by "you change Service selector and expect traffic to be sent immediately". ArgoCD BlueGreen and `rollouts-pod-template-hash` are the motivating case.

The reconciler honours those labels. `findMatchingServices` matches through `MatchServiceThatSelectsPod(pod, r.IgnoredServiceSelectorLabels)`, which strips them before matching.

The watch that feeds it does not. `ServiceToPodsMapper` listed Pods with `kube_client.MatchingLabels(svc.Spec.Selector)`, the full current selector, so on a Service change it only ever enqueued the Pods the selector matches right now. The Pods on the other side of the switch never reconciled, and never gained or lost their `Ignored` inbound.

Reproduced on a live cluster with `KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS` set. After the Service selector changed, the Pod on the other side kept only its service-less inbound:

```
second-7f7cb6bb95-lgdrx  port=49151 state=Ready
```

Annotating that Pod to force a reconcile produced what the feature intends, with no other change:

```
second-7f7cb6bb95-lgdrx  port=80 state=Ignored
```

So the feature works and the watch simply never fires for the Pods it is meant to cover.

## Implementation information

`ServiceToPodsMapper` takes the ignored labels and strips them before listing, so the watch and the reconciler agree on which Pods a Service change can affect.

The unit test pins both directions: with no ignored labels only the matching Pod is enqueued, and with the differing label ignored both sides of the switch are. It fails without the mapper change.

## On #18432

This does not close it, and I would rather say so than imply otherwise.

#18432 is a request dropped while a Service selector moves. There are two independent reconciles behind one Service edit, and this fixes one of them. The other is still unordered: watching both resources across a flip, the MeshService selector repointed about a millisecond before the Dataplane gained the matching inbound, and for that window the MeshService selects a Dataplane whose inbound does not match its port, so `fillLocalMeshServices` yields no endpoints. Widening the window by flipping repeatedly reproduced failures directly, 4 in 900 requests.

The e2e spec is unpended here so CI can answer the question. Eight consecutive local runs pass with this change against roughly half failing before it, but the earlier failures were on a machine under memory pressure and the gating path is the incoming Pod's promotion, which this change does not touch, so I do not trust the local numbers as causation. If CI is green over this run and reruns, that is real evidence. If it is red, the spec goes back to pending and #18432 keeps the remaining ordering problem, which needs a decision about whether endpoint generation should tolerate the transition rather than a controller fix.

## Supporting documentation

Found while working through #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD