### PR TITLE
ci(backport): stop inventing a file the branch never had

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -154,16 +154,31 @@ jobs:
             echo "Cherry-picked without conflicts!"
           else
             echo "LABELS=${BASE_LABELS},conflict" >> "$GITHUB_ENV"
+            # A path the target branch does not have, modified by the commit,
+            # cannot be resolved by staging it: that writes a whole file this
+            # branch never carried, and the result reads like a real backport.
+            DROPPED=$(git status --porcelain | awk '$1 == "DU" || $1 == "UD" { print $2 }')
             {
               echo "DIFF<<EOF"
               echo ":warning: :warning: :warning: Conflicts happened when cherry-picking! :warning: :warning: :warning:"
               echo '```'
               git status
               echo '```'
+              if [[ -n "${DROPPED}" ]]; then
+                echo ":x: These paths do not exist on \`${TARGET_BRANCH}\`, so they were left out rather than created from the source branch. Decide where the change belongs here:"
+                echo '```'
+                echo "${DROPPED}"
+                echo '```'
+              fi
               echo "EOF"
             } >> "$GITHUB_ENV"
+            if [[ -n "${DROPPED}" ]]; then
+              echo "${DROPPED}" | xargs git rm -q -f --
+            fi
             git add .
-            git cherry-pick --continue
+            # Dropping every conflicted path can leave nothing to commit, and an
+            # empty draft still has to reach review.
+            git -c core.editor=true cherry-pick --continue || git commit --allow-empty --no-edit
           fi
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:


### PR DESCRIPTION
## Motivation

A cherry-pick that touches a file the target branch does not have stops with that path in `DU` - deleted by us, modified by them. `git add .` resolves it by staging what is in the worktree, which for a `DU` is the source branch's entire file.

The backport then arrives carrying a whole document the branch never had, with no conflict markers in it, so it reads like a real backport. A file that only exists from a recent release is the usual shape: backporting a change to it opens pull requests against older branches that create the file from scratch, carrying instructions written for a much later version onto branches that predate every one of them.

## Implementation information

- A `DU` or `UD` path is left out instead of staged, and named in the pull request body, so someone decides where the change belongs on that branch. The label and the draft state are unchanged: this case was already a conflict
- Dropping every conflicted path can leave nothing to commit, and `cherry-pick --continue` refuses an empty result. It falls back to an empty commit so the draft still opens - an empty backport that has to be looked at is the honest outcome, and silently opening nothing is not
- Five cases exercised against real repositories: a path missing on the target is dropped and named; an ordinary content conflict still stages its markers exactly as before; a clean cherry-pick is untouched; dropping every path still opens a draft with an unchanged tree; and the same input on the current code reproduces the fabricated file
