### PR TITLE
fix(helm): match Zone in the defaulting webhook

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,14 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
+### `Zone` on Kubernetes reaches the defaulting webhook
+
+The defaulting webhook selected `zone` where the CRD plural is `zones`, so the rule matched nothing and a `Zone` written straight to the Kubernetes API skipped the webhook entirely. It now matches, which means a `Zone` created or updated with `kubectl` gets the same computed labels a `Zone` created through the HTTP API already got: `kuma.io/display-name`, `kuma.io/origin`, and on a zone control plane `kuma.io/zone` and `kuma.io/env`.
+
+**Action required**
+
+None. `Zone` resources that already exist are untouched until something writes to them, and the labels are added, never removed. If you select zones by label, a `Zone` applied with `kubectl` before the upgrade may lack the labels until it is next written.
+
 ### Fields that the API linter had skipped were brought in line
 
 A linter bug hid a set of API fields from the shape checks the rest of the API follows. Fixing the fields changes two schemas, both by dropping a declared default:

--- a/app/kumactl/cmd/install/install_control_plane_test.go
+++ b/app/kumactl/cmd/install/install_control_plane_test.go
@@ -2,14 +2,18 @@ package install_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	k8s_yaml "k8s.io/apimachinery/pkg/util/yaml"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kumahq/kuma/v3/app/kumactl/pkg/test"
@@ -68,6 +72,77 @@ var _ = Context("kumactl install control-plane", func() {
 		// and output matches golden files
 		actual := stdout.Bytes()
 		Expect(actual).To(matchers.MatchGoldenEqual(filepath.Join("testdata", "install-control-plane.dump-values.yaml")))
+	})
+
+	It("should only reference existing kuma.io CRDs in admission webhook rules", func() {
+		// given
+		stdout, stderr, rootCmd := test.DefaultTestingRootCmd("install",
+			"control-plane",
+			"--tls-general-secret", "general-tls-secret",
+			"--tls-general-ca-bundle", "XYZ",
+			"--without-kubernetes-connection",
+		)
+
+		// when
+		err := rootCmd.Execute()
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stderr.String()).To(BeEmpty())
+
+		type renderedObject struct {
+			Kind string `json:"kind"`
+			Spec struct {
+				Group string `json:"group"`
+				Names struct {
+					Plural string `json:"plural"`
+				} `json:"names"`
+			} `json:"spec"`
+			Webhooks []struct {
+				Name  string `json:"name"`
+				Rules []struct {
+					APIGroups []string `json:"apiGroups"`
+					Resources []string `json:"resources"`
+				} `json:"rules"`
+			} `json:"webhooks"`
+		}
+
+		plurals := map[string]struct{}{}
+		referenced := map[string][]string{}
+		decoder := k8s_yaml.NewYAMLOrJSONDecoder(bytes.NewReader(stdout.Bytes()), 4096)
+		for {
+			obj := renderedObject{}
+			err := decoder.Decode(&obj)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			Expect(err).ToNot(HaveOccurred())
+
+			switch obj.Kind {
+			case "CustomResourceDefinition":
+				if obj.Spec.Group == "kuma.io" {
+					plurals[obj.Spec.Names.Plural] = struct{}{}
+				}
+			case "MutatingWebhookConfiguration", "ValidatingWebhookConfiguration":
+				for _, webhook := range obj.Webhooks {
+					for _, rule := range webhook.Rules {
+						if !slices.Contains(rule.APIGroups, "kuma.io") {
+							continue
+						}
+						referenced[webhook.Name] = append(referenced[webhook.Name], rule.Resources...)
+					}
+				}
+			}
+		}
+
+		Expect(plurals).ToNot(BeEmpty())
+		Expect(referenced).ToNot(BeEmpty())
+		for webhook, resources := range referenced {
+			for _, resource := range resources {
+				Expect(plurals).To(HaveKey(resource),
+					fmt.Sprintf("webhook %q selects %q which is not the plural of any kuma.io CRD", webhook, resource))
+			}
+		}
 	})
 
 	type testCase struct {

--- a/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.cni-enabled.golden.yaml
@@ -711,7 +711,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -948,7 +948,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.defaults.golden.yaml
@@ -8655,7 +8655,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -8886,7 +8886,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.gateway-api-present.yaml
@@ -8655,7 +8655,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -8886,7 +8886,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.override-env-vars.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.overrides.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 345e5805076edc29201056aff714082e531755a43278703503620812d06dd10f
-        checksum/tls-secrets: e7212923dbf9a5bcf53519b130d72323b7c1304ebf0bf4ab8f8d3a86df45daab
+        checksum/tls-secrets: 4cce690dd10573f8132993729fa7c3d5d588edd09c413e4c11d945c92bc08e69
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -748,7 +748,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.registry.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.skip-crds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.skip-crds.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-set.yaml
@@ -8655,7 +8655,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -8890,7 +8890,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.with-helm-values.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-control-plane.zone.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -727,7 +727,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomDNSNames.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 70ec950dfed1e939554cf4ecc48fb145391899439a98289d74f3e2f26405802a
+        checksum/tls-secrets: 30ea8640119eb8dc63f097dfe30fe092c321a1b302a8fc41f36ced8195e5d31e
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -725,7 +725,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerCustomIssuer.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 70ec950dfed1e939554cf4ecc48fb145391899439a98289d74f3e2f26405802a
+        checksum/tls-secrets: 30ea8640119eb8dc63f097dfe30fe092c321a1b302a8fc41f36ced8195e5d31e
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -725,7 +725,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/certManagerEnabled.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 70ec950dfed1e939554cf4ecc48fb145391899439a98289d74f3e2f26405802a
+        checksum/tls-secrets: 30ea8640119eb8dc63f097dfe30fe092c321a1b302a8fc41f36ced8195e5d31e
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -725,7 +725,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/controlPlaneOnlySkipRBAC.golden.yaml
@@ -253,7 +253,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -484,7 +484,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dataplane-resources.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/dnsConfigOption.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -730,7 +730,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/doNotChangeTlsChecksum.golden.yaml
@@ -722,7 +722,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/empty.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/envVarsDownwardApi.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -727,7 +727,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix12847.golden.yaml
@@ -713,7 +713,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -950,7 +950,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix13029.golden.yaml
@@ -731,7 +731,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -968,7 +968,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4485.golden.yaml
@@ -517,7 +517,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 29b18f39ff6a91dbd502d8d3e340bdf5466548962e995dfb4fff5b1420888685
-        checksum/tls-secrets: 0d6655c1224ec5c7be9253c883ac1f543537c32d6e75096524c255794fffc0c0
+        checksum/tls-secrets: 276353f18a4566b60c0c81900d933326f3375a3277505129a1f79637cbe7e26c
       labels: 
         app: kuma-control-plane
         "foo": "baz"
@@ -756,7 +756,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4496.golden.yaml
@@ -503,7 +503,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 3f84aee85f37d8d5f2d8f4a9d3944a95dc08ba3a7b65d051456735670ca6fab2
-        checksum/tls-secrets: 617adf1351cb3c4c7b0defb4ffa6004460e8823e13842010e76b19a0d1368534
+        checksum/tls-secrets: 192af4c9aac2c933e1e7a79a396848c33a770b35630cef6385d7f3da542f279e
       labels: 
         app: kuma-control-plane
         "foo": "bar"
@@ -764,7 +764,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix4935.golden.yaml
@@ -715,7 +715,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
         bim: "bam"
         foo: "{\"bar\": \"baz\"}"
       labels: 
@@ -984,7 +984,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/fix7724.golden.yaml
@@ -495,7 +495,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -726,7 +726,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDefaultImage.golden.yaml
@@ -558,7 +558,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -909,7 +909,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyDeploymentAnnotations.golden.yaml
@@ -558,7 +558,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -915,7 +915,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyImageOverride.golden.yaml
@@ -558,7 +558,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -909,7 +909,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyMultipleMeshes.golden.yaml
@@ -624,7 +624,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -1095,7 +1095,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyPodOverrides.golden.yaml
@@ -570,7 +570,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -924,7 +924,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceAnnotationsLabels.golden.yaml
@@ -564,7 +564,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -915,7 +915,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/meshZoneProxyServiceSpec.golden.yaml
@@ -563,7 +563,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -928,7 +928,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/minReadySeconds.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -723,7 +723,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/roleBindingInNamespaces.golden.yaml
@@ -511,7 +511,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: d241ae08fcc8ba73c94daa99000a5e9ebe4d844e24868d5d4cb281e03bf366df
+        checksum/tls-secrets: 33a25a94b6f3ae27266a99b67cf37e2ec286d90ef95e02b39c072e207ade7dd5
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -748,7 +748,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/securityContext.golden.yaml
@@ -492,7 +492,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -724,7 +724,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
+++ b/app/kumactl/cmd/install/testdata/install-cp-helm/skipRBAC.golden.yaml
@@ -155,7 +155,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 1fa6f39d97a8aad47eff6f6670269d3333a30c2e107b0a9d14b2aa23e0f3bf24
-        checksum/tls-secrets: 9f2a0399dbf821d32c2693aa10f41cbd0de43d38bdced833d6850a01b44a9ce8
+        checksum/tls-secrets: f6033fcf07311251d42af5ec4d088306bf0aa0300daf9ddcd142032744c4fdbd
       labels: 
         app: kuma-control-plane
         app.kubernetes.io/name: kuma
@@ -386,7 +386,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
           - meshaccesslogs
           - meshcircuitbreakers

--- a/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
+++ b/deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml
@@ -110,7 +110,7 @@ webhooks:
           - meshes
           - dataplanes
           - dataplaneinsights
-          - zone
+          - zones
           - zoneinsights
         {{- range $policy, $v := .Values.plugins.policies }}
         {{- if $v }}


### PR DESCRIPTION
## Motivation

The `mesh.defaulter.kuma-admission.kuma.io` webhook lists `zone` under `resources`, but the CRD plural is `zones`. Admission rules match on the plural, so the rule has never selected anything and a `Zone` written through the Kubernetes API has been skipping the defaulting webhook since the resource was added to the list in #11020. The sibling `validator.kuma-admission.kuma.io` webhook already uses `zones`, and every other entry in the defaulter list is a plural, so the singular is a typo rather than a deliberate exclusion.

The visible consequence is that computed labels depend on how the resource was written. A `Zone` created through the HTTP API goes through `resource_write_endpoints.go`, which calls `labels.Compute` and stores `kuma.io/display-name` and `kuma.io/origin`. The same `Zone` applied with `kubectl` gets neither.

> Changelog: fix(helm): match Zone in the defaulting webhook

## Implementation information

- `deployments/charts/kuma/templates/cp-webhooks-and-secrets.yaml`: `zone` -> `zones` in the defaulter rule. The regenerated install goldens carry that line plus the `checksum/tls-secrets` annotation, which hashes the webhook configuration.
- `app/kumactl/cmd/install/install_control_plane_test.go`: a new spec renders the control plane with CRDs, collects the plural of every `kuma.io` CRD, and asserts that each resource named in a `kuma.io` admission rule is one of them. Reverting the chart line alone fails it with `webhook "mesh.defaulter.kuma-admission.kuma.io" selects "zone" which is not the plural of any kuma.io CRD`, so it pins this class of typo for both webhooks and for the plugin policy and resource lists the chart renders into them.
- `UPGRADE.md`: the labels are additive and existing resources are untouched until something writes to them, but a `Zone` applied with `kubectl` before the upgrade keeps its current labels until its next write, which matters if you select zones by label.

## Supporting documentation

The defaulting handler denies the same writes the validating webhook already denies, so no new rejection path opens up. `IsOperationAllowed` short-circuits for the control plane's own service account, and for a user write on a federated zone it returns the same `IsReadOnly` refusal the validator already returns for `zones`.
