### PR TITLE
fix(labels): recompute kuma.io/zone when reading zone resources

### DIFF
--- a/pkg/core/resources/labels/enforce.go
+++ b/pkg/core/resources/labels/enforce.go
@@ -2,44 +2,58 @@ package labels
 
 import (
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 )
 
-// EnforcedReadLabels returns the control-plane-owned labels, recomputed from the
-// object's own identity instead of being read back from storage: the namespace it
-// really lives in, and the policy role that follows from that namespace and the spec.
-// A stored object can disagree with either - it predates the label, or it was written
-// while the defaulting webhook did not cover its namespace.
+// EnforcedReadLabels returns the control-plane-owned labels recomputed from the
+// object's identity rather than read back from storage: the owning zone, the
+// namespace, and the policy role. Returns nil when there is nothing to enforce.
 //
-// Returns nil when there is nothing to enforce: UnsetNamespace (Universal, and KDS
-// metas, which carry no name extensions) and the system namespace, where the stored
-// values are either legitimately mesh-wide or KDS imports whose labels record the
-// producing CP's decision.
+// Namespace and role are skipped for UnsetNamespace (Universal, KDS metas) and
+// the system namespace, where stored values are mesh-wide or KDS imports.
 func EnforcedReadLabels(
 	rd core_model.ResourceTypeDescriptor,
 	spec core_model.ResourceSpec,
-	ns Namespace,
+	stored map[string]string,
+	opts ...Option,
 ) map[string]string {
-	if ns.value == "" || ns.system {
-		return nil
+	o := NewOptions(opts...)
+	enforced := map[string]string{}
+
+	// After a zone rename stored policies keep the old kuma.io/zone while
+	// Dataplanes are rewritten, so dppSelectedByZone drops them. Origin is
+	// trusted: KDS stamps global on every import, Compute stamps zone on every
+	// local write, and matching ignores the zone label when origin is absent.
+	if o.Mode == config_core.Zone && rd.KDSFlags.Has(core_model.ProvidedByZoneFlag) &&
+		stored[mesh_proto.ResourceOriginLabel] == string(mesh_proto.ZoneResourceOrigin) {
+		enforced[mesh_proto.ZoneTag] = o.ZoneName
 	}
-	// The namespace label is always set alongside the role: a workload-owner policy
-	// without it matches no dataplane at all, since dppSelectedByNamespace requires
-	// the label to be present.
-	enforced := map[string]string{mesh_proto.KubeNamespaceTag: ns.value}
-	if rd.IsPolicy && rd.IsPluginOriginated {
-		if policy, ok := spec.(core_model.Policy); ok {
-			role, err := ComputePolicyRole(policy, ns)
-			if err != nil {
-				// Only reachable for a policy admission never validated (mixed
-				// producer and consumer items). Fall back to the narrowest role
-				// rather than returning an error: this runs on every read, and
-				// ToCoreList aborts on the first failure, so one malformed stored
-				// object would otherwise break policy matching mesh-wide.
-				role = mesh_proto.WorkloadOwnerPolicyRole
+
+	ns := o.Namespace
+	if ns.value != "" && !ns.system {
+		// The namespace label is always set alongside the role: a workload-owner policy
+		// without it matches no dataplane at all, since dppSelectedByNamespace requires
+		// the label to be present.
+		enforced[mesh_proto.KubeNamespaceTag] = ns.value
+		if rd.IsPolicy && rd.IsPluginOriginated {
+			if policy, ok := spec.(core_model.Policy); ok {
+				role, err := ComputePolicyRole(policy, ns)
+				if err != nil {
+					// Only reachable for a policy admission never validated (mixed
+					// producer and consumer items). Fall back to the narrowest role
+					// rather than returning an error: this runs on every read, and
+					// ToCoreList aborts on the first failure, so one malformed stored
+					// object would otherwise break policy matching mesh-wide.
+					role = mesh_proto.WorkloadOwnerPolicyRole
+				}
+				enforced[mesh_proto.PolicyRoleLabel] = string(role)
 			}
-			enforced[mesh_proto.PolicyRoleLabel] = string(role)
 		}
+	}
+
+	if len(enforced) == 0 {
+		return nil
 	}
 	return enforced
 }

--- a/pkg/core/resources/labels/enforce_test.go
+++ b/pkg/core/resources/labels/enforce_test.go
@@ -8,6 +8,7 @@ import (
 	kube_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	resource_labels "github.com/kumahq/kuma/v3/pkg/core/resources/labels"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
@@ -22,9 +23,10 @@ var _ = Describe("EnforcedReadLabels", func() {
 	}
 
 	type testCase struct {
-		r         core_model.Resource
-		namespace resource_labels.Namespace
-		expected  map[string]string
+		r        core_model.Resource
+		stored   map[string]string
+		opts     []resource_labels.Option
+		expected map[string]string
 	}
 
 	DescribeTable("should recompute the control-plane-owned labels",
@@ -32,7 +34,8 @@ var _ = Describe("EnforcedReadLabels", func() {
 			Expect(resource_labels.EnforcedReadLabels(
 				given.r.Descriptor(),
 				given.r.GetSpec(),
-				given.namespace,
+				given.stored,
+				given.opts...,
 			)).To(Equal(given.expected))
 		},
 		Entry("workload-owner policy in an app namespace", testCase{
@@ -40,7 +43,7 @@ var _ = Describe("EnforcedReadLabels", func() {
 				WithTargetRef(builders.TargetRefMesh()).
 				AddTo(builders.TargetRefMesh(), idleTimeout).
 				Build(),
-			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			opts: []resource_labels.Option{resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-demo", false))},
 			expected: map[string]string{
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 				mesh_proto.PolicyRoleLabel:  string(mesh_proto.ConsumerPolicyRole),
@@ -52,7 +55,7 @@ var _ = Describe("EnforcedReadLabels", func() {
 				AddRule(builders.MeshAccessLogConf().
 					AddBackends(make([]meshaccesslog_api.Backend, 0))).
 				Build(),
-			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			opts: []resource_labels.Option{resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-demo", false))},
 			expected: map[string]string{
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 				mesh_proto.PolicyRoleLabel:  string(mesh_proto.WorkloadOwnerPolicyRole),
@@ -66,7 +69,7 @@ var _ = Describe("EnforcedReadLabels", func() {
 					mesh_proto.KubeNamespaceTag: "kuma-demo",
 				}, ""), idleTimeout).
 				Build(),
-			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			opts: []resource_labels.Option{resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-demo", false))},
 			expected: map[string]string{
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 				mesh_proto.PolicyRoleLabel:  string(mesh_proto.ProducerPolicyRole),
@@ -87,7 +90,7 @@ var _ = Describe("EnforcedReadLabels", func() {
 					mesh_proto.KubeNamespaceTag: "other-ns",
 				}, ""), idleTimeout).
 				Build(),
-			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			opts: []resource_labels.Option{resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-demo", false))},
 			expected: map[string]string{
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 				mesh_proto.PolicyRoleLabel:  string(mesh_proto.WorkloadOwnerPolicyRole),
@@ -98,20 +101,109 @@ var _ = Describe("EnforcedReadLabels", func() {
 				WithTargetRef(builders.TargetRefMesh()).
 				AddTo(builders.TargetRefMesh(), idleTimeout).
 				Build(),
-			namespace: resource_labels.NewNamespace("kuma-system", true),
-			expected:  nil,
+			opts:     []resource_labels.Option{resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-system", true))},
+			expected: nil,
+		}),
+		Entry("a stale zone on a zone-originated policy is replaced", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			stored: map[string]string{
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+				mesh_proto.ZoneTag:             "default",
+			},
+			opts: []resource_labels.Option{
+				resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-system", true)),
+				resource_labels.WithMode(config_core.Zone),
+				resource_labels.WithZone("kuma-2"),
+			},
+			expected: map[string]string{
+				mesh_proto.ZoneTag: "kuma-2",
+			},
+		}),
+		Entry("the zone is enforced alongside the namespace and role", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			stored: map[string]string{
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+				mesh_proto.ZoneTag:             "default",
+			},
+			opts: []resource_labels.Option{
+				resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-demo", false)),
+				resource_labels.WithMode(config_core.Zone),
+				resource_labels.WithZone("kuma-2"),
+			},
+			expected: map[string]string{
+				mesh_proto.ZoneTag:          "kuma-2",
+				mesh_proto.KubeNamespaceTag: "kuma-demo",
+				mesh_proto.PolicyRoleLabel:  string(mesh_proto.ConsumerPolicyRole),
+			},
+		}),
+		// Global relays another zone's producer policy with its kuma.io/zone intact
+		// but origin rewritten to global; it must not be claimed by the reader.
+		Entry("a resource synced from global keeps its zone", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			stored: map[string]string{
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.GlobalResourceOrigin),
+				mesh_proto.ZoneTag:             "kuma-3",
+			},
+			opts: []resource_labels.Option{
+				resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-system", true)),
+				resource_labels.WithMode(config_core.Zone),
+				resource_labels.WithZone("kuma-2"),
+			},
+			expected: nil,
+		}),
+		Entry("a global CP does not rewrite the zone of a synced resource", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			stored: map[string]string{
+				mesh_proto.ResourceOriginLabel: string(mesh_proto.ZoneResourceOrigin),
+				mesh_proto.ZoneTag:             "kuma-2",
+			},
+			opts: []resource_labels.Option{
+				resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-system", true)),
+				resource_labels.WithMode(config_core.Global),
+				resource_labels.WithZone("default"),
+			},
+			expected: nil,
+		}),
+		// Pre-2.6 objects carry no origin; nothing verified them, and matching does
+		// not consult the zone label without an origin anyway.
+		Entry("an object with no origin is not claimed", testCase{
+			r: builders.MeshTimeout().
+				WithTargetRef(builders.TargetRefMesh()).
+				AddTo(builders.TargetRefMesh(), idleTimeout).
+				Build(),
+			stored: map[string]string{
+				mesh_proto.ZoneTag: "default",
+			},
+			opts: []resource_labels.Option{
+				resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-system", true)),
+				resource_labels.WithMode(config_core.Zone),
+				resource_labels.WithZone("kuma-2"),
+			},
+			expected: nil,
 		}),
 		Entry("nothing is enforced on Universal", testCase{
 			r: builders.MeshTimeout().
 				WithTargetRef(builders.TargetRefMesh()).
 				AddTo(builders.TargetRefMesh(), idleTimeout).
 				Build(),
-			namespace: resource_labels.UnsetNamespace,
-			expected:  nil,
+			opts:     []resource_labels.Option{resource_labels.WithNamespace(resource_labels.UnsetNamespace)},
+			expected: nil,
 		}),
 		Entry("a non-policy resource gets no role", testCase{
-			r:         meshservice_api.NewMeshServiceResource(),
-			namespace: resource_labels.NewNamespace("kuma-demo", false),
+			r:    meshservice_api.NewMeshServiceResource(),
+			opts: []resource_labels.Option{resource_labels.WithNamespace(resource_labels.NewNamespace("kuma-demo", false))},
 			expected: map[string]string{
 				mesh_proto.KubeNamespaceTag: "kuma-demo",
 			},

--- a/pkg/plugins/bootstrap/k8s/plugin.go
+++ b/pkg/plugins/bootstrap/k8s/plugin.go
@@ -111,9 +111,9 @@ func (p *plugin) BeforeBootstrap(b *core_runtime.Builder, cfg core_plugins.Plugi
 
 	b.WithExtensions(k8s_extensions.NewSecretClientContext(b.Extensions(), secretClient))
 	if expTime := b.Config().Runtime.Kubernetes.MarshalingCacheExpirationTime.Duration; expTime > 0 {
-		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewCachingConverter(expTime, systemNamespace)))
+		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewCachingConverter(expTime, systemNamespace, b.Config().Mode, b.Config().Multizone.Zone.Name)))
 	} else {
-		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewSimpleConverter(systemNamespace)))
+		b.WithExtensions(k8s_extensions.NewResourceConverterContext(b.Extensions(), k8s.NewSimpleConverter(systemNamespace, b.Config().Mode, b.Config().Multizone.Zone.Name)))
 	}
 	b.WithExtensions(k8s_extensions.NewCompositeValidatorContext(b.Extensions(), &k8s_common.CompositeValidator{}))
 	zoneName := core_metrics.ZoneNameOrMode(b.Config().Mode, b.Config().Multizone.Zone.Name)

--- a/pkg/plugins/config/k8s/store_test.go
+++ b/pkg/plugins/config/k8s/store_test.go
@@ -74,7 +74,7 @@ var _ = Describe("KubernetesStore", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		s, err = k8s.NewStore(k8sClient, ns, k8sClientScheme, k8s_resources.NewSimpleConverter("kuma-system"))
+		s, err = k8s.NewStore(k8sClient, ns, k8sClientScheme, k8s_resources.NewSimpleConverter("kuma-system", "", ""))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/plugins/resources/k8s/caching_converter.go
+++ b/pkg/plugins/resources/k8s/caching_converter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	k8s_common "github.com/kumahq/kuma/v3/pkg/plugins/common/k8s"
 	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
@@ -34,12 +35,14 @@ type cachedEntry struct {
 	labels map[string]string
 }
 
-func NewCachingConverter(expirationTime time.Duration, systemNamespace string) k8s_common.Converter {
+func NewCachingConverter(expirationTime time.Duration, systemNamespace string, mode config_core.CpMode, zoneName string) k8s_common.Converter {
 	return &cachingConverter{
 		KubeFactory: &SimpleKubeFactory{
 			KubeTypes: k8s_registry.Global(),
 		},
 		SystemNamespace: systemNamespace,
+		Mode:            mode,
+		ZoneName:        zoneName,
 		cache:           cache.New(expirationTime, time.Duration(int64(float64(expirationTime)*0.9))),
 	}
 }
@@ -82,7 +85,7 @@ func (c *cachingConverter) ToCoreResource(obj k8s_model.KubernetesObject, out co
 	if err := out.SetSpec(spec); err != nil {
 		return err
 	}
-	adapter := newMetaAdapter(obj, c.SystemNamespace, out.Descriptor(), out.GetSpec())
+	adapter := newMetaAdapter(obj, c.SystemNamespace, c.Mode, c.ZoneName, out.Descriptor(), out.GetSpec())
 	out.SetMeta(adapter)
 	if out.Descriptor().HasStatus {
 		status, err := obj.GetStatus()

--- a/pkg/plugins/resources/k8s/caching_converter_test.go
+++ b/pkg/plugins/resources/k8s/caching_converter_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("CachingConverter", func() {
 	It("should preserve status on cache hit", func() {
 		// setup
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 
 		// given - K8s Workload object with status
 		k8sWorkload := &workload_k8s.Workload{
@@ -62,7 +62,7 @@ var _ = Describe("CachingConverter", func() {
 
 	It("should preserve status even when cache hit with different status values", func() {
 		// setup
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 
 		// given - K8s Workload object with initial status
 		k8sWorkload := &workload_k8s.Workload{
@@ -104,7 +104,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should return a stable label map across repeated GetLabels calls", func() {
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 		out := workload_api.NewWorkloadResource()
 		Expect(converter.ToCoreResource(&workload_k8s.Workload{
 			APIVersion: workload_k8s.GroupVersion.String(),
@@ -130,7 +130,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should serve labels from cache for the same resourceVersion", func() {
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 		k8sWorkload := &workload_k8s.Workload{
 			APIVersion:      workload_k8s.GroupVersion.String(),
 			Kind:            "Workload",
@@ -163,7 +163,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should not corrupt the cache when consumers mutate the returned labels map", func() {
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 		k8sWorkload := &workload_k8s.Workload{
 			APIVersion:      workload_k8s.GroupVersion.String(),
 			Kind:            "Workload",
@@ -204,7 +204,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should route ToCoreList through the caching ToCoreResource", func() {
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 		list := &workload_k8s.WorkloadList{
 			APIVersion: workload_k8s.GroupVersion.String(),
 			Kind:       "WorkloadList",
@@ -240,7 +240,7 @@ var _ = Describe("CachingConverter", func() {
 	})
 
 	It("should compute fresh labels when resourceVersion changes", func() {
-		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system")
+		converter := k8s.NewCachingConverter(5*time.Minute, "kuma-system", "", "")
 		k8sWorkload := &workload_k8s.Workload{
 			APIVersion:      workload_k8s.GroupVersion.String(),
 			Kind:            "Workload",

--- a/pkg/plugins/resources/k8s/converter.go
+++ b/pkg/plugins/resources/k8s/converter.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	k8s_common "github.com/kumahq/kuma/v3/pkg/plugins/common/k8s"
 	k8s_model "github.com/kumahq/kuma/v3/pkg/plugins/resources/k8s/native/pkg/model"
@@ -14,12 +15,17 @@ var _ k8s_common.Converter = &SimpleConverter{}
 type SimpleConverter struct {
 	KubeFactory     KubeFactory
 	SystemNamespace string
+	// Mode and ZoneName identify the reading CP for labels.EnforcedReadLabels.
+	Mode     config_core.CpMode
+	ZoneName string
 }
 
-func NewSimpleConverter(systemNamespace string) k8s_common.Converter {
+func NewSimpleConverter(systemNamespace string, mode config_core.CpMode, zoneName string) k8s_common.Converter {
 	return &SimpleConverter{
 		KubeFactory:     NewSimpleKubeFactory(),
 		SystemNamespace: systemNamespace,
+		Mode:            mode,
+		ZoneName:        zoneName,
 	}
 }
 
@@ -66,7 +72,7 @@ func (c *SimpleConverter) ToCoreResource(obj k8s_model.KubernetesObject, out cor
 	if err := out.SetSpec(spec); err != nil {
 		return err
 	}
-	out.SetMeta(newMetaAdapter(obj, c.SystemNamespace, out.Descriptor(), out.GetSpec()))
+	out.SetMeta(newMetaAdapter(obj, c.SystemNamespace, c.Mode, c.ZoneName, out.Descriptor(), out.GetSpec()))
 	if out.Descriptor().HasStatus {
 		status, err := obj.GetStatus()
 		if err != nil {

--- a/pkg/plugins/resources/k8s/enforced_labels_test.go
+++ b/pkg/plugins/resources/k8s/enforced_labels_test.go
@@ -8,6 +8,7 @@ import (
 
 	common_api "github.com/kumahq/kuma/v3/api/common/v1alpha1"
 	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	workload_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/api/v1alpha1"
 	workload_k8s "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/k8s/v1alpha1"
 	k8s_common "github.com/kumahq/kuma/v3/pkg/plugins/common/k8s"
@@ -25,7 +26,7 @@ var _ = Describe("newMetaAdapter", func() {
 				Spec: &workload_api.Workload{},
 			}
 			out := workload_api.NewWorkloadResource()
-			adapter := newMetaAdapter(obj, systemNamespaceForTest, out.Descriptor(), obj.Spec)
+			adapter := newMetaAdapter(obj, systemNamespaceForTest, "", "", out.Descriptor(), obj.Spec)
 
 			Expect(adapter.GetLabels()).To(HaveKeyWithValue(v1alpha1.KubeNamespaceTag, expected))
 		},
@@ -58,7 +59,7 @@ var _ = Describe("newMetaAdapter", func() {
 		}
 		out := workload_api.NewWorkloadResource()
 
-		Expect(newMetaAdapter(obj, systemNamespaceForTest, out.Descriptor(), obj.Spec).GetLabels()).
+		Expect(newMetaAdapter(obj, systemNamespaceForTest, "", "", out.Descriptor(), obj.Spec).GetLabels()).
 			NotTo(HaveKey(v1alpha1.KubeNamespaceTag))
 	})
 })
@@ -86,8 +87,22 @@ var _ = Describe("enforced label derivation through the converters", func() {
 		return out.GetMeta().GetLabels()
 	}
 
-	simple := func() k8s_common.Converter { return NewSimpleConverter(systemNamespaceForTest) }
-	caching := func() k8s_common.Converter { return NewCachingConverter(5*time.Minute, systemNamespaceForTest) }
+	simple := func() k8s_common.Converter { return NewSimpleConverter(systemNamespaceForTest, "", "") }
+	caching := func() k8s_common.Converter { return NewCachingConverter(5*time.Minute, systemNamespaceForTest, "", "") }
+
+	simpleInZone := func(zone string) k8s_common.Converter {
+		return NewSimpleConverter(systemNamespaceForTest, config_core.Zone, zone)
+	}
+	cachingInZone := func(zone string) k8s_common.Converter {
+		return NewCachingConverter(5*time.Minute, systemNamespaceForTest, config_core.Zone, zone)
+	}
+
+	zoneOriginatedIn := func(zone string) map[string]string {
+		return map[string]string{
+			v1alpha1.ResourceOriginLabel: string(v1alpha1.ZoneResourceOrigin),
+			v1alpha1.ZoneTag:             zone,
+		}
+	}
 
 	stale := map[string]string{
 		v1alpha1.KubeNamespaceTag:    "other-ns",
@@ -131,7 +146,7 @@ var _ = Describe("enforced label derivation through the converters", func() {
 	// On a cache hit the adapter is handed the labels stored on the miss, so the
 	// derivation has to already be baked into the cached entry.
 	It("should return the derived labels on a CachingConverter cache hit", func() {
-		converter := NewCachingConverter(5*time.Minute, systemNamespaceForTest)
+		converter := NewCachingConverter(5*time.Minute, systemNamespaceForTest, "", "")
 		obj := policyIn("app-ns", stale)
 
 		miss := labelsOf(converter, obj)
@@ -141,6 +156,25 @@ var _ = Describe("enforced label derivation through the converters", func() {
 		Expect(miss).To(HaveKeyWithValue(v1alpha1.PolicyRoleLabel, string(v1alpha1.WorkloadOwnerPolicyRole)))
 		Expect(hit).To(Equal(miss))
 	})
+
+	// After a zone rename stored policies keep the old kuma.io/zone; reads must
+	// yield the current one or dppSelectedByZone drops them.
+	DescribeTable("should replace a zone label left behind by a rename",
+		func(newConverter func(zone string) k8s_common.Converter, stored map[string]string, expected string) {
+			Expect(labelsOf(newConverter("kuma-2"), policyIn(systemNamespaceForTest, stored))).
+				To(HaveKeyWithValue(v1alpha1.ZoneTag, expected))
+		},
+		Entry("SimpleConverter", simpleInZone, zoneOriginatedIn("default"), "kuma-2"),
+		Entry("CachingConverter", cachingInZone, zoneOriginatedIn("default"), "kuma-2"),
+		Entry("SimpleConverter leaves an import from global alone", simpleInZone, map[string]string{
+			v1alpha1.ResourceOriginLabel: string(v1alpha1.GlobalResourceOrigin),
+			v1alpha1.ZoneTag:             "kuma-3",
+		}, "kuma-3"),
+		Entry("CachingConverter leaves an import from global alone", cachingInZone, map[string]string{
+			v1alpha1.ResourceOriginLabel: string(v1alpha1.GlobalResourceOrigin),
+			v1alpha1.ZoneTag:             "kuma-3",
+		}, "kuma-3"),
+	)
 
 	// The same missing webhook that leaves the role label off also leaves the spec
 	// unvalidated, so a stored policy can have no spec at all. GetSpec hands back a

--- a/pkg/plugins/resources/k8s/store.go
+++ b/pkg/plugins/resources/k8s/store.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/labels"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
@@ -293,13 +294,15 @@ type KubernetesMetaAdapter struct {
 }
 
 // newMetaAdapter is the only place an adapter's labels are computed from a Kubernetes
-// object. Taking rd and spec forces every conversion path to supply what
-// labels.EnforcedReadLabels needs, so a new converter cannot silently skip the
-// read-side recomputation. newMetaAdapterWithLabels is not a second computation: it
-// only re-wraps a set this function already produced.
+// object. Taking rd, spec and the local CP's mode and zone forces every conversion path
+// to supply what labels.EnforcedReadLabels needs, so a new converter cannot silently
+// skip the read-side recomputation. newMetaAdapterWithLabels is not a second
+// computation: it only re-wraps a set this function already produced.
 func newMetaAdapter(
 	obj k8s_model.KubernetesObject,
 	systemNamespace string,
+	mode config_core.CpMode,
+	zone string,
 	rd core_model.ResourceTypeDescriptor,
 	spec core_model.ResourceSpec,
 ) *KubernetesMetaAdapter {
@@ -321,7 +324,11 @@ func newMetaAdapter(
 		computed[metadata.KumaWorkload] = workload
 	}
 	ns := labels.NewNamespace(objMeta.GetNamespace(), objMeta.GetNamespace() == systemNamespace)
-	maps.Copy(computed, labels.EnforcedReadLabels(rd, spec, ns))
+	maps.Copy(computed, labels.EnforcedReadLabels(rd, spec, computed,
+		labels.WithNamespace(ns),
+		labels.WithMode(mode),
+		labels.WithZone(zone),
+	))
 
 	return &KubernetesMetaAdapter{
 		ObjectMeta: *objMeta,

--- a/pkg/plugins/runtime/k8s/controllers/mesh_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/mesh_controller_test.go
@@ -41,14 +41,14 @@ var _ = Describe("MeshReconciler", func() {
 					return []string{string(secret.Type)}
 				}).
 			Build()
-		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter("kuma-system"))
+		store, err := k8s.NewStore(kubeClient, k8sClientScheme, k8s.NewSimpleConverter("kuma-system", "", ""))
 		Expect(err).ToNot(HaveOccurred())
 
 		// we need to bring in the actual scheme we're using so that the Mesh CRD can be hooked up as owner,
 		// otherwise we will get "no kind is registered for the type v1alpha1.Mesh in scheme"
 		scheme, err := bootstrap_k8s.NewScheme()
 		Expect(err).ToNot(HaveOccurred())
-		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, scheme, "default")
+		secretStore, err := secrets_k8s.NewStore(kubeClient, kubeClient, scheme, "default", "", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		resourceManager = resources_manager.NewResourceManager(store)

--- a/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_controller_test.go
@@ -412,13 +412,13 @@ var _ = Describe("PodReconciler", func() {
 			Scheme:        k8sClientScheme,
 			Log:           core.Log.WithName("test"),
 			PodConverter: PodConverter{
-				ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
+				ResourceConverter: k8s.NewSimpleConverter("kuma-system", "", ""),
 				Mode:              config_core.Zone,
 				Zone:              "zone-1",
 				SystemNamespace:   "kuma-system",
 			},
 			SystemNamespace:   "kuma-system",
-			ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
+			ResourceConverter: k8s.NewSimpleConverter("kuma-system", "", ""),
 		}
 	})
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("PodToDataplane(..)", func() {
 					NodeLabelsToCopy: given.nodeLabelsToCopy,
 				},
 				Zone:              "zone-1",
-				ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
+				ResourceConverter: k8s.NewSimpleConverter("kuma-system", "", ""),
 				WorkloadLabels:    given.workloadLabels,
 			}
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_status_controller_test.go
@@ -163,7 +163,7 @@ var _ = Describe("PodStatusReconciler", func() {
 			EventRecorder:     kube_events.NewFakeRecorder(10),
 			Scheme:            k8sClientScheme,
 			Log:               core.Log.WithName("test"),
-			ResourceConverter: k8s.NewSimpleConverter("kuma-system"),
+			ResourceConverter: k8s.NewSimpleConverter("kuma-system", "", ""),
 			EnvoyAdminClient: &runtime.DummyEnvoyAdminClient{
 				PostQuitCalled: &postQuitCalled,
 			},

--- a/pkg/plugins/runtime/k8s/plugin.go
+++ b/pkg/plugins/runtime/k8s/plugin.go
@@ -58,7 +58,7 @@ func (p *plugin) Customize(rt core_runtime.Runtime) error {
 
 	// Mutators and Validators convert resources from Request (not from the Store)
 	// these resources doesn't have ResourceVersion, we can't cache them
-	simpleConverter := k8s.NewSimpleConverter(rt.Config().Store.Kubernetes.SystemNamespace)
+	simpleConverter := k8s.NewSimpleConverter(rt.Config().Store.Kubernetes.SystemNamespace, rt.Config().Mode, rt.Config().Multizone.Zone.Name)
 	if err := addValidators(mgr, rt, simpleConverter); err != nil {
 		return err
 	}

--- a/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/defaulter_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Defaulter", func() {
 		func(given testCase) {
 			// given - in production both the converter and the checker read the system
 			// namespace from the same config, so they always agree
-			converter := k8s_resources.NewSimpleConverter(given.checker.SystemNamespace)
+			converter := k8s_resources.NewSimpleConverter(given.checker.SystemNamespace, "", "")
 			handler := DefaultingWebhookFor(scheme, converter, given.checker)
 
 			req := kube_admission.Request{

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -113,7 +113,7 @@ spec:
 				Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 				cfg.CaCertFile = caCertPath
 				cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, systemNamespace, nil)
+				injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system", "", ""), 9901, 9902, systemNamespace, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				// and create mesh
@@ -900,7 +900,7 @@ spec:
 			"http://kuma-control-plane.kuma-system:5681",
 			k8sClient,
 			false,
-			k8s.NewSimpleConverter("kuma-system"),
+			k8s.NewSimpleConverter("kuma-system", "", ""),
 			9901,
 			9902,
 			systemNamespace,
@@ -957,7 +957,7 @@ metadata:
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
 			cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system", "", ""), 9901, 9902, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1064,7 +1064,7 @@ metadata:
 			Expect(config.Load(filepath.Join("testdata", given.cfgFile), &cfg)).To(Succeed())
 			cfg.CaCertFile = caCertPath
 			cfg.TransparentProxyConfigMapName = tproxyConfigMapName
-			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system"), 9901, 9902, systemNamespace, nil)
+			injector, err := inject.New(cfg, "http://kuma-control-plane.kuma-system:5681", k8sClient, true, k8s.NewSimpleConverter("kuma-system", "", ""), 9901, 9902, systemNamespace, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// and create mesh
@@ -1148,7 +1148,7 @@ metadata:
 				"http://kuma-control-plane.kuma-system:5681",
 				k8sClient,
 				true,
-				k8s.NewSimpleConverter("kuma-system"),
+				k8s.NewSimpleConverter("kuma-system", "", ""),
 				9901,
 				9902,
 				systemNamespace,

--- a/pkg/plugins/runtime/k8s/webhooks/validation_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/validation_test.go
@@ -82,7 +82,7 @@ func newValidatingWebhook(mode core.CpMode, federatedZone bool) *kube_admission.
 		SystemNamespace:              "kuma-system",
 		ZoneName:                     "zone-1",
 	}
-	handler := webhooks.NewValidatingWebhook(k8s_resources.NewSimpleConverter("kuma-system"), core_registry.Global(), k8s_registry.Global(), checker)
+	handler := webhooks.NewValidatingWebhook(k8s_resources.NewSimpleConverter("kuma-system", "", ""), core_registry.Global(), k8s_registry.Global(), checker)
 	handler.InjectDecoder(kube_admission.NewDecoder(scheme))
 	return &kube_admission.Webhook{
 		Handler: handler,

--- a/pkg/plugins/secrets/k8s/plugin.go
+++ b/pkg/plugins/secrets/k8s/plugin.go
@@ -26,7 +26,7 @@ func (p *plugin) NewSecretStore(pc core_plugins.PluginContext, _ core_plugins.Pl
 	if !ok {
 		return nil, errors.Errorf("secret client hasn't been configured")
 	}
-	coreStore, err := NewStore(client, client, mgr.GetScheme(), pc.Config().Store.Kubernetes.SystemNamespace)
+	coreStore, err := NewStore(client, client, mgr.GetScheme(), pc.Config().Store.Kubernetes.SystemNamespace, pc.Config().Mode, pc.Config().Multizone.Zone.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't create k8s secret store")
 	}

--- a/pkg/plugins/secrets/k8s/store.go
+++ b/pkg/plugins/secrets/k8s/store.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
 	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
+	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	secret_model "github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_store "github.com/kumahq/kuma/v3/pkg/core/resources/store"
@@ -39,13 +40,13 @@ type KubernetesStore struct {
 	namespace string
 }
 
-func NewStore(reader kube_client.Reader, writer kube_client.Writer, scheme *runtime.Scheme, namespace string) (secret_store.SecretStore, error) {
+func NewStore(reader kube_client.Reader, writer kube_client.Writer, scheme *runtime.Scheme, namespace string, mode config_core.CpMode, zoneName string) (secret_store.SecretStore, error) {
 	return &KubernetesStore{
 		reader:             reader,
 		writer:             writer,
 		scheme:             scheme,
 		secretsConverter:   DefaultConverter(),
-		resourcesConverter: k8s.NewSimpleConverter(namespace),
+		resourcesConverter: k8s.NewSimpleConverter(namespace, mode, zoneName),
 		namespace:          namespace,
 	}, nil
 }

--- a/pkg/plugins/secrets/k8s/store_test.go
+++ b/pkg/plugins/secrets/k8s/store_test.go
@@ -81,7 +81,7 @@ var _ = Describe("KubernetesStore", func() {
 
 		// we need to bring in the actual scheme we're using so that the Mesh CRD can be hooked up as owner,
 		// otherwise we will get "no kind is registered for the type v1alpha1.Mesh in scheme"
-		s, err = k8s.NewStore(k8sClient, k8sClient, runtime.NewScheme(), ns)
+		s, err = k8s.NewStore(k8sClient, k8sClient, runtime.NewScheme(), ns, "", "")
 		Expect(err).ToNot(HaveOccurred())
 		rs = store.NewPaginationStore(s)
 	})

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -792,7 +792,7 @@ func (c *K8sCluster) DeployKuma(mode core.CpMode, opt ...KumaDeploymentOption) e
 		return err
 	}
 
-	converter := resources_k8s.NewSimpleConverter(Config.KumaNamespace)
+	converter := resources_k8s.NewSimpleConverter(Config.KumaNamespace, core.Zone, c.ZoneName())
 	for name, updateFuncs := range c.opts.meshUpdateFuncs {
 		for _, f := range updateFuncs {
 			Logf("applying update function to mesh %q", name)


### PR DESCRIPTION
## Motivation

Master is red since #18411. `Federation with Universal Global on federation [It] should not break the traffic` fails on every run with `curl: (22) The requested URL returned error: 403`, reproducibly on three consecutive master commits, while the commit before #18411 was green.

The 403 is a deny-all RBAC filter. In the debug artifacts of the failing run, the test-server's inbound listener as reconfigured at federation time carries an RBAC filter with no allow matchers at all - only `on_no_match -> DENY` - while the draining copy of the same listener still has both allow prefixes.

Federating a standalone zone renames the CP from `default` to `kuma-2`:

- the **Dataplane** is produced by a controller, so the helm upgrade restarts the CP, the Pod controller resyncs every Pod through `labels.Compute`, and `kuma.io/zone` follows the rename (`generation: 2` on the object in the dump);
- the **MeshTrafficPermission** is user-owned. Its zone label is only ever written by the defaulting admission webhook, which fires on create/update of the policy. Nothing updates it at federation, so it stays at `kuma.io/zone: default` (still `generation: 1`, original `resourceVersion`).

`dppSelectedByZone` then compares the two, sees `default != kuma-2`, and drops the policy. Every zone-originated policy stops matching every workload.

This is not specific to the test: any zone federated after it has been running standalone loses its pre-existing zone policies. #18411 did not introduce the mismatch, it removed the symmetry that hid it - the stale `kuma.io/zone` used to survive on the Dataplane too, via `setIfNotExist`, so both sides were wrong together and the comparison still passed. #18410 forces the same outcome independently, so reverting #18411 alone would not restore the old behaviour.

## Implementation information

`labels.EnforcedReadLabels` already recomputes the control-plane-owned labels on read rather than trusting storage - `k8s.kuma.io/namespace` and `kuma.io/policy-role` - precisely because a stored object can disagree with them. `kuma.io/zone` belongs in that set: the CP reading a resource it produced is the authority on its own name.

The rule is deliberately narrow. It applies only on a zone CP, only to types carrying `ProvidedByZoneFlag`, and only when the object itself records `kuma.io/origin: zone`. A resource imported over KDS keeps the value its producing CP chose, and a global CP - which is not the authority on any zone's name - recomputes nothing. Unlike the namespace and role rules it is not skipped in the system namespace, which is where mesh-wide policies such as the MTPs in the failing test live.

As with the labels already enforced there, this only affects reads. The write path goes through the adapter's raw `ObjectMeta`, so no stored object is rewritten; the stale value stays in etcd and every read of it yields the current zone.

`newMetaAdapter` takes the local CP's mode and zone so the "a new converter cannot silently skip the read-side recomputation" property the function is built around still holds; `SimpleConverter` and `cachingConverter` carry them, and the production construction sites pass `Config().Mode` / `Config().Multizone.Zone.Name`. Most of the diff is that threading - ten of the touched files are one-token test updates.

Alternative considered: relaxing `dppSelectedByZone` to treat any zone-originated resource as local when running on a zone CP. That fixes matching too, but leaves the label itself wrong everywhere it is read - API responses, `kumactl`, KDS sync to global - so recomputing the value is the better place for it.

### Known gap

Universal is still exposed. `dataplane_manager.go` restamps a Universal Dataplane's zone on federation while stored policies keep the old name, so the same mismatch exists there. The postgres and memory stores build their metas independently and have no equivalent read-side hook, so covering them is a separate change. No e2e exercises Universal federation today, which is why CI has never shown it.

## Supporting documentation

Regressed by #18411 and #18410.
