### PR TITLE
chore(api): unembed proto from generic insights

### DIFF
--- a/api/generic/insights.go
+++ b/api/generic/insights.go
@@ -2,8 +2,6 @@ package generic
 
 import (
 	"time"
-
-	"google.golang.org/protobuf/proto"
 )
 
 func AllSubscriptions[S Subscription, T interface{ GetSubscriptions() []S }](t T) []Subscription {
@@ -24,7 +22,6 @@ func GetSubscription[S Subscription, T interface{ GetSubscriptions() []S }](t T,
 }
 
 type Insight interface {
-	proto.Message
 	IsOnline() bool
 	GetLastSubscription() Subscription
 	GetSubscription(id string) Subscription
@@ -33,7 +30,6 @@ type Insight interface {
 }
 
 type Subscription interface {
-	proto.Message
 	GetId() string
 	GetGeneration() uint32
 	IsOnline() bool


### PR DESCRIPTION
## Motivation

`Insight` and `Subscription` in `api/generic` each embed `proto.Message`, which forces every implementation to be a generated protobuf type. Nothing needs that: across the 15 call sites in `pkg/gc`, `pkg/xds/server/callbacks`, `api/mesh/v1alpha1` and `api/system/v1alpha1`, no caller reaches `Reset`, `String` or `ProtoReflect` through either interface. Call sites that do want protobuf hold the concrete type already.

The embed is also the one thing stopping a plain Go struct from satisfying these interfaces, which is what the resource specs are moving toward for v3.

> Changelog: skip

## Implementation information

Four deleted lines: the two embeds and the now-unused `google.golang.org/protobuf/proto` import. The interfaces keep every method they declared, so this is not an API narrowing for existing implementations, only a widening of what may implement them.

Verified with `go build ./...` for both modules, `go vet`, `golangci-lint run ./api/...`, and the tests of every package that names one of these interfaces: `api/...`, `pkg/gc`, `pkg/xds/server/callbacks`, `pkg/insights/...` and `pkg/kds/...`.

## Supporting documentation

Groundwork for the protobuf removal in v3. It stands on its own regardless of that work landing: the constraint it removes was never used.
