### PR TITLE
test(framework): settle after mesh trust handout

### DIFF
--- a/test/framework/meshidentity.go
+++ b/test/framework/meshidentity.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/pkg/errors"
@@ -182,8 +183,15 @@ func DistributeMeshTrusts(global Cluster, mesh string, identityName string, zone
 			}
 		}
 	}
+
+	time.Sleep(trustPropagationDelay)
 	return nil
 }
+
+// Proxies reject peer certificates until the trust reaches them, 0.6-0.9s on a
+// loaded CI runner. Nothing exposes it: MeshService TLS status ignores peer
+// trust domains and DataplaneInsight carries no SDS stats.
+const trustPropagationDelay = 3 * time.Second
 
 // waitForMeshIdentity waits until KDS has delivered the MeshIdentity to the
 // zone. The zone cannot generate its CA (and therefore its MeshTrust) before


### PR DESCRIPTION
## Motivation

Multizone suites send cross-zone traffic as soon as `DistributeMeshTrusts` returns, but the call only applies the MeshTrust to the zone CP. Until the bundle reaches the proxies they reject every peer certificate issued by another zone's CA. In run 34333117550 the healthcheck suite opened with 25 `ssl.fail_verify_error` on the kuma-5 inbounds, matching the client's 25 `upstream_cx_connect_fail`; the CP pushed the new validation context 0.6-0.9s after the trusts were applied. The suites' `Eventually` absorbs it today, at the cost of a burst of dropped requests at the start of every such suite.

## Implementation information

`DistributeMeshTrusts` sleeps 3s before returning. There is no readiness signal to wait on instead: MeshService TLS status only tracks a proxy's own trust domain (`hasReadyIdentity` in `pkg/core/resources/apis/meshservice/status/updater.go`), and DataplaneInsight reports no SDS stats and is flushed every 10s. The proxy config dump is authoritative but means an inspect call per proxy per poll across the ~20 suites that distribute trusts.

## Supporting documentation

Envoy stats and config dumps from the e2e debug artifact of run 34333117550, job 102406515207.

> Changelog: skip