### PR TITLE
build(docs): keep the generated spec when generation fails

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -35,13 +35,17 @@ ifneq ($(strip $(DOCS_PROTOS)),)
 		$(DOCS_PROTOS)
 endif
 
+# Built beside the target and moved on success, so a failing generator cannot
+# leave the committed file truncated. pipefail because the redirect would
+# otherwise report sed's status and hide a helm or yq failure entirely.
 .PHONY: docs/generated/raw/rbac.yaml
 docs/generated/raw/rbac.yaml:
 	@mkdir -p docs/generated/raw
-	@$(HELM) template --namespace $(PROJECT_NAME)-system $(PROJECT_NAME) deployments/charts/$(PROJECT_NAME) | \
+	@set -o pipefail; $(HELM) template --namespace $(PROJECT_NAME)-system $(PROJECT_NAME) deployments/charts/$(PROJECT_NAME) | \
 	$(YQ) eval-all 'select((.kind == "ClusterRole" or .kind == "ClusterRoleBinding" or .kind == "Role" or .kind == "RoleBinding") and (.metadata.annotations["helm.sh/hook"] == null)) | del(.metadata.labels)' - | \
 	grep -Ev '^\s*#' | \
-	sed 's/[[:space:]]*#.*$$//' > $@
+	sed 's/[[:space:]]*#.*$$//' > $@.tmp || { rm -f $@.tmp; exit 1; }
+	@mv $@.tmp $@
 
 OAPI_TMP_DIR ?= $(BUILD_DIR)/oapitmp
 API_DIRS     ?= $(TOP)/api/openapi/specs:base
@@ -55,6 +59,8 @@ API_DIRS     ?= $(TOP)/api/openapi/specs:base
 docs/generated:
 	mkdir -p $@
 
+# The merge output is built beside the target and moved on success, so a failing
+# merge cannot leave the committed file truncated.
 .PHONY: docs/generated/openapi.yaml
 docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES) | docs/generated docs/generated/openapi/prepare/specs
 	@echo "Rewriting /specs/ paths in all YAML files..."
@@ -71,7 +77,8 @@ docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES) | docs/generated docs
 			REDOCLY_SUPPRESS_UPDATE_NOTICE=true mise exec -- redocly bundle $$f -o $(BUILD_DIR)/openapi-bundled/$$f || echo "Skipping $$f"; \
 		done
 	@echo "Merging all bundled specs..."
-	@mise exec -- oas-toolkit merge $$(find $(BUILD_DIR)/openapi-bundled -name '*.yaml' | LC_ALL=C sort) > $@
+	@mise exec -- oas-toolkit merge $$(find $(BUILD_DIR)/openapi-bundled -name '*.yaml' | LC_ALL=C sort) > $@.tmp || { rm -f $@.tmp; exit 1; }
+	@mv $@.tmp $@
 	@$(MAKE) --no-print-directory validate/openapi-generated-docs
 
 # Prepare $(OAPI_TMP_DIR) with a normalized directory layout for the generator


### PR DESCRIPTION
## Motivation

Both generated-docs targets redirect straight into a file that is committed to the repository. The shell truncates a redirect target before the command on the left ever runs, so any failure of the generator leaves an empty `docs/generated/openapi.yaml` or `docs/generated/raw/rbac.yaml` in the working tree.

`make check` runs from the `pre-push` hook, so this fires exactly when someone is trying to push. The push is refused, and the tree is left carrying a deletion of a tracked file that nobody asked for. Anyone who does not notice the second effect pushes it later or spends a while working out where it came from. It reproduces on any machine where the generator cannot run, whatever the reason, since the truncation happens before the tool is consulted.

The `rbac.yaml` target has the worse half of this. It is a four-stage pipeline whose exit status is `sed`'s, so a failing `helm` or `yq` still reports success, `make` carries on, and the file is quietly replaced by a truncated one rather than an obviously empty one.

## Implementation information

- Each target now writes to `$@.tmp` and moves it into place only after the generator exits zero, so the committed file is either untouched or completely replaced. The temporary file is removed on the failing path
- `set -o pipefail` on the `rbac.yaml` pipeline, so a `helm` or `yq` failure fails the target instead of being masked by `sed`'s status. The Makefile already selects bash, so it is available
- No change to what either target produces on the success path

Verified by running `make docs/generated/openapi.yaml` on a machine where the merge step fails. Before, the target's committed file went to zero bytes. After, it stays at its committed size, no `.tmp` is left behind, and `git status` is clean, while `make` still exits non-zero.

## Supporting documentation

None. Found while pushing an unrelated change.
