### PR TITLE
test(e2e): retry the cert-manager chart install

### DIFF
--- a/test/framework/deployments/certmanager/kubernetes.go
+++ b/test/framework/deployments/certmanager/kubernetes.go
@@ -2,9 +2,11 @@ package certmanager
 
 import (
 	"context"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,17 +29,27 @@ func (t *k8sDeployment) Deploy(cluster framework.Cluster) error {
 		KubectlOptions: cluster.GetKubectlOptions(t.namespace),
 	}
 
-	// Install cert-manager via Helm
-	_, err := helm.RunHelmCommandAndGetStdOutContextE(cluster.GetTesting(), context.Background(), &opts, "install", "cert-manager",
-		"--namespace", t.namespace,
-		"--create-namespace",
-		"--repo", "https://charts.jetstack.io",
-		"--version", t.version,
-		"--set", "installCRDs=true",
-		"--set", "startupapicheck.enabled=false",
-		"--wait",
-		"--timeout", "5m",
-		"cert-manager",
+	// The chart comes from an external repository, so a single unlucky fetch
+	// ("charts.jetstack.io/index.yaml": EOF) would otherwise take down the whole
+	// suite from BeforeAll. `upgrade --install` keeps the retry idempotent if an
+	// attempt fails after the release was created.
+	_, err := retry.DoWithRetryContextE(
+		cluster.GetTesting(), context.Background(),
+		"install cert-manager", 3, 5*time.Second,
+		func() (string, error) {
+			return helm.RunHelmCommandAndGetStdOutContextE(cluster.GetTesting(), context.Background(), &opts, "upgrade", "cert-manager",
+				"--install",
+				"--namespace", t.namespace,
+				"--create-namespace",
+				"--repo", "https://charts.jetstack.io",
+				"--version", t.version,
+				"--set", "installCRDs=true",
+				"--set", "startupapicheck.enabled=false",
+				"--wait",
+				"--timeout", "5m",
+				"cert-manager",
+			)
+		},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Motivation

> Changelog: skip

The `Cert-Manager CA Injection` suite failed on master's `e2e (default)` job:

```
[FAILED] in [BeforeAll] - test/e2e/webhooks/cert_manager.go:54
Unexpected error:
  INSTALLATION FAILED: looks like "https://charts.jetstack.io" is not a valid chart
  repository or cannot be reached: Get "https://charts.jetstack.io/index.yaml": EOF
```

Nothing in Kuma is wrong here. The chart is pulled from an external repository at test time by a single `helm install` with no retry, so one unlucky fetch fails `BeforeAll` and takes the whole suite with it. External fetches like this are a recurring source of master e2e flakes.

## Implementation information

The install is wrapped in a bounded retry, three attempts five seconds apart, using the same `retry.DoWithRetryContextE` helper other deployments in the framework already use.

It also switches to `helm upgrade --install`. A plain `install` is not safe to retry: if an attempt fails after the release was created, the next one dies with a name-already-in-use error, which would turn a recoverable blip into a different failure. `upgrade --install` makes the retry idempotent.

The failure that prompted this happens while fetching `index.yaml`, before any release exists, so the retry covers it directly.

Verified: builds and golangci-lint is clean. The failure itself is an external network condition, so it cannot be reproduced on demand; this removes the single point of failure rather than claiming to fix the network.

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD