### PR TITLE
ci(actions): pin mise version

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -157,6 +157,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: dist-tarballs-*
@@ -272,6 +274,8 @@ jobs:
       # container driver; the default docker driver cannot export cache.
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
       # Login must precede the build for the cache push; anonymous pulls of the
       # public cache tags work without it (PR runs).
       - name: Docker login for buildx cache push
@@ -413,6 +417,8 @@ jobs:
         run: |
           sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
       - name: package-helm-chart
         id: package-helm
         env:

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -38,6 +38,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold,aqua:stackrox/kube-linter"

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -27,6 +27,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -160,6 +160,8 @@ jobs:
           restore-keys: |
             go-build-${{ runner.os }}-
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "golangci-lint,skaffold"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -23,6 +23,8 @@ jobs:
       - id: checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Initialize CodeQL

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -18,6 +18,8 @@ jobs:
           ref: "master"
           fetch-depth: 0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -98,6 +98,8 @@ jobs:
           ref: ${{ env.BRANCH_NAME }}
           token: ${{ steps.github-app-token.outputs.token }}
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         if: steps.parse-commands.outputs.has_command == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,8 @@ jobs:
         with:
           ref: "master"
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: install-kuma-ci-tools

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -17,6 +17,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "clang-format,golangci-lint,skaffold"

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -28,6 +28,8 @@ jobs:
           ref: master
           path: repo
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: "sync docs" # loop over all the branches and generate the docs

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -39,6 +39,8 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MISE_DISABLE_TOOLS: "golangci-lint,skaffold"


### PR DESCRIPTION
## Motivation

Several `jdx/mise-action` usages on this branch have no `version` input, so the action resolves the latest mise release. The tag for a new mise version is pushed before its release assets are published, so during that window the download 404s and the job fails at setup:

```
curl -fsSL https://github.com/jdx/mise/releases/download/vX/mise-vX-linux-x64.tar.zst
curl: (22) The requested URL returned error: 404
```

This is upstream jdx/mise-action#616, open with no fix. It took `release-2.13` fully red today: the same commit went green at 19:27 UTC and red at 07:42 UTC the next morning, 51 minutes after the `v2026.9.3` tag was pushed without a release. mise tags roughly daily, so this recurs.

`master`, `release-2.14` and `release-2.13` pin every usage and are unaffected. This branch is still exposed.

> Changelog: skip

## Implementation information

Pin `version: 2026.8.14` on the usages that had none, so all 15 on the branch are pinned. That version was chosen because one existing pin on this branch already uses it, as do `release-2.13` and `master`.

Pre-existing pins are left untouched: the goal is that no usage resolves "latest", not that every usage agrees on one version. Some steps on this branch still pin `2026.7.16`, which predates this change and works.

## Supporting documentation

- Upstream issue: https://github.com/jdx/mise-action/issues/616
- Equivalent fix on release-2.13: #18542

https://claude.ai/code/session_01QoikWAX8GZyNKpYf43JKsW