### PR TITLE
fix(meshtls): apply tls params without inbounds

### DIFF
--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin.go
@@ -75,7 +75,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if err := applyToInbounds(rs, policies.FromRules, listeners.Inbound, proxy, ctx); err != nil {
 		return err
 	}
-	if err := applyToRealResources(policies.FromRules, rs); err != nil {
+	if err := applyToRealResources(policies, rs); err != nil {
 		return err
 	}
 
@@ -135,17 +135,15 @@ func applyToInbounds(
 }
 
 func applyToRealResources(
-	fromRules core_rules.FromRules,
+	policies core_xds.TypedMatchingPolicies,
 	rs *core_xds.ResourceSet,
 ) error {
-	return policies_xds.ForEachOrigin(rs, func(_ kri.Identifier, resType core_xds.ResourcesByType) error {
-		// there is only one rule always because we're in `Mesh/Mesh`
-		var conf api.Conf
-		for _, r := range fromRules.InboundRules {
-			conf = rules_inbound.MatchesAllIncomingTraffic[api.Conf](r)
-			break
-		}
+	conf, err := allIncomingTrafficConf(policies)
+	if err != nil {
+		return err
+	}
 
+	return policies_xds.ForEachOrigin(rs, func(_ kri.Identifier, resType core_xds.ResourcesByType) error {
 		for _, cluster := range resType[envoy_resource.ClusterType] {
 			if err := configureTLSParams(conf, cluster.Resource.(*envoy_cluster.Cluster)); err != nil {
 				return err
@@ -154,6 +152,34 @@ func applyToRealResources(
 
 		return nil
 	}, core_xds.NonMeshExternalService)
+}
+
+// allIncomingTrafficConf returns the conf that covers every connection, which
+// is what the upstream side of a cluster needs: the policy is always
+// `Mesh/Mesh` here, so any inbound rule carries it.
+//
+// A proxy with no inbounds, a delegated gateway being the case that matters,
+// has no inbound rules at all. Falling back to the policies matched for the
+// whole proxy keeps its clusters configured, instead of leaving them on
+// Envoy's client defaults while the backends they dial are pinned higher.
+func allIncomingTrafficConf(policies core_xds.TypedMatchingPolicies) (api.Conf, error) {
+	for _, rules := range policies.FromRules.InboundRules {
+		return rules_inbound.MatchesAllIncomingTraffic[api.Conf](rules), nil
+	}
+
+	matched := &api.MeshTLSResourceList{}
+	for _, policy := range policies.DataplanePolicies {
+		if err := matched.AddItem(policy); err != nil {
+			return api.Conf{}, err
+		}
+	}
+
+	rules, err := rules_inbound.BuildRules(matched)
+	if err != nil {
+		return api.Conf{}, err
+	}
+
+	return rules_inbound.MatchesAllIncomingTraffic[api.Conf](rules), nil
 }
 
 func configureTLSParams(conf api.Conf, cluster *envoy_cluster.Cluster) error {

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/test/resources/samples"
 	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	util_yaml "github.com/kumahq/kuma/v3/pkg/util/yaml"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
@@ -390,3 +391,61 @@ func getRulesAsFromRules(policyRules []api.Rule) core_rules.FromRules {
 		},
 	}
 }
+
+var _ = Describe("MeshTLS on a proxy without inbounds", func() {
+	It("should configure upstream TLS parameters from the mesh wide policy", func() {
+		// given
+		policy := getPolicy("strict-with-tls-params")
+
+		context := *xds_builders.Context().WithMeshBuilder(samples.MeshDefaultBuilder()).Build()
+
+		proxy := xds_builders.Proxy().
+			WithWorkloadIdentity(workloadIdentity()).
+			WithApiVersion(envoy_common.APIV3).
+			WithDataplane(
+				builders.Dataplane().
+					WithName("gateway").
+					WithMesh("default").
+					WithAddress("127.0.0.1").
+					WithTransparentProxying(15006, 15001, "ipv4").
+					AddOutbound(
+						builders.Outbound().
+							WithAddress("127.0.0.1").
+							WithPort(27777).
+							WithMeshService("outgoing", 80),
+					),
+			).
+			WithPolicies(xds_builders.MatchedPolicies().With(func(policies *core_xds.MatchedPolicies) {
+				policies.Dynamic = core_xds.PluginOriginatedPolicies{
+					api.MeshTLSType: core_xds.TypedMatchingPolicies{
+						Type:              api.MeshTLSType,
+						DataplanePolicies: []core_model.Resource{policy},
+					},
+				}
+			})).
+			Build()
+
+		resourceSet := core_xds.NewResourceSet()
+		resourceSet.Add(getMeshServiceResources(proxy)...)
+
+		// when
+		Expect(plugin.NewPlugin().(core_plugins.PolicyPlugin).Apply(resourceSet, context, proxy)).To(Succeed())
+
+		// then
+		var configured *envoy_cluster.Cluster
+		for _, resource := range resourceSet.Resources(envoy_resource.ClusterType) {
+			if cluster, ok := resource.Resource.(*envoy_cluster.Cluster); ok && cluster.Name == outgoingMeshService.String() {
+				configured = cluster
+			}
+		}
+		Expect(configured).ToNot(BeNil())
+
+		var tlsContext envoy_tls.UpstreamTlsContext
+		Expect(util_proto.UnmarshalAnyTo(configured.TransportSocket.GetTypedConfig(), &tlsContext)).To(Succeed())
+
+		params := tlsContext.GetCommonTlsContext().GetTlsParams()
+		Expect(params).ToNot(BeNil())
+		Expect(params.GetTlsMinimumProtocolVersion()).To(Equal(envoy_tls.TlsParameters_TLSv1_2))
+		Expect(params.GetTlsMaximumProtocolVersion()).To(Equal(envoy_tls.TlsParameters_TLSv1_3))
+	})
+})


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshtls): apply the TLS version and ciphers to the upstream side of proxies that have no inbounds, such as delegated gateways

A mesh-wide MeshTLS that pins TLS 1.3 breaks traffic from any proxy that has no inbounds of its own. The delegated gateway is where it shows: the backend is pinned to 1.3, the gateway's upstream side stays on Envoy's client default of TLS 1.2, and every new handshake fails.

From the gateway proxy during a failing run, roughly half the upstream connections to the backend die at TLS:

```
cluster...test-server_main.ssl.connection_error:     19
cluster...test-server_main.upstream_cx_connect_fail: 19
cluster...test-server_main.upstream_rq_5xx:          19
cluster...test-server_main.upstream_rq_total:        40
```

The backend has the policy. Its config dump carries `TLSv1_3` as both minimum and maximum on every filter chain, on all three replicas, and its inbound listener reports the older connections still on TLS 1.2 before erroring:

```
listener.self_inbound_dp_main.ssl.versions.TLSv1.2: 15
listener.self_inbound_dp_main.ssl.connection_error:  6
```

Six per replica across three replicas is the nineteen the gateway saw. The gateway's own clusters had no TLS parameters at all. Envoy defaults a client context to a maximum of TLS 1.2 while a server context defaults to 1.3, so an unpinned client cannot reach a pinned server. Pooled connections keep working, which is why this fails intermittently rather than every time.

Closes #18443

## Implementation information

`applyToRealResources` configures the upstream side, and it took the conf from the proxy's own inbound rules:

```go
var conf api.Conf
for _, r := range fromRules.InboundRules {
    conf = rules_inbound.MatchesAllIncomingTraffic[api.Conf](r)
    break
}
```

The comment above it, "there is only one rule always because we're in `Mesh/Mesh`", is what makes that safe for a sidecar: any inbound carries the mesh-wide conf. A proxy with no inbounds has no inbound rules, so the loop never runs and nothing is written.

The conf now falls back to the policies matched for the whole proxy. `MatchedPolicies` already records those in `DataplanePolicies` for a delegated gateway, since it keeps a policy whose targetRef selects the proxy even when it selects no inbounds, so the mesh-wide conf is available without changing how matching works. Building rules from that list reuses the existing merge logic rather than reaching into the spec.

Behaviour for a proxy with inbounds is unchanged: the first inbound rule still wins and the fallback is never reached. With no policy at all the conf stays zero and `configureTLSParams` already writes nothing.

The test builds a proxy with an outbound and no inbounds, gives it a mesh-wide MeshTLS through `DataplanePolicies`, and requires the resulting cluster to negotiate the pinned versions. It fails without the plugin change.

Verified: the MeshTLS plugin suite, every policy plugin suite and the xds suites pass, and golangci-lint is clean.

## Supporting documentation

Found from the e2e debug artifact of the failing shard on run 34022604753, while chasing the intermittent failure of the delegated gateway MeshTLS spec on master.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD