### PR TITLE
test(meshidentity): widen multizone mTLS budgets

### DIFF
--- a/test/e2e_env/multizone/meshidentity/meshidentity.go
+++ b/test/e2e_env/multizone/meshidentity/meshidentity.go
@@ -184,7 +184,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// and
 		Eventually(func(g Gomega) {
@@ -194,7 +194,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-2"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// and
 		Eventually(func(g Gomega) {
@@ -203,7 +203,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("uni-test-server-zone-4"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// when
 		yaml := fmt.Sprintf(`
@@ -241,7 +241,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// mTLS traffic in local zone works
 		Eventually(func(g Gomega) {
@@ -251,7 +251,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-2"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// and
 		Eventually(func(g Gomega) {
@@ -260,7 +260,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("uni-test-server-zone-4"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// when
 		// added Trust from zone 1 to zone 2
@@ -284,7 +284,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-2"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// cross zone traffic works: kube-2 -> kube-1
 		Eventually(func(g Gomega) {
@@ -294,7 +294,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// cross zone traffic works: kube-2 -> uni-1
 		Eventually(func(g Gomega) {
@@ -304,7 +304,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("uni-test-server-zone-4"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// cross zone traffic works: uni-1 -> kube-1
 		Eventually(func(g Gomega) {
@@ -313,7 +313,7 @@ spec:
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		}, "1m", "1s").MustPassRepeatedly(5).Should(Succeed())
 
 		// meshmultizone works
 		Expect(client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server-mi.mzsvc.mesh.local", client.WithNumberOfRequests(50))).


### PR DESCRIPTION
## Motivation

> Changelog: skip

`MeshIdentity should access the service in the same zone using mTLS` fails intermittently in the multizone suite with a timeout whose matcher had just succeeded:

```
[FAILED] Timed out after 30.001s.
There is no failure as the matcher passed to Eventually succeeded on its most recent iteration
```

Gomega only reports that when the deadline expires on an iteration that passed. The checks poll with `MustPassRepeatedly(5)`, so they need five consecutive successes inside a single 30 second deadline, and every iteration is a `kube` pod exec across zones followed by a one second interval. Five clean rounds already consume most of the budget, so a few slow requests exhaust it mid-streak even though traffic is working. The proxies are fine; the assertion runs out of time counting.

The universal suites keep 30 seconds for the same shape because `docker exec` there is sub-second. In multizone, Producer and MeshTimeout already allow a minute for it.

Seen on https://github.com/kumahq/kuma/actions/runs/34207329194/job/102001329871, one failure out of 232 specs.

## Implementation information

The ten checks in the multizone MeshIdentity spec move from 30 seconds to a minute. The poll interval, the repeat count and the assertions are unchanged, so the test still requires five consecutive successes and still fails if traffic is genuinely broken.

Nothing else in the suite changes. `meshtls` and `meshhttproute` carry the same shape in multizone and have not been observed failing, so they are left alone rather than widened speculatively.

## Supporting documentation

`ci/verify-stability` is set so the scheduled stability workflow reruns this until it is consistently green, which is the only way to demonstrate a flake fix.
