### PR TITLE
ci(actions): pin mise-action to v4.3.0

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # protoc-gen-go-grpc@1.1.0 fails to resolve on mise 2026.7.17+ (jdx/mise#11469); pin until this branch moves past that version.
           version: 2026.7.16
@@ -270,7 +270,7 @@ jobs:
       # Registry layer cache (DOCKER_BUILDX_OPTS in mk/docker.mk) needs the
       # container driver; the default docker driver cannot export cache.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # protoc-gen-go-grpc@1.1.0 fails to resolve on mise 2026.7.17+ (jdx/mise#11469); pin until this branch moves past that version.
           version: 2026.7.16
@@ -414,7 +414,7 @@ jobs:
         if: ${{ fromJSON(inputs.FULL_MATRIX) }}
         run: |
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # protoc-gen-go-grpc@1.1.0 fails to resolve on mise 2026.7.17+ (jdx/mise#11469); pin until this branch moves past that version.
           version: 2026.7.16

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # Keep in sync with the other pipeline workflows' mise pin (jdx/mise#11469).
           version: 2026.7.16

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # protoc-gen-go-grpc@1.1.0 fails to resolve on mise 2026.7.17+ (jdx/mise#11469); pin until this branch moves past that version.
           version: 2026.7.16

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON_RELEASE_2_11_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -159,7 +159,7 @@ jobs:
           key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             go-build-${{ runner.os }}-
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           # protoc-gen-go-grpc@1.1.0 fails to resolve on mise 2026.7.17+ (jdx/mise#11469); pin until this branch moves past that version.
           version: 2026.7.16

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Initialize CodeQL

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: "master"
           fetch-depth: 0
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -98,7 +98,7 @@ jobs:
           repository: ${{ env.REPO }}
           ref: ${{ env.BRANCH_NAME }}
           token: ${{ steps.github-app-token.outputs.token }}
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         if: steps.parse-commands.outputs.has_command == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: "master"
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: install-kuma-ci-tools

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           ref: master
           path: repo
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: "sync docs" # loop over all the branches and generate the docs

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ matrix.branch }}
-      - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "golangci-lint,skaffold"


### PR DESCRIPTION
## Motivation

This branch pins `jdx/mise-action` at v2.2.3 while `master` runs v4.3.0. v2 and v3 ship as Node 20 actions, a runtime GitHub Actions has deprecated. Each action version also computes its mise cache key differently, so the repo carries a separate several-hundred-MB mise cache per branch variant against a 10 GB repo-wide cache limit, which drives LRU eviction and cold tool installs on branches that changed nothing.

## Implementation information

Mechanical swap of every `jdx/mise-action@<sha>` reference under `.github/` to `c2a87611a18de5b3828c5652fe268e992400cb5c` (v4.3.0), matching `master`. No action inputs change: pinned `version:` values and `MISE_DISABLE_TOOLS` settings stay exactly as they are.

The upgrade is behaviour-neutral on this branch. `mise.toml` has no `[env]` block, so the env export added in v3.0.0 does nothing, and there is no `mise.lock`, so the automatic `--locked` install added in v4.1.0 does nothing. v4.1.0 adds the runner image to the default cache key, so expect one cold `mise install` per workflow on the first run after merge.

## Supporting documentation

- v4.0.0 is a Node 20 to Node 24 runtime bump with no configuration changes: https://github.com/jdx/mise-action/releases/tag/v4.0.0
- v4.1.0 scopes the cache key per runner image and notes the one-time miss: https://github.com/jdx/mise-action/releases/tag/v4.1.0
- Full release history: https://github.com/jdx/mise-action/releases

> Changelog: skip