### PR TITLE
ci(build): diagnose container structure test failure on master

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -296,6 +296,25 @@ jobs:
           make images/${{ matrix.image }} PREBUILT_BINARIES=true DOCKER_BUILDX_CACHE=true
       - run: |
           make docker/save/${{ matrix.image }}
+      - name: DEBUG inspect built image
+        run: |
+          IMG="${{ inputs.REGISTRY }}/${{ matrix.image }}:${{ inputs.VERSION_NAME }}-amd64"
+          echo "== docker images =="
+          docker images | grep -E "${{ matrix.image }}|REPOSITORY" || true
+          echo "== image inspect (config) =="
+          docker image inspect "$IMG" --format '{{json .Config}}' || true
+          echo "== image platform =="
+          docker image inspect "$IMG" --format 'os={{.Os}} arch={{.Architecture}} variant={{.Variant}}' || true
+          echo "== ls /usr/bin via busybox (absolute entrypoint) =="
+          docker run --rm --platform linux/amd64 --entrypoint /busybox/ls "$IMG" -la /usr/bin/ || true
+          echo "== PATH + direct exec via busybox sh =="
+          docker run --rm --platform linux/amd64 --entrypoint /busybox/sh "$IMG" -c 'echo "PATH=$PATH"; ls -la /usr/bin/ | head; /usr/bin/'"${{ matrix.image }}"' version' || true
+          echo "== absolute entrypoint exec =="
+          docker run --rm --platform linux/amd64 --entrypoint "/usr/bin/${{ matrix.image }}" "$IMG" version || true
+          echo "== default entrypoint =="
+          docker run --rm --platform linux/amd64 "$IMG" version || true
+          echo "== tar contents (saved image) =="
+          tar tf "build/docker/${{ matrix.image }}-amd64.tar" | head -20 || true
       - name: Run container structure test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-container-structure-test') && !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
         run: |

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -269,6 +269,8 @@ jobs:
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       # Registry layer cache (DOCKER_BUILDX_OPTS in mk/docker.mk) needs the
       # container driver; the default docker driver cannot export cache.
+      # Diagnostic PR: no-op change to exercise build-images + container
+      # structure tests on a pull_request run (ALLOW_PUSH=false).
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -271,6 +271,7 @@ jobs:
       # container driver; the default docker driver cannot export cache.
       # Diagnostic PR: no-op change to exercise build-images + container
       # structure tests on a pull_request run (ALLOW_PUSH=false).
+      # Second commit: retrigger with ci/run-build label set.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:

--- a/tools/releases/dockerfiles/envoy.Dockerfile
+++ b/tools/releases/dockerfiles/envoy.Dockerfile
@@ -1,4 +1,4 @@
 FROM debian:13.6@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1 AS envoy
 ARG ARCH
 
-COPY /build/artifacts-linux-$ARCH/envoy/envoy /envoy
+COPY --chmod=0755 /build/artifacts-linux-$ARCH/envoy/envoy /envoy

--- a/tools/releases/dockerfiles/kuma-cni.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-cni.Dockerfile
@@ -2,8 +2,8 @@ ARG ARCH
 FROM kumahq/base-root-debian12:no-push-$ARCH
 ARG ARCH
 
-COPY /build/artifacts-linux-$ARCH/kuma-cni/kuma-cni /opt/cni/bin/kuma-cni
-COPY /build/artifacts-linux-$ARCH/install-cni/install-cni /install-cni
+COPY --chmod=0755 /build/artifacts-linux-$ARCH/kuma-cni/kuma-cni /opt/cni/bin/kuma-cni
+COPY --chmod=0755 /build/artifacts-linux-$ARCH/install-cni/install-cni /install-cni
 
 ENV PATH=$PATH:/opt/cni/bin
 

--- a/tools/releases/dockerfiles/kuma-cp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-cp.Dockerfile
@@ -2,6 +2,6 @@ ARG ARCH
 FROM kumahq/static-debian12:no-push-$ARCH
 ARG ARCH
 
-COPY /build/artifacts-linux-${ARCH}/kuma-cp/kuma-cp /usr/bin
+COPY --chmod=0755 /build/artifacts-linux-${ARCH}/kuma-cp/kuma-cp /usr/bin
 
 ENTRYPOINT ["/usr/bin/kuma-cp"]

--- a/tools/releases/dockerfiles/kuma-dp.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-dp.Dockerfile
@@ -3,7 +3,7 @@ FROM kumahq/envoy:no-push-$ARCH AS envoy
 FROM kumahq/base-nossl-debian12:no-push-$ARCH
 ARG ARCH
 
-COPY /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp \
+COPY --chmod=0755 /build/artifacts-linux-$ARCH/kuma-dp/kuma-dp \
     /usr/bin/
 
 COPY --from=envoy /envoy /usr/bin/envoy

--- a/tools/releases/dockerfiles/kuma-init.Dockerfile
+++ b/tools/releases/dockerfiles/kuma-init.Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/k8s-staging-build-image/distroless-iptables:v0.9.6@sha256:33f27a340efd1f0a0341bd85755f1752af00b27debaf2f2876a3ef5dcc07f84a
 ARG ARCH
 
-COPY /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
+COPY --chmod=0755 /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin
 
 # this will be from a base image once it is done
 COPY /tools/releases/templates/LICENSE \

--- a/tools/releases/dockerfiles/kumactl.Dockerfile
+++ b/tools/releases/dockerfiles/kumactl.Dockerfile
@@ -4,6 +4,6 @@ ARG ARCH
 
 # override NOTICE
 COPY /tools/releases/templates/NOTICE /kuma/NOTICE
-COPY /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin/
+COPY --chmod=0755 /build/artifacts-linux-$ARCH/kumactl/kumactl /usr/bin/
 
 ENTRYPOINT ["/usr/bin/kumactl"]


### PR DESCRIPTION
Diagnostic PR — do not merge.

Master build_publish fails deterministically since fe5e8c185: all 5 build-images legs fail the container structure test with `exec: "<binary>": executable file not found in $PATH` (runc, at container create).

The structure test was skipped on the PRs that introduced the new build path (#18454), so the first real exercise was the master push. This PR exercises the same path on a pull_request run (ALLOW_PUSH=false, FULL_MATRIX=false) to determine whether the failure is push-context-specific.

Local reproduction attempts (all pass): exact command sequence, both arches, save/load round-trip, container-structure-test 1.22.1, and a dind environment matching the runner exactly (Docker 28.0.4, buildx 0.36.1, containerd 2.3.5, runc 1.4.3, overlay2). Base image config digest is bit-identical between CI and local builds.

> Changelog: skip