### PR TITLE
test(meshidentity): split converge from stability

### DIFF
--- a/test/e2e_env/multizone/meshidentity/meshidentity.go
+++ b/test/e2e_env/multizone/meshidentity/meshidentity.go
@@ -174,36 +174,27 @@ spec:
 		}
 	}
 
+	expectTraffic := func(from Cluster, destination string, instance string, opts ...client.CollectResponsesOptsFn) {
+		GinkgoHelper()
+		reachable := func(g Gomega) {
+			resp, err := client.CollectEchoResponse(from, "demo-client", destination, opts...)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(resp.Instance).To(Equal(instance))
+		}
+		Eventually(reachable, "30s", "1s").Should(Succeed())
+		Consistently(reachable, "5s", "1s").Should(Succeed())
+	}
+
 	It("should access the service in the same zone using mTLS", func() {
 		// given
 		// traffic in local zones works
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone1, "demo-client", "test-server",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone1, "test-server", "kube-test-server-zone-1", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// and
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone2, "demo-client", "test-server",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-2"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone2, "test-server", "kube-test-server-zone-2", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// and
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.UniZone1, "demo-client", "test-server.svc.mesh.local",
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("uni-test-server-zone-4"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.UniZone1, "test-server.svc.mesh.local", "uni-test-server-zone-4")
 
 		// when
 		yaml := fmt.Sprintf(`
@@ -234,33 +225,13 @@ spec:
 
 		// then
 		// mTLS traffic in local zone works
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone1, "demo-client", "test-server",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone1, "test-server", "kube-test-server-zone-1", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// mTLS traffic in local zone works
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone2, "demo-client", "test-server",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-2"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone2, "test-server", "kube-test-server-zone-2", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// and
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.UniZone1, "demo-client", "test-server.svc.mesh.local",
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("uni-test-server-zone-4"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.UniZone1, "test-server.svc.mesh.local", "uni-test-server-zone-4")
 
 		// when
 		// added Trust from zone 1 to zone 2
@@ -277,43 +248,16 @@ spec:
 		Expect(installTrustToZone(trustZone4, multizone.UniZone1.Name(), multizone.KubeZone2, true)).To(Succeed())
 
 		// cross zone traffic works: kube-1 -> kube-2
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone1, "demo-client", "test-server.meshidentity.svc.kuma-2.mesh.local",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-2"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone1, "test-server.meshidentity.svc.kuma-2.mesh.local", "kube-test-server-zone-2", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// cross zone traffic works: kube-2 -> kube-1
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone2, "demo-client", "test-server.meshidentity.svc.kuma-1.mesh.local",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone2, "test-server.meshidentity.svc.kuma-1.mesh.local", "kube-test-server-zone-1", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// cross zone traffic works: kube-2 -> uni-1
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.KubeZone2, "demo-client", "test-server.svc.kuma-4.mesh.local",
-				client.FromKubernetesPod(namespace, "demo-client"),
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("uni-test-server-zone-4"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.KubeZone2, "test-server.svc.kuma-4.mesh.local", "uni-test-server-zone-4", client.FromKubernetesPod(namespace, "demo-client"))
 
 		// cross zone traffic works: uni-1 -> kube-1
-		Eventually(func(g Gomega) {
-			resp, err := client.CollectEchoResponse(
-				multizone.UniZone1, "demo-client", "test-server.meshidentity.svc.kuma-1.mesh.local",
-			)
-			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(resp.Instance).To(Equal("kube-test-server-zone-1"))
-		}, "30s", "1s").MustPassRepeatedly(5).Should(Succeed())
+		expectTraffic(multizone.UniZone1, "test-server.meshidentity.svc.kuma-1.mesh.local", "kube-test-server-zone-1")
 
 		// meshmultizone works
 		Expect(client.CollectResponsesByInstance(multizone.UniZone1, "demo-client", "test-server-mi.mzsvc.mesh.local", client.WithNumberOfRequests(50))).


### PR DESCRIPTION
## Motivation

> Changelog: skip

`MeshIdentity should access the service in the same zone using mTLS` fails intermittently in the multizone suite, reporting a timeout whose matcher had just succeeded:

```
[FAILED] Timed out after 30.001s.
There is no failure as the matcher passed to Eventually succeeded on its most recent iteration
```

`Eventually(...).MustPassRepeatedly(5)` spends a single deadline on two different jobs: waiting for traffic to start working, and proving it keeps working. Every iteration here is a `kube` pod exec across zones, so five consecutive rounds already consume most of the 30 seconds, and whatever the route spends converging comes out of the same budget. When it runs out mid-streak the run fails even though each individual request succeeded, and the message says nothing about which route or which phase.

Raising the timeout hides this rather than fixing it, because the two budgets stay entangled and the failure stays uninformative.

Seen on https://github.com/kumahq/kuma/actions/runs/34207329194/job/102001329871, one failure out of 232 specs.

## Implementation information

`Eventually` now waits for a route to come up and `Consistently` proves it stays up, each with its own budget. Neither phase can fail for running out of room while succeeding: `Eventually` fails only if the route never works, `Consistently` only if it works and then stops.

The stability guarantee gets stronger. Five consecutive passes took as long as the requests happened to take, whereas holding for a fixed five seconds is the property these checks actually want, and it no longer varies with how slow the cluster is.

The ten checks were the same eight lines with different endpoints, so they collapse into one helper, taking 77 lines out of the spec. `GinkgoHelper` keeps a failure pointing at the route that broke rather than at the helper.

Only this spec changes. `meshtls` and `meshhttproute` share the shape in multizone and have not been observed failing, so they are left for a follow-up rather than rewritten speculatively.

## Supporting documentation

`ci/verify-stability` is set so the scheduled workflow reruns this until it is consistently green, which is the only real demonstration of a flake fix.
