### PR TITLE
test(framework): raise k3d image import timeout

### DIFF
--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1614,10 +1614,10 @@ func (c *K8sCluster) CreateNode(name string, label string) error {
 
 func (c *K8sCluster) LoadImages(names ...string) error {
 	// 3 retries with 0 backoff was too tight: a single transient docker
-	// daemon hiccup blew through all attempts before recovery. Bumped to
-	// 5 attempts with 5s backoff so a brief image-import failure does
-	// not fail the whole test suite.
-	_, err := retry.DoWithRetryContextE(c.GetTesting(), context.Background(), "load images", 5, 5*time.Second, func() (string, error) {
+	// daemon hiccup blew through all attempts before recovery. 3 attempts
+	// with 5s backoff cover that without burning minutes of wall clock when
+	// the import is slow rather than broken.
+	_, err := retry.DoWithRetryContextE(c.GetTesting(), context.Background(), "load images", 2, 5*time.Second, func() (string, error) {
 		err := c.loadImages(names...)
 		return "Loaded images " + strings.Join(names, ", "), err
 	})
@@ -1636,14 +1636,18 @@ func (c *K8sCluster) loadImages(names ...string) error {
 		defaultArgs := []string{"image", "import", "-m", "direct", "-c", c.name}
 		allArgs := append(defaultArgs, fullImageNames...)
 
-		// Put a timeout of 1 minute to this command, because for some reason the command can be stuck with
+		// Bound the command, because for some reason it can get stuck with
 		// ERRO[0004] Failed to copy read stream. write unix @->/run/docker.sock: use of closed network connection
-		ctx, cancelFn := context.WithTimeout(context.Background(), 1*time.Minute)
+		// 5 minutes, because k3d streams every image into every node of the
+		// cluster serially and callers add nodes before loading images.
+		ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancelFn()
 		importCmd := exec.CommandContext(ctx, "k3d", allArgs...)
-		importCmd.Stdout = os.Stdout
-		importCmd.Stderr = os.Stderr
-		return importCmd.Run()
+		out, err := importCmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "k3d image import (images=%v): %s", fullImageNames, strings.TrimSpace(string(out)))
+		}
+		return nil
 	case KindK8sType, AwsK8sType, AzureK8sType:
 		return errors.New("loading new images to a node not available for " + string(Config.K8sType))
 	default:


### PR DESCRIPTION
## Motivation

The `Taint controller prevents race condition following a slow CNI start` e2e spec flakes with `load images unsuccessful after 5 retries` and no other detail ([example run](https://github.com/kumahq/kuma/actions/runs/34207383870/job/102001555022)).

`LoadImages` capped each `k3d image import` at 1 minute. That spec calls `CreateNode` first, so the import has to stream 4 images — including the ~1GB `kuma-universal` that `democlient` and `testserver` both run — into two nodes, serially. On a slow runner that exceeds the cap, the k3d client is killed mid-stream, and since terratest runs `maxRetries+1` attempts, all 6 hit the same deadline: node created at 09:18:38, failure at 09:25:09, which is exactly 6 × 60s + 6 × 5s of backoff. The retries could never succeed, they only added 6.5 minutes of dead wall clock.

The import itself was fine. The debug artifact shows all 4 images present on the new node — only the client got killed.

The failure was also undiagnosable: `loadImages` wired k3d output to `os.Stdout`, which Ginkgo discards for parallel processes, and returned the bare `exec` error, so the spec reported `MaxRetriesExceeded` with no cause.

## Implementation information

Timeout raised from 1 minute to 5, matching what `PreloadImages` already allows for the same operation against a single node. Attempts dropped from 6 to 3, because a blown deadline is not transient and repeating it just burns CI time. Output is now captured and wrapped into the returned error, the way `PreloadImages` does it.

## Supporting documentation

Job log and Ginkgo report from the linked run; `k3d-second-*-0` in `kuma-1-k8s-nodes.json` of the `e2e-debug--amd64-v1.35.3-k3s1-flannel-0` artifact lists the imported images.

> Changelog: skip