### PR TITLE
test(gateway): wait for every MeshTLS replica

### DIFF
--- a/test/e2e_env/kubernetes/gateway/delegated.go
+++ b/test/e2e_env/kubernetes/gateway/delegated.go
@@ -82,7 +82,7 @@ metadata:
 							testserver.WithNamespace(config.Namespace),
 							testserver.WithName("test-server"),
 							testserver.WithStatefulSet(),
-							testserver.WithReplicas(3),
+							testserver.WithReplicas(delegated.TestServerReplicas),
 							testserver.WithPodLabels(map[string]string{"app.kubernetes.io/name": "test-server"}),
 						),
 						testserver.Install(

--- a/test/e2e_env/kubernetes/gateway/delegated/common.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/common.go
@@ -1,5 +1,10 @@
 package delegated
 
+// TestServerReplicas is how many test-server instances the delegated gateway
+// suite runs. The gateway load balances over all of them, so a spec that waits
+// for a policy to land has to wait for every one.
+const TestServerReplicas = 3
+
 type Config struct {
 	Namespace                   string
 	NamespaceOutsideMesh        string

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
@@ -66,7 +66,7 @@ spec:
 			// gateway load balances over every replica, so a request fails
 			// until the last of them has the policy, not the first.
 			Eventually(func(g Gomega) {
-				for i := 0; i < TestServerReplicas; i++ {
+				for i := range TestServerReplicas {
 					stdout, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput(
 						"inspect", "dataplane",
 						"-m", config.Mesh,

--- a/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
+++ b/test/e2e_env/kubernetes/gateway/delegated/meshtls.go
@@ -62,18 +62,22 @@ spec:
 
 			// check that the policy reached the data path the gateway uses.
 			// The gateway proxy has no inbounds of its own, so mesh traffic
-			// entering through it is secured by the backend's inbound.
+			// entering through it is secured by the backend's inbound. The
+			// gateway load balances over every replica, so a request fails
+			// until the last of them has the policy, not the first.
 			Eventually(func(g Gomega) {
-				stdout, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput(
-					"inspect", "dataplane",
-					"-m", config.Mesh,
-					fmt.Sprintf("test-server-0.%s", config.Namespace),
-					"--type=config-dump",
-				)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(stdout).To(ContainSubstring(`"tls_minimum_protocol_version": "TLSv1_3"`))
-				g.Expect(stdout).To(ContainSubstring(`"tls_maximum_protocol_version": "TLSv1_3"`))
-			}, "30s", "1s").Should(Succeed())
+				for i := 0; i < TestServerReplicas; i++ {
+					stdout, err := kubernetes.Cluster.GetKumactlOptions().RunKumactlAndGetOutput(
+						"inspect", "dataplane",
+						"-m", config.Mesh,
+						fmt.Sprintf("test-server-%d.%s", i, config.Namespace),
+						"--type=config-dump",
+					)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(stdout).To(ContainSubstring(`"tls_minimum_protocol_version": "TLSv1_3"`))
+					g.Expect(stdout).To(ContainSubstring(`"tls_maximum_protocol_version": "TLSv1_3"`))
+				}
+			}, "60s", "1s").Should(Succeed())
 
 			// check that communication to test-server works
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
## Motivation

> Changelog: skip

The delegated gateway MeshTLS spec, re-enabled in #18433, fails intermittently on the kubernetes job. It gets past the check that the policy landed and then fails the traffic check that follows, with a 503 through the gateway sustained for the whole 30s window:

```
[FAILED] Timed out after 30.000s.
The function passed to Eventually failed at .../delegated/meshtls.go:86 with:
  stderr: 'curl: (22) The requested URL returned error: 503'
```

The suite runs `test-server` as a StatefulSet with three replicas and the gateway load balances over all of them, but the check that the policy landed only inspected `test-server-0`. So the spec could move on while the other two replicas were still applying the new TLS parameters, and a request routed to one of those failed. Because the traffic check uses `MustPassRepeatedly(5)`, a single failure resets the counter, so one lagging replica is enough to starve it for the full window. That fits a 503 that persists for 30s far better than listener churn, which would clear in a second or two.

This is my regression from #18433 and it is on master, so it is fixed forward rather than parked.

## Implementation information

The check now waits for every replica to report `tls_minimum_protocol_version` and `tls_maximum_protocol_version` of `TLSv1_3` before the traffic check runs, and its budget goes to 60s because it now has three proxies to wait for rather than one. The traffic check itself is untouched, still 30s with `MustPassRepeatedly(5)`, so it keeps the same power to catch a real break.

The replica count moves into a `TestServerReplicas` constant that the suite setup and the spec share, so the spec cannot silently start checking fewer proxies than the suite runs.

## Supporting documentation

Part of #18018.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD