### PR TITLE
ci(mise): stop update-docs poisoning tool cache

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -34,6 +34,11 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           version: 2026.8.14
+          # The repo is checked out under repo/, so mise finds no config at the workspace
+          # root and installs nothing, while the cache key still hashes **/mise.toml. On a
+          # miss this job would save a mise-binary-only entry under the key every other
+          # job shares, and they all reinstall every tool until it gets evicted.
+          cache: false
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: "sync docs" # loop over all the branches and generate the docs


### PR DESCRIPTION
> Changelog: skip

## Motivation

Every job on master restores the mise cache and then reinstalls every tool anyway, about 2 minutes per job. In run 34368306142 the entry for `mise-v1-linux-x64-ubuntu24-2026.8.14-d90965d8…` was 34 MB: the mise binary and nothing else.

Root cause: `update-docs.yaml` checks the repo out under `repo/`. `jdx/mise-action` hashes `**/mise.toml` into the cache key, so the job gets the same key as every other job, but `mise install` runs at the workspace root, finds no config and installs nothing. When that job missed the cache (12:09 on 2026-09-09, run 34349382207) it saved the mise-only directory under the shared key. `mise-action` saves only on a miss, so every later job restored the 34 MB entry, reinstalled everything and never overwrote it, until GitHub evicted it around 15:44.

## Implementation information

`cache: false` on the `update-docs` mise step. The job only uses jq and yq from the runner image, so it needs neither the restore nor the save.

## Supporting documentation

- Poisoning save: https://github.com/kumahq/kuma/actions/runs/34349382207/job/102458679278 (`mise cache not found` followed by `Cache saved … with key: mise-v1-linux-x64-ubuntu24-2026.8.14-d90965d8…`, `mise install` took one second)
- Restore-then-reinstall in `check`: https://github.com/kumahq/kuma/actions/runs/34368306142/job/102523118897
- Save-on-miss-only in `mise-action`: https://github.com/jdx/mise-action/blob/c2a87611a18de5b3828c5652fe268e992400cb5c/src/index.ts (`run()` calls `saveCache` only when `restoreMiseCache` returned a key)
