### PR TITLE
fix(api-server): inline REST for non-proto specs

### DIFF
--- a/pkg/core/resources/model/rest/unversioned/resource.go
+++ b/pkg/core/resources/model/rest/unversioned/resource.go
@@ -3,12 +3,9 @@ package unversioned
 import (
 	"encoding/json"
 
-	"google.golang.org/protobuf/proto"
-
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
-	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
 
 type Resource struct {
@@ -73,7 +70,11 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		}
 		r.Spec = newR.GetSpec()
 	}
-	if err := util_proto.FromJSON(data, r.Spec.(proto.Message)); err != nil {
+	// The inlined form puts meta and spec fields in one object, so the whole document
+	// is handed to the spec decoder and the meta keys are ignored as unknown fields.
+	// core_model.FromJSON picks the protobuf or the plain JSON decoder, which is what
+	// lets a resource whose spec is a Go struct keep this representation.
+	if err := core_model.FromJSON(data, r.Spec); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/core/resources/model/rest/unversioned/resource_test.go
+++ b/pkg/core/resources/model/rest/unversioned/resource_test.go
@@ -9,6 +9,7 @@ import (
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	meshtrust_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshtrust/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest/unversioned"
@@ -134,5 +135,38 @@ var _ = Describe("Rest Resource", func() {
 				Expect(*rs.Next).To(Equal("http://localhost:5681/meshes?offset=1"))
 			})
 		})
+	})
+})
+
+var _ = Describe("Rest Resource with a spec that is not a protobuf message", func() {
+	It("should round trip through the inlined representation, so converting a core resource away from protobuf does not move its endpoint to the nested spec form", func() {
+		// given
+		res := &unversioned.Resource{
+			Meta: v1alpha1.ResourceMeta{Type: "MeshTrust", Name: "one", Mesh: "default"},
+			Spec: &meshtrust_api.MeshTrust{
+				TrustDomain: "default.mesh.local",
+				CABundles: []meshtrust_api.CABundle{{
+					Type: meshtrust_api.PemCABundleType,
+					PEM:  &meshtrust_api.PEM{Value: "cert"},
+				}},
+			},
+		}
+
+		// when
+		bytes, err := json.Marshal(res)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(bytes)).To(ContainSubstring(`"trustDomain":"default.mesh.local"`))
+		Expect(string(bytes)).ToNot(ContainSubstring(`"spec"`))
+
+		// when
+		back := &unversioned.Resource{Spec: &meshtrust_api.MeshTrust{}}
+		err = json.Unmarshal(bytes, back)
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(back.Meta).To(Equal(res.Meta))
+		Expect(back.Spec).To(Equal(res.Spec))
 	})
 })


### PR DESCRIPTION
## Motivation

> Changelog: fix(api-server): inline REST for non-proto specs

The inlined REST representation casts every spec to a protobuf message when decoding. A resource whose spec is a plain Go struct panics there with a missing `ProtoReflect` method, so today only protobuf-backed resources can use that representation.

That is a problem for the work in ☂️ #18525, which replaces the remaining protobuf resource specs with Go structs. Without this fix, converting a core resource also forces its REST endpoint from the inlined form to the nested `spec` form, changing the response shape of `/zones`, `/zone-insights`, `/meshes` and the rest for every client already parsing them. The API break would be incidental to a refactor rather than a decision anyone made.

Marshalling already selected the encoder by type, so only the decode side assumed protobuf.

## Implementation information

The decode path now uses the same helper the rest of the resource model uses, which picks the protobuf or the plain JSON decoder based on the spec type. Both decoders ignore unknown fields, which the inlined form relies on: it puts meta and spec keys in one object and hands the whole document to the spec decoder.

Behaviour for protobuf-backed resources is unchanged, which the existing tests in this package cover.

The new test round-trips a resource whose spec is a Go struct through the inlined form. Reverting the one-line change makes it fail with the original panic.

## Supporting documentation

Prerequisite for ☂️ #18525. Landing it separately keeps the API-shape question out of the conversion PRs, where it would be easy to miss.
