### PR TITLE
fix(dashboards): use labels emitted by kuma-dp

### DIFF
--- a/dashboards/grafana/README.md
+++ b/dashboards/grafana/README.md
@@ -8,45 +8,37 @@ under `kuma-VERSION/dashboards/grafana/`.
 See [MADR-096](../../docs/madr/decisions/096-observability-dashboards.md)
 for the decision record.
 
-## Prometheus scrape jobs
+## Metric source
 
-The dashboards filter metrics by `job` label. Users must scrape Kuma
-components into matching jobs:
+Proxy metrics come from the `MeshMetric` Prometheus backend, which kuma-dp exposes on port `5670`. Every sample it emits already carries `mesh`, `zone`, `kuma_workload` and `kuma_proxy_role` (`sidecar`, `gateway`, `zone-ingress` or `zone-egress`), so the dashboards select proxies by those labels and need no relabeling beyond `pod` and `namespace`.
 
-| Job                 | Targets                                       | Used by                                  |
-|---------------------|-----------------------------------------------|------------------------------------------|
-| `kuma-control-plane`| `kuma-cp` `/metrics` (port 5680)              | Control Plane dashboard                  |
-| `kuma-dataplanes`   | Workload sidecar `/stats/prometheus` (9902)   | Service / Mesh / Workload dashboards     |
-| `kuma-zone-proxies` | Zone Ingress + Zone Egress `/stats/prometheus`| Zone Ingress / Zone Egress dashboards    |
+Only the Control Plane dashboard filters by `job`, because `kuma-cp` metrics carry no proxy labels.
 
-Example scrape config for `kuma-zone-proxies` (Kubernetes pod SD):
+| Job                  | Targets                          | Used by                                     |
+|----------------------|----------------------------------|---------------------------------------------|
+| `kuma-control-plane` | `kuma-cp` `/metrics` (port 5680) | Control Plane dashboard                     |
+| any                  | kuma-dp `/metrics` (port 5670)   | Service / Mesh / Zone Ingress / Zone Egress |
+
+Example scrape config for proxies (Kubernetes pod SD). Zone Ingress and Zone Egress are ordinary `Dataplane`s with an injected sidecar, so this one job covers them too:
 
 ```yaml
-- job_name: kuma-zone-proxies
-  metrics_path: /stats/prometheus
+- job_name: kuma-dataplanes
+  metrics_path: /metrics
   kubernetes_sd_configs:
     - role: pod
-      namespaces:
-        names: [kuma-system]
   relabel_configs:
-    - source_labels: [__meta_kubernetes_pod_label_app]
-      regex: 'kuma-.*-(ingress|egress)'
+    - source_labels: [__meta_kubernetes_pod_container_name]
+      regex: kuma-sidecar
       action: keep
-    - source_labels: [__meta_kubernetes_pod_label_app]
-      regex: 'kuma-.*-(ingress|egress)'
-      target_label: proxy
-      replacement: '$1'
+    - source_labels: [__meta_kubernetes_pod_phase]
+      regex: Running
+      action: keep
     - source_labels: [__address__]
       regex: '(.+?)(:[0-9]+)?'
       target_label: __address__
-      replacement: '${1}:9902'
+      replacement: '${1}:5670'
     - source_labels: [__meta_kubernetes_pod_name]
       target_label: pod
-    - target_label: namespace
-      replacement: kuma-system
-    - target_label: zone
-      replacement: <your-zone-name>
+    - source_labels: [__meta_kubernetes_namespace]
+      target_label: namespace
 ```
-
-The zone proxy dashboards expect the `proxy`, `pod`, `namespace`, and
-`zone` labels above to be present on every scraped sample.

--- a/dashboards/grafana/kuma-control-plane.json
+++ b/dashboards/grafana/kuma-control-plane.json
@@ -2083,7 +2083,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",zone=~\"$zone\"})",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A",
           "instant": true
@@ -2160,7 +2160,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "min by (kuma_workload) ((envoy_listener_ssl_certificate_expiration_unix_time_seconds{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",envoy_listener_address=~\"self_inbound_dp_.*\"} - time()) / 3600)",
+          "expr": "min by (kuma_workload) ((envoy_listener_ssl_certificate_expiration_unix_time_seconds{mesh=\"$mesh\",zone=~\"$zone\",envoy_listener_address=~\"self_inbound_dp_.*\"} - time()) / 3600)",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -3944,7 +3944,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, zone)",
         "hide": 0,
         "includeAll": true,
         "label": "Zone",
@@ -3953,7 +3953,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, zone)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-mesh.json
+++ b/dashboards/grafana/kuma-mesh.json
@@ -1004,7 +1004,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload, zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1060,7 +1060,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
+          "expr": "sum by (kuma_workload, zone) (rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m]))",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1116,7 +1116,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1172,7 +1172,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
+          "expr": "sum by (kuma_workload, zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
           "legendFormat": "{{kuma_workload}}",
           "refId": "A"
         }
@@ -1767,7 +1767,7 @@
                 "value": [
                   {
                     "title": "Open Workload Health",
-                    "url": "/d/kuma-service-health/kuma-service-health?var-datasource=${datasource}&var-mesh=${__data.fields.mesh}&var-zone=${__data.fields.kuma_io_zone}&var-workload=${__data.fields.kuma_workload}"
+                    "url": "/d/kuma-service-health/kuma-service-health?var-datasource=${datasource}&var-mesh=${__data.fields.mesh}&var-zone=${__data.fields.zone}&var-workload=${__data.fields.kuma_workload}"
                   }
                 ]
               }
@@ -1776,7 +1776,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "kuma_io_zone"
+              "options": "zone"
             },
             "properties": [
               {
@@ -1825,31 +1825,31 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (kuma_workload, zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "format": "table",
           "instant": true,
           "refId": "A"
         },
         {
-          "expr": "clamp_min(1 - ((sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) * 0) / sum by (kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))), 0)",
+          "expr": "clamp_min(1 - ((sum by (kuma_workload, zone) (rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or sum by (kuma_workload, zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) * 0) / sum by (kuma_workload, zone) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))), 0)",
           "format": "table",
           "instant": true,
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, kuma_io_zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, kuma_workload, zone) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "format": "table",
           "instant": true,
           "refId": "C"
         },
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_server_memory_allocated{mesh=\"$mesh\"})",
+          "expr": "sum by (kuma_workload, zone) (envoy_server_memory_allocated{mesh=\"$mesh\"})",
           "format": "table",
           "instant": true,
           "refId": "D"
         },
         {
-          "expr": "sum by (kuma_workload, kuma_io_zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
+          "expr": "sum by (kuma_workload, zone) (envoy_http_downstream_cx_active{mesh=\"$mesh\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
           "format": "table",
           "instant": true,
           "refId": "E"

--- a/dashboards/grafana/kuma-service-debug.json
+++ b/dashboards/grafana/kuma-service-debug.json
@@ -110,17 +110,17 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} total",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_http1_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_http1_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} HTTP/1.1",
           "refId": "B"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_http2_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_http2_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} HTTP/2",
           "refId": "C"
         }
@@ -246,7 +246,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix, envoy_response_code_class) (rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix, envoy_response_code_class) (rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -310,17 +310,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} p50",
           "refId": "C"
         }
@@ -396,7 +396,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -506,7 +506,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
           "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -570,12 +570,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p50",
           "refId": "B"
         }
@@ -667,12 +667,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_rbac_denied{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_rbac_denied{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} denied/s",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_rbac_denied{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_rbac_denied{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} total",
           "refId": "B"
         }
@@ -737,12 +737,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Outbound",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_listener_address) (rate(envoy_listener_ssl_handshake{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum by (envoy_listener_address) (rate(envoy_listener_ssl_handshake{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "{{envoy_listener_address}}",
           "refId": "B"
         }
@@ -808,7 +808,7 @@
       },
       "targets": [
         {
-          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"})",
           "legendFormat": "Server Cert",
           "refId": "A"
         }
@@ -917,17 +917,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Retries",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_success{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Success",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_retry_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Overflow",
           "refId": "C"
         }
@@ -1007,17 +1007,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Connect Timeout",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Request Timeout",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_max_duration_reached{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Max Duration",
           "refId": "C"
         }
@@ -1082,17 +1082,17 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_rx_reset{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} RX Reset",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_tx_reset{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} TX Reset",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Cancelled",
           "refId": "C"
         }
@@ -1189,7 +1189,7 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1279,17 +1279,17 @@
       },
       "targets": [
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} RQ",
           "refId": "A"
         },
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending",
           "refId": "B"
         },
         {
-          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "max(envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} CX",
           "refId": "C"
         }
@@ -1354,22 +1354,22 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_cx_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} CX Overflow",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending Overflow",
           "refId": "B"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_no_route{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_no_route{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "No Route",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} LB Panic",
           "refId": "D"
         }
@@ -1434,17 +1434,17 @@
       },
       "targets": [
         {
-          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_rq{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_rq{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
           "legendFormat": "{{envoy_cluster_name}} rq",
           "refId": "A"
         },
         {
-          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_cx{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_cx{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
           "legendFormat": "{{envoy_cluster_name}} cx",
           "refId": "B"
         },
         {
-          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_pending{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
+          "expr": "min by (envoy_cluster_name) (envoy_cluster_circuit_breakers_default_remaining_pending{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"})",
           "legendFormat": "{{envoy_cluster_name}} pending",
           "refId": "C"
         }
@@ -1520,7 +1520,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_http_downstream_cx_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_http_downstream_cx_active{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
           "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
@@ -1616,12 +1616,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} Remote Close",
           "refId": "C"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_destroy_local{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} Local Close",
           "refId": "D"
         }
@@ -1697,7 +1697,7 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_upstream_cx_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_cx_active{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "B"
         }
@@ -1793,12 +1793,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}} Remote Close",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) - sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_destroy_remote{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}} Local Close",
           "refId": "B"
         }
@@ -1863,12 +1863,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_connect_ms_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} Connect p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} Lifetime p99",
           "refId": "B"
         }
@@ -1945,12 +1945,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} RX",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} TX",
           "refId": "B"
         }
@@ -2015,7 +2015,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_http_downstream_rq_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (envoy_http_downstream_rq_active{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"})",
           "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "C"
         }
@@ -2092,12 +2092,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}} RX",
           "refId": "C"
         },
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}} TX",
           "refId": "D"
         }
@@ -2162,12 +2162,12 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_upstream_rq_pending_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_rq_pending_active{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Pending",
           "refId": "A"
         },
         {
-          "expr": "sum(envoy_cluster_upstream_rq_active{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_upstream_rq_active{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}} Active",
           "refId": "B"
         }
@@ -2231,12 +2231,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_cluster_upstream_rq_per_cx_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\",envoy_cluster_name!~\"localhost_.*|kuma_.*|self_.*|system_.*\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p50",
           "refId": "B"
         }
@@ -2323,7 +2323,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(kuma_dp_dns_request_duration_seconds_count{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})))",
+          "expr": "sum(rate(kuma_dp_dns_request_duration_seconds_count{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"})))",
           "legendFormat": "total",
           "refId": "A"
         }
@@ -2398,22 +2398,22 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(kuma_dp_dns_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(kuma_dp_dns_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
           "legendFormat": "local p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(kuma_dp_dns_upstream_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(kuma_dp_dns_upstream_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
           "legendFormat": "upstream p99",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(kuma_dp_dns_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(kuma_dp_dns_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
           "legendFormat": "local p50",
           "refId": "C"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(kuma_dp_dns_upstream_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(kuma_dp_dns_upstream_request_duration_seconds_bucket{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}))) by (le))",
           "legendFormat": "upstream p50",
           "refId": "D"
         }
@@ -2487,7 +2487,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (qtype, source) (rate(kuma_dp_dns_queries_total{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})))",
+          "expr": "sum by (qtype, source) (rate(kuma_dp_dns_queries_total{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"})))",
           "legendFormat": "{{qtype}} / {{source}}",
           "refId": "A"
         }
@@ -2591,7 +2591,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (rcode) (rate(kuma_dp_dns_response_codes_total{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})))",
+          "expr": "sum by (rcode) (rate(kuma_dp_dns_response_codes_total{mesh=\"$mesh\"}[5m]) * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"})))",
           "legendFormat": "{{rcode}}",
           "refId": "A"
         }
@@ -2660,7 +2660,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (pod) (kuma_dp_dns_entries_total{mesh=\"$mesh\"} * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"})))",
+          "expr": "sum by (pod) (kuma_dp_dns_entries_total{mesh=\"$mesh\"} * on(pod) group_left() (max by (pod) (envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"})))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2730,7 +2730,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "envoy_server_memory_allocated{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_memory_allocated{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2793,7 +2793,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "envoy_server_uptime{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_uptime{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -2849,7 +2849,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(envoy_control_plane_ds_handshake_bucket{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\",kuma_workload=\"$workload\"}[5m])))",
           "legendFormat": "p99",
           "refId": "A"
         }
@@ -2910,7 +2910,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, zone)",
         "hide": 0,
         "includeAll": true,
         "label": "Zone",
@@ -2919,7 +2919,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, zone)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2934,7 +2934,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, namespace)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -2944,7 +2944,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, namespace)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2959,7 +2959,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\"}, kuma_workload)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\"}, kuma_workload)",
         "hide": 0,
         "includeAll": false,
         "label": "Workload",
@@ -2968,7 +2968,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",kuma_io_zone=~\"$zone\"}, kuma_workload)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",namespace=~\"$namespace\",zone=~\"$zone\"}, kuma_workload)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-service-health.json
+++ b/dashboards/grafana/kuma-service-health.json
@@ -102,7 +102,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / (sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) > 0), 0) or vector(100)",
+          "expr": "100 * clamp_min(1 - (sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\",envoy_response_code_class=\"5\"}[5m])) or vector(0)) / (sum(rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) > 0), 0) or vector(100)",
           "legendFormat": "Success Rate",
           "refId": "A"
         }
@@ -242,7 +242,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
@@ -297,7 +297,7 @@
       },
       "targets": [
         {
-          "expr": "count(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"})",
+          "expr": "count(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -383,7 +383,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_rq_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
@@ -518,7 +518,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
+          "expr": "sum(rate(envoy_http_downstream_rq_xx_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (envoy_response_code_class)",
           "legendFormat": "{{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -592,12 +592,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(envoy_http_downstream_rq_time_bucket{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "B"
         }
@@ -683,12 +683,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_listener_address) (envoy_listener_downstream_cx_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_listener_address=~\"self_inbound_dp_.*\"})",
+          "expr": "sum by (envoy_listener_address) (envoy_listener_downstream_cx_active{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_listener_address=~\"self_inbound_dp_.*\"})",
           "legendFormat": "{{envoy_listener_address}} active",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_listener_address) (rate(envoy_listener_downstream_cx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_listener_address=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_listener_address) (rate(envoy_listener_downstream_cx_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_listener_address=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_listener_address}} new/s",
           "refId": "B"
         }
@@ -762,22 +762,22 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_rx_bytes_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_http_downstream_cx_tx_bytes_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_http_conn_manager_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}} tx",
           "refId": "B"
         },
         {
-          "expr": "sum by (envoy_tcp_prefix) (rate(envoy_tcp_downstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_tcp_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_tcp_prefix) (rate(envoy_tcp_downstream_cx_rx_bytes_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_tcp_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_tcp_prefix}} rx (tcp)",
           "refId": "C"
         },
         {
-          "expr": "sum by (envoy_tcp_prefix) (rate(envoy_tcp_downstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_tcp_prefix=~\"self_inbound_dp_.*\"}[5m]))",
+          "expr": "sum by (envoy_tcp_prefix) (rate(envoy_tcp_downstream_cx_tx_bytes_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_tcp_prefix=~\"self_inbound_dp_.*\"}[5m]))",
           "legendFormat": "{{envoy_tcp_prefix}} tx (tcp)",
           "refId": "D"
         }
@@ -863,7 +863,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -998,7 +998,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
+          "expr": "sum(rate(envoy_cluster_upstream_rq_xx{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name, envoy_response_code_class)",
           "legendFormat": "{{envoy_cluster_name}} {{envoy_response_code_class}}xx",
           "refId": "A"
         }
@@ -1072,7 +1072,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (le, envoy_cluster_name))",
           "legendFormat": "{{envoy_cluster_name}} p99",
           "refId": "A"
         }
@@ -1158,7 +1158,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1232,12 +1232,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}} rx",
           "refId": "A"
         },
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}} tx",
           "refId": "B"
         }
@@ -1307,7 +1307,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_rbac_denied{namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum by (envoy_http_conn_manager_prefix) (rate(envoy_rbac_denied{namespace=~\"$namespace\",mesh=\"$mesh\",zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "{{envoy_http_conn_manager_prefix}}",
           "refId": "A"
         }
@@ -1363,7 +1363,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_ssl_handshake{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m]))",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1420,7 +1420,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{namespace=~\"$namespace\",mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
+          "expr": "sum by (pod) (rate(envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{namespace=~\"$namespace\",mesh=\"$mesh\",zone=~\"$zone\",kuma_workload=\"$workload\"}[5m]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1536,14 +1536,14 @@
       },
       "targets": [
         {
-          "expr": "envoy_control_plane_connected_state{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_control_plane_connected_state{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"}",
           "legendFormat": "",
           "refId": "A",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "envoy_server_uptime{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"}",
+          "expr": "envoy_server_uptime{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"}",
           "legendFormat": "",
           "refId": "B",
           "format": "table",
@@ -1578,9 +1578,9 @@
               "mesh": true,
               "mesh 1": true,
               "mesh 2": true,
-              "kuma_io_zone": true,
-              "kuma_io_zone 1": true,
-              "kuma_io_zone 2": true,
+              "zone": true,
+              "zone 1": true,
+              "zone 2": true,
               "kuma_workload": true,
               "kuma_workload 1": true,
               "kuma_workload 2": true,
@@ -1657,14 +1657,14 @@
       },
       "targets": [
         {
-          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\"})",
           "legendFormat": "",
           "refId": "A"
         }
       ],
       "title": "mTLS Cert Expiry",
       "type": "stat",
-      "description": "0 is normal \u2014 Kuma rotates mTLS certs every 24h"
+      "description": "0 is normal — Kuma rotates mTLS certs every 24h"
     },
     {
       "datasource": {
@@ -1754,7 +1754,7 @@
       },
       "targets": [
         {
-          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
+          "expr": "sum(envoy_cluster_membership_healthy{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1847,7 +1847,7 @@
       },
       "targets": [
         {
-          "expr": "clamp_max(max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"} + envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"} + envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name), 1)",
+          "expr": "clamp_max(max(envoy_cluster_circuit_breakers_default_rq_open{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"} + envoy_cluster_circuit_breakers_default_cx_open{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"} + envoy_cluster_circuit_breakers_default_rq_pending_open{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}) by (envoy_cluster_name), 1)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1924,7 +1924,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
+          "expr": "sum(rate(envoy_cluster_lb_healthy_panic{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\"$destination\"}[5m])) by (envoy_cluster_name)",
           "legendFormat": "{{envoy_cluster_name}}",
           "refId": "A"
         }
@@ -1987,7 +1987,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, zone)",
         "hide": 0,
         "includeAll": true,
         "label": "Zone",
@@ -1996,7 +1996,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, zone)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2011,7 +2011,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, namespace)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".*",
@@ -2021,7 +2021,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, namespace)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2036,7 +2036,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, kuma_workload)",
+        "definition": "label_values(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\"}, kuma_workload)",
         "hide": 0,
         "includeAll": false,
         "label": "Workload",
@@ -2045,7 +2045,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\"}, kuma_workload)",
+          "query": "label_values(envoy_server_live{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\"}, kuma_workload)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -2060,7 +2060,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+        "definition": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Destination",
@@ -2069,7 +2069,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
+          "query": "label_values(envoy_cluster_membership_total{mesh=\"$mesh\",zone=~\"$zone\",namespace=~\"$namespace\",kuma_workload=\"$workload\",envoy_cluster_name=~\".*_m?svc_.*\"}, envoy_cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-zone-egress.json
+++ b/dashboards/grafana/kuma-zone-egress.json
@@ -52,7 +52,7 @@
                 "0": {
                   "color": "red",
                   "index": 0,
-                  "text": "0 \u2014 DOWN"
+                  "text": "0 — DOWN"
                 }
               },
               "type": "value"
@@ -104,7 +104,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(envoy_control_plane_connected_state{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"})",
+          "expr": "sum(envoy_control_plane_connected_state{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "connected",
           "refId": "A"
         }
@@ -164,7 +164,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(envoy_server_uptime{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(envoy_server_uptime{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -234,7 +234,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min(envoy_server_days_until_first_cert_expiring{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "min cert expiry",
           "refId": "A"
         }
@@ -325,7 +325,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_listener_downstream_cx_active{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"})",
+          "expr": "sum (envoy_listener_downstream_cx_active{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "downstream cx (all replicas)",
           "refId": "A"
         }
@@ -417,7 +417,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "upstream req/s (all replicas)",
           "refId": "A"
         }
@@ -509,7 +509,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_server_memory_heap_size{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"})",
+          "expr": "sum (envoy_server_memory_heap_size{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "heap (all replicas)",
           "refId": "A"
         }
@@ -602,7 +602,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(envoy_control_plane_connected_state{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(envoy_control_plane_connected_state{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -692,7 +692,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(envoy_listener_downstream_cx_active{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(envoy_listener_downstream_cx_active{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -870,7 +870,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -959,7 +959,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_connect_fail{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_connect_fail{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -1051,7 +1051,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} downstream (from local proxies)",
           "refId": "A"
         },
@@ -1060,7 +1060,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} upstream (zone / external out)",
           "refId": "B"
         }
@@ -1152,7 +1152,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_tx_bytes_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_tx_bytes_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} tx",
           "refId": "A"
         },
@@ -1161,7 +1161,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_rx_bytes_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_rx_bytes_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} rx",
           "refId": "B"
         }
@@ -1252,8 +1252,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
-          "legendFormat": "{{ replica }} \u00b7 {{ envoy_cluster_name }}",
+          "expr": "label_replace(sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "legendFormat": "{{ replica }} · {{ envoy_cluster_name }}",
           "refId": "A"
         }
       ],
@@ -1341,8 +1341,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(histogram_quantile(0.95, sum by (pod, le, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_ms_bucket{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
-          "legendFormat": "{{ replica }} \u00b7 {{ envoy_cluster_name }}",
+          "expr": "label_replace(histogram_quantile(0.95, sum by (pod, le, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_ms_bucket{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "legendFormat": "{{ replica }} · {{ envoy_cluster_name }}",
           "refId": "A"
         }
       ],
@@ -1431,8 +1431,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod, envoy_cluster_name) (envoy_cluster_membership_healthy{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
-          "legendFormat": "{{ replica }} \u00b7 {{ envoy_cluster_name }} healthy",
+          "expr": "label_replace(sum by (pod, envoy_cluster_name) (envoy_cluster_membership_healthy{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "legendFormat": "{{ replica }} · {{ envoy_cluster_name }} healthy",
           "refId": "A"
         }
       ],
@@ -1522,7 +1522,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_handshake{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_handshake{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} handshakes",
           "refId": "A"
         },
@@ -1531,7 +1531,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_fail_verify_error{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_fail_verify_error{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} verify failures",
           "refId": "B"
         },
@@ -1540,7 +1540,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_connection_error{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_connection_error{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} connection errors",
           "refId": "C"
         }
@@ -1645,7 +1645,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (envoy_cluster_name)(rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval])), \"mes\", \"$1\", \"envoy_cluster_name\", \"kri_extsvc_[^_]*_[^_]*_[^_]*_(.+?)_[^_]*\")",
+          "expr": "label_replace(sum by (envoy_cluster_name)(rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval])), \"mes\", \"$1\", \"envoy_cluster_name\", \"kri_extsvc_[^_]*_[^_]*_[^_]*_(.+?)_[^_]*\")",
           "legendFormat": "{{ mes }}",
           "refId": "A"
         }
@@ -1737,7 +1737,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (envoy_cluster_name)(envoy_cluster_upstream_cx_active{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}), \"mes\", \"$1\", \"envoy_cluster_name\", \"kri_extsvc_[^_]*_[^_]*_[^_]*_(.+?)_[^_]*\")",
+          "expr": "label_replace(sum by (envoy_cluster_name)(envoy_cluster_upstream_cx_active{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}), \"mes\", \"$1\", \"envoy_cluster_name\", \"kri_extsvc_[^_]*_[^_]*_[^_]*_(.+?)_[^_]*\")",
           "legendFormat": "{{ mes }}",
           "refId": "A"
         }
@@ -1829,7 +1829,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (envoy_cluster_name)(rate(envoy_cluster_upstream_cx_connect_fail{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval])), \"mes\", \"$1\", \"envoy_cluster_name\", \"kri_extsvc_[^_]*_[^_]*_[^_]*_(.+?)_[^_]*\")",
+          "expr": "label_replace(sum by (envoy_cluster_name)(rate(envoy_cluster_upstream_cx_connect_fail{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval])), \"mes\", \"$1\", \"envoy_cluster_name\", \"kri_extsvc_[^_]*_[^_]*_[^_]*_(.+?)_[^_]*\")",
           "legendFormat": "{{ mes }}",
           "refId": "A"
         }
@@ -1951,7 +1951,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
           "legendFormat": "{{ envoy_response_code_class }}xx",
           "refId": "A"
         }
@@ -2040,7 +2040,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_ms_bucket{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_ms_bucket{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval])))",
           "legendFormat": "{{ envoy_cluster_name }}",
           "refId": "A"
         }
@@ -2132,7 +2132,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_tx_bytes_total{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
           "legendFormat": "{{ envoy_cluster_name }} tx",
           "refId": "A"
         },
@@ -2141,7 +2141,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_rx_bytes_total{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
           "legendFormat": "{{ envoy_cluster_name }} rx",
           "refId": "B"
         }
@@ -2237,7 +2237,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_cluster_name) (envoy_cluster_upstream_cx_active{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"})",
+          "expr": "sum by (envoy_cluster_name) (envoy_cluster_upstream_cx_active{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"})",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -2247,7 +2247,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_cluster_name) (envoy_cluster_membership_healthy{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"})",
+          "expr": "sum by (envoy_cluster_name) (envoy_cluster_membership_healthy{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"})",
           "format": "table",
           "instant": true,
           "refId": "B"
@@ -2257,7 +2257,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_fail{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_cx_connect_fail{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name=~\"kri_extsvc_.+_($mes)_[^_]*\"}[$__rate_interval]))",
           "format": "table",
           "instant": true,
           "refId": "C"
@@ -2385,7 +2385,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_cx_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_cx_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "connections",
           "refId": "A"
         },
@@ -2394,7 +2394,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "requests",
           "refId": "B"
         },
@@ -2403,7 +2403,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_pending_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_pending_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "pending",
           "refId": "C"
         },
@@ -2412,7 +2412,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_retry_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_retry_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"})",
           "legendFormat": "retries",
           "refId": "D"
         }
@@ -2550,7 +2550,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_retry{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_retry{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "retries",
           "refId": "A"
         },
@@ -2559,7 +2559,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_retry_success{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_retry_success{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "retry success",
           "refId": "B"
         },
@@ -2568,7 +2568,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_timeout{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_timeout{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "timeouts",
           "refId": "C"
         }
@@ -2660,7 +2660,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_pending_overflow{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_pending_overflow{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "rq pending overflow",
           "refId": "A"
         },
@@ -2669,7 +2669,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_cx_pool_overflow{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_cx_pool_overflow{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "cx pool overflow",
           "refId": "B"
         }
@@ -2761,7 +2761,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_listener_downstream_cx_overflow{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_downstream_cx_overflow{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "cx overflow",
           "refId": "A"
         },
@@ -2770,7 +2770,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_listener_downstream_cx_overload_reject{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_downstream_cx_overload_reject{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "overload reject",
           "refId": "B"
         }
@@ -2862,7 +2862,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (rate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (rate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -2954,7 +2954,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_miss{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_miss{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} miss",
           "refId": "A"
         },
@@ -2963,7 +2963,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_mega_miss{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_mega_miss{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} mega miss",
           "refId": "B"
         }
@@ -3055,7 +3055,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))",
           "legendFormat": "{{ envoy_response_code_class }}xx",
           "refId": "A"
         }
@@ -3160,7 +3160,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_update_rejected{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_update_rejected{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "CDS rejected",
           "refId": "A"
         },
@@ -3169,7 +3169,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_listener_manager_lds_update_rejected{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_manager_lds_update_rejected{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "LDS rejected",
           "refId": "B"
         }
@@ -3261,7 +3261,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (envoy_control_plane_pending_requests{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (envoy_control_plane_pending_requests{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -3354,7 +3354,7 @@
             "uid": "${datasource}"
           },
           "refId": "A",
-          "expr": "sum (rate(envoy_cluster_update_success{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_update_success{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "CDS accepted"
         },
         {
@@ -3363,7 +3363,7 @@
             "uid": "${datasource}"
           },
           "refId": "B",
-          "expr": "sum (rate(envoy_listener_manager_lds_update_success{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"egress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_manager_lds_update_success{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-egress\"}[$__rate_interval]))",
           "legendFormat": "LDS accepted"
         }
       ]
@@ -3395,7 +3395,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\"}, namespace)",
+        "definition": "label_values(envoy_server_uptime{kuma_proxy_role=\"zone-egress\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
@@ -3404,7 +3404,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\"}, namespace)",
+          "query": "label_values(envoy_server_uptime{kuma_proxy_role=\"zone-egress\"}, namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -3419,7 +3419,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\", namespace=~\"$namespace\"}, zone)",
+        "definition": "label_values(envoy_server_uptime{namespace=~\"$namespace\"}, zone)",
         "hide": 0,
         "includeAll": true,
         "label": "Zone",
@@ -3428,7 +3428,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\", namespace=~\"$namespace\"}, zone)",
+          "query": "label_values(envoy_server_uptime{kuma_proxy_role=\"zone-egress\", namespace=~\"$namespace\"}, zone)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -3443,7 +3443,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_cluster_upstream_cx_total{job=\"kuma-zone-proxies\", envoy_cluster_name=~\"kri_extsvc_.+\"}, envoy_cluster_name)",
+        "definition": "label_values(envoy_cluster_upstream_cx_total{kuma_proxy_role=\"zone-egress\", envoy_cluster_name=~\"kri_extsvc_.+\"}, envoy_cluster_name)",
         "hide": 0,
         "includeAll": true,
         "allValue": ".+",
@@ -3453,7 +3453,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_cluster_upstream_cx_total{job=\"kuma-zone-proxies\", envoy_cluster_name=~\"kri_extsvc_.+\"}, envoy_cluster_name)",
+          "query": "label_values(envoy_cluster_upstream_cx_total{kuma_proxy_role=\"zone-egress\", envoy_cluster_name=~\"kri_extsvc_.+\"}, envoy_cluster_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/dashboards/grafana/kuma-zone-ingress.json
+++ b/dashboards/grafana/kuma-zone-ingress.json
@@ -52,7 +52,7 @@
                 "0": {
                   "color": "red",
                   "index": 0,
-                  "text": "0 \u2014 DOWN"
+                  "text": "0 — DOWN"
                 }
               },
               "type": "value"
@@ -104,7 +104,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(envoy_control_plane_connected_state{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"})",
+          "expr": "sum(envoy_control_plane_connected_state{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "connected",
           "refId": "A"
         }
@@ -164,7 +164,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(envoy_server_uptime{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(envoy_server_uptime{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -234,7 +234,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "min(envoy_server_days_until_first_cert_expiring{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"})",
+          "expr": "min(envoy_server_days_until_first_cert_expiring{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "min cert expiry",
           "refId": "A"
         }
@@ -325,7 +325,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_listener_downstream_cx_active{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"})",
+          "expr": "sum (envoy_listener_downstream_cx_active{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "downstream cx (all replicas)",
           "refId": "A"
         }
@@ -417,7 +417,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "upstream req/s (all replicas)",
           "refId": "A"
         }
@@ -509,7 +509,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_server_memory_heap_size{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"})",
+          "expr": "sum (envoy_server_memory_heap_size{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "heap (all replicas)",
           "refId": "A"
         }
@@ -602,7 +602,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(envoy_control_plane_connected_state{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(envoy_control_plane_connected_state{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}, \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -692,7 +692,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(envoy_listener_downstream_cx_active{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(envoy_listener_downstream_cx_active{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -781,7 +781,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -870,7 +870,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -959,7 +959,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_connect_fail{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_connect_fail{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -1051,7 +1051,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_downstream_cx_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} downstream (cross-zone in)",
           "refId": "A"
         },
@@ -1060,7 +1060,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_cluster_upstream_cx_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} upstream (to local services)",
           "refId": "B"
         }
@@ -1152,7 +1152,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_tcp_downstream_cx_rx_bytes_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_tcp_downstream_cx_rx_bytes_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} rx",
           "refId": "A"
         },
@@ -1161,7 +1161,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_tcp_downstream_cx_tx_bytes_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_tcp_downstream_cx_tx_bytes_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} tx",
           "refId": "B"
         }
@@ -1252,8 +1252,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
-          "legendFormat": "{{ replica }} \u00b7 {{ envoy_cluster_name }}",
+          "expr": "label_replace(sum by (pod, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "legendFormat": "{{ replica }} · {{ envoy_cluster_name }}",
           "refId": "A"
         }
       ],
@@ -1341,8 +1341,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(histogram_quantile(0.95, sum by (pod, le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
-          "legendFormat": "{{ replica }} \u00b7 {{ envoy_cluster_name }}",
+          "expr": "label_replace(histogram_quantile(0.95, sum by (pod, le, envoy_cluster_name) (rate(envoy_cluster_upstream_rq_time_bucket{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "legendFormat": "{{ replica }} · {{ envoy_cluster_name }}",
           "refId": "A"
         }
       ],
@@ -1431,8 +1431,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod, envoy_cluster_name) (envoy_cluster_membership_healthy{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
-          "legendFormat": "{{ replica }} \u00b7 {{ envoy_cluster_name }} healthy",
+          "expr": "label_replace(sum by (pod, envoy_cluster_name) (envoy_cluster_membership_healthy{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "legendFormat": "{{ replica }} · {{ envoy_cluster_name }} healthy",
           "refId": "A"
         }
       ],
@@ -1522,7 +1522,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_handshake{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_handshake{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} handshakes",
           "refId": "A"
         },
@@ -1531,7 +1531,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_fail_verify_error{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_fail_verify_error{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} verify failures",
           "refId": "B"
         },
@@ -1540,7 +1540,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_connection_error{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod)(rate(envoy_listener_ssl_connection_error{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} connection errors",
           "refId": "C"
         }
@@ -1647,7 +1647,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_cx_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_cx_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "connections",
           "refId": "A"
         },
@@ -1656,7 +1656,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "requests",
           "refId": "B"
         },
@@ -1665,7 +1665,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_pending_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_pending_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "pending",
           "refId": "C"
         },
@@ -1674,7 +1674,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_retry_open{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"})",
+          "expr": "sum (envoy_cluster_circuit_breakers_default_rq_retry_open{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"})",
           "legendFormat": "retries",
           "refId": "D"
         }
@@ -1812,7 +1812,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_retry{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_retry{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "retries",
           "refId": "A"
         },
@@ -1821,7 +1821,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_retry_success{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_retry_success{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "retry success",
           "refId": "B"
         },
@@ -1830,7 +1830,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_timeout{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_timeout{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "timeouts",
           "refId": "C"
         }
@@ -1922,7 +1922,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_rq_pending_overflow{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_rq_pending_overflow{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "rq pending overflow",
           "refId": "A"
         },
@@ -1931,7 +1931,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_upstream_cx_pool_overflow{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_upstream_cx_pool_overflow{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "cx pool overflow",
           "refId": "B"
         }
@@ -2023,7 +2023,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_listener_downstream_cx_overflow{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_downstream_cx_overflow{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "cx overflow",
           "refId": "A"
         },
@@ -2032,7 +2032,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_listener_downstream_cx_overload_reject{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_downstream_cx_overload_reject{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "overload reject",
           "refId": "B"
         }
@@ -2124,7 +2124,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (rate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (rate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -2216,7 +2216,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_miss{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_miss{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} miss",
           "refId": "A"
         },
@@ -2225,7 +2225,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_mega_miss{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (rate(envoy_server_watchdog_mega_miss{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval])), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }} mega miss",
           "refId": "B"
         }
@@ -2317,7 +2317,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))",
+          "expr": "sum by (envoy_response_code_class) (rate(envoy_cluster_upstream_rq_xx{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\"}[$__rate_interval]))",
           "legendFormat": "{{ envoy_response_code_class }}xx",
           "refId": "A"
         }
@@ -2422,7 +2422,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_cluster_update_rejected{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_update_rejected{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "CDS rejected",
           "refId": "A"
         },
@@ -2431,7 +2431,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum (rate(envoy_listener_manager_lds_update_rejected{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_manager_lds_update_rejected{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "LDS rejected",
           "refId": "B"
         }
@@ -2523,7 +2523,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "label_replace(sum by (pod) (envoy_control_plane_pending_requests{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
+          "expr": "label_replace(sum by (pod) (envoy_control_plane_pending_requests{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}), \"replica\", \"$1\", \"pod\", \"^.*-([^-]+)$\")",
           "legendFormat": "{{ replica }}",
           "refId": "A"
         }
@@ -2616,7 +2616,7 @@
             "uid": "${datasource}"
           },
           "refId": "A",
-          "expr": "sum (rate(envoy_cluster_update_success{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_cluster_update_success{namespace=~\"$namespace\", zone=~\"$zone\", envoy_cluster_name!~\"kuma_.*|_kuma_.*|access_log_sink|.*passthrough.*|.*transparentproxy.*\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "CDS accepted"
         },
         {
@@ -2625,7 +2625,7 @@
             "uid": "${datasource}"
           },
           "refId": "B",
-          "expr": "sum (rate(envoy_listener_manager_lds_update_success{job=\"kuma-zone-proxies\", namespace=~\"$namespace\", zone=~\"$zone\", proxy=\"ingress\"}[$__rate_interval]))",
+          "expr": "sum (rate(envoy_listener_manager_lds_update_success{namespace=~\"$namespace\", zone=~\"$zone\", kuma_proxy_role=\"zone-ingress\"}[$__rate_interval]))",
           "legendFormat": "LDS accepted"
         }
       ]
@@ -2657,7 +2657,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\"}, namespace)",
+        "definition": "label_values(envoy_server_uptime{kuma_proxy_role=\"zone-ingress\"}, namespace)",
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
@@ -2666,7 +2666,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\"}, namespace)",
+          "query": "label_values(envoy_server_uptime{kuma_proxy_role=\"zone-ingress\"}, namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -2681,7 +2681,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\", namespace=~\"$namespace\"}, zone)",
+        "definition": "label_values(envoy_server_uptime{namespace=~\"$namespace\"}, zone)",
         "hide": 0,
         "includeAll": true,
         "label": "Zone",
@@ -2690,7 +2690,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(envoy_server_uptime{job=\"kuma-zone-proxies\", namespace=~\"$namespace\"}, zone)",
+          "query": "label_values(envoy_server_uptime{kuma_proxy_role=\"zone-ingress\", namespace=~\"$namespace\"}, zone)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Motivation

The Zone Ingress and Zone Egress dashboards are empty. They filter on `proxy="egress"` and `job="kuma-zone-proxies"`, but nothing emits those labels — kuma-dp sends `kuma_proxy_role`, `zone`, `mesh` and `kuma_workload`. The other dashboards filter on `kuma_io_zone`, which only the DNS metrics carry, while envoy metrics use `zone`. That one goes unnoticed: with the variable empty the matcher turns into a regex that also matches series without the label, so panels still draw and only the zone dropdown is dead.

## Implementation information

Queries now use `kuma_proxy_role` and `zone`. The `job` matcher is gone from the zone dashboards, since role alone identifies a zone proxy, and stays on Control Plane where the metrics have no proxy labels. Also fixed the `namespace` variable in Workload Health, which filtered on itself, and rewrote the README to point at the MeshMetric endpoint instead of the old relabeling recipe.

Checked on a two-zone k3d cluster scraping 5670 with no Kuma-specific relabeling: Zone Egress went from 15 to 26 panels with data, Workload Debug from 0 to 52.

## Supporting documentation

MADR-096. Labels come from `pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go`.
