### PR TITLE
perf(policy): hoist dataplane hash out of per-plugin cache key building

### DIFF
--- a/pkg/core/plugins/interfaces.go
+++ b/pkg/core/plugins/interfaces.go
@@ -98,6 +98,8 @@ type MatchedPoliciesConfig struct {
 	// nil disables caching
 	Cache              PolicyMatchingCacheAccessor
 	PolicyMatchingHash string
+	// DataplaneHash is a precomputed DataplaneResource.Hash(), computed on demand when nil; callers looping over policy types should set it once. EXC:FILE011:documents-a-non-obvious-invariant
+	DataplaneHash []byte
 }
 
 func NewMatchedPoliciesConfig(opts ...MatchedPoliciesOption) *MatchedPoliciesConfig {
@@ -120,6 +122,12 @@ func WithCache(c PolicyMatchingCacheAccessor, policyMatchingHash string) Matched
 	return func(cfg *MatchedPoliciesConfig) {
 		cfg.Cache = c
 		cfg.PolicyMatchingHash = policyMatchingHash
+	}
+}
+
+func WithDataplaneHash(hash []byte) MatchedPoliciesOption {
+	return func(cfg *MatchedPoliciesConfig) {
+		cfg.DataplaneHash = hash
 	}
 }
 

--- a/pkg/plugins/policies/core/matchers/cache.go
+++ b/pkg/plugins/policies/core/matchers/cache.go
@@ -58,7 +58,11 @@ func BuildCacheKey(rType string, cfg *core_plugins.MatchedPoliciesConfig, dpp *c
 	} else {
 		_, _ = h.Write([]byte{0})
 	}
-	_, _ = h.Write(dpp.Hash())
+	dppHash := cfg.DataplaneHash
+	if dppHash == nil {
+		dppHash = dpp.Hash()
+	}
+	_, _ = h.Write(dppHash)
 	_, _ = h.Write([]byte(cfg.PolicyMatchingHash))
 	return string(h.Sum(nil))
 }

--- a/pkg/plugins/policies/core/matchers/cache_test.go
+++ b/pkg/plugins/policies/core/matchers/cache_test.go
@@ -68,6 +68,27 @@ var _ = Describe("PolicyMatchingCache", func() {
 			k2 := matchers.BuildCacheKey("TypeA", cfg, dppV2)
 			Expect(k1).ToNot(Equal(k2))
 		})
+
+		It("returns the same key for precomputed and on-demand dataplane hash", func() {
+			dpp := readDPP(filepath.Join("testdata", "matchedpolicies", "fromrules", "01.dataplane.yaml"))
+			onDemand := matchers.BuildCacheKey("TypeA", core_plugins.NewMatchedPoliciesConfig(core_plugins.WithCache(nil, "hash1")), dpp)
+			precomputed := matchers.BuildCacheKey("TypeA", core_plugins.NewMatchedPoliciesConfig(core_plugins.WithCache(nil, "hash1"), core_plugins.WithDataplaneHash(dpp.Hash())), dpp)
+			Expect(precomputed).To(Equal(onDemand))
+		})
+
+		It("returns distinct keys for distinct dataplanes with precomputed hashes", func() {
+			dpp := readDPP(filepath.Join("testdata", "matchedpolicies", "fromrules", "01.dataplane.yaml"))
+			k1 := matchers.BuildCacheKey("TypeA", core_plugins.NewMatchedPoliciesConfig(core_plugins.WithCache(nil, "hash1"), core_plugins.WithDataplaneHash(dpp.Hash())), dpp)
+
+			dppV2 := readDPP(filepath.Join("testdata", "matchedpolicies", "fromrules", "01.dataplane.yaml"))
+			dppV2.SetMeta(&test_model.ResourceMeta{
+				Name:    dppV2.GetMeta().GetName(),
+				Mesh:    dppV2.GetMeta().GetMesh(),
+				Version: "v2",
+			})
+			k2 := matchers.BuildCacheKey("TypeA", core_plugins.NewMatchedPoliciesConfig(core_plugins.WithCache(nil, "hash1"), core_plugins.WithDataplaneHash(dppV2.Hash())), dppV2)
+			Expect(k1).ToNot(Equal(k2))
+		})
 	})
 
 	Describe("GetIfPresent / Put", func() {

--- a/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
@@ -1,0 +1,139 @@
+package matchers_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/matchers"
+	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
+)
+
+func benchResources(b *testing.B, numPolicies int) xds_context.Resources {
+	b.Helper()
+	core_plugins.InitAll(policies.NameToModule)
+	resources := xds_context.NewResources()
+	list := &meshtimeout_api.MeshTimeoutResourceList{}
+	for i := range numPolicies {
+		var targetRef common_api.TargetRef
+		switch i % 3 {
+		case 0:
+			targetRef = common_api.TargetRef{Kind: common_api.Mesh}
+		case 1:
+			targetRef = common_api.TargetRef{
+				Kind:   common_api.Dataplane,
+				Labels: pointer.To(map[string]string{"app": "backend"}),
+			}
+		default:
+			targetRef = common_api.TargetRef{
+				Kind:   common_api.Dataplane,
+				Labels: pointer.To(map[string]string{"team": "infra"}),
+			}
+		}
+		mt := builders.MeshTimeout().
+			WithName(fmt.Sprintf("mt-%d", i)).
+			WithTargetRef(targetRef).
+			AddRule([]common_api.Match{}, meshtimeout_api.Conf{
+				ConnectionTimeout: pointer.To(k8s.Duration{Duration: 10 * time.Second}),
+			}).
+			Build()
+		if err := list.AddItem(mt); err != nil {
+			b.Fatal(err)
+		}
+	}
+	resources.MeshLocalResources[meshtimeout_api.MeshTimeoutType] = list
+	return resources
+}
+
+func benchDataplane(b *testing.B) *core_mesh.DataplaneResource {
+	b.Helper()
+	return builders.Dataplane().
+		WithName("dp-1").
+		WithMesh("default").
+		WithVersion("1").
+		WithLabels(map[string]string{
+			mesh_proto.ZoneTag:          "zone-1",
+			mesh_proto.KubeNamespaceTag: "default",
+			"team":                      "infra",
+			"app":                       "backend",
+		}).
+		WithAddress("127.0.0.1").
+		WithServices("backend").
+		WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
+		WithTransparentProxying(15001, 15006, "").
+		Build()
+}
+
+func benchCache() *matchers.PolicyMatchingCache {
+	return matchers.NewPolicyMatchingCache(prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "bench_policy_matching_cache",
+	}, []string{"result"}), 1000)
+}
+
+func benchmarkPluginLoopCacheHit(b *testing.B, hoistHash bool) {
+	b.Helper()
+	dpp := benchDataplane(b)
+	resources := benchResources(b, 10)
+	cache := benchCache()
+	opts := []core_plugins.MatchedPoliciesOption{core_plugins.WithCache(cache, "mesh-hash")}
+	if hoistHash {
+		opts = append(opts, core_plugins.WithDataplaneHash(dpp.Hash()))
+	}
+
+	if _, err := matchers.MatchedPolicies(meshtimeout_api.MeshTimeoutType, dpp, resources, opts...); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for range 17 {
+			if _, err := matchers.MatchedPolicies(meshtimeout_api.MeshTimeoutType, dpp, resources, opts...); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkMatchedPoliciesPluginLoopCacheHit(b *testing.B) {
+	benchmarkPluginLoopCacheHit(b, false)
+}
+
+func BenchmarkMatchedPoliciesPluginLoopCacheHitHoistedHash(b *testing.B) {
+	benchmarkPluginLoopCacheHit(b, true)
+}
+
+func BenchmarkMatchedPoliciesCacheMiss(b *testing.B) {
+	dpp := benchDataplane(b)
+	resources := benchResources(b, 10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := matchers.MatchedPolicies(meshtimeout_api.MeshTimeoutType, dpp, resources); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildCacheKey(b *testing.B) {
+	dpp := benchDataplane(b)
+	cfg := core_plugins.NewMatchedPoliciesConfig(core_plugins.WithCache(nil, "mesh-hash"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = matchers.BuildCacheKey(string(meshtimeout_api.MeshTimeoutType), cfg, dpp)
+	}
+}

--- a/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
@@ -114,7 +114,7 @@ func BenchmarkMatchedPoliciesPluginLoopCacheHitHoistedHash(b *testing.B) {
 	benchmarkPluginLoopCacheHit(b, true)
 }
 
-func BenchmarkMatchedPoliciesCacheMiss(b *testing.B) {
+func BenchmarkMatchedPoliciesNoCache(b *testing.B) {
 	dpp := benchDataplane(b)
 	resources := benchResources(b, 10)
 

--- a/pkg/xds/sync/dataplane_proxy_builder.go
+++ b/pkg/xds/sync/dataplane_proxy_builder.go
@@ -130,7 +130,10 @@ func (p *DataplaneProxyBuilder) matchPolicies(meshContext xds_context.MeshContex
 		opts = append(opts, core_plugins.IncludeShadow())
 	}
 	if p.policyMatchingCache != nil {
-		opts = append(opts, core_plugins.WithCache(p.policyMatchingCache, meshContext.PolicyMatchingHash))
+		opts = append(opts,
+			core_plugins.WithCache(p.policyMatchingCache, meshContext.PolicyMatchingHash),
+			core_plugins.WithDataplaneHash(dataplane.Hash()),
+		)
 	}
 	for _, p := range core_plugins.Plugins().PolicyPlugins() {
 		res, err := p.Plugin.MatchedPolicies(dataplane, resources, opts...)


### PR DESCRIPTION
## Motivation

During a dataplane sync, `DataplaneProxyBuilder.matchPolicies` calls `MatchedPolicies` once per policy plugin (17 in the tree). Each call builds a cache key via `BuildCacheKey`, which runs `dpp.Hash()` — a deterministic `proto.Marshal` of the whole dataplane spec plus sorted-label writes. That's 17 identical hashes per dataplane per sync, paid on every cache hit too.

Benchmarks of the policy-matching hot path showed ~75% of the warm-cache per-call overhead was this repeated hash.

## Implementation information

- Added `DataplaneHash []byte` to `MatchedPoliciesConfig` and a `WithDataplaneHash` option.
- `DataplaneProxyBuilder.matchPolicies` computes `dataplane.Hash()\) once per sync and passes it to all plugins.
- `BuildCacheKey` uses the provided hash, falling back to computing it when not set (keeps other callers — inspect API, mads — unchanged).
- Added benchmarks in `pkg/plugins/policies/core/matchers/dataplane_bench_test.go`.

Benchmark (17-plugin loop, warm cache, 10 MeshTimeout policies, M4 Max):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 22123 | 7082 | 391 |
| after | 4918 | 1642 | 51 |

~4.5x faster on the cache-hit path; ~17µs saved per dataplane sync (~17ms per 1000 dataplanes per mesh-context change).

## Supporting documentation

> Changelog: skip