### PR TITLE
fix(k8s): stop dropping traffic on selector move

### DIFF
--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -395,9 +395,10 @@ runtime:
         # Redirect port for DNS
         port: 15053 # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_PORT
       # IgnoredServiceSelectorLabels defines a list ignored labels in Service selector.
-      # A Pod that matches a Service on every other label gets the Service's inbounds upfront, so its
-      # sidecar is already listening when the selector moves onto it. Which Pods actually receive traffic
-      # is decided by the MeshService selector, which still matches the full set of labels.
+      # A Pod that matches a Service on every other label gets that Service's inbounds in a ready
+      # state, so it is already an eligible endpoint when the selector moves onto it. Which Pods
+      # actually receive traffic is decided by the MeshService selector, which still matches the
+      # full set of labels.
       # It is useful when you change Service selector and expect traffic to be sent immediately.
       # An example of this is ArgoCD's BlueGreen deployment and "rollouts-pod-template-hash" selector.
       ignoredServiceSelectorLabels: [] # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -395,7 +395,9 @@ runtime:
         # Redirect port for DNS
         port: 15053 # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_PORT
       # IgnoredServiceSelectorLabels defines a list ignored labels in Service selector.
-      # If Pod matches a Service with ignored labels, but does not match it fully, it gets Ignored inbound.
+      # A Pod that matches a Service on every other label gets the Service's inbounds upfront, so its
+      # sidecar is already listening when the selector moves onto it. Which Pods actually receive traffic
+      # is decided by the MeshService selector, which still matches the full set of labels.
       # It is useful when you change Service selector and expect traffic to be sent immediately.
       # An example of this is ArgoCD's BlueGreen deployment and "rollouts-pod-template-hash" selector.
       ignoredServiceSelectorLabels: [] # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -395,9 +395,10 @@ runtime:
         # Redirect port for DNS
         port: 15053 # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_PORT
       # IgnoredServiceSelectorLabels defines a list ignored labels in Service selector.
-      # A Pod that matches a Service on every other label gets the Service's inbounds upfront, so its
-      # sidecar is already listening when the selector moves onto it. Which Pods actually receive traffic
-      # is decided by the MeshService selector, which still matches the full set of labels.
+      # A Pod that matches a Service on every other label gets that Service's inbounds in a ready
+      # state, so it is already an eligible endpoint when the selector moves onto it. Which Pods
+      # actually receive traffic is decided by the MeshService selector, which still matches the
+      # full set of labels.
       # It is useful when you change Service selector and expect traffic to be sent immediately.
       # An example of this is ArgoCD's BlueGreen deployment and "rollouts-pod-template-hash" selector.
       ignoredServiceSelectorLabels: [] # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -395,7 +395,9 @@ runtime:
         # Redirect port for DNS
         port: 15053 # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_BUILTIN_DNS_PORT
       # IgnoredServiceSelectorLabels defines a list ignored labels in Service selector.
-      # If Pod matches a Service with ignored labels, but does not match it fully, it gets Ignored inbound.
+      # A Pod that matches a Service on every other label gets the Service's inbounds upfront, so its
+      # sidecar is already listening when the selector moves onto it. Which Pods actually receive traffic
+      # is decided by the MeshService selector, which still matches the full set of labels.
       # It is useful when you change Service selector and expect traffic to be sent immediately.
       # An example of this is ArgoCD's BlueGreen deployment and "rollouts-pod-template-hash" selector.
       ignoredServiceSelectorLabels: [] # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -238,9 +238,10 @@ type Injector struct {
 	CaCertFile string     `json:"caCertFile" envconfig:"kuma_runtime_kubernetes_injector_ca_cert_file"`
 	BuiltinDNS BuiltinDNS `json:"builtinDNS"`
 	// IgnoredServiceSelectorLabels defines a list ignored labels in Service selector.
-	// A Pod that matches a Service on every other label gets the Service's inbounds upfront, so its
-	// sidecar is already listening when the selector moves onto it. Which Pods actually receive traffic
-	// is decided by the MeshService selector, which still matches the full set of labels.
+	// A Pod that matches a Service on every other label gets that Service's inbounds in a ready
+	// state, so it is already an eligible endpoint when the selector moves onto it. Which Pods
+	// actually receive traffic is decided by the MeshService selector, which still matches the
+	// full set of labels.
 	// It is useful when you change Service selector and expect traffic to be sent immediately.
 	// An example of this is ArgoCD's BlueGreen deployment and "rollouts-pod-template-hash" selector.
 	IgnoredServiceSelectorLabels []string `json:"ignoredServiceSelectorLabels" envconfig:"KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS"`

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -238,7 +238,9 @@ type Injector struct {
 	CaCertFile string     `json:"caCertFile" envconfig:"kuma_runtime_kubernetes_injector_ca_cert_file"`
 	BuiltinDNS BuiltinDNS `json:"builtinDNS"`
 	// IgnoredServiceSelectorLabels defines a list ignored labels in Service selector.
-	// If Pod matches a Service with ignored labels, but does not match it fully, it gets Ignored inbound.
+	// A Pod that matches a Service on every other label gets the Service's inbounds upfront, so its
+	// sidecar is already listening when the selector moves onto it. Which Pods actually receive traffic
+	// is decided by the MeshService selector, which still matches the full set of labels.
 	// It is useful when you change Service selector and expect traffic to be sent immediately.
 	// An example of this is ArgoCD's BlueGreen deployment and "rollouts-pod-template-hash" selector.
 	IgnoredServiceSelectorLabels []string `json:"ignoredServiceSelectorLabels" envconfig:"KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS"`

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
-	kube_labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -67,11 +66,6 @@ func (ic *InboundConverter) inboundForService(pod *kube_core.Pod, service *kube_
 
 		if !podReady(pod, container) {
 			state = mesh_proto.Dataplane_Networking_Inbound_NotReady
-			health.Ready = false
-		}
-
-		if !kube_labels.SelectorFromSet(service.Spec.Selector).Matches(kube_labels.Set(pod.Labels)) {
-			state = mesh_proto.Dataplane_Networking_Inbound_Ignored
 			health.Ready = false
 		}
 

--- a/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/inbound_converter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	kube_core "k8s.io/api/core/v1"
+	kube_labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	kube_client "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -131,7 +132,7 @@ func (ic *InboundConverter) InboundInterfacesFor(pod *kube_core.Pod, services []
 }
 
 func (ic *InboundConverter) inboundInterfacesFor(pod *kube_core.Pod, services []*kube_core.Service) []*mesh_proto.Dataplane_Networking_Inbound {
-	var ifaces []*mesh_proto.Dataplane_Networking_Inbound
+	var selecting, ignoredLabelsOnly []*kube_core.Service
 	for _, svc := range services {
 		// Services of ExternalName type should not have any selectors.
 		// Kubernetes does not validate this, so in rare cases, a service of
@@ -139,9 +140,22 @@ func (ic *InboundConverter) inboundInterfacesFor(pod *kube_core.Pod, services []
 		// happens, we would incorrectly generate inbounds including
 		// ExternalName service. We do not currently support ExternalName
 		// services, so we can safely skip them from processing.
-		if svc.Spec.Type != kube_core.ServiceTypeExternalName {
-			ifaces = append(ifaces, ic.inboundForService(pod, svc)...)
+		if svc.Spec.Type == kube_core.ServiceTypeExternalName {
+			continue
 		}
+		if kube_labels.SelectorFromSet(svc.Spec.Selector).Matches(kube_labels.Set(pod.Labels)) {
+			selecting = append(selecting, svc)
+		} else {
+			ignoredLabelsOnly = append(ignoredLabelsOnly, svc)
+		}
+	}
+
+	var ifaces []*mesh_proto.Dataplane_Networking_Inbound
+	// Services reaching this Pod only because of IgnoredServiceSelectorLabels go last:
+	// deduplicateInboundsByAddressAndPort keeps the first inbound on a port, so the protocol
+	// stays the one of the Service that currently selects the Pod.
+	for _, svc := range append(selecting, ignoredLabelsOnly...) {
+		ifaces = append(ifaces, ic.inboundForService(pod, svc)...)
 	}
 
 	if len(ifaces) == 0 {
@@ -161,8 +175,6 @@ func deduplicateInboundsByAddressAndPort(ifaces []*mesh_proto.Dataplane_Networki
 			return 3
 		case mesh_proto.Dataplane_Networking_Inbound_NotReady:
 			return 2
-		case mesh_proto.Dataplane_Networking_Inbound_Ignored:
-			return 1
 		default:
 			return 0
 		}

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -385,6 +385,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "47.services-for-pod.yaml",
 			dataplane:      "47.dataplane.yaml",
 		}),
+		// only b-preview selects the Pod, so its protocol has to win over the alphabetically
+		// earlier a-active, which reaches the Pod through ignoredServiceSelectorLabels
+		Entry("48. Two Services on one port, one matching only on the ignored label", testCase{
+			pod:            "48.pod.yaml",
+			servicesForPod: "48.services-for-pod.yaml",
+			dataplane:      "48.dataplane.yaml",
+		}),
 	)
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -378,6 +378,13 @@ var _ = Describe("PodToDataplane(..)", func() {
 			servicesForPod: "46.services-for-pod.yaml",
 			expectedErr:    `annotation "kuma.io/gateway" has wrong value "bogus"`,
 		}),
+		// the Pod reaches the converter through ignoredServiceSelectorLabels, so its inbound must be
+		// ready before the selector moves onto it. MeshService selectors decide who gets traffic.
+		Entry("47. Pod that the Service selector does not fully match gets a ready inbound", testCase{
+			pod:            "47.pod.yaml",
+			servicesForPod: "47.services-for-pod.yaml",
+			dataplane:      "47.dataplane.yaml",
+		}),
 	)
 })
 

--- a/pkg/plugins/runtime/k8s/controllers/testdata/47.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/47.dataplane.yaml
@@ -1,0 +1,18 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/display-name: example
+    kuma.io/mesh: default
+    rollouts-pod-template-hash: green
+  name: example
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health:
+        ready: true
+      name: main
+      port: 8080
+      protocol: http

--- a/pkg/plugins/runtime/k8s/controllers/testdata/47.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/47.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    rollouts-pod-template-hash: green
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 8080
+          name: main
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/47.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/47.services-for-pod.yaml
@@ -1,0 +1,13 @@
+metadata:
+  namespace: demo
+  name: example
+spec:
+  clusterIP: 192.168.0.1
+  selector:
+    app: example
+    rollouts-pod-template-hash: blue
+  ports:
+    - protocol: TCP
+      appProtocol: http
+      port: 80
+      targetPort: main

--- a/pkg/plugins/runtime/k8s/controllers/testdata/48.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/48.dataplane.yaml
@@ -1,0 +1,18 @@
+mesh: default
+metadata:
+  labels:
+    app: example
+    k8s.kuma.io/namespace: demo
+    kuma.io/display-name: example
+    kuma.io/mesh: default
+    rollouts-pod-template-hash: green
+  name: example
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+    - health:
+        ready: true
+      name: main
+      port: 8080
+      protocol: tcp

--- a/pkg/plugins/runtime/k8s/controllers/testdata/48.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/48.pod.yaml
@@ -1,0 +1,17 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    rollouts-pod-template-hash: green
+    kuma.io/sidecar-injection: enabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 8080
+          name: main
+status:
+  podIP: 192.168.0.1
+  containerStatuses:
+    - ready: true
+      started: true

--- a/pkg/plugins/runtime/k8s/controllers/testdata/48.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/48.services-for-pod.yaml
@@ -1,0 +1,26 @@
+metadata:
+  namespace: demo
+  name: a-active
+spec:
+  clusterIP: 192.168.0.2
+  selector:
+    app: example
+    rollouts-pod-template-hash: blue
+  ports:
+    - protocol: TCP
+      appProtocol: http
+      port: 80
+      targetPort: main
+---
+metadata:
+  namespace: demo
+  name: b-preview
+spec:
+  clusterIP: 192.168.0.3
+  selector:
+    app: example
+    rollouts-pod-template-hash: green
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: main


### PR DESCRIPTION
## Motivation

Moving a Kubernetes Service selector from one set of pods to another drops requests — the client gets 503s for a couple of seconds while the endpoint set changes. This is ordinary operator behaviour during a blue/green rollout. It fails `Change Service should gracefully switch to other service` on the kubernetes shard (https://github.com/kumahq/kuma/actions/runs/34202415372/job/101985248515), where the client's cluster had no host for 1.9s: `upstream_cx_none_healthy: 3`, `lb_healthy_panic: 3`. Refs #18432 — that issue also covers default deployments, which this does not fix; see below.

## Implementation information

The Service selector is encoded twice: in `MeshService.spec.selector.dataplaneLabels`, written by `kuma-mesh-service-controller`, and as the `Ignored` inbound state on each `Dataplane`, written by `kuma-pod-controller`. `fillLocalMeshServices` requires both — label match and `GetHealthyInbounds()` — so on a selector move the two encodings disagree for as long as the second controller takes, and the MeshService resolves to zero endpoints in between.

`inboundForService` re-applied a strict selector match that its own caller had already relaxed: `findMatchingServices` picks Services with `ignoredServiceSelectorLabels` stripped, and the converter then re-tested them strictly and marked the inbound `Ignored` with `health.Ready = false`. Dropping that check leaves pod readiness as the only input to inbound state. Membership is unaffected, since the MeshService selector still matches the full label set, so no pod receives traffic the Service does not select. Both Dataplanes are now identical across the selector move, `CreateOrUpdate` reports `unchanged`, and the only remaining write is the MeshService selector — one write, one snapshot, no empty endpoint set.

Ready inbounds rank equally in `deduplicateInboundsByAddressAndPort`, which keeps the first one on a port, so `inboundInterfacesFor` now orders Services that select the Pod ahead of those reaching it only through `ignoredServiceSelectorLabels`. Without that, a port served by two Services would take its protocol from whichever sorted first by name rather than from the one selecting the Pod. Case 48 pins it.

## Supporting documentation

With `ignoredServiceSelectorLabels` unset the removed branch is unreachable, so this is a no-op for default deployments — and in that configuration a gap remains, because the incoming pod has no matching inbound at all until its Dataplane is rewritten. Closing that needs outgoing endpoints to be retained past the selector move, which is a design call rather than a patch. An in-flight request can also still be reset when the old host is removed, which the default `MeshRetry` the e2e spec deletes would absorb.
