### PR TITLE
test(framework): authenticate InspectEnvoyProxy

### DIFF
--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -43,8 +43,8 @@ type K8sControlPlane struct {
 	apiHeaders []string
 	refreshMu  sync.Mutex
 
-	// Both inspect callers poll inside an Eventually, so the secret read is
-	// done once per control plane instead of once per request.
+	// Both inspect callers poll inside an Eventually, so this is read once per
+	// control plane rather than once per request.
 	adminTokenMu sync.Mutex
 	adminToken   string
 }
@@ -171,9 +171,8 @@ func (c *K8sControlPlane) VerifyKumaCtl() error {
 	return c.kumactl.RunKumactl("get", "meshes")
 }
 
-// parseAPIHeaders turns `name=value` entries into a header map. The value is
-// everything after the first `=`, so a bearer token carrying base64 padding
-// survives, and an entry without one is skipped rather than panicking.
+// parseAPIHeaders splits `name=value` entries on the first `=`, so a bearer
+// token carrying base64 padding survives, and skips an entry without one.
 func parseAPIHeaders(apiHeaders []string) map[string]string {
 	headers := map[string]string{}
 	for _, header := range apiHeaders {
@@ -252,21 +251,19 @@ func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
 	if authnType, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"]; exist && authnType != "tokens" {
 		return "", nil
 	}
-	// Nothing writes the secret when the bootstrap is off, so without this the
-	// read below burns the whole retry budget before returning an error. The
-	// control plane parses this with strconv.ParseBool, so "0" and "False"
-	// disable it too. A deployment that turns it off through WithYamlConfig
-	// instead is not visible here.
+	// Nothing writes the secret when the bootstrap is off, so the read below
+	// would spend the whole retry budget. ParseBool because the control plane
+	// does; a deployment that disables it through WithYamlConfig is invisible
+	// here.
 	if bootstrap, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN"]; exist {
 		if enabled, err := strconv.ParseBool(bootstrap); err == nil && !enabled {
 			return "", nil
 		}
 	}
 	if c.cluster.opts.helmOpts["controlPlane.environment"] == "universal" {
-		// Reading the bootstrapped token is itself an admin request, and the
-		// chart pins localhostIsAdmin false on this path, so there is nothing to
-		// read unless the deployment put loopback admin back. Saying so costs
-		// nothing; asking anyway costs the whole retry budget and then fails.
+		// Reading the token is itself an admin request, and the chart pins
+		// localhostIsAdmin false here, so it can only succeed if the deployment
+		// put loopback admin back.
 		if loopbackAdmin, _ := strconv.ParseBool(c.cluster.opts.env["KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN"]); !loopbackAdmin {
 			return "", nil
 		}
@@ -291,12 +288,9 @@ func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
 	})
 }
 
-// cachedAdminToken returns the bootstrapped admin token, reading the secret
-// once. An empty string means there is no token to attach, which is the answer
-// on a control plane that does not authenticate with tokens or does not
-// bootstrap one; both answer without reading anything, so they cost nothing to
-// repeat. A failure is not cached, or one blip would outlive the Eventually
-// the callers poll inside.
+// cachedAdminToken returns the bootstrapped admin token, or an empty string
+// when there is none to attach. A failure is not cached: one blip would
+// otherwise outlive the Eventually the callers poll inside.
 func (c *K8sControlPlane) cachedAdminToken() (string, error) {
 	c.adminTokenMu.Lock()
 	defer c.adminTokenMu.Unlock()
@@ -401,9 +395,8 @@ func (c *K8sControlPlane) InspectEnvoyProxy(inspectPath string, query url.Values
 		reqURL += "?" + encoded
 	}
 
-	// Read before the deadline is armed. A cold read retries for longer than
-	// the deadline allows, and spending it here would fail the request itself
-	// with a timeout that blames the control plane.
+	// Before the deadline is armed: a cold read retries for longer than the
+	// deadline allows, and would spend it.
 	token, err := c.cachedAdminToken()
 	if err != nil {
 		return nil, err

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -45,9 +45,8 @@ type K8sControlPlane struct {
 
 	// Both inspect callers poll inside an Eventually, so the secret read is
 	// done once per control plane instead of once per request.
-	adminTokenOnce sync.Once
-	adminToken     string
-	adminTokenErr  error
+	adminTokenMu sync.Mutex
+	adminToken   string
 }
 
 func NewK8sControlPlane(
@@ -172,12 +171,21 @@ func (c *K8sControlPlane) VerifyKumaCtl() error {
 	return c.kumactl.RunKumactl("get", "meshes")
 }
 
-func (c *K8sControlPlane) VerifyKumaREST() error {
+// parseAPIHeaders turns `name=value` entries into a header map. The value is
+// everything after the first `=`, so a bearer token carrying base64 padding
+// survives, and an entry without one is skipped rather than panicking.
+func parseAPIHeaders(apiHeaders []string) map[string]string {
 	headers := map[string]string{}
-	for _, header := range c.apiHeaders {
-		res := strings.Split(header, "=")
-		headers[res[0]] = res[1]
+	for _, header := range apiHeaders {
+		if kv := strings.SplitN(header, "=", 2); len(kv) == 2 {
+			headers[kv[0]] = kv[1]
+		}
 	}
+	return headers
+}
+
+func (c *K8sControlPlane) VerifyKumaREST() error {
+	headers := parseAPIHeaders(c.apiHeaders)
 	_, err := http_helper.HTTPDoWithRetryContextE(
 		c.t,
 		context.Background(),
@@ -271,15 +279,25 @@ func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
 	})
 }
 
-// cachedAdminToken returns the bootstrapped admin token, reading it at most
+// cachedAdminToken returns the bootstrapped admin token, reading the secret
 // once. An empty string means there is no token to attach, which is the answer
 // on a control plane that does not authenticate with tokens or does not
-// bootstrap one.
+// bootstrap one; both answer without reading anything, so they cost nothing to
+// repeat. A failure is not cached, or one blip would outlive the Eventually
+// the callers poll inside.
 func (c *K8sControlPlane) cachedAdminToken() (string, error) {
-	c.adminTokenOnce.Do(func() {
-		c.adminToken, c.adminTokenErr = c.retrieveAdminToken()
-	})
-	return c.adminToken, c.adminTokenErr
+	c.adminTokenMu.Lock()
+	defer c.adminTokenMu.Unlock()
+
+	if c.adminToken != "" {
+		return c.adminToken, nil
+	}
+	token, err := c.retrieveAdminToken()
+	if err != nil {
+		return "", err
+	}
+	c.adminToken = token
+	return token, nil
 }
 
 func (c *K8sControlPlane) InstallCP(args ...string) (string, error) {
@@ -386,10 +404,8 @@ func (c *K8sControlPlane) InspectEnvoyProxy(inspectPath string, query url.Values
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	// Set after the token so an explicit Authorization in apiHeaders wins.
-	for _, header := range c.apiHeaders {
-		if kv := strings.SplitN(header, "=", 2); len(kv) == 2 {
-			req.Header.Set(kv[0], kv[1])
-		}
+	for name, value := range parseAPIHeaders(c.apiHeaders) {
+		req.Header.Set(name, value)
 	}
 
 	client := &http.Client{Timeout: inspectEnvoyProxyTimeout}

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/test/framework/kumactl"
@@ -247,18 +248,55 @@ func (c *K8sControlPlane) FinalizeAddWithPortFwd(
 	return c.kumactl.KumactlConfigControlPlanesAdd(c.name, c.GetAPIServerAddress(), token, c.apiHeaders)
 }
 
-func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
-	if authnType, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"]; exist && authnType != "tokens" {
-		return "", nil
+// adminTokenSettings is the part of the control plane's own config that decides
+// whether a bootstrapped token exists, so a deployment can turn it off through
+// WithYamlConfig rather than the environment.
+type adminTokenSettings struct {
+	ApiServer struct {
+		Authn struct {
+			Type   string `json:"type"`
+			Tokens struct {
+				BootstrapAdminToken *bool `json:"bootstrapAdminToken"`
+			} `json:"tokens"`
+		} `json:"authn"`
+	} `json:"apiServer"`
+}
+
+// bootstrapsAdminToken answers without reading anything. Without it the read in
+// retrieveAdminToken spends the whole retry budget on a secret nothing writes.
+// The environment wins over the file, as it does in the control plane.
+func (c *K8sControlPlane) bootstrapsAdminToken() bool {
+	var cfg adminTokenSettings
+	if raw := c.cluster.opts.yamlConfig; raw != "" {
+		// A config this malformed fails the deployment itself, so the guard
+		// gives it the benefit of the doubt rather than deciding on it.
+		_ = yaml.Unmarshal([]byte(raw), &cfg)
 	}
-	// Nothing writes the secret when the bootstrap is off, so the read below
-	// would spend the whole retry budget. ParseBool because the control plane
-	// does; a deployment that disables it through WithYamlConfig is invisible
-	// here.
-	if bootstrap, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN"]; exist {
-		if enabled, err := strconv.ParseBool(bootstrap); err == nil && !enabled {
-			return "", nil
+
+	authnType := cfg.ApiServer.Authn.Type
+	if fromEnv, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"]; exist {
+		authnType = fromEnv
+	}
+	if authnType != "" && authnType != "tokens" {
+		return false
+	}
+
+	bootstrap := true
+	if fromYaml := cfg.ApiServer.Authn.Tokens.BootstrapAdminToken; fromYaml != nil {
+		bootstrap = *fromYaml
+	}
+	if fromEnv, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN"]; exist {
+		// ParseBool because the control plane parses it that way.
+		if parsed, err := strconv.ParseBool(fromEnv); err == nil {
+			bootstrap = parsed
 		}
+	}
+	return bootstrap
+}
+
+func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
+	if !c.bootstrapsAdminToken() {
+		return "", nil
 	}
 	if c.cluster.opts.helmOpts["controlPlane.environment"] == "universal" {
 		// Reading the token is itself an admin request, and the chart pins

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -42,6 +42,12 @@ type K8sControlPlane struct {
 	replicas   int
 	apiHeaders []string
 	refreshMu  sync.Mutex
+
+	// Both inspect callers poll inside an Eventually, so the secret read is
+	// done once per control plane instead of once per request.
+	adminTokenOnce sync.Once
+	adminToken     string
+	adminTokenErr  error
 }
 
 func NewK8sControlPlane(
@@ -238,6 +244,11 @@ func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
 	if authnType, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TYPE"]; exist && authnType != "tokens" {
 		return "", nil
 	}
+	// Nothing writes the secret when the bootstrap is off, so without this the
+	// read below burns the whole retry budget before returning an error.
+	if bootstrap, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN"]; exist && bootstrap == "false" {
+		return "", nil
+	}
 	if c.cluster.opts.helmOpts["controlPlane.environment"] == "universal" {
 		body, err := http_helper.HTTPDoWithRetryWithOptionsE(c.t, http_helper.HttpDoOptions{
 			Method:    "GET",
@@ -258,6 +269,17 @@ func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
 		}
 		return string(sec.Data["value"]), nil
 	})
+}
+
+// cachedAdminToken returns the bootstrapped admin token, reading it at most
+// once. An empty string means there is no token to attach, which is the answer
+// on a control plane that does not authenticate with tokens or does not
+// bootstrap one.
+func (c *K8sControlPlane) cachedAdminToken() (string, error) {
+	c.adminTokenOnce.Do(func() {
+		c.adminToken, c.adminTokenErr = c.retrieveAdminToken()
+	})
+	return c.adminToken, c.adminTokenErr
 }
 
 func (c *K8sControlPlane) InstallCP(args ...string) (string, error) {
@@ -356,6 +378,14 @@ func (c *K8sControlPlane) InspectEnvoyProxy(inspectPath string, query url.Values
 	if err != nil {
 		return nil, err
 	}
+	token, err := c.cachedAdminToken()
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	// Set after the token so an explicit Authorization in apiHeaders wins.
 	for _, header := range c.apiHeaders {
 		if kv := strings.SplitN(header, "=", 2); len(kv) == 2 {
 			req.Header.Set(kv[0], kv[1])

--- a/test/framework/k8s_controlplane.go
+++ b/test/framework/k8s_controlplane.go
@@ -253,11 +253,23 @@ func (c *K8sControlPlane) retrieveAdminToken() (string, error) {
 		return "", nil
 	}
 	// Nothing writes the secret when the bootstrap is off, so without this the
-	// read below burns the whole retry budget before returning an error.
-	if bootstrap, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN"]; exist && bootstrap == "false" {
-		return "", nil
+	// read below burns the whole retry budget before returning an error. The
+	// control plane parses this with strconv.ParseBool, so "0" and "False"
+	// disable it too. A deployment that turns it off through WithYamlConfig
+	// instead is not visible here.
+	if bootstrap, exist := c.cluster.opts.env["KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN"]; exist {
+		if enabled, err := strconv.ParseBool(bootstrap); err == nil && !enabled {
+			return "", nil
+		}
 	}
 	if c.cluster.opts.helmOpts["controlPlane.environment"] == "universal" {
+		// Reading the bootstrapped token is itself an admin request, and the
+		// chart pins localhostIsAdmin false on this path, so there is nothing to
+		// read unless the deployment put loopback admin back. Saying so costs
+		// nothing; asking anyway costs the whole retry budget and then fails.
+		if loopbackAdmin, _ := strconv.ParseBool(c.cluster.opts.env["KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN"]); !loopbackAdmin {
+			return "", nil
+		}
 		body, err := http_helper.HTTPDoWithRetryWithOptionsE(c.t, http_helper.HttpDoOptions{
 			Method:    "GET",
 			Url:       c.GetAPIServerAddress() + "/global-secrets/admin-user-token",
@@ -389,14 +401,18 @@ func (c *K8sControlPlane) InspectEnvoyProxy(inspectPath string, query url.Values
 		reqURL += "?" + encoded
 	}
 
+	// Read before the deadline is armed. A cold read retries for longer than
+	// the deadline allows, and spending it here would fail the request itself
+	// with a timeout that blames the control plane.
+	token, err := c.cachedAdminToken()
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), inspectEnvoyProxyTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, err
-	}
-	token, err := c.cachedAdminToken()
 	if err != nil {
 		return nil, err
 	}

--- a/test/framework/k8s_controlplane_test.go
+++ b/test/framework/k8s_controlplane_test.go
@@ -12,15 +12,19 @@ import (
 )
 
 var _ = Describe("K8sControlPlane", func() {
-	// controlPlaneWithToken returns a control plane pointed at srv, with the
-	// admin token already resolved to token so nothing reads a secret.
+	// controlPlaneWithToken returns a control plane pointed at srv. A non-empty
+	// token is seeded into the cache; an empty one leaves the cache cold and
+	// lets retrieveAdminToken answer from the cluster options, so nothing here
+	// reads a secret either way.
 	controlPlaneWithToken := func(srv *httptest.Server, token string, apiHeaders ...string) *K8sControlPlane {
-		cp := &K8sControlPlane{
+		return &K8sControlPlane{
 			portFwd:    portforward.Tunnel{Endpoint: srv.Listener.Addr().String()},
 			apiHeaders: apiHeaders,
+			adminToken: token,
+			cluster: &K8sCluster{opts: kumaDeploymentOptions{
+				env: map[string]string{"KUMA_API_SERVER_AUTHN_TYPE": "external"},
+			}},
 		}
-		cp.adminTokenOnce.Do(func() { cp.adminToken = token })
-		return cp
 	}
 
 	Describe("retrieveAdminToken", func() {
@@ -38,6 +42,35 @@ var _ = Describe("K8sControlPlane", func() {
 			}}}
 
 			Expect(cp.retrieveAdminToken()).To(BeEmpty())
+		})
+	})
+
+	Describe("parseAPIHeaders", func() {
+		It("should keep a value that contains the separator", func() {
+			Expect(parseAPIHeaders([]string{"Authorization=Bearer abc=="})).
+				To(Equal(map[string]string{"Authorization": "Bearer abc=="}))
+		})
+
+		It("should skip an entry that is not a pair", func() {
+			Expect(parseAPIHeaders([]string{"Authorization"})).To(BeEmpty())
+		})
+	})
+
+	Describe("cachedAdminToken", func() {
+		It("should keep answering when there is no token to cache", func() {
+			cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
+				env: map[string]string{"KUMA_API_SERVER_AUTHN_TYPE": "external"},
+			}}}
+
+			Expect(cp.cachedAdminToken()).To(BeEmpty())
+			Expect(cp.cachedAdminToken()).To(BeEmpty())
+		})
+
+		It("should answer from the cache once it holds a token", func() {
+			// No cluster, so a second read would panic rather than pass.
+			cp := &K8sControlPlane{adminToken: "admin-token"}
+
+			Expect(cp.cachedAdminToken()).To(Equal("admin-token"))
 		})
 	})
 

--- a/test/framework/k8s_controlplane_test.go
+++ b/test/framework/k8s_controlplane_test.go
@@ -1,0 +1,84 @@
+package framework
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kumahq/kuma/v3/test/framework/portforward"
+)
+
+var _ = Describe("K8sControlPlane", func() {
+	// controlPlaneWithToken returns a control plane pointed at srv, with the
+	// admin token already resolved to token so nothing reads a secret.
+	controlPlaneWithToken := func(srv *httptest.Server, token string, apiHeaders ...string) *K8sControlPlane {
+		cp := &K8sControlPlane{
+			portFwd:    portforward.Tunnel{Endpoint: srv.Listener.Addr().String()},
+			apiHeaders: apiHeaders,
+		}
+		cp.adminTokenOnce.Do(func() { cp.adminToken = token })
+		return cp
+	}
+
+	Describe("retrieveAdminToken", func() {
+		It("should not look for a secret when the control plane does not authenticate with tokens", func() {
+			cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
+				env: map[string]string{"KUMA_API_SERVER_AUTHN_TYPE": "external"},
+			}}}
+
+			Expect(cp.retrieveAdminToken()).To(BeEmpty())
+		})
+
+		It("should not look for a secret that is never bootstrapped", func() {
+			cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
+				env: map[string]string{"KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN": "false"},
+			}}}
+
+			Expect(cp.retrieveAdminToken()).To(BeEmpty())
+		})
+	})
+
+	Describe("InspectEnvoyProxy", func() {
+		var srv *httptest.Server
+		var seen http.Header
+
+		BeforeEach(func() {
+			seen = nil
+			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen = r.Header.Clone()
+				_, _ = w.Write([]byte("{}"))
+			}))
+			DeferCleanup(srv.Close)
+		})
+
+		It("should authenticate with the bootstrapped admin token", func() {
+			cp := controlPlaneWithToken(srv, "admin-token")
+
+			_, err := cp.InspectEnvoyProxy("/meshes/default/dataplanes/dp-1/stats", url.Values{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(seen.Get("Authorization")).To(Equal("Bearer admin-token"))
+		})
+
+		It("should send no credential when there is no token to attach", func() {
+			cp := controlPlaneWithToken(srv, "")
+
+			_, err := cp.InspectEnvoyProxy("/meshes/default/dataplanes/dp-1/stats", url.Values{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(seen).ToNot(HaveKey("Authorization"))
+		})
+
+		It("should let an explicit Authorization header win", func() {
+			cp := controlPlaneWithToken(srv, "admin-token", "Authorization=Bearer caller-token")
+
+			_, err := cp.InspectEnvoyProxy("/meshes/default/dataplanes/dp-1/stats", url.Values{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(seen.Get("Authorization")).To(Equal("Bearer caller-token"))
+		})
+	})
+})

--- a/test/framework/k8s_controlplane_test.go
+++ b/test/framework/k8s_controlplane_test.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,6 +29,23 @@ var _ = Describe("K8sControlPlane", func() {
 		}
 	}
 
+	// universalControlPlane deploys the Helm universal path, where the token is
+	// read over HTTP rather than from a Secret. env overrides the deployment
+	// options that decide whether that read is even attempted.
+	universalControlPlane := func(srv *httptest.Server, env map[string]string) *K8sControlPlane {
+		if env == nil {
+			env = map[string]string{}
+		}
+		return &K8sControlPlane{
+			t:       GinkgoT(),
+			portFwd: portforward.Tunnel{Endpoint: srv.Listener.Addr().String()},
+			cluster: &K8sCluster{opts: kumaDeploymentOptions{
+				env:      env,
+				helmOpts: map[string]string{"controlPlane.environment": "universal"},
+			}},
+		}
+	}
+
 	Describe("retrieveAdminToken", func() {
 		It("should not look for a secret when the control plane does not authenticate with tokens", func() {
 			cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
@@ -36,12 +55,30 @@ var _ = Describe("K8sControlPlane", func() {
 			Expect(cp.retrieveAdminToken()).To(BeEmpty())
 		})
 
-		It("should not look for a secret that is never bootstrapped", func() {
-			cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
-				env: map[string]string{"KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN": "false"},
-			}}}
+		DescribeTable("should not look for a secret that is never bootstrapped",
+			func(value string) {
+				cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
+					env: map[string]string{"KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN": value},
+				}}}
+
+				Expect(cp.retrieveAdminToken()).To(BeEmpty())
+			},
+			// The control plane parses this with strconv.ParseBool, so the guard
+			// has to answer to every spelling that turns the bootstrap off.
+			Entry("false", "false"),
+			Entry("False", "False"),
+			Entry("0", "0"),
+			Entry("f", "f"),
+		)
+
+		It("should not read the universal secret over a loopback that is not admin", func() {
+			var reads int
+			srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reads++ }))
+			DeferCleanup(srv.Close)
+			cp := universalControlPlane(srv, nil)
 
 			Expect(cp.retrieveAdminToken()).To(BeEmpty())
+			Expect(reads).To(BeZero())
 		})
 	})
 
@@ -66,11 +103,20 @@ var _ = Describe("K8sControlPlane", func() {
 			Expect(cp.cachedAdminToken()).To(BeEmpty())
 		})
 
-		It("should answer from the cache once it holds a token", func() {
-			// No cluster, so a second read would panic rather than pass.
-			cp := &K8sControlPlane{adminToken: "admin-token"}
+		It("should read the secret once and answer from the cache after that", func() {
+			var reads int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				reads++
+				_, _ = fmt.Fprintf(w, `{"data":%q}`, base64.StdEncoding.EncodeToString([]byte("admin-token")))
+			}))
+			DeferCleanup(srv.Close)
+			cp := universalControlPlane(srv, map[string]string{
+				"KUMA_API_SERVER_AUTHN_LOCALHOST_IS_ADMIN": "true",
+			})
 
 			Expect(cp.cachedAdminToken()).To(Equal("admin-token"))
+			Expect(cp.cachedAdminToken()).To(Equal("admin-token"))
+			Expect(reads).To(Equal(1))
 		})
 	})
 

--- a/test/framework/k8s_controlplane_test.go
+++ b/test/framework/k8s_controlplane_test.go
@@ -67,6 +67,27 @@ var _ = Describe("K8sControlPlane", func() {
 			Entry("f", "f"),
 		)
 
+		DescribeTable("should not look for a secret a yaml config turned off",
+			func(yamlConfig string) {
+				cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
+					yamlConfig: yamlConfig,
+				}}}
+
+				Expect(cp.retrieveAdminToken()).To(BeEmpty())
+			},
+			Entry("bootstrap off", "apiServer: {authn: {tokens: {bootstrapAdminToken: false}}}"),
+			Entry("another authenticator", "apiServer: {authn: {type: external}}"),
+		)
+
+		It("should let the environment override the yaml config, as the control plane does", func() {
+			cp := &K8sControlPlane{cluster: &K8sCluster{opts: kumaDeploymentOptions{
+				yamlConfig: "apiServer: {authn: {tokens: {bootstrapAdminToken: false}}}",
+				env:        map[string]string{"KUMA_API_SERVER_AUTHN_TOKENS_BOOTSTRAP_ADMIN_TOKEN": "true"},
+			}}}
+
+			Expect(cp.bootstrapsAdminToken()).To(BeTrue())
+		})
+
 		It("should not read the universal secret over a loopback that is not admin", func() {
 			var reads int
 			srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { reads++ }))

--- a/test/framework/k8s_controlplane_test.go
+++ b/test/framework/k8s_controlplane_test.go
@@ -14,10 +14,8 @@ import (
 )
 
 var _ = Describe("K8sControlPlane", func() {
-	// controlPlaneWithToken returns a control plane pointed at srv. A non-empty
-	// token is seeded into the cache; an empty one leaves the cache cold and
-	// lets retrieveAdminToken answer from the cluster options, so nothing here
-	// reads a secret either way.
+	// An empty token leaves the cache cold, and the authn type below makes
+	// retrieveAdminToken answer without reading anything.
 	controlPlaneWithToken := func(srv *httptest.Server, token string, apiHeaders ...string) *K8sControlPlane {
 		return &K8sControlPlane{
 			portFwd:    portforward.Tunnel{Endpoint: srv.Listener.Addr().String()},
@@ -29,9 +27,8 @@ var _ = Describe("K8sControlPlane", func() {
 		}
 	}
 
-	// universalControlPlane deploys the Helm universal path, where the token is
-	// read over HTTP rather than from a Secret. env overrides the deployment
-	// options that decide whether that read is even attempted.
+	// The Helm universal path reads the token over HTTP rather than from a
+	// Secret, so a server stands in for the control plane.
 	universalControlPlane := func(srv *httptest.Server, env map[string]string) *K8sControlPlane {
 		if env == nil {
 			env = map[string]string{}
@@ -63,8 +60,7 @@ var _ = Describe("K8sControlPlane", func() {
 
 				Expect(cp.retrieveAdminToken()).To(BeEmpty())
 			},
-			// The control plane parses this with strconv.ParseBool, so the guard
-			// has to answer to every spelling that turns the bootstrap off.
+			// Every spelling ParseBool reads as off.
 			Entry("false", "false"),
 			Entry("False", "False"),
 			Entry("0", "0"),


### PR DESCRIPTION
## Motivation

`K8sControlPlane.InspectEnvoyProxy` sent its request with no credential, so the inspect helpers only worked against a control plane that treats an anonymous caller as an administrator. On Kubernetes that is the tunnel's loopback identity. On a control plane that has narrowed its default `AccessRoleBinding`, or set `apiServer.authn.localhostIsAdmin: false`, the same helpers return 403 and the spec fails for a reason unrelated to what it was testing.

Everything needed was already in the file and nothing connected the two: `retrieveAdminToken` reads the bootstrapped `admin-user-token` and handles the Kubernetes and universal cases, and the inspect path already loops `apiHeaders` onto every request.

## Implementation information

- `InspectEnvoyProxy` attaches the bootstrapped admin token as a bearer, and attaches nothing when there is no token, rather than sending an empty one. `retrieveAdminToken` already answers with an empty string on a control plane that does not authenticate with tokens
- The token is set before `apiHeaders` is applied, so an explicit `Authorization` passed by the caller still wins
- The secret is read once per control plane, behind a `sync.Once`. Both known callers poll inside an `Eventually`, so a read per request would multiply the retry budget by the number of polls
- `retrieveAdminToken` also stops looking for a secret nobody writes. With `apiServer.authn.tokens.bootstrapAdminToken` false there is no secret to find, and the Kubernetes branch spent the whole retry budget discovering that on every call. This is the same shape as the existing authn-type guard beside it, and reaches the other two callers as well
- Specs cover both guards, the bearer, the empty-token case and the header precedence. They run against an `httptest` server with the token pre-resolved, so nothing in them reads a secret or needs a cluster

## Supporting documentation

Fix #18455
