### PR TITLE
ci(actions): run master PRs on GitHub runners

### DIFF
--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -283,13 +283,15 @@ jobs:
       IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
       # Per-arch lookup (each side independent):
       #   1. fork PR                    -> free GitHub-hosted runners (security)
-      #   2. master branch              -> free GitHub-hosted runners
+      #   2. master (push, or PR targeting it) -> free GitHub-hosted runners
       #   3. vars.RUNS_ON_MASTER_<ARCH> -> per-branch + per-arch override
       #   4. vars.RUNS_ON_<ARCH>        -> global per-arch override
       #   5. default                    -> the standard self-hosted Kong pool
+      # `github.base_ref` is the PR target branch and is empty outside pull_request,
+      # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || github.ref_name == 'master') && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.base_ref || github.ref_name) == 'master') && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
     secrets: inherit
   build_publish:
     permissions:


### PR DESCRIPTION
## Motivation

Every same-repo pull request ran its test matrix on the self-hosted Kong runner pool, including PRs targeting master, which were supposed to use the free GitHub-hosted runners.

## Implementation information

The runner selection expression for `RUNNERS_BY_ARCH` checked `github.ref_name == 'master'`, but on a `pull_request` event `github.ref_name` is `<PR-number>/merge` and never equals a branch name, so only pushes to master matched and every PR fell through to the self-hosted default. The check now uses `(github.base_ref || github.ref_name) == 'master'`: `github.base_ref` is the PR target branch and is empty outside `pull_request`, so pushes and tags keep resolving through `github.ref_name`. Fork PRs are unaffected and still go to GitHub-hosted runners, and release-* branches (PRs and pushes alike) stay on the self-hosted pool.

## Supporting documentation

https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables

> Changelog: skip