### PR TITLE
fix(api-server): align catalog writability

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
+### Resource catalogs report control-plane writability
+
+The `readOnly` field returned by `GET /_resources` now reports whether generic `PUT` and `DELETE` operations are disabled for that resource type on the current control plane. On Global control planes, resources provided by Zones now report `readOnly: true`. On writable federated Zone control planes, resources provided by the Zone now report `readOnly: false`. `GET /policies` already used these semantics and is unchanged.
+
+**Action required**
+
+Dynamic clients should use `readOnly` as the capability of the current control plane, not as an intrinsic property of the resource type. No action is needed for Kubernetes installations using the default read-only API configuration.
+
 ### The legacy per-policy inspect paths `{policy}/{name}/dataplanes` are removed
 
 `GET /meshes/{mesh}/{policyType}/{policyName}/dataplanes` for every inspectable policy type is removed and answers `404`. The replacement `GET /meshes/{mesh}/{policyType}/{policyName}/_resources/dataplanes` returns the list of dataplanes the policy matches.

--- a/app/kumactl/cmd/export/export_test.go
+++ b/app/kumactl/cmd/export/export_test.go
@@ -222,5 +222,5 @@ var _ client.ResourcesListClient = &staticResourcesListClient{}
 func (s staticResourcesListClient) List(ctx context.Context) (api_types.ResourceTypeDescriptionList, error) {
 	// match the real /_resources endpoint, which only lists types exposed over REST
 	defs := registry.Global().ObjectDescriptors(model.HasWsEnabled())
-	return mappers.MapResourceTypeDescription(defs, false, true), nil
+	return mappers.MapResourceTypeDescription(defs, false, false, true), nil
 }

--- a/pkg/api-server/mappers/resource_type_description.go
+++ b/pkg/api-server/mappers/resource_type_description.go
@@ -8,12 +8,12 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 )
 
-func MapResourceTypeDescription(defs []model.ResourceTypeDescriptor, readOnly bool, federatedZone bool) api_types.ResourceTypeDescriptionList {
+func MapResourceTypeDescription(defs []model.ResourceTypeDescriptor, readOnly bool, isGlobal bool, federatedZone bool) api_types.ResourceTypeDescriptionList {
 	response := api_types.ResourceTypeDescriptionList{}
 	for _, def := range defs {
 		td := api_common.ResourceTypeDescription{
 			Name:                string(def.Name),
-			ReadOnly:            readOnly || federatedZone || def.ReadOnly,
+			ReadOnly:            readOnly || def.IsReadOnly(isGlobal, federatedZone),
 			Path:                def.WsPath,
 			SingularDisplayName: def.SingularDisplayName,
 			PluralDisplayName:   def.PluralDisplayName,

--- a/pkg/api-server/mappers/resource_type_description_test.go
+++ b/pkg/api-server/mappers/resource_type_description_test.go
@@ -92,7 +92,8 @@ func TestMapResourceTypeDescriptionReadOnly(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			test.descriptor.Name = "TestResource"

--- a/pkg/api-server/mappers/resource_type_description_test.go
+++ b/pkg/api-server/mappers/resource_type_description_test.go
@@ -20,7 +20,7 @@ func TestMapResourceTypeDescriptionPreservesRulesTargetRefPolicies(t *testing.T)
 			HasToTargetRef:    true,
 			HasRulesTargetRef: true,
 		},
-	}, false, false)
+	}, false, false, false)
 
 	require.Len(t, response.Resources, 1)
 	require.NotNil(t, response.Resources[0].Policy)
@@ -28,4 +28,99 @@ func TestMapResourceTypeDescriptionPreservesRulesTargetRefPolicies(t *testing.T)
 	require.False(t, response.Resources[0].Policy.IsFromAsRules)
 	require.True(t, response.Resources[0].Policy.HasRulesTargetRef)
 	require.True(t, response.Resources[0].Policy.HasToTargetRef)
+}
+
+func TestMapResourceTypeDescriptionReadOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		readOnly      bool
+		isGlobal      bool
+		federatedZone bool
+		descriptor    model.ResourceTypeDescriptor
+		expected      bool
+	}{
+		{
+			name:       "standalone Zone can write resources without KDS ownership",
+			descriptor: model.ResourceTypeDescriptor{},
+		},
+		{
+			name:     "Global can write resources provided by Global",
+			isGlobal: true,
+			descriptor: model.ResourceTypeDescriptor{
+				KDSFlags: model.GlobalToZonesFlag,
+			},
+		},
+		{
+			name:     "Global cannot write resources provided by Zone",
+			isGlobal: true,
+			descriptor: model.ResourceTypeDescriptor{
+				KDSFlags: model.ZoneToGlobalFlag,
+			},
+			expected: true,
+		},
+		{
+			name:          "federated Zone can write resources provided by Zone",
+			federatedZone: true,
+			descriptor: model.ResourceTypeDescriptor{
+				KDSFlags: model.ZoneToGlobalFlag,
+			},
+		},
+		{
+			name:          "federated Zone cannot write resources provided by Global",
+			federatedZone: true,
+			descriptor: model.ResourceTypeDescriptor{
+				KDSFlags: model.GlobalToZonesFlag,
+			},
+			expected: true,
+		},
+		{
+			name: "descriptor read-only wins",
+			descriptor: model.ResourceTypeDescriptor{
+				ReadOnly: true,
+			},
+			expected: true,
+		},
+		{
+			name:     "API read-only wins",
+			readOnly: true,
+			descriptor: model.ResourceTypeDescriptor{
+				KDSFlags: model.GlobalToZonesFlag | model.ZoneToGlobalFlag,
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			test.descriptor.Name = "TestResource"
+
+			response := MapResourceTypeDescription(
+				[]model.ResourceTypeDescriptor{test.descriptor},
+				test.readOnly,
+				test.isGlobal,
+				test.federatedZone,
+			)
+
+			require.Len(t, response.Resources, 1)
+			require.Equal(t, test.expected, response.Resources[0].ReadOnly)
+		})
+	}
+}
+
+func TestMapResourceTypeDescriptionFederationIsIndependentFromReadOnly(t *testing.T) {
+	t.Parallel()
+
+	descriptor := model.ResourceTypeDescriptor{
+		Name:     "GlobalProvidedResource",
+		KDSFlags: model.GlobalToZonesFlag,
+	}
+
+	response := MapResourceTypeDescription([]model.ResourceTypeDescriptor{descriptor}, true, false, true)
+
+	require.Len(t, response.Resources, 1)
+	require.True(t, response.Resources[0].ReadOnly)
+	require.True(t, response.Resources[0].IncludeInFederation)
 }

--- a/pkg/api-server/policies_endpoints.go
+++ b/pkg/api-server/policies_endpoints.go
@@ -36,6 +36,6 @@ func addPoliciesWsEndpoints(ws *restful.WebService, isGlobal bool, isFederatedZo
 		return response, nil
 	})))
 	ws.Route(ws.GET("/_resources").To(handle(func(_ *restful.Request) (any, error) {
-		return mappers.MapResourceTypeDescription(defs, readOnly, isFederatedZone), nil
+		return mappers.MapResourceTypeDescription(defs, readOnly, isGlobal, isFederatedZone), nil
 	})))
 }

--- a/pkg/api-server/policies_endpoints_test.go
+++ b/pkg/api-server/policies_endpoints_test.go
@@ -1,0 +1,134 @@
+package api_server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/gomega"
+
+	api_types "github.com/kumahq/kuma/v3/api/openapi/types"
+	"github.com/kumahq/kuma/v3/pkg/api-server/types"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+)
+
+func TestCatalogReadOnlyParity(t *testing.T) {
+	descriptors := []core_model.ResourceTypeDescriptor{
+		catalogPolicy("GlobalProvided", core_model.GlobalToZonesFlag, false),
+		catalogPolicy("ZoneProvided", core_model.ZoneToGlobalFlag, false),
+		catalogPolicy("ProvidedByBoth", core_model.GlobalToZonesFlag|core_model.ZoneToGlobalFlag, false),
+		catalogPolicy("NoProvider", core_model.KDSDisabledFlag, false),
+		catalogPolicy("IntrinsicReadOnly", core_model.GlobalToZonesFlag|core_model.ZoneToGlobalFlag, true),
+	}
+	tests := []struct {
+		name          string
+		isGlobal      bool
+		federatedZone bool
+		readOnly      bool
+		expected      map[string]bool
+	}{
+		{
+			name: "standalone Zone",
+			expected: map[string]bool{
+				"GlobalProvided":    false,
+				"ZoneProvided":      false,
+				"ProvidedByBoth":    false,
+				"NoProvider":        false,
+				"IntrinsicReadOnly": true,
+			},
+		},
+		{
+			name:     "Global",
+			isGlobal: true,
+			expected: map[string]bool{
+				"GlobalProvided":    false,
+				"ZoneProvided":      true,
+				"ProvidedByBoth":    false,
+				"NoProvider":        true,
+				"IntrinsicReadOnly": true,
+			},
+		},
+		{
+			name:          "federated Zone",
+			federatedZone: true,
+			expected: map[string]bool{
+				"GlobalProvided":    true,
+				"ZoneProvided":      false,
+				"ProvidedByBoth":    false,
+				"NoProvider":        true,
+				"IntrinsicReadOnly": true,
+			},
+		},
+		{
+			name:     "API read-only",
+			readOnly: true,
+			expected: map[string]bool{
+				"GlobalProvided":    true,
+				"ZoneProvided":      true,
+				"ProvidedByBoth":    true,
+				"NoProvider":        true,
+				"IntrinsicReadOnly": true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			policies, resources := catalogResponses(g, descriptors, test.isGlobal, test.federatedZone, test.readOnly)
+
+			g.Expect(policies.Policies).To(HaveLen(len(test.expected)))
+			g.Expect(resources.Resources).To(HaveLen(len(test.expected)))
+			resourceReadOnly := map[string]bool{}
+			for _, resource := range resources.Resources {
+				resourceReadOnly[resource.Name] = resource.ReadOnly
+			}
+			for _, policy := range policies.Policies {
+				g.Expect(policy.ReadOnly).To(Equal(test.expected[policy.Name]), policy.Name)
+				g.Expect(resourceReadOnly).To(HaveKeyWithValue(policy.Name, policy.ReadOnly))
+			}
+		})
+	}
+}
+
+func catalogPolicy(name core_model.ResourceType, flags core_model.KDSFlagType, readOnly bool) core_model.ResourceTypeDescriptor {
+	return core_model.ResourceTypeDescriptor{
+		Name:     name,
+		WsPath:   string(name),
+		Scope:    core_model.ScopeMesh,
+		KDSFlags: flags,
+		ReadOnly: readOnly,
+		IsPolicy: true,
+	}
+}
+
+func catalogResponses(
+	g *WithT,
+	descriptors []core_model.ResourceTypeDescriptor,
+	isGlobal bool,
+	federatedZone bool,
+	readOnly bool,
+) (types.PoliciesResponse, api_types.ResourceTypeDescriptionList) {
+	g.THelper()
+	ws := new(restful.WebService)
+	addPoliciesWsEndpoints(ws, isGlobal, federatedZone, readOnly, descriptors)
+	container := restful.NewContainer()
+	container.Add(ws)
+
+	get := func(path string, target any) {
+		request := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, http.NoBody)
+		response := httptest.NewRecorder()
+		container.ServeHTTP(response, request)
+		g.Expect(response.Code).To(Equal(http.StatusOK))
+		g.Expect(json.Unmarshal(response.Body.Bytes(), target)).To(Succeed())
+	}
+
+	policies := types.PoliciesResponse{}
+	resources := api_types.ResourceTypeDescriptionList{}
+	get("/policies", &policies)
+	get("/_resources", &resources)
+	return policies, resources
+}


### PR DESCRIPTION
## Motivation

`GET /_resources` reports writability differently from the CRUD routes and `GET /policies` on Global and federated Zone control planes. Dynamic clients therefore receive incorrect capability information.

## Implementation information

- Derive resource catalog `readOnly` from API read-only mode and `ResourceTypeDescriptor.IsReadOnly` using the current control-plane context.
- Keep federation inclusion independent from writability.
- Add truth-table coverage and endpoint parity tests for standalone Zone, Global, federated Zone, API read-only, intrinsic read-only, and KDS ownership combinations.
- Document the observable catalog behavior change in `UPGRADE.md`.

## Supporting documentation

Follows #18440.

> Changelog: fix(api-server): align catalog writability