### PR TITLE
test(federation): pin zone name before federating

### DIFF
--- a/test/e2e/federation/federation_universal.go
+++ b/test/e2e/federation/federation_universal.go
@@ -39,17 +39,13 @@ func FederateKubeZoneCPToUniversalGlobal() {
 			Install(Kuma(core.Zone,
 				WithInstallationMode(HelmInstallationMode),
 				WithHelmReleaseName(releaseName),
+				WithHelmOpt("controlPlane.zone", zone.ZoneName()),
 			)).
 			Install(NamespaceWithSidecarInjection(TestNamespace)).
 			Install(MeshKubernetes("default")).
 			Install(MeshIdentityBundledKubernetes("default", "identity-default")).
-			// Federating renames the zone: it runs standalone first, where
-			// {{ .Zone }} resolves to "default", and picks up its real name once
-			// it points at Global. Both trust domains have to be allowed or the
-			// re-issued certificates stop matching after federation.
 			Install(MeshTrafficPermissionAllowAllKubernetesWorkloadIdentity("default",
-				"default.default.mesh.local",
-				fmt.Sprintf("default.%s.mesh.local", zone.ZoneName()),
+				MeshIdentityTrustDomain("default", zone),
 			)).
 			Install(Parallel(
 				democlient.Install(),


### PR DESCRIPTION
## Motivation

The zone CP in this test is installed standalone, and the framework only passes `controlPlane.zone` when a global address is set (`test/framework/k8s_cluster.go`), so the CP fell back to the config default `default`. Federating then renamed it to the cluster name, re-issuing every workload certificate under a new trust domain mid-test. The MeshTrafficPermission had to allow both `default.default.mesh.local` and the post-federation one to keep traffic flowing.

## Implementation information

Set `controlPlane.zone` on the initial Helm install so the zone keeps the same name before and after federation, and narrow the MeshTrafficPermission to the single trust domain `MeshIdentityTrustDomain` derives. This also matches what universal clusters already do, where the zone name is always set in zone mode.

> Changelog: skip

xref: https://github.com/kumahq/kuma/issues/13838
