### PR TITLE
test(kds): seed the perf harness with the Zone API

### DIFF
--- a/pkg/test/kds/perf/global_scale_test.go
+++ b/pkg/test/kds/perf/global_scale_test.go
@@ -17,16 +17,13 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/protobuf/types/known/wrapperspb"
-
 	mesh_proto "github.com/kumahq/kuma/v3/api/mesh/v1alpha1"
-	system_proto "github.com/kumahq/kuma/v3/api/system/v1alpha1"
 	kuma_cp "github.com/kumahq/kuma/v3/pkg/config/app/kuma-cp"
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
 	config_types "github.com/kumahq/kuma/v3/pkg/config/types"
 	"github.com/kumahq/kuma/v3/pkg/core"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
-	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/system"
+	zone_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/zone/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/registry"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
@@ -36,6 +33,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
 	test_grpc "github.com/kumahq/kuma/v3/pkg/test/grpc"
 	"github.com/kumahq/kuma/v3/pkg/test/kds/setup"
+	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 // countingStore counts store operations so a run can be expressed in store
@@ -114,8 +112,8 @@ func seed(t *testing.T, st store.ResourceStore, meshes, zones, policiesPerType i
 	t.Helper()
 	ctx := context.Background()
 	for z := range zones {
-		zone := system.NewZoneResource()
-		zone.Spec = &system_proto.Zone{Enabled: wrapperspb.Bool(true)}
+		zone := zone_api.NewZoneResource()
+		zone.Spec.Enabled = pointer.To(true)
 		if err := st.Create(ctx, zone, store.CreateByKey(zoneName(z), core_model.NoMesh)); err != nil {
 			t.Fatalf("seed zone: %v", err)
 		}
@@ -130,7 +128,7 @@ func seed(t *testing.T, st store.ResourceStore, meshes, zones, policiesPerType i
 
 	created := 0
 	for _, typ := range types {
-		if typ == core_mesh.MeshType || typ == system.ZoneType {
+		if typ == core_mesh.MeshType || typ == zone_api.ZoneType {
 			continue
 		}
 		desc, err := registry.Global().DescriptorFor(typ)


### PR DESCRIPTION
## Motivation

Master is red. `check` fails on `4bbb82f348` with a typecheck error:

```
pkg/test/kds/perf/global_scale_test.go:117:18: undefined: system.NewZoneResource
pkg/test/kds/perf/global_scale_test.go:118:29: undefined: system_proto.Zone
pkg/test/kds/perf/global_scale_test.go:133:49: undefined: system.ZoneType
```

Neither change that produced this is wrong on its own. #18621 added the harness while `system.NewZoneResource` still existed, and #18564 removed that API after #18621's last run. Each was green against the tree it was tested on, and the breakage only exists in the merge of the two. `go build ./...` does not compile `_test.go` files, so nothing below `golangci-lint` catches it.

> Changelog: skip

## Implementation information

Seed the harness through `zone_api.NewZoneResource()` and set `Spec.Enabled` with `pointer.To`, matching how the rest of the tree constructs a Zone since #18564. The unused `system`, `system_proto` and `wrapperspb` imports go with it.

The harness is skipped unless `KUMA_KDS_PERF=1`, so compiling it is not evidence that it still works. Ran it for real:

```
KUMA_KDS_PERF=1 KDS_ZONES=3 KDS_MESHES=2 KDS_RESYNC=1s go test ./pkg/test/kds/perf/ -run TestGlobalKDSScale
=== zones=3 meshes=2 types=28 flush=5s resync=1s over 30s ===
store LIST :     420 total      14.0/s    4.67/s per zone
KDS responses delivered: 84 (2.8/s)
--- PASS: TestGlobalKDSScale (30.00s)
```

Zones seed, KDS delivers for each of them, and `GET ZoneInsight` still shows up per zone.

## Supporting documentation

`golangci-lint run ./pkg/test/kds/perf/...` reports 0 issues with the change and reproduces the master failure without it.
