### PR TITLE
ci(actions): fail the build on cloudsmith errors

### DIFF
--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -62,7 +62,6 @@ publish/pulp/$(DISTRIBUTION_TARGET_NAME)-$(1)-$(2):
 		-e PULP_HOST=$(PULP_HOST) \
 		-e CLOUDSMITH_API_KEY='$(CLOUDSMITH_API_KEY)' \
 		-e CLOUDSMITH_DRY_RUN='' \
-		-e IGNORE_CLOUDSMITH_FAILURES=x \
 		-e USE_CLOUDSMITH=x \
 		-e USE_PULP=x \
 		-v $(TOP)/build/distributions/out:/files:ro \


### PR DESCRIPTION
## Motivation

> Changelog: skip

Follow-up to #18562, which restored Cloudsmith publishing but left `IGNORE_CLOUDSMITH_FAILURES=x` in place. Review feedback on that PR asked for it to go, and it landed before the change was made:

> not removing this can lead to us not noticing failures again, should we just remove this in this PR?

That flag is the reason a broken upload went unnoticed from early August until yesterday. Every master build stayed green while the CLI printed:

```
  check that CLOUDSMITH_API_KEY is set correctly
ignoring cloudsmith upload failures/errors, proceeding
```

A publish that does not publish should fail the job.

## Implementation information

Dropped `-e IGNORE_CLOUDSMITH_FAILURES=x` from the release-script container in `mk/distribution.mk`. Nothing else sets or reads it.

Running with `ci/force-publish` so the publish path is exercised without the flag before this merges.

## Supporting documentation

- The regression it hid: https://github.com/kumahq/kuma/pull/18562

https://claude.ai/code/session_01CZHqxKT6dbGEUg434dfQ52
