### PR TITLE
fix(meshservice): hold TLS status pending one pass

### DIFF
--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -4307,6 +4307,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -4307,6 +4307,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -4307,6 +4307,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-crds.all.golden.yaml
@@ -6653,6 +6653,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
+++ b/deployments/charts/kuma/crds/kuma.io_meshservices.yaml
@@ -213,6 +213,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -18982,6 +18982,7 @@ components:
                   enum:
                     - Ready
                     - NotReady
+                    - Pending
                   type: string
               type: object
             vips:

--- a/docs/generated/raw/crds/kuma.io_meshservices.yaml
+++ b/docs/generated/raw/crds/kuma.io_meshservices.yaml
@@ -213,6 +213,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/meshservice.go
@@ -65,12 +65,19 @@ const (
 	StateUnavailable State = "Unavailable"
 )
 
-// +kubebuilder:validation:Enum=Ready;NotReady
+// +kubebuilder:validation:Enum=Ready;NotReady;Pending
 type TLSStatus string
 
 const (
 	TLSReady    TLSStatus = "Ready"
 	TLSNotReady TLSStatus = "NotReady"
+	// TLSPending means every proxy backing the service is certified, but its
+	// clients are not told to originate mTLS yet. A proxy gets its identity
+	// independently of the destination's, so flipping clients in the same pass
+	// that certifies the destination drops every request sent before the
+	// destination's inbound TLS chain arrives. Holding one status interval here
+	// gives destinations that time; the next pass promotes to Ready.
+	TLSPending TLSStatus = "Pending"
 )
 
 type TLS struct {

--- a/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
+++ b/pkg/core/resources/apis/meshservice/api/v1alpha1/rest.yaml
@@ -387,6 +387,7 @@ components:
                   enum:
                     - Ready
                     - NotReady
+                    - Pending
                   type: string
               type: object
             vips:

--- a/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
+++ b/pkg/core/resources/apis/meshservice/k8s/crd/kuma.io_meshservices.yaml
@@ -213,6 +213,7 @@ spec:
                     enum:
                     - Ready
                     - NotReady
+                    - Pending
                     type: string
                 type: object
               vips:

--- a/pkg/core/resources/apis/meshservice/status/updater.go
+++ b/pkg/core/resources/apis/meshservice/status/updater.go
@@ -246,6 +246,15 @@ func (s *StatusUpdater) buildTLS(
 	if tlsReadyDpps != len(dpps) {
 		return notReady
 	}
+	if existing.Status != meshservice_api.TLSPending {
+		// Every proxy is certified for the first time. Leave clients on
+		// plaintext for one interval so the destinations can pick up their
+		// certificates and inbound TLS chains before anyone originates mTLS
+		// towards them.
+		return meshservice_api.TLS{
+			Status: meshservice_api.TLSPending,
+		}
+	}
 	return meshservice_api.TLS{
 		Status: meshservice_api.TLSReady,
 	}

--- a/pkg/core/resources/apis/meshservice/status/updater_test.go
+++ b/pkg/core/resources/apis/meshservice/status/updater_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	test_metrics "github.com/kumahq/kuma/v3/pkg/test/metrics"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/samples"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	"github.com/kumahq/kuma/v3/pkg/util/proto"
@@ -427,5 +428,61 @@ var _ = Describe("Updater", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(test_metrics.FindMetric(metrics, "component_ms_status_updater")).ToNot(BeNil())
 		}, "10s", "100ms").Should(Succeed())
+	})
+})
+
+var _ = Describe("buildTLS", func() {
+	updater := &StatusUpdater{logger: logr.Discard(), localZone: "east"}
+
+	identity := builders.MeshIdentity().
+		WithBundled().
+		WithSelector(&common_api.LabelSelector{
+			MatchLabels: &map[string]string{"app": "test"},
+		}).
+		WithInitializedStatus().
+		Build()
+
+	certifiedDpp := samples.DataplaneBackendBuilder().
+		WithMesh("test").
+		Build()
+	certifiedDpp.Meta = &test_model.ResourceMeta{
+		Name:   "dp-1",
+		Mesh:   "test",
+		Labels: map[string]string{"app": "test"},
+	}
+
+	identities := []*meshidentity_api.MeshIdentityResource{identity}
+	trustDomains := map[string]struct{}{"test.east.mesh.local": {}}
+	dpps := []*core_mesh.DataplaneResource{certifiedDpp}
+
+	It("should hold the first certified pass in Pending", func() {
+		Expect(updater.buildTLS(meshservice_api.TLS{}, dpps, identities, trustDomains).Status).
+			To(Equal(meshservice_api.TLSPending))
+	})
+
+	It("should promote Pending to Ready on the next pass", func() {
+		pending := meshservice_api.TLS{Status: meshservice_api.TLSPending}
+		Expect(updater.buildTLS(pending, dpps, identities, trustDomains).Status).
+			To(Equal(meshservice_api.TLSReady))
+	})
+
+	It("should keep Ready latched", func() {
+		ready := meshservice_api.TLS{Status: meshservice_api.TLSReady}
+		Expect(updater.buildTLS(ready, dpps, identities, trustDomains).Status).
+			To(Equal(meshservice_api.TLSReady))
+	})
+
+	It("should drop back to NotReady when coverage is lost", func() {
+		pending := meshservice_api.TLS{Status: meshservice_api.TLSPending}
+		Expect(updater.buildTLS(pending, dpps, nil, trustDomains).Status).
+			To(Equal(meshservice_api.TLSNotReady))
+	})
+
+	It("should stay NotReady while any proxy is uncertified", func() {
+		uncertified := samples.DataplaneBackendBuilder().WithMesh("test").Build()
+		uncertified.Meta = &test_model.ResourceMeta{Name: "dp-2", Mesh: "test"}
+		both := []*core_mesh.DataplaneResource{certifiedDpp, uncertified}
+		Expect(updater.buildTLS(meshservice_api.TLS{}, both, identities, trustDomains).Status).
+			To(Equal(meshservice_api.TLSNotReady))
 	})
 })


### PR DESCRIPTION
## Motivation

> Changelog: fix(meshservice): stop telling clients to originate mTLS before the destination can terminate it

Turning on a `MeshIdentity` for a running mesh drops requests. A client proxy can be told to originate mTLS before the destination proxy has an inbound filter chain that terminates it, and every request sent in that window fails the handshake. It shows up as a flaky `MeshService should switch to permissive mTLS without drop of the traffic`, which has fired three times on master today alone, on three different jobs.

The client is already gated on the destination: `GenerateClusters` only attaches an upstream TLS context when `ms.TerminatesTLS()` is true, which reads `MeshService.status.tls`. The problem is that the status is computed from intent rather than evidence. `buildTLS` marks a service `Ready` as soon as an initialized `MeshIdentity` matches every backing `Dataplane`, which happens in the same pass that generates the destination's own config. The two proxies then reconcile independently with no ordering between them, and the measured skew was 273 ms.

Closes #18134

## Implementation information

`status.tls` gains a `Pending` value, and the status updater's own tick becomes the ordering primitive.

The first pass in which every backing proxy is certified now returns `Pending`. Only the following pass promotes to `Ready`. `TerminatesTLS()` is unchanged and still gates on `Ready`, so destinations get a full status interval to pick up their certificates and inbound TLS chains while their clients stay on plaintext.

The existing invariants are kept deliberately, since each one matters:

- `Ready` stays latched, so a newly added uncertified instance cannot flip a live service back and cause the very drop this prevents.
- Losing identity coverage still falls back to `NotReady`, including from `Pending`.
- A partially certified service stays `NotReady` and is never promoted early.

`buildTLS` is unexported and its test file is in the same package, so the five new cases assert those transitions directly rather than inferring them through a polling `Eventually`.

## Scope

This fixes the documented rollout path, which starts from `MeshTLS: Permissive`.

It does not fix enabling an identity while `MeshTLS` is already `Strict`. There the destination starts rejecting plaintext the instant it is certified, so no ordering between client and destination helps, and this change slightly widens that window from the push skew to one status interval. That path is not the documented rollout.

The two follow-ups the issue lists stay open: moving the client-side decision to per-endpoint EDS metadata, and the same class of gap in cross-zone trust propagation.

## Supporting documentation

Verified: the whole `meshservice` package tree passes, `make check` is clean after regenerating the CRD, OpenAPI and docs artifacts the new enum value touches, and the e2e spec that catches this passes locally (`4 Passed | 0 Failed`).

https://claude.ai/code/session_01PMNWKmiCA3xx73DGJZVUvD