### PR TITLE
ci(actions): trim test_unit cache footprint

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -38,18 +38,31 @@ jobs:
           version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - name: Cache Go build
+      # Module contents are a pure function of go.sum, so one immutable entry
+      # is shared with the build-binaries job and every branch.
+      - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
+          path: ~/go/pkg/mod
+          key: go-mod-dist-${{ hashFiles('**/go.sum') }}
+      # Pull requests restore by prefix from the newest push-event entry
+      # instead of writing their own short-lived merge-ref entries.
+      - name: Restore Go build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
           key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
           restore-keys: |
             go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-test-race-${{ runner.os }}-
       - run: |
           make test
+      - name: Save Go build cache
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
   gen_e2e_matrix:
     timeout-minutes: 2
     runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}


### PR DESCRIPTION
## Motivation

The repository cache budget is 10 GB shared across all branches and PR merge refs (raising it requires enterprise billing, which is unavailable). `test_unit` was the largest churn source: every PR push saved a ~1 GB `go-test-race-*` entry scoped to `refs/pull/N/merge`, restorable only by that same PR, evicting entries other jobs rely on. At the time of writing ~7 GB of the pool was `go-test-race-*` entries.

## What changed

Same treatment as #18454 gave `build-binaries`:

- `~/go/pkg/mod` split into a shared immutable `go-mod-dist-<go.sum>` entry (module contents are a pure function of go.sum; also shared with `build-binaries`)
- `~/.cache/go-build` keeps the per-commit rolling key with prefix restore, but saves only on `push` events
- PR runs are restore-only: they get a warm cache from the newest master entry via prefix restore

## Impact on PRs

No slowdown. Go's build cache is content-addressed, so restoring master's entry hits everything except the packages the PR itself touches — same as restoring the PR's own previous entry. Net effect is positive: less eviction pressure means test/build entries survive longer.

> Changelog: skip