### PR TITLE
perf(rules): bucket mergeByKey keys by JSON encoding

### DIFF
--- a/pkg/plugins/policies/core/rules/merge/merge.go
+++ b/pkg/plugins/policies/core/rules/merge/merge.go
@@ -42,7 +42,7 @@ func Confs(confs []any) ([]any, error) {
 
 		result, err := mergeConfs(confs)
 		if err != nil {
-			return nil, errors.Wrap(err, "couldn't merge JSON patches")
+			return nil, errors.Wrap(err, "couldn't merge policy configurations")
 		}
 
 		valueResult := reflect.ValueOf(result)
@@ -440,7 +440,7 @@ func mergePatchDocs(doc, patch rawDoc) {
 	}
 }
 
-// pruneNulls mirrors json-patch: null-valued object keys are dropped recursively, while null array elements are kept. EXC:FILE011:documents-a-non-obvious-invariant
+// pruneNulls mirrors json-patch: nulls are pruned recursively, including inside arrays — stricter than RFC 7396 (arrays atomic), but byte-compatible with the previous jsonpatch.MergePatch chain, which is the compatibility bar. EXC:FILE011:documents-a-non-obvious-invariant
 func pruneNulls(v any) any {
 	switch t := v.(type) {
 	case rawDoc:

--- a/pkg/plugins/policies/core/rules/merge/merge.go
+++ b/pkg/plugins/policies/core/rules/merge/merge.go
@@ -626,16 +626,22 @@ func mergeByKey(vals reflect.Value) (reflect.Value, error) {
 		return reflect.Value{}, fmt.Errorf("a merge by key field must have a field tagged as %s and a Default field", mergeKey)
 	}
 	var defaultsByKey []acc
+	// EXC:FILE011:explains-why-not-what — candidates for DeepEqual are bucketed by JSON encoding because matches can't be map keys: DeepEqual values always marshal identically, so only same-bucket entries can match. This avoids scanning every accumulated key with DeepEqual per value, which is quadratic.
+	candidatesByJSON := map[string][]int{}
 	for i := 0; i < vals.Len(); i++ {
 		value := vals.Index(i)
 
 		mergeKeyValue := value.FieldByName(key.Name).Interface()
 		valueDef := []any{value.FieldByName(defaultFieldName).Interface()}
 
-		// We can't have a map keyed by matches so we use a slice and call
-		// search through it calling `DeepEqual`. We define the order of matches
-		// by where it appears with the most precedence (i.e. the last appearance)
-		for accIndex, accRule := range defaultsByKey {
+		keyJSON, err := json.Marshal(mergeKeyValue)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+
+		// EXC:FILE011:pre-existing-comment — we define the order of matches by where it appears with the most precedence (i.e. the last appearance)
+		for _, accIndex := range candidatesByJSON[string(keyJSON)] {
+			accRule := defaultsByKey[accIndex]
 			if accRule.Skip {
 				continue
 			}
@@ -643,12 +649,12 @@ func mergeByKey(vals reflect.Value) (reflect.Value, error) {
 				continue
 			}
 			valueDef = append(accRule.Defaults, valueDef...)
-			// Later rules overwrite earlier ones but we also want the order of
-			// the later rule to take priority so we skip this in the future
+			// EXC:FILE011:pre-existing-comment — later rules overwrite earlier ones but we also want the order of the later rule to take priority so we skip this in the future
 			defaultsByKey[accIndex] = acc{
 				Skip: true,
 			}
 		}
+		candidatesByJSON[string(keyJSON)] = append(candidatesByJSON[string(keyJSON)], len(defaultsByKey))
 		defaultsByKey = append(defaultsByKey, acc{
 			Key:      mergeKeyValue,
 			Defaults: valueDef,

--- a/pkg/plugins/policies/core/rules/merge/merge.go
+++ b/pkg/plugins/policies/core/rules/merge/merge.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -193,21 +194,20 @@ func getConfMeta(t reflect.Type) *confMeta {
 }
 
 var scalarJSONLeaves = []reflect.Type{
-	reflect.TypeOf(k8s.Duration{}),
-	reflect.TypeOf(intstr.IntOrString{}),
+	reflect.TypeFor[k8s.Duration](),
+	reflect.TypeFor[intstr.IntOrString](),
 }
 
-var marshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+var marshalerType = reflect.TypeFor[json.Marshaler]()
 
 // buildConfMeta decides whether a conf type can be merged without JSON
 // round-trips: only plain structs, pointers, slices and scalar leaves are
-// supported. Types with custom JSON marshalling (except known scalar leaves
+// supported. Types with custom JSON marshaling (except known scalar leaves
 // like k8s.Duration), maps, interfaces and embedded fields fall back to
 // mergeViaJSON to preserve exact semantics. EXC:FILE011:documents-a-non-obvious-invariant
 func buildConfMeta(t reflect.Type) *confMeta {
 	meta := &confMeta{supported: true}
-	for i := range t.NumField() {
-		f := t.Field(i)
+	for f := range t.Fields() {
 		if !f.IsExported() {
 			continue
 		}
@@ -226,7 +226,7 @@ func buildConfMeta(t reflect.Type) *confMeta {
 			return meta
 		}
 		meta.fields = append(meta.fields, confField{
-			index:     i,
+			index:     f.Index[0],
 			omitEmpty: opts.Contains("omitempty"),
 			leaf:      leaf,
 		})
@@ -234,22 +234,19 @@ func buildConfMeta(t reflect.Type) *confMeta {
 	return meta
 }
 
-func classifyField(t reflect.Type) (leaf, supported bool) {
+func classifyField(t reflect.Type) (bool, bool) {
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
-	for _, leafType := range scalarJSONLeaves {
-		if t == leafType {
-			return true, true
-		}
+	if slices.Contains(scalarJSONLeaves, t) {
+		return true, true
 	}
 	if t.Implements(marshalerType) || reflect.PointerTo(t).Implements(marshalerType) {
 		return false, false
 	}
 	switch t.Kind() {
 	case reflect.Struct:
-		for i := range t.NumField() {
-			f := t.Field(i)
+		for f := range t.Fields() {
 			if !f.IsExported() {
 				continue
 			}

--- a/pkg/plugins/policies/core/rules/merge/merge.go
+++ b/pkg/plugins/policies/core/rules/merge/merge.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
-	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/pkg/errors"
+	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/common"
@@ -37,7 +39,7 @@ func Confs(confs []any) ([]any, error) {
 	for _, taggedConfs := range taggedConfsList {
 		confs := taggedConfs.Confs
 
-		result, err := mergeJSONPatches(confs)
+		result, err := mergeConfs(confs)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't merge JSON patches")
 		}
@@ -59,36 +61,431 @@ func Confs(confs []any) ([]any, error) {
 	return interfaces, nil
 }
 
-// mergeJSONPatches merges a list of confs to a single conf using the algorithm described in https://www.rfc-editor.org/rfc/rfc7396
-func mergeJSONPatches(confs []reflect.Value) (any, error) {
-	resultBytes := []byte{}
-	for i := range confs {
-		conf := confs[i].Interface()
-		confBytes, err := json.Marshal(conf)
-		if err != nil {
-			return nil, err
-		}
-		if len(resultBytes) == 0 {
-			resultBytes = confBytes
-			continue
-		}
-		resultBytes, err = jsonpatch.MergePatch(resultBytes, confBytes)
-		if err != nil {
-			return nil, err
-		}
+// mergeConfs merges a list of confs to a single conf using the algorithm described in https://www.rfc-editor.org/rfc/rfc7396
+func mergeConfs(confs []reflect.Value) (any, error) {
+	if getConfMeta(derefType(confs[0].Type())).supported {
+		return mergeTyped(confs)
 	}
+	return mergeViaJSON(confs)
+}
 
+func derefType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
+}
+
+// mergeTyped applies RFC 7396 semantics directly on conf structs, avoiding JSON round-trips entirely. EXC:FILE011:explains-why-not-what
+func mergeTyped(confs []reflect.Value) (any, error) {
 	confType := confs[0].Type()
 	result, err := newConf(confType)
 	if err != nil {
 		return nil, err
 	}
 
+	acc := reflect.ValueOf(result).Elem()
+	if acc.Kind() == reflect.Pointer {
+		acc.Set(reflect.New(acc.Type().Elem()))
+		acc = acc.Elem()
+	}
+	for i := range confs {
+		v := confs[i]
+		for v.Kind() == reflect.Pointer {
+			if v.IsNil() {
+				return nil, errors.New("cannot merge nil conf")
+			}
+			v = v.Elem()
+		}
+		mergeInto(acc, v)
+	}
+
+	return result, nil
+}
+
+func mergeInto(acc, patch reflect.Value) {
+	meta := getConfMeta(patch.Type())
+	for _, f := range meta.fields {
+		pv := patch.Field(f.index)
+		if f.omitEmpty && isEmptyValue(pv) {
+			continue
+		}
+		mergeValue(acc.Field(f.index), pv, f)
+	}
+}
+
+func mergeValue(acc, patch reflect.Value, f confField) {
+	if patch.Kind() == reflect.Pointer {
+		if patch.IsNil() {
+			acc.Set(reflect.Zero(acc.Type()))
+			return
+		}
+		if f.leaf {
+			acc.Set(deepCopyValue(patch))
+			return
+		}
+		if acc.Kind() == reflect.Pointer && !acc.IsNil() {
+			mergeInto(acc.Elem(), patch.Elem())
+			return
+		}
+		acc.Set(deepCopyValue(patch))
+		return
+	}
+	if f.leaf {
+		acc.Set(deepCopyValue(patch))
+		return
+	}
+	mergeInto(acc, patch)
+}
+
+func deepCopyValue(v reflect.Value) reflect.Value {
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		c := reflect.New(v.Type().Elem())
+		c.Elem().Set(deepCopyValue(v.Elem()))
+		return c
+	case reflect.Slice:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		c := reflect.MakeSlice(v.Type(), v.Len(), v.Len())
+		for i := range v.Len() {
+			c.Index(i).Set(deepCopyValue(v.Index(i)))
+		}
+		return c
+	case reflect.Struct:
+		c := reflect.New(v.Type()).Elem()
+		c.Set(v)
+		for i := range v.NumField() {
+			if v.Type().Field(i).IsExported() {
+				c.Field(i).Set(deepCopyValue(v.Field(i)))
+			}
+		}
+		return c
+	default:
+		return v
+	}
+}
+
+type confField struct {
+	index     int
+	omitEmpty bool
+	leaf      bool
+}
+
+type confMeta struct {
+	fields    []confField
+	supported bool
+}
+
+var confMetaCache sync.Map
+
+func getConfMeta(t reflect.Type) *confMeta {
+	if meta, ok := confMetaCache.Load(t); ok {
+		return meta.(*confMeta)
+	}
+	meta := buildConfMeta(t)
+	confMetaCache.Store(t, meta)
+	return meta
+}
+
+var scalarJSONLeaves = []reflect.Type{
+	reflect.TypeOf(k8s.Duration{}),
+	reflect.TypeOf(intstr.IntOrString{}),
+}
+
+var marshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+
+// buildConfMeta decides whether a conf type can be merged without JSON
+// round-trips: only plain structs, pointers, slices and scalar leaves are
+// supported. Types with custom JSON marshalling (except known scalar leaves
+// like k8s.Duration), maps, interfaces and embedded fields fall back to
+// mergeViaJSON to preserve exact semantics. EXC:FILE011:documents-a-non-obvious-invariant
+func buildConfMeta(t reflect.Type) *confMeta {
+	meta := &confMeta{supported: true}
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseJSONTag(tag)
+		if f.Anonymous && name == "" {
+			meta.supported = false
+			return meta
+		}
+		leaf, supported := classifyField(f.Type)
+		if !supported {
+			meta.supported = false
+			return meta
+		}
+		meta.fields = append(meta.fields, confField{
+			index:     i,
+			omitEmpty: opts.Contains("omitempty"),
+			leaf:      leaf,
+		})
+	}
+	return meta
+}
+
+func classifyField(t reflect.Type) (leaf, supported bool) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	for _, leafType := range scalarJSONLeaves {
+		if t == leafType {
+			return true, true
+		}
+	}
+	if t.Implements(marshalerType) || reflect.PointerTo(t).Implements(marshalerType) {
+		return false, false
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		for i := range t.NumField() {
+			f := t.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			tag := f.Tag.Get("json")
+			if tag == "-" {
+				continue
+			}
+			if f.Anonymous && tag == "" {
+				return false, false
+			}
+			if _, supported := classifyField(f.Type); !supported {
+				return false, false
+			}
+		}
+		return false, true
+	case reflect.Slice, reflect.Array:
+		_, supported := classifyField(t.Elem())
+		return true, supported
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+func parseJSONTag(tag string) (string, tagOptions) {
+	name, opts, _ := strings.Cut(tag, ",")
+	return name, tagOptions(opts)
+}
+
+type tagOptions string
+
+func (o tagOptions) Contains(option string) bool {
+	for s := range strings.SplitSeq(string(o), ",") {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}
+
+// isEmptyValue mirrors encoding/json's omitempty emptiness check. EXC:FILE011:documents-a-non-obvious-invariant
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+// mergeViaJSON merges a list of confs to a single conf using the algorithm described in https://www.rfc-editor.org/rfc/rfc7396
+func mergeViaJSON(confs []reflect.Value) (any, error) {
+	confType := confs[0].Type()
+	result, err := newConf(confType)
+	if err != nil {
+		return nil, err
+	}
+
+	firstBytes, err := json.Marshal(confs[0].Interface())
+	if err != nil {
+		return nil, err
+	}
+	if len(confs) == 1 {
+		if err := json.Unmarshal(firstBytes, result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	// Decode every conf once and merge on a tree of raw documents: round-tripping the accumulated document through jsonpatch.MergePatch on every step is quadratic in its size. EXC:FILE011:explains-why-not-what
+	acc, err := decodeDoc(firstBytes)
+	if err != nil {
+		return nil, err
+	}
+	for i := 1; i < len(confs); i++ {
+		confBytes, err := json.Marshal(confs[i].Interface())
+		if err != nil {
+			return nil, err
+		}
+		patch, err := decodeDoc(confBytes)
+		if err != nil {
+			return nil, err
+		}
+		if patch == nil {
+			acc = nil
+			continue
+		}
+		if acc == nil {
+			return nil, errors.New("invalid JSON document")
+		}
+		mergePatchDocs(acc, patch)
+	}
+
+	resultBytes, err := json.Marshal(acc)
+	if err != nil {
+		return nil, err
+	}
 	if err := json.Unmarshal(resultBytes, result); err != nil {
 		return nil, err
 	}
 
 	return result, nil
+}
+
+// rawDoc is a decoded JSON object. Values are nil (JSON null), json.RawMessage
+// (verbatim leaf, including unmerged objects) or rawDoc (an object that took
+// part in a merge). Keeping untouched subtrees as RawMessage avoids
+// decode/encode round-trips for them. EXC:FILE011:documents-a-non-obvious-invariant
+type rawDoc map[string]any
+
+func decodeDoc(data []byte) (rawDoc, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	if doc == nil {
+		return nil, nil
+	}
+	res := make(rawDoc, len(doc))
+	for k, v := range doc {
+		res[k] = v
+	}
+	return res, nil
+}
+
+func isNullNode(v any) bool {
+	if v == nil {
+		return true
+	}
+	raw, ok := v.(json.RawMessage)
+	return ok && isNullJSON(raw)
+}
+
+func isNullJSON(raw json.RawMessage) bool {
+	return string(raw) == "null"
+}
+
+// asDoc decodes v into a rawDoc if v is a JSON object. EXC:FILE011:documents-a-non-obvious-invariant
+func asDoc(v any) (rawDoc, bool) {
+	switch t := v.(type) {
+	case rawDoc:
+		return t, true
+	case json.RawMessage:
+		doc, err := decodeDoc(t)
+		if err != nil {
+			return nil, false
+		}
+		return doc, doc != nil
+	default:
+		return nil, false
+	}
+}
+
+// mergePatchDocs applies RFC 7396 semantics of jsonpatch.MergePatch: null patch values delete the key, object values present on both sides merge recursively, anything else replaces. EXC:FILE011:documents-a-non-obvious-invariant
+func mergePatchDocs(doc, patch rawDoc) {
+	for k, v := range patch {
+		if isNullNode(v) {
+			delete(doc, k)
+			continue
+		}
+		cur, ok := doc[k]
+		if !ok || isNullNode(cur) {
+			doc[k] = pruneNulls(v)
+			continue
+		}
+		curDoc, curIsDoc := asDoc(cur)
+		patchDoc, patchIsDoc := asDoc(v)
+		switch {
+		case curIsDoc && patchIsDoc:
+			mergePatchDocs(curDoc, patchDoc)
+			doc[k] = curDoc
+		case !curIsDoc:
+			doc[k] = pruneNulls(v)
+		default:
+			doc[k] = v
+		}
+	}
+}
+
+// pruneNulls mirrors json-patch: null-valued object keys are dropped recursively, while null array elements are kept. EXC:FILE011:documents-a-non-obvious-invariant
+func pruneNulls(v any) any {
+	switch t := v.(type) {
+	case rawDoc:
+		for k, val := range t {
+			if isNullNode(val) {
+				delete(t, k)
+			} else {
+				t[k] = pruneNulls(val)
+			}
+		}
+		return t
+	case json.RawMessage:
+		if doc, ok := asDoc(t); ok {
+			return pruneNulls(doc)
+		}
+		var ary []json.RawMessage
+		if err := json.Unmarshal(t, &ary); err == nil {
+			for i, elem := range ary {
+				if elem == nil || isNullJSON(elem) {
+					continue
+				}
+				switch pruned := pruneNulls(elem).(type) {
+				case json.RawMessage:
+					ary[i] = pruned
+				default:
+					out, err := json.Marshal(pruned)
+					if err != nil {
+						continue
+					}
+					ary[i] = out
+				}
+			}
+			out, err := json.Marshal(ary)
+			if err != nil {
+				return t
+			}
+			return json.RawMessage(out)
+		}
+		return t
+	default:
+		return v
+	}
 }
 
 type acc struct {

--- a/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
@@ -8,6 +8,7 @@ import (
 	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/merge"
+	meshhttproute_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
 	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
@@ -58,3 +59,39 @@ func BenchmarkConfsMeshWidePolicies(b *testing.B) {
 		benchmarkConfs(b, len(confs))
 	})
 }
+
+func benchmarkMergeByKey(b *testing.B, policies, rulesPerPolicy int) {
+	b.Helper()
+	confs := []any{}
+	for i := 0; i < policies; i++ {
+		rules := []meshhttproute_api.Rule{}
+		for j := 0; j < rulesPerPolicy; j++ {
+			rules = append(rules, meshhttproute_api.Rule{
+				Matches: []meshhttproute_api.Match{{
+					Path: &meshhttproute_api.PathMatch{
+						Type:  meshhttproute_api.Exact,
+						Value: fmt.Sprintf("/policy-%d/rule-%d", i, j),
+					},
+					Method: pointer.To(meshhttproute_api.Method("GET")),
+				}},
+			})
+		}
+		confs = append(confs, meshhttproute_api.PolicyDefault{Rules: rules})
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := merge.Confs(confs)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) != 1 {
+			b.Fatalf("expected 1 merged conf, got %d", len(out))
+		}
+	}
+}
+
+func BenchmarkMergeByKey10x10(b *testing.B) { benchmarkMergeByKey(b, 10, 10) }
+func BenchmarkMergeByKey20x20(b *testing.B) { benchmarkMergeByKey(b, 20, 20) }
+func BenchmarkMergeByKey40x10(b *testing.B) { benchmarkMergeByKey(b, 40, 10) }

--- a/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
@@ -1,0 +1,60 @@
+package merge_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/merge"
+	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+)
+
+func benchmarkConfs(b *testing.B, n int) {
+	b.Helper()
+	confs := []any{}
+	for i := 0; i < n; i++ {
+		confs = append(confs, meshtimeout_api.Conf{
+			ConnectionTimeout: pointer.To(k8s.Duration{Duration: time.Duration(i+1) * time.Second}),
+			IdleTimeout:       pointer.To(k8s.Duration{Duration: time.Duration(20+i%7) * time.Second}),
+			Http: &meshtimeout_api.Http{
+				RequestTimeout:    pointer.To(k8s.Duration{Duration: 15 * time.Second}),
+				StreamIdleTimeout: pointer.To(k8s.Duration{Duration: time.Duration(i+1) * time.Minute}),
+			},
+		})
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := merge.Confs(confs)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) != 1 {
+			b.Fatalf("expected 1 merged conf, got %d", len(out))
+		}
+	}
+}
+
+func BenchmarkConfs1(b *testing.B)  { benchmarkConfs(b, 1) }
+func BenchmarkConfs2(b *testing.B)  { benchmarkConfs(b, 2) }
+func BenchmarkConfs10(b *testing.B) { benchmarkConfs(b, 10) }
+func BenchmarkConfs40(b *testing.B) { benchmarkConfs(b, 40) }
+
+func BenchmarkConfsMeshWidePolicies(b *testing.B) {
+	confs := []any{}
+	for i := 0; i < 40; i++ {
+		confs = append(confs, meshtimeout_api.Conf{
+			ConnectionTimeout: pointer.To(k8s.Duration{Duration: time.Duration(i+1) * time.Second}),
+			Http: &meshtimeout_api.Http{
+				RequestTimeout: pointer.To(k8s.Duration{Duration: 15 * time.Second}),
+			},
+		})
+	}
+	b.Run(fmt.Sprintf("n=%d", len(confs)), func(b *testing.B) {
+		benchmarkConfs(b, len(confs))
+	})
+}

--- a/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
@@ -15,7 +15,7 @@ import (
 func benchmarkConfs(b *testing.B, n int) {
 	b.Helper()
 	confs := []any{}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		confs = append(confs, meshtimeout_api.Conf{
 			ConnectionTimeout: pointer.To(k8s.Duration{Duration: time.Duration(i+1) * time.Second}),
 			IdleTimeout:       pointer.To(k8s.Duration{Duration: time.Duration(20+i%7) * time.Second}),
@@ -46,7 +46,7 @@ func BenchmarkConfs40(b *testing.B) { benchmarkConfs(b, 40) }
 
 func BenchmarkConfsMeshWidePolicies(b *testing.B) {
 	confs := []any{}
-	for i := 0; i < 40; i++ {
+	for i := range 40 {
 		confs = append(confs, meshtimeout_api.Conf{
 			ConnectionTimeout: pointer.To(k8s.Duration{Duration: time.Duration(i+1) * time.Second}),
 			Http: &meshtimeout_api.Http{

--- a/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_bench_test.go
@@ -63,9 +63,9 @@ func BenchmarkConfsMeshWidePolicies(b *testing.B) {
 func benchmarkMergeByKey(b *testing.B, policies, rulesPerPolicy int) {
 	b.Helper()
 	confs := []any{}
-	for i := 0; i < policies; i++ {
+	for i := range policies {
 		rules := []meshhttproute_api.Rule{}
-		for j := 0; j < rulesPerPolicy; j++ {
+		for j := range rulesPerPolicy {
 			rules = append(rules, meshhttproute_api.Rule{
 				Matches: []meshhttproute_api.Match{{
 					Path: &meshhttproute_api.PathMatch{

--- a/pkg/plugins/policies/core/rules/merge/merge_equivalence_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_equivalence_test.go
@@ -1,0 +1,145 @@
+package merge_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8s "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/merge"
+	meshaccesslog_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshaccesslog/api/v1alpha1"
+	meshcircuitbreaker_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshcircuitbreaker/api/v1alpha1"
+	meshtimeout_api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshtimeout/api/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+)
+
+func baselineMerge[T any](confs []T) T {
+	GinkgoHelper()
+	var resultBytes []byte
+	for _, conf := range confs {
+		confBytes, err := json.Marshal(conf)
+		Expect(err).ToNot(HaveOccurred())
+		if len(resultBytes) == 0 {
+			resultBytes = confBytes
+			continue
+		}
+		resultBytes, err = jsonpatch.MergePatch(resultBytes, confBytes)
+		Expect(err).ToNot(HaveOccurred())
+	}
+	var result T
+	Expect(json.Unmarshal(resultBytes, &result)).To(Succeed())
+	return result
+}
+
+func runEquivalence[T any](r *rand.Rand, n int, randomConf func(*rand.Rand) T) {
+	GinkgoHelper()
+	confs := []T{}
+	anyConfs := []any{}
+	for i := 0; i < n; i++ {
+		conf := randomConf(r)
+		confs = append(confs, conf)
+		anyConfs = append(anyConfs, conf)
+	}
+
+	merged, err := merge.Confs(anyConfs)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(merged).To(HaveLen(1))
+
+	expected := baselineMerge(confs)
+	Expect(merged[0]).To(Equal(expected))
+}
+
+var _ = Describe("mergeConfs equivalence with jsonpatch.MergePatch", func() {
+	randomTimeoutConf := func(r *rand.Rand) meshtimeout_api.Conf {
+		conf := meshtimeout_api.Conf{}
+		if r.Intn(2) == 0 {
+			conf.ConnectionTimeout = pointer.To(k8s.Duration{Duration: time.Duration(r.Intn(100)) * time.Second})
+		}
+		if r.Intn(2) == 0 {
+			conf.IdleTimeout = pointer.To(k8s.Duration{Duration: time.Duration(r.Intn(100)) * time.Second})
+		}
+		if r.Intn(2) == 0 {
+			http := &meshtimeout_api.Http{}
+			if r.Intn(2) == 0 {
+				http.RequestTimeout = pointer.To(k8s.Duration{Duration: time.Duration(r.Intn(100)) * time.Second})
+			}
+			if r.Intn(2) == 0 {
+				http.StreamIdleTimeout = pointer.To(k8s.Duration{Duration: time.Duration(r.Intn(100)) * time.Second})
+			}
+			if r.Intn(4) == 0 {
+				http.MaxStreamDuration = pointer.To(k8s.Duration{Duration: time.Duration(r.Intn(100)) * time.Second})
+			}
+			conf.Http = http
+		}
+		return conf
+	}
+
+	randomCircuitBreakerConf := func(r *rand.Rand) meshcircuitbreaker_api.Conf {
+		conf := meshcircuitbreaker_api.Conf{}
+		if r.Intn(2) == 0 {
+			conf.ConnectionLimits = &meshcircuitbreaker_api.ConnectionLimits{
+				MaxConnections: pointer.To(uint32(r.Intn(1000))),
+			}
+		}
+		if r.Intn(2) == 0 {
+			outlier := &meshcircuitbreaker_api.OutlierDetection{
+				Disabled:           pointer.To(r.Intn(2) == 0),
+				Interval:           pointer.To(k8s.Duration{Duration: time.Duration(r.Intn(100)) * time.Second}),
+				MaxEjectionPercent: pointer.To(uint32(r.Intn(100))),
+			}
+			if r.Intn(2) == 0 {
+				outlier.Detectors = &meshcircuitbreaker_api.Detectors{
+					SuccessRate: &meshcircuitbreaker_api.DetectorSuccessRateFailures{
+						MinimumHosts:            pointer.To(uint32(r.Intn(10))),
+						StandardDeviationFactor: pointer.To(intstr.FromInt32(int32(r.Intn(200)))),
+					},
+				}
+			}
+			conf.OutlierDetection = outlier
+		}
+		return conf
+	}
+
+	randomAccessLogConf := func(r *rand.Rand) meshaccesslog_api.Conf {
+		conf := meshaccesslog_api.Conf{}
+		if r.Intn(2) == 0 {
+			backend := meshaccesslog_api.Backend{
+				Type: meshaccesslog_api.OtelTelemetryBackendType,
+				OpenTelemetry: &meshaccesslog_api.OtelBackend{
+					Attributes: &[]meshaccesslog_api.OtelAttribute{
+						{Key: "mesh", Value: fmt.Sprintf("mesh-%d", r.Intn(10))},
+					},
+				},
+			}
+			if r.Intn(2) == 0 {
+				backend.OpenTelemetry.Body = &apiextensionsv1.JSON{
+					Raw: []byte(fmt.Sprintf(`{"kvlistValue":{"values":[{"key":"k%d","value":{"stringValue":"v%d"}}]}}`, r.Intn(5), r.Intn(5))),
+				}
+			}
+			conf.Backends = &[]meshaccesslog_api.Backend{backend}
+		}
+		return conf
+	}
+
+	for _, seed := range []int64{1, 2, 3, 4, 5} {
+		for _, n := range []int{2, 3, 5, 10, 40} {
+			seed, n := seed, n
+			It(fmt.Sprintf("MeshTimeout should match baseline for seed=%d n=%d", seed, n), func() {
+				runEquivalence(rand.New(rand.NewSource(seed)), n, randomTimeoutConf)
+			})
+			It(fmt.Sprintf("MeshCircuitBreaker should match baseline for seed=%d n=%d", seed, n), func() {
+				runEquivalence(rand.New(rand.NewSource(seed)), n, randomCircuitBreakerConf)
+			})
+			It(fmt.Sprintf("MeshAccessLog should match baseline for seed=%d n=%d", seed, n), func() {
+				runEquivalence(rand.New(rand.NewSource(seed)), n, randomAccessLogConf)
+			})
+		}
+	}
+})

--- a/pkg/plugins/policies/core/rules/merge/merge_equivalence_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_equivalence_test.go
@@ -42,7 +42,7 @@ func runEquivalence[T any](r *rand.Rand, n int, randomConf func(*rand.Rand) T) {
 	GinkgoHelper()
 	confs := []T{}
 	anyConfs := []any{}
-	for i := 0; i < n; i++ {
+	for range n {
 		conf := randomConf(r)
 		confs = append(confs, conf)
 		anyConfs = append(anyConfs, conf)

--- a/pkg/plugins/policies/core/rules/merge/merge_equivalence_test.go
+++ b/pkg/plugins/policies/core/rules/merge/merge_equivalence_test.go
@@ -119,8 +119,12 @@ var _ = Describe("mergeConfs equivalence with jsonpatch.MergePatch", func() {
 				},
 			}
 			if r.Intn(2) == 0 {
+				body := fmt.Sprintf(`{"kvlistValue":{"values":[{"key":"k%d","value":{"stringValue":"v%d"}}]}}`, r.Intn(5), r.Intn(5))
+				if r.Intn(3) == 0 {
+					body = `{"kvlistValue":{"values":[{"key":null}]}}`
+				}
 				backend.OpenTelemetry.Body = &apiextensionsv1.JSON{
-					Raw: []byte(fmt.Sprintf(`{"kvlistValue":{"values":[{"key":"k%d","value":{"stringValue":"v%d"}}]}}`, r.Intn(5), r.Intn(5))),
+					Raw: []byte(body),
 				}
 			}
 			conf.Backends = &[]meshaccesslog_api.Backend{backend}


### PR DESCRIPTION
## Motivation

`mergeByKey` (used for `policyMerge:"mergeValuesByKey"` fields, e.g. MeshHTTPRoute `rules`) grouped entries by scanning every accumulated key with `reflect.DeepEqual` for each value — quadratic in the number of rules. Merging 20 policies × 20 rules took ~10.9ms per call.

## Implementation

Candidate keys are now bucketed by their JSON encoding: `DeepEqual` values of the same static type always marshal identically (deterministic field order, sorted map keys), so only same-bucket entries can match. `DeepEqual` still runs within a bucket, preserving exact existing semantics; the scan becomes O(N) marshals instead of O(N×K) DeepEquals.

Stacked on #18488 (same file); only the last commit is new.

## Correctness

- Existing `merge_test.go` mergeValuesByKey cases and all policy plugin golden tests pass.
- New benchmarks with distinct MeshHTTPRoute rule matches per policy.

## Benchmarks

`BenchmarkMergeByKey<P>x<R>` merging P MeshHTTPRoute policies with R distinct-match rules each (Apple M4 Max):

| shape | before | after |
|-------|--------|-------|
| 10×10 (100 rules) | 1227 µs | 851 µs |
| 20×20 (400 rules) | 10869 µs | 3257 µs |
| 40×10 (400 rules) | 10765 µs | 3353 µs |

3.3x at 400 rules and scaling is now linear in rule count (remaining cost is the per-distinct-key `Confs` merge, which is inherent).

> Changelog: skip