### PR TITLE
perf(policy): cut matching constant factors

### DIFF
--- a/pkg/plugins/policies/core/matchers/dataplane.go
+++ b/pkg/plugins/policies/core/matchers/dataplane.go
@@ -316,10 +316,26 @@ func allInboundListeners(dpp *core_mesh.DataplaneResource) []core_rules.InboundL
 }
 
 func SortByTargetRef(rl core_model.ResourceList) core_model.ResourceList {
+	type sortableResource struct {
+		resource    core_model.Resource
+		origin      mesh_proto.ResourceOrigin
+		role        mesh_proto.PolicyRole
+		displayName string
+	}
 	rs := rl.GetItems()
-	slices.SortFunc(rs, func(r1, r2 core_model.Resource) int {
-		p1, ok1 := r1.GetSpec().(core_model.Policy)
-		p2, ok2 := r2.GetSpec().(core_model.Policy)
+	sortable := make([]sortableResource, 0, len(rs))
+	for _, r := range rs {
+		origin, _ := core_model.ResourceOrigin(r.GetMeta())
+		sortable = append(sortable, sortableResource{
+			resource:    r,
+			origin:      origin,
+			role:        core_model.PolicyRole(r.GetMeta()),
+			displayName: core_model.GetDisplayName(r.GetMeta()),
+		})
+	}
+	slices.SortFunc(sortable, func(s1, s2 sortableResource) int {
+		p1, ok1 := s1.resource.GetSpec().(core_model.Policy)
+		p2, ok2 := s2.resource.GetSpec().(core_model.Policy)
 		if !ok1 || !ok2 {
 			panic("resource doesn't support TargetRef matching")
 		}
@@ -333,21 +349,19 @@ func SortByTargetRef(rl core_model.ResourceList) core_model.ResourceList {
 			return less
 		}
 
-		o1, _ := core_model.ResourceOrigin(r1.GetMeta())
-		o2, _ := core_model.ResourceOrigin(r2.GetMeta())
-		if less := o1.Compare(o2); less != 0 {
+		if less := s1.origin.Compare(s2.origin); less != 0 {
 			return less
 		}
 
-		if less := core_model.PolicyRole(r1.GetMeta()).Compare(core_model.PolicyRole(r2.GetMeta())); less != 0 {
+		if less := s1.role.Compare(s2.role); less != 0 {
 			return less
 		}
 
-		return cmp.Compare(core_model.GetDisplayName(r2.GetMeta()), core_model.GetDisplayName(r1.GetMeta()))
+		return cmp.Compare(s2.displayName, s1.displayName)
 	})
 	rv := registry.Global().MustNewList(rl.GetItemType())
-	for _, r := range rs {
-		_ = rv.AddItem(r)
+	for _, s := range sortable {
+		_ = rv.AddItem(s.resource)
 	}
 	return rv
 }

--- a/pkg/plugins/policies/core/matchers/sort_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/sort_bench_test.go
@@ -1,0 +1,48 @@
+package matchers_test
+
+import (
+	"fmt"
+	"testing"
+
+	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
+	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/matchers"
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshhttproute/api/v1alpha1"
+	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
+)
+
+func BenchmarkSortByTargetRef(b *testing.B) {
+	registry.RegisterTypeIfAbsent(v1alpha1.MeshHTTPRouteResourceTypeDescriptor)
+	for _, n := range []int{10, 50, 200} {
+		b.Run(fmt.Sprintf("policies=%d", n), func(b *testing.B) {
+			list := &v1alpha1.MeshHTTPRouteResourceList{}
+			for i := 0; i < n; i++ {
+				list.Items = append(list.Items, &v1alpha1.MeshHTTPRouteResource{
+					Meta: &test_model.ResourceMeta{
+						Mesh: "mesh-1",
+						Name: fmt.Sprintf("route-%d", n-i),
+						Labels: map[string]string{
+							mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+							mesh_proto.PolicyRoleLabel:     string(mesh_proto.ConsumerPolicyRole),
+							mesh_proto.DisplayName:         fmt.Sprintf("route-%d", n-i),
+							mesh_proto.KubeNamespaceTag:    "ns-a",
+						},
+					},
+					Spec: &v1alpha1.MeshHTTPRoute{
+						TargetRef: &common_api.TopLevelTargetRef{
+							Kind:   common_api.TopLevelTargetRefKindDataplane,
+							Labels: pointer.To(map[string]string{"app": fmt.Sprintf("app-%d", i%10)}),
+						},
+					},
+				})
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = matchers.SortByTargetRef(list)
+			}
+		})
+	}
+}

--- a/pkg/plugins/policies/core/matchers/sort_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/sort_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkSortByTargetRef(b *testing.B) {
 	for _, n := range []int{10, 50, 200} {
 		b.Run(fmt.Sprintf("policies=%d", n), func(b *testing.B) {
 			list := &v1alpha1.MeshHTTPRouteResourceList{}
-			for i := 0; i < n; i++ {
+			for i := range n {
 				list.Items = append(list.Items, &v1alpha1.MeshHTTPRouteResource{
 					Meta: &test_model.ResourceMeta{
 						Mesh: "mesh-1",

--- a/pkg/plugins/policies/core/rules/subsetutils/subset.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subset.go
@@ -28,19 +28,19 @@ func (ss Subset) IsSubset(other Subset) bool {
 	if len(ss) == 0 {
 		return true
 	}
-	otherByKeys := map[string][]Tag{}
-	for _, t := range other {
-		otherByKeys[t.Key] = append(otherByKeys[t.Key], t)
-	}
 	for _, tag := range ss {
-		oTags, ok := otherByKeys[tag.Key]
-		if !ok {
-			return false
-		}
-		for _, otherTag := range oTags {
+		found := false
+		for _, otherTag := range other {
+			if otherTag.Key != tag.Key {
+				continue
+			}
+			found = true
 			if !isSubset(tag, otherTag) {
 				return false
 			}
+		}
+		if !found {
+			return false
 		}
 	}
 	return true

--- a/pkg/plugins/policies/core/rules/subsetutils/subset_bench_test.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subset_bench_test.go
@@ -1,0 +1,39 @@
+package subsetutils_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
+)
+
+func BenchmarkIsSubset(b *testing.B) {
+	newLabels := func(n int) map[string]string {
+		m := map[string]string{}
+		for i := 0; i < n; i++ {
+			m[fmt.Sprintf("label-%d", i)] = fmt.Sprintf("value-%d", i)
+		}
+		return m
+	}
+	for _, n := range []int{1, 5, 10} {
+		query := subsetutils.NewSubset(newLabels(n))
+		match := subsetutils.NewSubset(newLabels(n))
+		mismatch := subsetutils.NewSubset(map[string]string{"app": "demo"})
+		b.Run(fmt.Sprintf("labels=%d/match", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if !query.IsSubset(match) {
+					b.Fatal("expected subset")
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("labels=%d/mismatch", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if query.IsSubset(mismatch) {
+					b.Fatal("expected no subset")
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugins/policies/core/rules/subsetutils/subset_bench_test.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/subset_bench_test.go
@@ -10,7 +10,7 @@ import (
 func BenchmarkIsSubset(b *testing.B) {
 	newLabels := func(n int) map[string]string {
 		m := map[string]string{}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			m[fmt.Sprintf("label-%d", i)] = fmt.Sprintf("value-%d", i)
 		}
 		return m

--- a/pkg/plugins/policies/core/rules/subsetutils/suite_test.go
+++ b/pkg/plugins/policies/core/rules/subsetutils/suite_test.go
@@ -1,0 +1,11 @@
+package subsetutils_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestSubsetutils(t *testing.T) {
+	test.RunSpecs(t, "Subsetutils Suite")
+}


### PR DESCRIPTION
## Motivation

Two constant-factor costs in the per-dataplane policy matching path, visible in a 120s pprof capture on a local k3d cluster (50 dataplanes, policy churn):

- `SortByTargetRef` (~2.3% CPU): the sort comparator recomputed `ResourceOrigin`, `PolicyRole` and `GetDisplayName` from resource meta on every comparison — O(N log N) label lookups per sort.
- `Subset.IsSubset`: allocated a map + slices on every call to group tags by key, although label sets are tiny (typically 1–10 entries).

## Implementation

- `SortByTargetRef`: decorate-sort-undecorate — derive origin/role/display-name once per resource up front, compare precomputed values in the comparator. Ordering semantics unchanged.
- `IsSubset`: replaced the per-call map with a linear scan. Identical semantics (every tag in `ss` must have at least one same-key tag in `other`, and all same-key tags must satisfy `isSubset`), zero allocations.

## Benchmarks

New benchmarks (Apple M4 Max), before → after:

| benchmark | before | after | speedup |
|-----------|--------|-------|---------|
| IsSubset labels=1 match | 108 ns, 1 alloc | 9 ns, 0 allocs | 12x |
| IsSubset labels=5 match | 200 ns, 5 allocs | 84 ns, 0 allocs | 2.4x |
| IsSubset labels=10 match | 630 ns, 13 allocs | 268 ns, 0 allocs | 2.4x |
| SortByTargetRef policies=10 | 2393 ns | 1662 ns | 1.4x |
| SortByTargetRef policies=50 | 62 µs | 28 µs | 2.2x |
| SortByTargetRef policies=200 | 579 µs | 96 µs | 6.0x |

## Correctness

All `./pkg/plugins/policies/...` tests pass, including the existing `IsSubset` table tests in `rules_test.go` and `MatchedPolicies` golden tests.

> Changelog: skip