### PR TITLE
test(k8s): wait for MeshService TLS

### DIFF
--- a/test/e2e_env/kubernetes/graceful/change_service.go
+++ b/test/e2e_env/kubernetes/graceful/change_service.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	meshservice_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshservice/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshretry/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/util/channels"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
@@ -135,6 +136,14 @@ func ChangeService() {
 	}
 
 	It("should gracefully switch to other service", func() {
+		// Keep service bootstrap outside the selector transition. A successful
+		// plaintext request does not mean clients have received the mTLS cluster.
+		Eventually(func(g Gomega) {
+			_, status, err := GetMeshServiceStatus(kubernetes.Cluster, "test-server."+namespace, mesh)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(status.TLS.Status).To(Equal(meshservice_api.TLSReady))
+		}, "30s", "1s").Should(Succeed())
+
 		// given traffic to the first server
 		Eventually(func(g Gomega) {
 			instance, err := doRequest()


### PR DESCRIPTION
## Motivation

The Change Service e2e test can start its selector transition while the generated MeshService is still moving from plaintext to mTLS. One successful plaintext request is not proof that the client has received the stable TLS cluster.

In the failed run, the spec started at 20:44:58, MeshService TLS became Ready at 20:45:04, and the client received the TLS CDS update at 20:45:06. All six 503 responses occurred inside that bootstrap window. Envoy recorded six remotely destroyed connections with active requests and no zero-healthy-host event.

> Changelog: skip

## Implementation information

Wait for the generated test-server MeshService to report TLS Ready before establishing the initial traffic baseline. MeshRetry stays deleted, and the selector transition still fails on any dropped background request.

## Supporting documentation

- `go test ./test/e2e_env/kubernetes/graceful`
- `git diff --check`
- Adversarial review: clean