### PR TITLE
chore(build): run master on GitHub-hosted runners

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -283,12 +283,13 @@ jobs:
       IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
       # Per-arch lookup (each side independent):
       #   1. fork PR                    -> free GitHub-hosted runners (security)
-      #   2. vars.RUNS_ON_MASTER_<ARCH> -> per-branch + per-arch override
-      #   3. vars.RUNS_ON_<ARCH>        -> global per-arch override
-      #   4. default                    -> the standard self-hosted Kong pool
+      #   2. master branch              -> free GitHub-hosted runners
+      #   3. vars.RUNS_ON_MASTER_<ARCH> -> per-branch + per-arch override
+      #   4. vars.RUNS_ON_<ARCH>        -> global per-arch override
+      #   5. default                    -> the standard self-hosted Kong pool
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.ref_name == 'master') && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
     secrets: inherit
   build_publish:
     permissions:


### PR DESCRIPTION
## Motivation

Following successful https://github.com/kumahq/kuma/pull/17438 move the `test` job matrix runners for **pushes to master (and workflow dispatch)** from the self-hosted Kong pool to the free GitHub-hosted pool (`ubuntu-24.04` / `ubuntu-24.04-arm`). This scopes the runner switch to master only, unlike the earlier full switch in kumahq/kuma#16333 that was reverted in kumahq/kuma#16415.

Reapplies kumahq/kuma#17475, which was reverted in kumahq/kuma#17490.

## Implementation information

Adds `github.ref_name == 'master'` to the GitHub-hosted branch of the `RUNNERS_BY_ARCH` expression in `.github/workflows/build-test-distribute.yaml`. `github.ref_name` is `master` only on push-to-master; PRs get `NNN/merge`, release branches and tags get their own names, so all other refs keep using the Kong pool. Fork PRs already run on GitHub-hosted runners. The `vars.RUNS_ON_MASTER_*` / `vars.RUNS_ON_*` overrides still apply to the non-master path.

## Supporting documentation

> Changelog: skip