### PR TITLE
fix(framework): drop the unused contextcheck directive

### DIFF
--- a/test/framework/image_archive.go
+++ b/test/framework/image_archive.go
@@ -78,7 +78,7 @@ func saveSinglePlatformArchive(ctx context.Context, platform string, images ...s
 		pinned = fmt.Sprintf(" (pinned to %s first: %s)", platform, strings.TrimSpace(string(out)))
 		Logf("docker image save --platform %s failed, retrying unpinned: %s", platform, strings.TrimSpace(string(out)))
 		used = ""
-		out, err = exec.CommandContext(ctx, "docker", dockerSaveArgs(path, "", images)...).CombinedOutput() //nolint:contextcheck // same deadline, second shot
+		out, err = exec.CommandContext(ctx, "docker", dockerSaveArgs(path, "", images)...).CombinedOutput()
 	}
 	if err != nil {
 		cleanup()


### PR DESCRIPTION
## Motivation

The `//nolint:contextcheck` on the unpinned `docker image save` retry in #18606 suppresses nothing. The call already passes the enclosing `ctx` to `exec.CommandContext`, so contextcheck never had anything to report there. It went unnoticed on master because contextcheck is not in the enabled linter set here, and `nolintlint` skips directives naming a linter that did not run.

The backports make that visible: release-2.11 and release-2.12 enable both linters, and `check` fails on them with `directive '//nolint:contextcheck // same deadline, second shot' is unused for linter "contextcheck" (nolintlint)`.

## Implementation information

- Drops the directive. Verified against release-2.7, which has contextcheck enabled, that `golangci-lint run --default=none -E contextcheck ./test/framework/...` reports 0 issues without it.
- The same commit is on all six backport branches of #18606, so the file stays identical across them.

> Changelog: skip
