### PR TITLE
chore(deps): stop bumping kube-openapi digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -383,6 +383,23 @@
     },
     {
       "description": [
+        " Disable digest updates for k8s.io/kube-openapi. The module is untagged and tracks",
+        " kubernetes master, so digest bumps pull in changes made for the next unreleased k8s",
+        " minor. Those routinely break the build against the released k8s.io/api* stack: the",
+        " c4db2bd digest switched schemaconv to sigs.k8s.io/structured-merge-diff/v7, which no",
+        " longer type-checks against apimachinery v0.37.0 (still on v6).",
+        "",
+        " Kuma only uses kube-openapi's pkg/validation/{strfmt,validate}, so there is nothing to",
+        " gain from moving ahead of the stack. Leaving this to MVS keeps the direct require in",
+        " sync with whatever k8s.io/apimachinery pins, and it advances with the k8s.io/* bumps"
+      ],
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["k8s.io/kube-openapi"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
+    {
+      "description": [
         " Catch-all rule that applies the standard commit message format for all dependencies",
         "",
         " This rule extends the shared baseline preset to ensure consistent commit message",


### PR DESCRIPTION
## Motivation

Renovate keeps proposing `k8s.io/kube-openapi` digest bumps that cannot build. The module is untagged, so Renovate follows kubernetes master, which carries changes for the next unreleased k8s minor. https://github.com/kumahq/kuma/pull/18460 is the current example: digest `c4db2bd` switched `pkg/schemaconv` to `sigs.k8s.io/structured-merge-diff/v7`, and `k8s.io/apimachinery@v0.37.0` still compiles against v6, so `go build ./...` fails in `k8s.io/apimachinery/pkg/util/managedfields/internal` with `cannot use typeSchema.Types (variable of type []structured-merge-diff/v7/schema.TypeDef) as []structured-merge-diff/v6/schema.TypeDef`. There is no fix inside such a PR — it only becomes buildable once the whole k8s.io stack moves, and today only `v0.38.0-alpha.0` exists.

## Implementation information

Disable `digest` updates for `k8s.io/kube-openapi` in the gomod manager. Kuma only imports `pkg/validation/strfmt` and `pkg/validation/validate`, so there is nothing to gain from running ahead of the stack. The direct require now moves through MVS together with the `k8s.io/api*` bumps, which is the only point at which the new digest is actually compatible.

## Supporting documentation

- https://github.com/kumahq/kuma/pull/18460 — the failing bump this rule prevents

> Changelog: skip