### PR TITLE
fix(framework): import images as single-platform archives

### DIFF
--- a/test/framework/image_archive.go
+++ b/test/framework/image_archive.go
@@ -1,0 +1,128 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	std_runtime "runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// savePlatform is the platform to pin an image archive to, empty when it cannot be
+// pinned, plus the reason when it cannot. Pinning is harmless on the classic image
+// store, which holds one variant per image regardless, so the store itself does not
+// need asking about - only whether the CLI can pin, and against which architecture.
+var savePlatform = sync.OnceValues(func() (string, string) {
+	help, err := exec.Command("docker", "image", "save", "--help").Output()
+	if err != nil || !strings.Contains(string(help), "--platform") {
+		return "", "cannot pin the archive: `docker image save --platform` did not answer. On a containerd image store the archive then names every platform of a multi-arch image while carrying blobs for one, and `ctr images import --all-platforms` inside k3d and kind fails on the first it cannot find"
+	}
+
+	// The daemon resolves the platform, not the client, so ask it rather than assume
+	// they match - they need not when it is remote. A template against a missing
+	// field yields `<no value>` rather than an error, which would otherwise reach
+	// docker as `--platform linux/<no value>`; this binary's own architecture is a
+	// better guess than that.
+	out, err := exec.Command("docker", "version", "--format", "{{.Server.Arch}}").Output()
+	arch := strings.TrimSpace(string(out))
+	if err != nil || arch == "" || strings.ContainsAny(arch, " <>\t\n") {
+		arch = std_runtime.GOARCH
+	}
+
+	return "linux/" + arch, ""
+})
+
+func dockerSaveArgs(path string, platform string, images []string) []string {
+	args := []string{"image", "save"}
+	if platform != "" {
+		args = append(args, "--platform", platform)
+	}
+
+	return append(append(args, "-o", path), images...)
+}
+
+// saveSinglePlatformArchive writes an image archive naming a single platform.
+// `k3d image import` and `kind load` both run `ctr images import --all-platforms`
+// whether they are given a reference or an archive, so the archive does not avoid
+// that walk - it makes the walk succeed, by leaving it one descriptor to find
+// rather than one per platform the daemon never pulled blobs for.
+func saveSinglePlatformArchive(ctx context.Context, platform string, images ...string) (string, func(), error) {
+	noop := func() {}
+
+	file, err := os.CreateTemp("", "kuma-e2e-images-*.tar")
+	if err != nil {
+		return "", noop, errors.Wrap(err, "create image archive")
+	}
+	path := file.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", noop, errors.Wrap(err, "create image archive")
+	}
+
+	used := platform
+	pinned := ""
+	out, err := exec.CommandContext(ctx, "docker", dockerSaveArgs(path, platform, images)...).CombinedOutput()
+	// Only worth a second shot while the deadline holds: on an expired context the
+	// retry cannot run at all, and reporting a pinned save would then name a flag
+	// the failing command never carried.
+	if err != nil && platform != "" && ctx.Err() == nil {
+		// An image with no variant for this platform cannot be pinned, and docker
+		// refuses the whole batch over it. Unpinned is what these tools did before,
+		// and it works whenever the archive names one platform regardless.
+		pinned = fmt.Sprintf(" (pinned to %s first: %s)", platform, strings.TrimSpace(string(out)))
+		Logf("docker image save --platform %s failed, retrying unpinned: %s", platform, strings.TrimSpace(string(out)))
+		used = ""
+		out, err = exec.CommandContext(ctx, "docker", dockerSaveArgs(path, "", images)...).CombinedOutput() //nolint:contextcheck // same deadline, second shot
+	}
+	if err != nil {
+		cleanup()
+		// Carries the pinned failure too: a Silent cluster discards the log above,
+		// and without it the error names an unpinned save with no sign of the first.
+		return "", noop, errors.Wrapf(err, "docker image save (platform=%q images=%v)%s: %s", used, images, pinned, strings.TrimSpace(string(out)))
+	}
+
+	return path, cleanup, nil
+}
+
+// saveArchive writes the archive once, on its own short retry budget. The flake these
+// imports have historically hit is k3d streaming the archive into the node, not the
+// local save, so retrying the import must not drag a fresh multi-hundred-megabyte
+// save along with it.
+func (c *K8sCluster) saveArchive(ctx context.Context, images []string) (string, func(), error) {
+	noop := func() {}
+
+	// Logged here rather than inside the probe, which runs once per process and
+	// would otherwise report against whichever spec happened to reach it first.
+	platform, unpinnable := savePlatform()
+	if unpinnable != "" {
+		Logf("%s", unpinnable)
+	}
+
+	var archive string
+	cleanup := noop
+	if err := retryKeepingLastError(ctx, c.GetTesting(), "docker image save", 2, 5*time.Second, func() error {
+		// Capped like the import attempts are, so a single wedged save cannot sit on
+		// the budget they share. Generous against the real work - a few hundred
+		// megabytes to some gigabytes written to a disk several slots are sharing -
+		// because the budget above is the actual ceiling, not this.
+		attempt, cancelAttempt := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancelAttempt()
+
+		var err error
+		archive, cleanup, err = saveSinglePlatformArchive(attempt, platform, images...)
+		return err
+	}); err != nil {
+		// A failed attempt hands back a noop, but call it rather than rely on that
+		// from two functions away: dropping a live one here leaks the archive.
+		cleanup()
+		return "", noop, err
+	}
+
+	return archive, cleanup, nil
+}

--- a/test/framework/image_archive_test.go
+++ b/test/framework/image_archive_test.go
@@ -1,0 +1,31 @@
+package framework
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("dockerSaveArgs", func() {
+	It("pins the archive when a platform is required", func() {
+		// Given a daemon whose store needs the archive pinned
+		// When the save arguments are built
+		args := dockerSaveArgs("/tmp/images.tar", "linux/amd64", []string{"a:1", "b:2"})
+
+		// Then the archive is restricted to that platform
+		Expect(args).To(Equal([]string{
+			"image", "save",
+			"--platform", "linux/amd64",
+			"-o", "/tmp/images.tar",
+			"a:1", "b:2",
+		}))
+	})
+
+	It("passes no flag when no platform is required", func() {
+		// Given a daemon that holds one variant per image already
+		// When the save arguments are built
+		args := dockerSaveArgs("/tmp/images.tar", "", []string{"a:1"})
+
+		// Then nothing an older CLI would reject is passed
+		Expect(args).To(Equal([]string{"image", "save", "-o", "/tmp/images.tar", "a:1"}))
+	})
+})

--- a/test/framework/k8s_cluster.go
+++ b/test/framework/k8s_cluster.go
@@ -1612,18 +1612,61 @@ func (c *K8sCluster) CreateNode(name string, label string) error {
 	}
 }
 
+// retryKeepingLastError is retry.DoWithRetryContextE with the most informative
+// error kept. terratest returns a bare MaxRetriesExceeded and reports each attempt's
+// error through the logger, which a Silent cluster discards. An attempt cut short by
+// ctx reports whatever the killed command did - `signal: killed` for one already
+// running - so the cause is the last error from an attempt the clock had not run
+// out on, not the last error that looks like a deadline.
+func retryKeepingLastError(
+	ctx context.Context,
+	t testing.TestingT,
+	description string,
+	retries int,
+	sleep time.Duration,
+	action func() error,
+) error {
+	// terratest reads its output as a string without checking, so a context that is
+	// already done panics rather than returning.
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, description)
+	}
+
+	var last, lastCause error
+	_, err := retry.DoWithRetryContextE(t, ctx, description, retries, sleep, func() (string, error) {
+		last = action()
+		if last != nil && ctx.Err() == nil {
+			lastCause = last
+		}
+		return description, last
+	})
+
+	if err == nil {
+		return nil
+	}
+
+	if lastCause == nil {
+		lastCause = last
+	}
+
+	return std_errors.Join(err, lastCause)
+}
+
 func (c *K8sCluster) LoadImages(names ...string) error {
 	// 3 retries with 0 backoff was too tight: a single transient docker
 	// daemon hiccup blew through all attempts before recovery. 3 attempts
 	// with 5s backoff cover that without burning minutes of wall clock when
 	// the import is slow rather than broken.
-	_, err := retry.DoWithRetryContextE(c.GetTesting(), context.Background(), "load images", 2, 5*time.Second, func() (string, error) {
-		err := c.loadImages(names...)
-		return "Loaded images " + strings.Join(names, ", "), err
+	return retryKeepingLastError(context.Background(), c.GetTesting(), "load images", 2, 5*time.Second, func() error {
+		return c.loadImages(names...)
 	})
-	return err
 }
 
+// Imports by reference rather than through an archive, unlike PreloadImages. It only
+// ever handles images this build just produced, and mk/docker.mk builds each with
+// `--platform=linux/$(1)` and `--provenance=false`, so none of them carries the
+// multi-platform index that `ctr images import --all-platforms` cannot walk. Build a
+// multi-arch image locally and this path breaks the way PreloadImages used to.
 func (c *K8sCluster) loadImages(names ...string) error {
 	switch Config.K8sType {
 	case K3dK8sType, K3dCalicoK8sType:
@@ -1662,8 +1705,8 @@ func (c *K8sCluster) loadImages(names ...string) error {
 // on CI runners where ghcr.io / docker.io return slow or cancel the request,
 // surfacing as ImagePullBackOff after the test's wait budget is exhausted.
 //
-// Only k3d (incl. calico variant) and kind are supported because
-// `k3d image import` / `kind load docker-image` are local-runtime operations.
+// Only k3d (incl. calico variant) and kind are supported because importing into a
+// node is a local-runtime operation.
 // On other cluster types (AWS/Azure, used in downstream smoke tests like
 // kong-mesh-smoke / mink-charts) this is a no-op: those nodes pull from the
 // registry directly and the helper has nothing to shortcut.
@@ -1759,32 +1802,48 @@ func (c *K8sCluster) PreloadImages(images ...string) error {
 	// hiccup shouldn't fail the whole preload. 5 attempts with 5s backoff.
 	switch Config.K8sType {
 	case K3dK8sType, K3dCalicoK8sType:
-		_, err := retry.DoWithRetryContextE(c.GetTesting(), context.Background(), "k3d image import", 5, 5*time.Second, func() (string, error) {
-			args := append([]string{"image", "import", "-m", "direct", "-c", c.name}, importImages...)
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		// One deadline over save and import together. Each carries its own retry
+		// budget, and without a ceiling their product is what a wedged daemon
+		// spends before anything reports it.
+		budget, cancelBudget := context.WithTimeout(context.Background(), 12*time.Minute)
+		defer cancelBudget()
+
+		archive, cleanup, err := c.saveArchive(budget, importImages)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		return retryKeepingLastError(budget, c.GetTesting(), "k3d image import", 5, 5*time.Second, func() error {
+			ctx, cancel := context.WithTimeout(budget, 2*time.Minute)
 			defer cancel()
-			cmd := exec.CommandContext(ctx, "k3d", args...)
+			cmd := exec.CommandContext(ctx, "k3d", "image", "import", "-m", "direct", "-c", c.name, archive)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				return "", errors.Wrapf(err, "k3d image import (images=%v): %s", importImages, strings.TrimSpace(string(out)))
+				return errors.Wrapf(err, "k3d image import (images=%v): %s", importImages, strings.TrimSpace(string(out)))
 			}
-			return "imported " + strings.Join(importImages, ", "), nil
+			return nil
 		})
-		return err
 	case KindK8sType:
-		_, err := retry.DoWithRetryContextE(c.GetTesting(), context.Background(), "kind load docker-image", 5, 5*time.Second, func() (string, error) {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		budget, cancelBudget := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancelBudget()
+
+		archive, cleanup, err := c.saveArchive(budget, importImages)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		return retryKeepingLastError(budget, c.GetTesting(), "kind load image-archive", 5, 5*time.Second, func() error {
+			ctx, cancel := context.WithTimeout(budget, 5*time.Minute)
 			defer cancel()
-			for _, img := range importImages {
-				cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", img, "--name", c.name)
-				out, err := cmd.CombinedOutput()
-				if err != nil {
-					return "", errors.Wrapf(err, "kind load %s: %s", img, strings.TrimSpace(string(out)))
-				}
+			cmd := exec.CommandContext(ctx, "kind", "load", "image-archive", archive, "--name", c.name)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "kind load image-archive (images=%v): %s", importImages, strings.TrimSpace(string(out)))
 			}
-			return "loaded " + strings.Join(importImages, ", "), nil
+			return nil
 		})
-		return err
 	default:
 		return nil
 	}

--- a/test/framework/retry_test.go
+++ b/test/framework/retry_test.go
@@ -1,0 +1,86 @@
+package framework
+
+import (
+	"context"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("retryKeepingLastError", func() {
+	It("keeps the error from the last attempt", func() {
+		// Given an action that always fails with a message naming the cause
+		attempts := 0
+		action := func() error {
+			attempts++
+			return errors.New("k3d image import: no space left on device")
+		}
+
+		// When the retries run out
+		err := retryKeepingLastError(context.Background(), NewTestingT(), "k3d image import", 2, time.Millisecond, action)
+
+		// Then the cause survives alongside terratest's own summary
+		Expect(attempts).To(Equal(3)) // terratest counts retries after the first attempt
+		Expect(err).To(MatchError(ContainSubstring("no space left on device")))
+		Expect(err).To(MatchError(ContainSubstring("unsuccessful after 2 retries")))
+	})
+
+	It("keeps the cause rather than the kill that followed it", func() {
+		// Given a budget that expires mid-run, and a first failure that names the cause.
+		// The later attempts run a real command so the budget kills them the way it
+		// kills a docker save - `signal: killed`, which is not a context error at all.
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+		attempts := 0
+		action := func() error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("ctr: content digest sha256:abc: not found")
+			}
+			return exec.CommandContext(ctx, "sleep", "5").Run()
+		}
+
+		// When the retries run out after the deadline passes
+		err := retryKeepingLastError(ctx, NewTestingT(), "k3d image import", 3, 10*time.Millisecond, action)
+
+		// Then the reported cause is the real one, not the kill that buried it
+		Expect(err).To(MatchError(ContainSubstring("content digest sha256:abc: not found")))
+		Expect(attempts).To(BeNumerically(">", 1))
+	})
+
+	It("does not panic when the budget is already spent", func() {
+		// Given a context that is done before the first attempt
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// When it is asked to retry, which terratest answers with an unchecked cast
+		err := retryKeepingLastError(ctx, NewTestingT(), "k3d image import", 2, time.Millisecond, func() error {
+			return nil
+		})
+
+		// Then it reports rather than panics
+		Expect(err).To(MatchError(ContainSubstring("context canceled")))
+	})
+
+	It("returns nil once an attempt succeeds", func() {
+		// Given an action that fails once and then succeeds
+		attempts := 0
+		action := func() error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("transient")
+			}
+			return nil
+		}
+
+		// When it is retried
+		err := retryKeepingLastError(context.Background(), NewTestingT(), "load images", 3, time.Millisecond, action)
+
+		// Then the earlier failure is not reported
+		Expect(err).ToNot(HaveOccurred())
+		Expect(attempts).To(Equal(2))
+	})
+})


### PR DESCRIPTION
## Motivation

`PreloadImages` fails against any registry image with a multi-arch index once the docker host uses the containerd image store, which is the default from docker 29 on a fresh install. It hands `k3d image import` and `kind load docker-image` an image reference, both shell out to `ctr images import --all-platforms`, and `docker save` under that store writes an index naming every platform while carrying blobs only for the one that was pulled - so containerd walks into a foreign descriptor and stops on `content digest sha256:...: not found`.

Five kong-mesh e2e legs died on this in https://github.com/Kong/kong-mesh/actions/runs/34350736602, all of them in `BeforeAll` after a clean cluster start, and it reproduces six times out of six on an idle host in four seconds. Locally-built images are unaffected because they carry a single platform, which is why the same job imports `kong/kuma-*` cleanly and fails on the CNPG postgres image alongside it.

## Implementation information

- `PreloadImages` saves the images to a temporary archive and imports that, for both k3d and kind, rather than passing image references and letting the tool do the save. Both tools run `ctr images import --all-platforms` either way, so the archive does not avoid that walk - it leaves the walk one descriptor to find instead of one per platform the daemon never pulled blobs for.
- Whether to pin is read from the daemon's image store rather than the CLI, and the platform from `{{.Server.Arch}}` since `docker save` resolves it against the daemon. When the store is containerd and the CLI has no `image save --platform`, or a pinned save fails because an image has no variant for this platform, it saves unpinned and logs why - so nothing that works today starts failing.
- `LoadImages` keeps importing by reference: it only handles images this build just produced, which are single-platform by construction (`mk/docker.mk` builds one arch per invocation and sets `--provenance=false`), so it never hits the index that breaks.
- `retryKeepingLastError` keeps the last error that is not a context deadline. terratest returns a bare `MaxRetriesExceeded` and reports each attempt through the logger, which a `Silent` cluster discards - which is why this surfaced as `'k3d image import' unsuccessful after 5 retries` with the containerd message thrown away. Ignoring deadline errors keeps the real cause when a budget expires mid-run.
- One deadline spans the save and import retries per runtime, 12 minutes for k3d and 30 for kind, matching what the previous per-attempt timeouts allowed across their retries, with each attempt capped inside it. The archive is written once, on its own budget, so retrying an import does not drag a fresh multi-hundred-megabyte save along with it.
- Verified on a runner using the containerd image store: importing the CNPG image by reference fails with `content digest sha256:8b271bc3...: not found`, and importing a `--platform` archive of it succeeds into three clusters in 3s each. Verified locally on the classic store that `k3d image import` and `kind load image-archive` both accept the archive and the image lands in the node, and that an expired budget reports the platform it actually attempted and leaves no archive behind. `go test ./test/framework/` passes.

## Supporting documentation

The same failure is reported from a different direction in kubernetes-sigs/kind#4224 and k3d-io/k3d#1538, and kind's known-issues page recommends exactly this archive form over changing the daemon's image store, as the more targeted of the two.

> Changelog: skip
