### PR TITLE
docs(openapi): pin merge order to C collation

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -69,7 +69,7 @@ docs/generated/openapi.yaml: $(DOCS_OPENAPI_PREREQUISITES) | docs/generated docs
 			REDOCLY_SUPPRESS_UPDATE_NOTICE=true mise exec -- redocly bundle $$f -o $(BUILD_DIR)/openapi-bundled/$$f || echo "Skipping $$f"; \
 		done
 	@echo "Merging all bundled specs..."
-	@mise exec -- oas-toolkit merge $$(find $(BUILD_DIR)/openapi-bundled -name '*.yaml' | sort) > $@
+	@mise exec -- oas-toolkit merge $$(find $(BUILD_DIR)/openapi-bundled -name '*.yaml' | LC_ALL=C sort) > $@
 	@$(MAKE) --no-print-directory validate/openapi-generated-docs
 
 # Prepare $(OAPI_TMP_DIR) with a normalized directory layout for the generator


### PR DESCRIPTION
## Motivation

Backport of #16976 to `release-2.14`.

`make check` on this branch produces a non-empty `docs/generated/openapi.yaml` on some machines and a clean one on others. The merge step orders the bundled specs with a bare `find ... | sort`, so the order follows the caller's collation. Under C, `protoresources/accessrole/rest.yaml` sorts before `protoresources/accessrolebinding/rest.yaml` because `/` (0x2F) precedes `b`; under en_US.UTF-8 the `/` is ignored at the primary level and the two swap, which reshuffles the merged paths:

```
-  /access-roles:
-      operationId: getAccessRoleList
+  /access-role-bindings:
+      operationId: getAccessRoleBindingList
```

Kong Mesh hit this on `release-2.14` when its CI moved to a runner image with a UTF-8 locale: the same commit that passes `check` on one runner fails on another, and regenerating the file only moves the failure to the machines that pass today.

## Implementation information

Forces `LC_ALL=C sort`, same one-line change as #16976. `accessrole`/`accessrolebinding` is the only pair among the bundled specs whose names share a prefix, so it is the only one that moves.

## Supporting documentation

> Changelog: skip
