### PR TITLE
feat(kuma-dp): log resolved DNS queries

### DIFF
--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -36,6 +36,7 @@ import (
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	dns_dpapi "github.com/kumahq/kuma/v3/pkg/dns/dpapi"
+	kuma_log "github.com/kumahq/kuma/v3/pkg/log"
 	meshmetric_dpapi "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/dpapi"
 	tproxy_config "github.com/kumahq/kuma/v3/pkg/transparentproxy/config"
 	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
@@ -109,6 +110,12 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			if err := config.Load("", cfg); err != nil {
 				runLog.Error(err, "unable to load configuration")
 				return err
+			}
+
+			if spec := cfg.DataplaneRuntime.ComponentLogLevel; spec != "" {
+				if err := kuma_log.ApplyComponentLevels(kuma_log.GlobalComponentLevelRegistry(), spec); err != nil {
+					return errors.Wrap(err, "invalid component log level")
+				}
 			}
 
 			var tpCfg *tproxy_dp.DataplaneConfig
@@ -441,6 +448,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 	cmd.PersistentFlags().StringToStringVarP(&cfg.DataplaneRuntime.ResourceVars, "dataplane-var", "v", map[string]string{}, "Variables to replace Dataplane template")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.EnvoyLogLevel, "envoy-log-level", "", "Envoy log level. Available values are: [trace][debug][info][warning|warn][error][critical][off]. By default it inherits Kuma DP logging level.")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.EnvoyComponentLogLevel, "envoy-component-log-level", "", "Configures Envoy's --component-log-level")
+	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.ComponentLogLevel, "component-log-level", "", "Raises the log level of individual kuma-dp components, as comma separated component:level pairs, for example \"dnsproxy:debug\"")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.Metrics.CertPath, "metrics-cert-path", cfg.DataplaneRuntime.Metrics.CertPath, "A path to the certificate for metrics listener")
 	cmd.PersistentFlags().StringVar(&cfg.DataplaneRuntime.Metrics.KeyPath, "metrics-key-path", cfg.DataplaneRuntime.Metrics.KeyPath, "A path to the certificate key for metrics listener")
 	cmd.PersistentFlags().BoolVar(&cfg.DataplaneRuntime.BindOutbounds, "bind-outbounds", cfg.DataplaneRuntime.BindOutbounds, "If true then dataplane bind outbounds to real addresses")

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -161,14 +161,16 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 		m.QueriesTotal.WithLabelValues(qtype, source).Inc()
 		m.ResponseCodesTotal.WithLabelValues(rcodeLabel(response.Rcode)).Inc()
 	}
-	log.V(1).Info("resolved query",
-		"name", name,
-		"type", qtype,
-		"rcode", rcodeLabel(response.Rcode),
-		"source", source,
-		"answers", answers(response.Answer),
-		"duration", time.Since(start),
-	)
+	if queryLog := log.V(1); queryLog.Enabled() {
+		queryLog.Info("resolved query",
+			"name", name,
+			"type", qtype,
+			"rcode", rcodeLabel(response.Rcode),
+			"source", source,
+			"answers", answers(response.Answer),
+			"duration", time.Since(start),
+		)
+	}
 	err := res.WriteMsg(response)
 	if err != nil {
 		log.Error(err, "failed to write upstreamResponse")

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -177,8 +177,11 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 	}
 }
 
-// answers renders the addresses a query resolved to, so the log line shows the
-// result and not just that a lookup happened.
+// answers renders what a query resolved to, so the log line shows the result
+// and not just that a lookup happened. Every query is logged, not only the A
+// and AAAA ones answered from the local map, so records of any type reach this.
+// Only the record data is kept: the presentation format a record renders itself
+// in repeats the name, TTL and class already on the log line.
 func answers(rrs []dns.RR) []string {
 	var out []string
 	for _, rr := range rrs {
@@ -188,7 +191,7 @@ func answers(rrs []dns.RR) []string {
 		case *dns.AAAA:
 			out = append(out, record.AAAA.String())
 		default:
-			out = append(out, rr.String())
+			out = append(out, strings.TrimPrefix(rr.String(), rr.Header().String()))
 		}
 	}
 	return out

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component.go
@@ -124,7 +124,6 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 			dnsMap := s.dnsMap.Load()
 			dnsEntry = dnsMap.AAAARecords[req.Question[0].Name]
 		}
-		log.V(1).Info("got request", "type", req.Question[0].Qtype, "name", req.Question[0].Name, "entry", dnsEntry)
 	}
 	if dnsEntry != nil {
 		response = new(dns.Msg)
@@ -148,22 +147,49 @@ func (s *Server) Handler(res dns.ResponseWriter, req *dns.Msg) {
 			m.UpstreamRequestDuration.Observe(time.Since(proxyStart).Seconds())
 		}
 	}
-	if m := s.metrics.Load(); m != nil {
-		qtype := "other"
-		source := "upstream"
-		if len(req.Question) > 0 {
-			qtype = qtypeLabel(req.Question[0].Qtype)
-			if dnsEntry != nil {
-				source = "local"
-			}
+	qtype := "other"
+	source := "upstream"
+	var name string
+	if len(req.Question) > 0 {
+		qtype = qtypeLabel(req.Question[0].Qtype)
+		name = req.Question[0].Name
+		if dnsEntry != nil {
+			source = "local"
 		}
+	}
+	if m := s.metrics.Load(); m != nil {
 		m.QueriesTotal.WithLabelValues(qtype, source).Inc()
 		m.ResponseCodesTotal.WithLabelValues(rcodeLabel(response.Rcode)).Inc()
 	}
+	log.V(1).Info("resolved query",
+		"name", name,
+		"type", qtype,
+		"rcode", rcodeLabel(response.Rcode),
+		"source", source,
+		"answers", answers(response.Answer),
+		"duration", time.Since(start),
+	)
 	err := res.WriteMsg(response)
 	if err != nil {
 		log.Error(err, "failed to write upstreamResponse")
 	}
+}
+
+// answers renders the addresses a query resolved to, so the log line shows the
+// result and not just that a lookup happened.
+func answers(rrs []dns.RR) []string {
+	var out []string
+	for _, rr := range rrs {
+		switch record := rr.(type) {
+		case *dns.A:
+			out = append(out, record.A.String())
+		case *dns.AAAA:
+			out = append(out, record.AAAA.String())
+		default:
+			out = append(out, rr.String())
+		}
+	}
+	return out
 }
 
 func (s *Server) Start(stop <-chan struct{}) error {

--- a/app/kuma-dp/pkg/dataplane/dnsproxy/component_test.go
+++ b/app/kuma-dp/pkg/dataplane/dnsproxy/component_test.go
@@ -281,4 +281,27 @@ var _ = Describe("components", func() {
 		Eventually(errCh).Should(Receive(&startErr))
 		Expect(startErr).To(HaveOccurred())
 	})
+	It("proxies a record type it does not answer from the local map", func() {
+		f := func(req *dns.Msg) (*dns.Msg, error) { //nolint:unparam
+			response := new(dns.Msg)
+			response.SetRcode(req, dns.RcodeSuccess)
+			response.Answer = []dns.RR{
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: req.Question[0].Name, Ttl: 30, Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+					Target: "other.example.com.",
+				},
+			}
+			return response, nil
+		}
+		mock.Store(&f)
+		msg := &dns.Msg{}
+		msg.SetQuestion("www.example.com.", dns.TypeCNAME)
+
+		c := new(dns.Client)
+		res, _, err := c.Exchange(msg, address)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.Rcode).To(Equal(dns.RcodeSuccess))
+		Expect(res.Answer).To(HaveLen(1))
+		Expect(res.Answer[0].(*dns.CNAME).Target).To(Equal("other.example.com."))
+	})
 })

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -210,6 +210,10 @@ type DataplaneRuntime struct {
 	// EnvoyComponentLogLevel configures Envoy's --component-log-level and uses
 	// the exact same syntax: https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
 	EnvoyComponentLogLevel string `json:"envoyComponentLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_envoy_component_log_level"`
+	// ComponentLogLevel raises the log level of individual kuma-dp components
+	// without raising it for the whole process. Comma separated component:level
+	// pairs, for example "dnsproxy:debug".
+	ComponentLogLevel string `json:"componentLogLevel,omitempty" envconfig:"kuma_dataplane_runtime_component_log_level"`
 	// Resources defines the resources for this proxy.
 	Resources DataplaneResources `json:"resources,omitempty"`
 	// Metrics defines properties of metrics

--- a/pkg/config/app/kuma-dp/config_test.go
+++ b/pkg/config/app/kuma-dp/config_test.go
@@ -28,6 +28,8 @@ var _ = Describe("Config", func() {
 		// and
 		Expect(cfg.ControlPlane.URL).To(Equal("https://kuma-control-plane.internal:5682"))
 		Expect(cfg.Dataplane.DrainTime.Duration).To(Equal(60 * time.Second))
+		Expect(cfg.DataplaneRuntime.EnvoyLogLevel).To(Equal("trace"))
+		Expect(cfg.DataplaneRuntime.ComponentLogLevel).To(Equal("dnsproxy:debug"))
 	})
 
 	Context("with modified environment variables", func() {
@@ -62,6 +64,7 @@ var _ = Describe("Config", func() {
 				"KUMA_DATAPLANE_RUNTIME_WORK_DIR":                               "/var/run/envoy",
 				"KUMA_DATAPLANE_RUNTIME_TOKEN_PATH":                             "/tmp/token",
 				"KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL":                        "trace",
+				"KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL":                    "dnsproxy:debug",
 				"KUMA_DATAPLANE_RUNTIME_DYNAMIC_CONFIGURATION_REFRESH_INTERVAL": "5s",
 				"KUMA_DNS_ENABLED":                                              "true",
 				"KUMA_DNS_PROXY_PORT":                                           "5300",
@@ -90,6 +93,7 @@ var _ = Describe("Config", func() {
 			Expect(cfg.DataplaneRuntime.WorkDir).To(Equal("/var/run/envoy"))
 			Expect(cfg.DataplaneRuntime.TokenPath).To(Equal("/tmp/token"))
 			Expect(cfg.DataplaneRuntime.EnvoyLogLevel).To(Equal("trace"))
+			Expect(cfg.DataplaneRuntime.ComponentLogLevel).To(Equal("dnsproxy:debug"))
 			Expect(cfg.DataplaneRuntime.DynamicConfiguration.RefreshInterval.Duration).To(Equal(5 * time.Second))
 			Expect(cfg.DNS.Enabled).To(BeTrue())
 			Expect(cfg.DNS.ProxyPort).To(Equal(uint32(5300)))

--- a/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
+++ b/pkg/config/app/kuma-dp/testdata/valid-config.input.yaml
@@ -12,3 +12,4 @@ dataplane:
 dataplaneRuntime:
   binaryPath: envoy.sh
   envoyLogLevel: trace
+  componentLogLevel: dnsproxy:debug

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -157,6 +157,14 @@ func SplitHierarchy(name string) []string {
 // ApplyComponentLevels sets the overrides described by a comma separated list
 // of component:level pairs, for example "dnsproxy:debug,xds.server:debug".
 func ApplyComponentLevels(r *ComponentLevelRegistry, spec string) error {
+	type componentLevel struct {
+		component string
+		level     LogLevel
+	}
+	// The spec is parsed in full before anything is applied, so one that is
+	// rejected halfway through does not leave the registry holding the
+	// overrides that preceded the bad entry.
+	var parsed []componentLevel
 	for pair := range strings.SplitSeq(spec, ",") {
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
@@ -174,7 +182,10 @@ func ApplyComponentLevels(r *ComponentLevelRegistry, spec string) error {
 		if err != nil {
 			return err
 		}
-		if err := r.SetLevel(component, level); err != nil {
+		parsed = append(parsed, componentLevel{component: component, level: level})
+	}
+	for _, cl := range parsed {
+		if err := r.SetLevel(cl.component, cl.level); err != nil {
 			return err
 		}
 	}

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -153,3 +153,30 @@ func SplitHierarchy(name string) []string {
 	}
 	return names
 }
+
+// ApplyComponentLevels sets the overrides described by a comma separated list
+// of component:level pairs, for example "dnsproxy:debug,xds.server:debug".
+func ApplyComponentLevels(r *ComponentLevelRegistry, spec string) error {
+	for pair := range strings.SplitSeq(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		component, levelName, found := strings.Cut(pair, ":")
+		if !found {
+			return fmt.Errorf("%q is not a component:level pair", pair)
+		}
+		component = strings.TrimSpace(component)
+		if err := ValidateComponentName(component); err != nil {
+			return err
+		}
+		level, err := ParseLogLevel(strings.TrimSpace(levelName))
+		if err != nil {
+			return err
+		}
+		if err := r.SetLevel(component, level); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/log/component_level.go
+++ b/pkg/log/component_level.go
@@ -80,6 +80,26 @@ func (r *ComponentLevelRegistry) SetLevel(component string, level LogLevel) erro
 	return nil
 }
 
+// SetLevels applies several overrides as one unit. Either every level is set or,
+// if the batch would exceed MaxOverrides, none of them is and the registry is
+// left as it was.
+func (r *ComponentLevelRegistry) SetLevels(levels map[string]LogLevel) error {
+	if len(levels) == 0 {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current := *r.snapshot.Load()
+	next := make(map[string]LogLevel, len(current)+len(levels))
+	maps.Copy(next, current)
+	maps.Copy(next, levels)
+	if len(next) > MaxOverrides {
+		return fmt.Errorf("maximum number of component overrides (%d) reached", MaxOverrides)
+	}
+	r.snapshot.Store(&next)
+	return nil
+}
+
 // ResetLevel removes the log level override for the given component.
 func (r *ComponentLevelRegistry) ResetLevel(component string) {
 	current := *r.snapshot.Load()
@@ -157,14 +177,10 @@ func SplitHierarchy(name string) []string {
 // ApplyComponentLevels sets the overrides described by a comma separated list
 // of component:level pairs, for example "dnsproxy:debug,xds.server:debug".
 func ApplyComponentLevels(r *ComponentLevelRegistry, spec string) error {
-	type componentLevel struct {
-		component string
-		level     LogLevel
-	}
-	// The spec is parsed in full before anything is applied, so one that is
-	// rejected halfway through does not leave the registry holding the
-	// overrides that preceded the bad entry.
-	var parsed []componentLevel
+	// The spec is parsed in full and applied as one unit, so a spec that is
+	// rejected -- whether by a malformed entry or by exceeding MaxOverrides --
+	// never leaves the registry holding the entries that preceded the failure.
+	parsed := map[string]LogLevel{}
 	for pair := range strings.SplitSeq(spec, ",") {
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
@@ -182,12 +198,7 @@ func ApplyComponentLevels(r *ComponentLevelRegistry, spec string) error {
 		if err != nil {
 			return err
 		}
-		parsed = append(parsed, componentLevel{component: component, level: level})
+		parsed[component] = level
 	}
-	for _, cl := range parsed {
-		if err := r.SetLevel(cl.component, cl.level); err != nil {
-			return err
-		}
-	}
-	return nil
+	return r.SetLevels(parsed)
 }

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -218,6 +218,8 @@ var _ = Describe("ApplyComponentLevels", func() {
 			Expect(registry.ListOverrides()).To(BeEmpty())
 		},
 		Entry("no separator", "dnsproxy"),
+		Entry("a valid pair followed by an invalid one", "dnsproxy:debug,invalid"),
+		Entry("a valid pair followed by an unknown level", "dnsproxy:debug,xds:verbose"),
 		Entry("unknown level", "dnsproxy:verbose"),
 		Entry("empty component", ":debug"),
 		Entry("invalid component name", "dns proxy:debug"),

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -210,6 +210,8 @@ var _ = Describe("ApplyComponentLevels", func() {
 			"dnsproxy": kuma_log.DebugLevel,
 		}),
 		Entry("nothing at all", "", map[string]kuma_log.LogLevel{}),
+		Entry("only separators", ",,", map[string]kuma_log.LogLevel{}),
+		Entry("only whitespace", " ", map[string]kuma_log.LogLevel{}),
 	)
 
 	DescribeTable("rejected specs",
@@ -222,6 +224,8 @@ var _ = Describe("ApplyComponentLevels", func() {
 		Entry("a valid pair followed by an unknown level", "dnsproxy:debug,xds:verbose"),
 		Entry("unknown level", "dnsproxy:verbose"),
 		Entry("empty component", ":debug"),
+		Entry("empty component and level", ":"),
+		Entry("empty level", "dnsproxy:"),
 		Entry("invalid component name", "dns proxy:debug"),
 	)
 })

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -182,3 +182,44 @@ var _ = Describe("SplitHierarchy", func() {
 		Entry("four segments", "a.b.c.d", []string{"a.b.c.d", "a.b.c", "a.b", "a"}),
 	)
 })
+
+var _ = Describe("ApplyComponentLevels", func() {
+	var registry *kuma_log.ComponentLevelRegistry
+
+	BeforeEach(func() {
+		registry = kuma_log.NewComponentLevelRegistry()
+	})
+
+	DescribeTable("valid specs",
+		func(spec string, expected map[string]kuma_log.LogLevel) {
+			Expect(kuma_log.ApplyComponentLevels(registry, spec)).To(Succeed())
+			Expect(registry.ListOverrides()).To(Equal(expected))
+		},
+		Entry("a single pair", "dnsproxy:debug", map[string]kuma_log.LogLevel{
+			"dnsproxy": kuma_log.DebugLevel,
+		}),
+		Entry("several pairs", "dnsproxy:debug,xds.server:info", map[string]kuma_log.LogLevel{
+			"dnsproxy":   kuma_log.DebugLevel,
+			"xds.server": kuma_log.InfoLevel,
+		}),
+		Entry("surrounding whitespace", " dnsproxy : debug , xds:info ", map[string]kuma_log.LogLevel{
+			"dnsproxy": kuma_log.DebugLevel,
+			"xds":      kuma_log.InfoLevel,
+		}),
+		Entry("empty entries", "dnsproxy:debug,,", map[string]kuma_log.LogLevel{
+			"dnsproxy": kuma_log.DebugLevel,
+		}),
+		Entry("nothing at all", "", map[string]kuma_log.LogLevel{}),
+	)
+
+	DescribeTable("rejected specs",
+		func(spec string) {
+			Expect(kuma_log.ApplyComponentLevels(registry, spec)).To(HaveOccurred())
+			Expect(registry.ListOverrides()).To(BeEmpty())
+		},
+		Entry("no separator", "dnsproxy"),
+		Entry("unknown level", "dnsproxy:verbose"),
+		Entry("empty component", ":debug"),
+		Entry("invalid component name", "dns proxy:debug"),
+	)
+})

--- a/pkg/log/component_level_test.go
+++ b/pkg/log/component_level_test.go
@@ -226,6 +226,15 @@ var _ = Describe("ApplyComponentLevels", func() {
 		Entry("empty component", ":debug"),
 		Entry("empty component and level", ":"),
 		Entry("empty level", "dnsproxy:"),
+		Entry("more overrides than the registry allows", tooManyOverrides()),
 		Entry("invalid component name", "dns proxy:debug"),
 	)
 })
+
+func tooManyOverrides() string {
+	pairs := make([]string, 0, kuma_log.MaxOverrides+1)
+	for i := range kuma_log.MaxOverrides + 1 {
+		pairs = append(pairs, fmt.Sprintf("c%d:debug", i))
+	}
+	return strings.Join(pairs, ",")
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -82,10 +82,9 @@ func NewLoggerTo(destWriter io.Writer, level LogLevel) logr.Logger {
 // NewLoggerToWithRegistry creates a logger writing to destWriter using the
 // given registry for per-component level overrides. The inner zap logger is
 // created at max verbosity — all level filtering is done by the sink.
+// A level of OffLevel still returns a real logger rather than a discarding one,
+// so that a per-component override can raise a single component back above it.
 func NewLoggerToWithRegistry(destWriter io.Writer, level LogLevel, registry *ComponentLevelRegistry) logr.Logger {
-	if level == OffLevel {
-		return logr.Discard()
-	}
 	baseLevel := newAtomicLogLevel(level)
 	// Inner logger at max verbosity so Info() never filters
 	innerZap := buildZapLogger(destWriter, zap.NewAtomicLevelAt(maxVerbosity), level == DebugLevel)

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -115,3 +115,26 @@ var _ = Describe("Logger", func() {
 		)
 	})
 })
+
+var _ = Describe("NewLoggerToWithRegistry", func() {
+	It("lets a component override raise logging above an off base level", func() {
+		out := &bytes.Buffer{}
+		registry := kuma_log.NewComponentLevelRegistry()
+		Expect(registry.SetLevel("dnsproxy", kuma_log.DebugLevel)).To(Succeed())
+
+		logger := kuma_log.NewLoggerToWithRegistry(out, kuma_log.OffLevel, registry)
+		logger.WithName("dnsproxy").V(1).Info("visible")
+		logger.WithName("other").Info("hidden")
+
+		Expect(out.String()).To(ContainSubstring("visible"))
+		Expect(out.String()).ToNot(ContainSubstring("hidden"))
+	})
+
+	It("stays silent at an off base level without an override", func() {
+		out := &bytes.Buffer{}
+		logger := kuma_log.NewLoggerToWithRegistry(out, kuma_log.OffLevel, kuma_log.NewComponentLevelRegistry())
+		logger.WithName("dnsproxy").Info("hidden")
+
+		Expect(out.String()).To(BeEmpty())
+	})
+})

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -307,6 +307,12 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 			Value: complogLevel,
 		}
 	}
+	if dpCompLogLevel, exist := metadata.Annotations(podAnnotations).GetString(metadata.KumaComponentLogLevel); exist {
+		envVars["KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL"] = kube_core.EnvVar{
+			Name:  "KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL",
+			Value: dpCompLogLevel,
+		}
+	}
 
 	if i.otelPipeEnabled {
 		envVars["HOST_IP"] = kube_core.EnvVar{

--- a/pkg/plugins/runtime/k8s/containers/factory_test.go
+++ b/pkg/plugins/runtime/k8s/containers/factory_test.go
@@ -9,6 +9,7 @@ import (
 
 	runtime_k8s "github.com/kumahq/kuma/v3/pkg/config/plugins/runtime/k8s"
 	config_types "github.com/kumahq/kuma/v3/pkg/config/types"
+	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 )
 
 var _ = Describe("DataplaneProxyFactory", func() {
@@ -36,6 +37,39 @@ var _ = Describe("DataplaneProxyFactory", func() {
 
 			_, ok := findEnvVar(envVars, "KUMA_DATAPLANE_RUNTIME_OTEL_ENV_ENABLED")
 			Expect(ok).To(BeFalse(), "expected KUMA_DATAPLANE_RUNTIME_OTEL_ENV_ENABLED to stay unset")
+		})
+
+		It("passes the component log level annotation to the sidecar", func() {
+			factory := &DataplaneProxyFactory{
+				ContainerConfig: runtime_k8s.DataplaneContainer{
+					DrainTime: config_types.Duration{Duration: 30 * time.Second},
+					EnvVars:   map[string]string{},
+				},
+				BuiltinDNS: runtime_k8s.BuiltinDNS{},
+			}
+			envVars, err := factory.sidecarEnvVars("default", map[string]string{
+				metadata.KumaComponentLogLevel: "dnsproxy:debug",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			envVar, ok := findEnvVar(envVars, "KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL")
+			Expect(ok).To(BeTrue(), "expected KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL to be set")
+			Expect(envVar.Value).To(Equal("dnsproxy:debug"))
+		})
+
+		It("leaves the component log level unset without the annotation", func() {
+			factory := &DataplaneProxyFactory{
+				ContainerConfig: runtime_k8s.DataplaneContainer{
+					DrainTime: config_types.Duration{Duration: 30 * time.Second},
+					EnvVars:   map[string]string{},
+				},
+				BuiltinDNS: runtime_k8s.BuiltinDNS{},
+			}
+			envVars, err := factory.sidecarEnvVars("default", nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, ok := findEnvVar(envVars, "KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL")
+			Expect(ok).To(BeFalse())
 		})
 	})
 })

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -70,6 +70,11 @@ const (
 	KumaEnvoyLogLevel          = "kuma.io/envoy-log-level"
 	KumaEnvoyComponentLogLevel = "kuma.io/envoy-component-log-level"
 
+	// KumaComponentLogLevel raises the log level of individual kuma-dp
+	// components without raising it for the whole sidecar. Comma separated
+	// component:level pairs, for example "dnsproxy:debug".
+	KumaComponentLogLevel = "kuma.io/component-log-level"
+
 	// KumaInitFirst allows to specify whether the init container should be prepended or appended to the existing
 	// list of init containers
 	KumaInitFirst = "kuma.io/init-first"


### PR DESCRIPTION
## Motivation

> Changelog: feat(kuma-dp): log resolved DNS queries, and add a per-component log level for kuma-dp

Removing CoreDNS from the data plane took `dataPlane.dnsLogging` with it, and the embedded DNS proxy never replaced the capability. #14311 asks for it back, and the use case in that thread is specific: run an app you did not write, watch the sidecar log, and see which hostnames it tries to resolve as it starts, so you can write the right `MeshExternalService` for each one.

The proxy does have one query log line today, but it cannot serve that. It fires *before* resolution, prints the query type as a raw integer (`1`, `28`), dumps the whole matched map entry, and says nothing about the outcome, so it answers "a lookup happened" rather than "what did it resolve to".

@lahabana's point on the issue was that this should ride on the general per-component logging work rather than a bespoke `dnsLogging` flag. That is what this does.

## Implementation information

**The log line moves to after resolution** and reports what actually happened: the name, the type as a label, the addresses it resolved to, the response code, whether it was answered from the local map or upstream, and how long it took. It reuses the `qtype`/`source` values the metrics block was already computing, so the two can no longer disagree.

```
resolved query  name=example.com. type=A rcode=noerror source=upstream answers=[17.0.0.1] duration=1.2ms
```

**Making it reachable needed a second piece.** The line is `V(1)`, and on Kubernetes the sidecar runs with `--log-level=info` hardcoded in the container factory, so the only way to see it was a `ContainerPatch` raising the level for the whole sidecar — debug for everything, on a proxy that is not quiet.

kuma-dp now accepts a per-component log level, wired into the `ComponentLevelRegistry` that already exists and that the control plane exposes over its diagnostics API. Every kuma-dp logger already goes through that registry, so no logging plumbing changed; only a way to populate it was missing.

It follows the path `envoy-component-log-level` already takes, one layer at a time:

- annotation `kuma.io/component-log-level`, read by the container factory
- env var `KUMA_DATAPLANE_RUNTIME_COMPONENT_LOG_LEVEL`
- flag `--component-log-level`

all taking comma-separated `component:level` pairs, so DNS logging is:

```yaml
metadata:
  annotations:
    kuma.io/component-log-level: "dnsproxy:debug"
```

An invalid value fails at startup rather than being silently ignored.

Tests cover the spec parser (including the rejected forms) and the annotation reaching the sidecar as the right env var. The log line itself is not asserted on: `dnsproxy` binds its logger at package init and the test suite replaces `core.SetLogger` with a no-op, so capturing its output would mean changing production code to inject a logger.

## Supporting documentation

Closes #14311. Part of #17812.

Also usable beyond DNS — any kuma-dp component can be raised on its own, which is the point @lahabana was making.

https://claude.ai/code/session_01FrPKyyJgkf5bmZFg3q9rPV