### PR TITLE
test(k8s): restore sidecar label in goldens

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/testdata/47.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/47.dataplane.yaml
@@ -5,6 +5,7 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
+    kuma.io/sidecar-injection: enabled
     rollouts-pod-template-hash: green
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/48.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/48.dataplane.yaml
@@ -5,6 +5,7 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
+    kuma.io/sidecar-injection: enabled
     rollouts-pod-template-hash: green
   name: example
 spec:


### PR DESCRIPTION
## Motivation

> Changelog: skip

`master` has been red since 99783a245 on two unit specs:

```
[FAIL] PodToDataplane(..) 47. Pod that the Service selector does not fully match gets a ready inbound
[FAIL] PodToDataplane(..) 48. Two Services on one port, one matching only on the ignored label
```

The two specs arrived in #18561 while #18411 was in the tree, so their golden files were generated with reserved pod labels dropped from the computed Dataplane labels. #18566 reverted #18411 but did not regenerate them, so the goldens still expect the labels to be absent while the code now emits them.

Both input pods carry `kuma.io/sidecar-injection: enabled`, and eight other dataplane goldens already carry it through to the Dataplane, so the current output is right and only these two files are stale.

## Implementation information

The two goldens gain the `kuma.io/sidecar-injection: enabled` label. Nothing else changes: the diff is one line in each file, and the rest of the suite already passed.

```
$ go test ./pkg/plugins/runtime/k8s/controllers/
ok  github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/controllers
```

## Supporting documentation

Reproduced on a clean checkout of master before the change and verified green after. This unblocks every open PR, since the two specs fail on all of them.
