### PR TITLE
fix(meshmetric): honor includeUnused sidecar flag

### DIFF
--- a/app/kuma-dp/pkg/dataplane/metrics/server.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server.go
@@ -74,11 +74,18 @@ func AddPrometheusFormat(queryParameters url.Values) url.Values {
 	return queryParameters
 }
 
+// AddSidecarParameters applies the MeshMetric sidecar settings to the Envoy admin query.
+// Envoy treats "usedonly" as a flag, so the key must be absent - not empty - to scrape unused stats.
 func AddSidecarParameters(sidecar *v1alpha12.Sidecar) func(queryParameters url.Values) url.Values {
 	values := v1alpha1.EnvoyMetricsFilter(sidecar)
+	_, filterUnused := values["usedonly"]
 
 	return func(queryParameters url.Values) url.Values {
-		queryParameters.Set("usedonly", values.Get("usedonly"))
+		if filterUnused {
+			queryParameters.Set("usedonly", "")
+		} else {
+			queryParameters.Del("usedonly")
+		}
 		return queryParameters
 	}
 }

--- a/app/kuma-dp/pkg/dataplane/metrics/server_test.go
+++ b/app/kuma-dp/pkg/dataplane/metrics/server_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/api/v1alpha1"
 )
 
-var includeUnused = true
+var (
+	includeUnused = true
+	excludeUnused = false
+)
 
 var _ = Describe("Rewriting the metrics URL", func() {
 	type testCase struct {
@@ -51,13 +54,31 @@ var _ = Describe("Rewriting the metrics URL", func() {
 			expected:      "http://127.0.0.1:80/stats",
 			queryModifier: RemoveQueryParameters,
 		}),
-		Entry("add usedonly and filter parameters", testCase{
+		Entry("not add usedonly parameter when unused metrics are included", testCase{
+			address:   "127.0.0.1",
+			input:     "http://foo/bar?one=two&three=four",
+			adminPort: 80,
+			expected:  "http://127.0.0.1:80/stats?one=two&three=four",
+			queryModifier: AddSidecarParameters(&v1alpha1.Sidecar{
+				IncludeUnused: &includeUnused,
+			}),
+		}),
+		Entry("drop usedonly parameter passed by the scraper when unused metrics are included", testCase{
+			address:   "127.0.0.1",
+			input:     "http://foo/bar?one=two&usedonly",
+			adminPort: 80,
+			expected:  "http://127.0.0.1:80/stats?one=two",
+			queryModifier: AddSidecarParameters(&v1alpha1.Sidecar{
+				IncludeUnused: &includeUnused,
+			}),
+		}),
+		Entry("add usedonly parameter when unused metrics are excluded", testCase{
 			address:   "127.0.0.1",
 			input:     "http://foo/bar?one=two&three=four",
 			adminPort: 80,
 			expected:  "http://127.0.0.1:80/stats?one=two&three=four&usedonly=",
 			queryModifier: AddSidecarParameters(&v1alpha1.Sidecar{
-				IncludeUnused: &includeUnused,
+				IncludeUnused: &excludeUnused,
 			}),
 		}),
 		Entry("add default usedonly parameter", testCase{


### PR DESCRIPTION
## Motivation

Fixes #18476.

`includeUnused: true` on a MeshMetric sidecar is a no-op. Envoy's admin endpoint treats `usedonly` as a presence-only flag - the value is ignored, so `?usedonly=` filters unused stats exactly like `?usedonly`. `AddSidecarParameters` always called `Set("usedonly", ...)`, writing the key even when `EnvoyMetricsFilter` returned an empty `url.Values`, so the query sent to Envoy was byte-identical whether `includeUnused` was true, false, or unset.

The result is that never-incremented counters are dropped at the Envoy admin call, before profiles and `include` selectors ever run. Users see this as `envoy_listener_manager_lds_*` / `envoy_cluster_manager_cds_*` stats (`update_rejected`, `update_failure`, ...) missing from the MeshMetric output no matter which `include` regex they write, while the raw admin `/stats/prometheus` on the same pod shows them.

Both backends are affected - Prometheus and OpenTelemetry share the same query modifier.

> Changelog: fix(meshmetric): honor includeUnused sidecar flag

## Implementation information

Drop the `usedonly` key entirely when unused metrics should be scraped, and keep setting it when they should not. `Del` also covers the case where the scraper's own request URL carried `usedonly`, which the old `Set` silently preserved.

Unit tests now cover all three states of the flag. The previous entry asserted the buggy behaviour: it passed `IncludeUnused: true` and expected `usedonly=` in the resulting URL, which is why this went unnoticed. The e2e suite only exercised `includeUnused: false`, where the bug is invisible.

## Supporting documentation

Envoy admin parses the parameter as a flag, not a value: `used_only_(params.find("usedonly") != params.end())`.

https://claude.ai/code/session_017TdsQNnnBW17cfeuR6Tzws
