### PR TITLE
test(federation): fix single-shot traffic check

### DIFF
--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -119,12 +119,18 @@ func FederateKubeZoneCPToUniversalGlobal() {
 		})
 
 		It("should not break the traffic", func() {
-			Consistently(func(g Gomega) {
+			reachable := func(g Gomega) {
 				_, err := client.CollectEchoResponse(zone, "demo-client", "test-server",
 					client.FromKubernetesPod(TestNamespace, "demo-client"),
 				)
 				g.Expect(err).ToNot(HaveOccurred())
-			}, "3s", "100s").Should(Succeed())
+			}
+			// The specs above confirm the global control plane received the zone's
+			// resources, which says nothing about the zone finishing the certificate
+			// rotation that federation triggers. Wait for that, then hold, so a route
+			// that comes back and immediately drops still fails.
+			Eventually(reachable, "30s", "1s").Should(Succeed())
+			Consistently(reachable, "5s", "500ms").Should(Succeed())
 		})
 	})
 }


### PR DESCRIPTION
## Motivation

> Changelog: skip

`Federation with Universal Global should not break the traffic` fails intermittently with a `403` from the demo client, after 0.07 seconds:

```
[FAILED] Failed after 0.070s.
The function passed to Consistently failed at federation_universal.go:126 with:
  stderr: 'curl: (22) The requested URL returned error: 403'
```

The check runs `Consistently` with a three second window and a **hundred second** polling interval. Gomega runs the function once, and the window closes long before the next poll is due, so the spec samples traffic exactly once. It claims traffic survives federation while never observing continuity at all.

That single sample is also taken too early. Federation renames the zone, which rotates its SPIFFE trust domain and re-issues every certificate. The setup already anticipates this and allows both the old and the new trust domain. The two specs that run before this one only confirm the global control plane received the zone's dataplanes and policies, which says nothing about the zone finishing its rotation, so the one request can land mid-rotation and come back `403`.

Seen on https://github.com/kumahq/kuma/actions/runs/34218580354/job/102036461946.

## Implementation information

`Eventually` waits for the route to come back after the rotation, then `Consistently` holds it for five seconds at 500ms. The check goes from one sample to eleven, and a route that recovers and immediately drops again still fails.

Fixing only the interval would keep the spec sampling from the moment the previous spec ended, which is exactly the window the rotation is still in.

This does not claim federation is disruption free during the upgrade itself. Proving that needs traffic running across the helm upgrade in the setup, and this spec has never done that. The comment in the code says so, so the next reader does not mistake the assertion for a stronger guarantee than it makes.

## Supporting documentation

Found while investigating CI on #18545, which is unrelated to this spec: that change routes protobuf specs through the identical decode call and cannot produce a `403`.

`ci/verify-stability` is set so the scheduled workflow reruns this until it is consistently green.
