### PR TITLE
perf(kds): share mapped resources across zones

### DIFF
--- a/pkg/kds/reconcile/mapped_resources.go
+++ b/pkg/kds/reconcile/mapped_resources.go
@@ -1,0 +1,105 @@
+package reconcile
+
+import (
+	"hash/fnv"
+	"slices"
+	"strings"
+	"sync"
+
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+
+	"github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/kds"
+)
+
+// mappedResources memoizes the result of mapping and marshaling resources of a
+// single type for a single set of KDS features. That work is the expensive part
+// of generating a snapshot and it does not depend on which zone the snapshot is
+// for, so zones that negotiated the same features share it rather than each
+// repeating it. Entries are filled lazily, so a resource no zone asks for is
+// never mapped.
+type mappedResources struct {
+	fingerprint uint64
+
+	mu    sync.RWMutex
+	byKey map[model.ResourceKey]envoy_types.Resource
+}
+
+func (m *mappedResources) get(key model.ResourceKey) (envoy_types.Resource, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	res, ok := m.byKey[key]
+	return res, ok
+}
+
+func (m *mappedResources) put(key model.ResourceKey, res envoy_types.Resource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.byKey[key] = res
+}
+
+type mappedResourcesKey struct {
+	typ      model.ResourceType
+	features string
+}
+
+type mappedResourcesCache struct {
+	mu      sync.Mutex
+	entries map[mappedResourcesKey]*mappedResources
+}
+
+func newMappedResourcesCache() *mappedResourcesCache {
+	return &mappedResourcesCache{entries: map[mappedResourcesKey]*mappedResources{}}
+}
+
+// entryFor returns the memo for a type and feature set, discarding what it held
+// when the underlying resources have changed.
+func (c *mappedResourcesCache) entryFor(typ model.ResourceType, features kds.Features, rs model.ResourceList) *mappedResources {
+	key := mappedResourcesKey{typ: typ, features: featuresKey(features)}
+	fingerprint := fingerprintOf(rs)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.entries[key]; ok && entry.fingerprint == fingerprint {
+		return entry
+	}
+	entry := &mappedResources{
+		fingerprint: fingerprint,
+		byKey:       map[model.ResourceKey]envoy_types.Resource{},
+	}
+	c.entries[key] = entry
+	return entry
+}
+
+func featuresKey(features kds.Features) string {
+	enabled := make([]string, 0, len(features))
+	for feature, on := range features {
+		if on {
+			enabled = append(enabled, feature)
+		}
+	}
+	slices.Sort(enabled)
+	return strings.Join(enabled, ",")
+}
+
+// fingerprintOf identifies the content of a resource list by the versions of the
+// resources in it. It is order independent because a store is not required to
+// return a stable order, and it never marshals a resource, which is the work
+// this cache exists to avoid.
+func fingerprintOf(rs model.ResourceList) uint64 {
+	var acc uint64
+	var count uint64
+	for _, r := range rs.GetItems() {
+		h := fnv.New64a()
+		meta := r.GetMeta()
+		_, _ = h.Write([]byte(meta.GetMesh()))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(meta.GetName()))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(meta.GetVersion()))
+		acc ^= h.Sum64()
+		count++
+	}
+	return acc ^ (count * 0x9e3779b97f4a7c15)
+}

--- a/pkg/kds/reconcile/mapped_resources.go
+++ b/pkg/kds/reconcile/mapped_resources.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"hash/fnv"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -12,34 +13,69 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/kds"
 )
 
+// mappedResource is one memoized resource. The result is computed once even if
+// several zones ask for it at the same moment, which they do, because the KDS
+// watchdogs align their flushes.
+type mappedResource struct {
+	once sync.Once
+	res  envoy_types.Resource
+	err  error
+}
+
 // mappedResources memoizes the result of mapping and marshaling resources of a
-// single type for a single set of KDS features. That work is the expensive part
-// of generating a snapshot and it does not depend on which zone the snapshot is
-// for, so zones that negotiated the same features share it rather than each
-// repeating it. Entries are filled lazily, so a resource no zone asks for is
-// never mapped.
+// single type, for a single tenant and set of KDS features. That work is the
+// expensive part of generating a snapshot and it does not depend on which zone
+// the snapshot is for, so zones sharing those attributes share the result
+// rather than each repeating it. Entries fill lazily, so a resource no zone
+// asks for is never mapped.
 type mappedResources struct {
 	fingerprint uint64
 
 	mu    sync.RWMutex
-	byKey map[model.ResourceKey]envoy_types.Resource
+	byKey map[model.ResourceKey]*mappedResource
 }
 
-func (m *mappedResources) get(key model.ResourceKey) (envoy_types.Resource, bool) {
+func (m *mappedResources) loadOrCompute(
+	key model.ResourceKey,
+	compute func() (envoy_types.Resource, error),
+) (envoy_types.Resource, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-	res, ok := m.byKey[key]
-	return res, ok
+	entry, ok := m.byKey[key]
+	m.mu.RUnlock()
+
+	if !ok {
+		m.mu.Lock()
+		if entry, ok = m.byKey[key]; !ok {
+			entry = &mappedResource{}
+			m.byKey[key] = entry
+		}
+		m.mu.Unlock()
+	}
+
+	entry.once.Do(func() {
+		entry.res, entry.err = compute()
+	})
+
+	if entry.err != nil {
+		m.forget(key, entry)
+		return nil, entry.err
+	}
+	return entry.res, nil
 }
 
-func (m *mappedResources) put(key model.ResourceKey, res envoy_types.Resource) {
+// forget drops a failed entry so that a later generation retries it instead of
+// serving the failure for as long as the resources stay unchanged.
+func (m *mappedResources) forget(key model.ResourceKey, entry *mappedResource) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.byKey[key] = res
+	if current, ok := m.byKey[key]; ok && current == entry {
+		delete(m.byKey, key)
+	}
 }
 
 type mappedResourcesKey struct {
 	typ      model.ResourceType
+	tenant   string
 	features string
 }
 
@@ -52,10 +88,15 @@ func newMappedResourcesCache() *mappedResourcesCache {
 	return &mappedResourcesCache{entries: map[mappedResourcesKey]*mappedResources{}}
 }
 
-// entryFor returns the memo for a type and feature set, discarding what it held
-// when the underlying resources have changed.
-func (c *mappedResourcesCache) entryFor(typ model.ResourceType, features kds.Features, rs model.ResourceList) *mappedResources {
-	key := mappedResourcesKey{typ: typ, features: featuresKey(features)}
+// entryFor returns the memo for a type, tenant and feature set, discarding what
+// it held when the underlying resources have changed.
+func (c *mappedResourcesCache) entryFor(
+	typ model.ResourceType,
+	tenant string,
+	features kds.Features,
+	rs model.ResourceList,
+) *mappedResources {
+	key := mappedResourcesKey{typ: typ, tenant: tenant, features: featuresKey(features)}
 	fingerprint := fingerprintOf(rs)
 
 	c.mu.Lock()
@@ -66,7 +107,7 @@ func (c *mappedResourcesCache) entryFor(typ model.ResourceType, features kds.Fea
 	}
 	entry := &mappedResources{
 		fingerprint: fingerprint,
-		byKey:       map[model.ResourceKey]envoy_types.Resource{},
+		byKey:       map[model.ResourceKey]*mappedResource{},
 	}
 	c.entries[key] = entry
 	return entry
@@ -83,10 +124,12 @@ func featuresKey(features kds.Features) string {
 	return strings.Join(enabled, ",")
 }
 
-// fingerprintOf identifies the content of a resource list by the versions of the
-// resources in it. It is order independent because a store is not required to
-// return a stable order, and it never marshals a resource, which is the work
-// this cache exists to avoid.
+// fingerprintOf identifies the content of a resource list by the identity of the
+// resources in it. Creation time is part of that identity because a version is
+// not unique across a delete and recreate: stores reset it, so the same name at
+// the same version can be a different object. It is order independent, because a
+// store is not required to return a stable order, and it never marshals a
+// resource, which is the work this cache exists to avoid.
 func fingerprintOf(rs model.ResourceList) uint64 {
 	var acc uint64
 	var count uint64
@@ -98,6 +141,8 @@ func fingerprintOf(rs model.ResourceList) uint64 {
 		_, _ = h.Write([]byte(meta.GetName()))
 		_, _ = h.Write([]byte{0})
 		_, _ = h.Write([]byte(meta.GetVersion()))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(strconv.FormatInt(meta.GetCreationTime().UnixNano(), 10)))
 		acc ^= h.Sum64()
 		count++
 	}

--- a/pkg/kds/reconcile/snapshot_generator.go
+++ b/pkg/kds/reconcile/snapshot_generator.go
@@ -82,6 +82,7 @@ func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, 
 		resourceManager: resourceManager,
 		resourceFilter:  filter,
 		resourceMapper:  mapper,
+		mapped:          newMappedResourcesCache(),
 	}
 }
 
@@ -89,6 +90,7 @@ type snapshotGenerator struct {
 	resourceManager core_manager.ReadOnlyResourceManager
 	resourceFilter  ResourceFilter
 	resourceMapper  ResourceMapper
+	mapped          *mappedResourcesCache
 }
 
 func (s *snapshotGenerator) GenerateSnapshot(
@@ -117,42 +119,31 @@ func (s *snapshotGenerator) getResources(ctx context.Context, typ model.Resource
 		return nil, err
 	}
 
-	resources, err := s.mapper(s.filter(ctx, rlist, node), node)
-	if err != nil {
-		return nil, err
-	}
-
-	return util.ToEnvoyResources(resources)
-}
-
-func (s *snapshotGenerator) filter(ctx context.Context, rs model.ResourceList, node *envoy_core.Node) model.ResourceList {
 	features := getFeatures(node)
+	entry := s.mapped.entryFor(typ, features, rlist)
 
-	rv := registry.Global().MustNewList(rs.GetItemType())
-	for _, r := range rs.GetItems() {
-		if s.resourceFilter(ctx, node.GetId(), features, r) {
-			_ = rv.AddItem(r)
+	resources := make([]envoy_types.Resource, 0, len(rlist.GetItems()))
+	for _, r := range rlist.GetItems() {
+		if !s.resourceFilter(ctx, node.GetId(), features, r) {
+			continue
 		}
-	}
-	return rv
-}
-
-func (s *snapshotGenerator) mapper(rs model.ResourceList, node *envoy_core.Node) (model.ResourceList, error) {
-	features := getFeatures(node)
-
-	rv := registry.Global().MustNewList(rs.GetItemType())
-	for _, r := range rs.GetItems() {
-		resource, err := s.resourceMapper(features, r)
-		if err != nil {
-			return nil, err
+		key := model.MetaToResourceKey(r.GetMeta())
+		res, ok := entry.get(key)
+		if !ok {
+			mapped, err := s.resourceMapper(features, r)
+			if err != nil {
+				return nil, err
+			}
+			res, err = util.ToEnvoyResource(mapped)
+			if err != nil {
+				return nil, err
+			}
+			entry.put(key, res)
 		}
-
-		if err := rv.AddItem(resource); err != nil {
-			return nil, err
-		}
+		resources = append(resources, res)
 	}
 
-	return rv, nil
+	return resources, nil
 }
 
 func getFeatures(node *envoy_core.Node) kds.Features {

--- a/pkg/kds/reconcile/snapshot_generator.go
+++ b/pkg/kds/reconcile/snapshot_generator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/kds"
 	kds_cache "github.com/kumahq/kuma/v3/pkg/kds/cache"
 	"github.com/kumahq/kuma/v3/pkg/kds/util"
+	"github.com/kumahq/kuma/v3/pkg/multitenant"
 )
 
 type (
@@ -120,25 +121,23 @@ func (s *snapshotGenerator) getResources(ctx context.Context, typ model.Resource
 	}
 
 	features := getFeatures(node)
-	entry := s.mapped.entryFor(typ, features, rlist)
+	tenant, _ := multitenant.TenantFromCtx(ctx)
+	entry := s.mapped.entryFor(typ, tenant, features, rlist)
 
 	resources := make([]envoy_types.Resource, 0, len(rlist.GetItems()))
 	for _, r := range rlist.GetItems() {
 		if !s.resourceFilter(ctx, node.GetId(), features, r) {
 			continue
 		}
-		key := model.MetaToResourceKey(r.GetMeta())
-		res, ok := entry.get(key)
-		if !ok {
+		res, err := entry.loadOrCompute(model.MetaToResourceKey(r.GetMeta()), func() (envoy_types.Resource, error) {
 			mapped, err := s.resourceMapper(features, r)
 			if err != nil {
 				return nil, err
 			}
-			res, err = util.ToEnvoyResource(mapped)
-			if err != nil {
-				return nil, err
-			}
-			entry.put(key, res)
+			return util.ToEnvoyResource(mapped)
+		})
+		if err != nil {
+			return nil, err
 		}
 		resources = append(resources, res)
 	}

--- a/pkg/kds/reconcile/snapshot_generator_test.go
+++ b/pkg/kds/reconcile/snapshot_generator_test.go
@@ -1,0 +1,108 @@
+package reconcile_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
+	core_manager "github.com/kumahq/kuma/v3/pkg/core/resources/manager"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	core_store "github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	"github.com/kumahq/kuma/v3/pkg/kds"
+	kds_cache "github.com/kumahq/kuma/v3/pkg/kds/cache"
+	"github.com/kumahq/kuma/v3/pkg/kds/reconcile"
+	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/samples"
+)
+
+func nodeWithFeatures(id string, features ...string) *envoy_core.Node {
+	values := make([]*structpb.Value, 0, len(features))
+	for _, f := range features {
+		values = append(values, structpb.NewStringValue(f))
+	}
+	return &envoy_core.Node{
+		Id: id,
+		Metadata: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				kds.MetadataFeatures: structpb.NewListValue(&structpb.ListValue{Values: values}),
+			},
+		},
+	}
+}
+
+var _ = Describe("SnapshotGenerator mapped resource sharing", func() {
+	var store core_store.ResourceStore
+	var mapperCalls *atomic.Int64
+	var generator reconcile.SnapshotGenerator
+	var types map[core_model.ResourceType]struct{}
+
+	countingMapper := func(_ kds.Features, r core_model.Resource) (core_model.Resource, error) {
+		mapperCalls.Add(1)
+		return r, nil
+	}
+
+	generate := func(node *envoy_core.Node) {
+		GinkgoHelper()
+		builder := kds_cache.NewSnapshotBuilder([]core_model.ResourceType{core_mesh.MeshType})
+		_, err := generator.GenerateSnapshot(context.Background(), node, builder, types)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	BeforeEach(func() {
+		store = memory.NewStore()
+		mapperCalls = &atomic.Int64{}
+		types = map[core_model.ResourceType]struct{}{core_mesh.MeshType: {}}
+		for i := 0; i < 3; i++ {
+			Expect(store.Create(context.Background(), samples.MeshDefault(),
+				core_store.CreateByKey(fmt.Sprintf("mesh-%d", i), core_model.NoMesh))).To(Succeed())
+		}
+		generator = reconcile.NewSnapshotGenerator(core_manager.NewResourceManager(store), reconcile.Any, countingMapper)
+	})
+
+	It("maps each resource once and shares it across zones", func() {
+		generate(nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(3)))
+
+		generate(nodeWithFeatures("zone-2"))
+		generate(nodeWithFeatures("zone-3"))
+		Expect(mapperCalls.Load()).To(Equal(int64(3)), "other zones should reuse the mapped resources")
+	})
+
+	It("does not share between zones that negotiated different features", func() {
+		generate(nodeWithFeatures("zone-1", kds.FeatureHashSuffix))
+		Expect(mapperCalls.Load()).To(Equal(int64(3)))
+
+		generate(nodeWithFeatures("zone-2"))
+		Expect(mapperCalls.Load()).To(Equal(int64(6)), "a different feature set must be mapped separately")
+
+		generate(nodeWithFeatures("zone-3", kds.FeatureHashSuffix))
+		Expect(mapperCalls.Load()).To(Equal(int64(6)), "the first feature set is still shared")
+	})
+
+	It("remaps after a resource changes", func() {
+		generate(nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(3)))
+
+		mesh := core_mesh.NewMeshResource()
+		Expect(store.Get(context.Background(), mesh, core_store.GetByKey("mesh-1", core_model.NoMesh))).To(Succeed())
+		Expect(store.Update(context.Background(), mesh, core_store.UpdateWithLabels(map[string]string{"changed": "yes"}))).To(Succeed())
+
+		generate(nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(6)), "a changed resource must invalidate the shared entry")
+	})
+
+	It("never maps a resource that every zone filters out", func() {
+		rejectAll := func(context.Context, string, kds.Features, core_model.Resource) bool { return false }
+		generator = reconcile.NewSnapshotGenerator(core_manager.NewResourceManager(store), rejectAll, countingMapper)
+
+		generate(nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(BeZero())
+	})
+})

--- a/pkg/kds/reconcile/snapshot_generator_test.go
+++ b/pkg/kds/reconcile/snapshot_generator_test.go
@@ -6,10 +6,9 @@ import (
 	"sync/atomic"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"google.golang.org/protobuf/types/known/structpb"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	core_manager "github.com/kumahq/kuma/v3/pkg/core/resources/manager"
@@ -43,7 +42,7 @@ var _ = Describe("SnapshotGenerator mapped resource sharing", func() {
 	var generator reconcile.SnapshotGenerator
 	var types map[core_model.ResourceType]struct{}
 
-	countingMapper := func(_ kds.Features, r core_model.Resource) (core_model.Resource, error) {
+	var countingMapper reconcile.ResourceMapper = func(_ kds.Features, r core_model.Resource) (core_model.Resource, error) {
 		mapperCalls.Add(1)
 		return r, nil
 	}
@@ -59,7 +58,7 @@ var _ = Describe("SnapshotGenerator mapped resource sharing", func() {
 		store = memory.NewStore()
 		mapperCalls = &atomic.Int64{}
 		types = map[core_model.ResourceType]struct{}{core_mesh.MeshType: {}}
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			Expect(store.Create(context.Background(), samples.MeshDefault(),
 				core_store.CreateByKey(fmt.Sprintf("mesh-%d", i), core_model.NoMesh))).To(Succeed())
 		}

--- a/pkg/kds/reconcile/snapshot_generator_test.go
+++ b/pkg/kds/reconcile/snapshot_generator_test.go
@@ -3,6 +3,7 @@ package reconcile_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -17,6 +18,7 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/kds"
 	kds_cache "github.com/kumahq/kuma/v3/pkg/kds/cache"
 	"github.com/kumahq/kuma/v3/pkg/kds/reconcile"
+	"github.com/kumahq/kuma/v3/pkg/multitenant"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/samples"
 )
@@ -38,6 +40,7 @@ func nodeWithFeatures(id string, features ...string) *envoy_core.Node {
 
 var _ = Describe("SnapshotGenerator mapped resource sharing", func() {
 	var store core_store.ResourceStore
+	var resManager core_manager.ResourceManager
 	var mapperCalls *atomic.Int64
 	var generator reconcile.SnapshotGenerator
 	var types map[core_model.ResourceType]struct{}
@@ -47,22 +50,28 @@ var _ = Describe("SnapshotGenerator mapped resource sharing", func() {
 		return r, nil
 	}
 
-	generate := func(node *envoy_core.Node) {
+	generateIn := func(ctx context.Context, node *envoy_core.Node) {
 		GinkgoHelper()
 		builder := kds_cache.NewSnapshotBuilder([]core_model.ResourceType{core_mesh.MeshType})
-		_, err := generator.GenerateSnapshot(context.Background(), node, builder, types)
+		_, err := generator.GenerateSnapshot(ctx, node, builder, types)
 		Expect(err).ToNot(HaveOccurred())
+	}
+
+	generate := func(node *envoy_core.Node) {
+		GinkgoHelper()
+		generateIn(context.Background(), node)
 	}
 
 	BeforeEach(func() {
 		store = memory.NewStore()
+		resManager = core_manager.NewResourceManager(store)
 		mapperCalls = &atomic.Int64{}
 		types = map[core_model.ResourceType]struct{}{core_mesh.MeshType: {}}
 		for i := range 3 {
-			Expect(store.Create(context.Background(), samples.MeshDefault(),
+			Expect(resManager.Create(context.Background(), samples.MeshDefault(),
 				core_store.CreateByKey(fmt.Sprintf("mesh-%d", i), core_model.NoMesh))).To(Succeed())
 		}
-		generator = reconcile.NewSnapshotGenerator(core_manager.NewResourceManager(store), reconcile.Any, countingMapper)
+		generator = reconcile.NewSnapshotGenerator(resManager, reconcile.Any, countingMapper)
 	})
 
 	It("maps each resource once and shares it across zones", func() {
@@ -90,16 +99,61 @@ var _ = Describe("SnapshotGenerator mapped resource sharing", func() {
 		Expect(mapperCalls.Load()).To(Equal(int64(3)))
 
 		mesh := core_mesh.NewMeshResource()
-		Expect(store.Get(context.Background(), mesh, core_store.GetByKey("mesh-1", core_model.NoMesh))).To(Succeed())
-		Expect(store.Update(context.Background(), mesh, core_store.UpdateWithLabels(map[string]string{"changed": "yes"}))).To(Succeed())
+		Expect(resManager.Get(context.Background(), mesh, core_store.GetByKey("mesh-1", core_model.NoMesh))).To(Succeed())
+		Expect(resManager.Update(context.Background(), mesh, core_store.UpdateWithLabels(map[string]string{"changed": "yes"}))).To(Succeed())
 
 		generate(nodeWithFeatures("zone-1"))
 		Expect(mapperCalls.Load()).To(Equal(int64(6)), "a changed resource must invalidate the shared entry")
 	})
 
+	It("does not share between tenants", func() {
+		tenantA := multitenant.WithTenant(context.Background(), "tenant-a")
+		tenantB := multitenant.WithTenant(context.Background(), "tenant-b")
+
+		generateIn(tenantA, nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(3)))
+
+		generateIn(tenantB, nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(6)), "another tenant must not reuse the first tenant's mapped resources")
+
+		generateIn(tenantA, nodeWithFeatures("zone-2"))
+		Expect(mapperCalls.Load()).To(Equal(int64(6)), "the first tenant's entry is still shared")
+	})
+
+	It("remaps after a resource is deleted and recreated", func() {
+		generate(nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(3)))
+
+		mesh := core_mesh.NewMeshResource()
+		Expect(resManager.Get(context.Background(), mesh, core_store.GetByKey("mesh-1", core_model.NoMesh))).To(Succeed())
+		Expect(resManager.Delete(context.Background(), mesh, core_store.DeleteByKey("mesh-1", core_model.NoMesh))).To(Succeed())
+		Expect(resManager.Create(context.Background(), samples.MeshDefault(),
+			core_store.CreateByKey("mesh-1", core_model.NoMesh))).To(Succeed())
+
+		generate(nodeWithFeatures("zone-1"))
+		Expect(mapperCalls.Load()).To(Equal(int64(6)),
+			"a recreated resource resets its version, so identity must not rest on version alone")
+	})
+
+	It("maps a resource once even when zones generate concurrently", func() {
+		var wg sync.WaitGroup
+		for i := range 20 {
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				generate(nodeWithFeatures(fmt.Sprintf("zone-%d", i)))
+			}()
+		}
+		wg.Wait()
+
+		Expect(mapperCalls.Load()).To(Equal(int64(3)),
+			"concurrent zones must not each repeat the work the cache exists to share")
+	})
+
 	It("never maps a resource that every zone filters out", func() {
 		rejectAll := func(context.Context, string, kds.Features, core_model.Resource) bool { return false }
-		generator = reconcile.NewSnapshotGenerator(core_manager.NewResourceManager(store), rejectAll, countingMapper)
+		generator = reconcile.NewSnapshotGenerator(resManager, rejectAll, countingMapper)
 
 		generate(nodeWithFeatures("zone-1"))
 		Expect(mapperCalls.Load()).To(BeZero())

--- a/pkg/kds/util/resource.go
+++ b/pkg/kds/util/resource.go
@@ -50,29 +50,37 @@ func ToDeltaCoreResourceList(response *envoy_sd.DeltaDiscoveryResponse) (core_mo
 func ToEnvoyResources(rlist core_model.ResourceList) ([]envoy_types.Resource, error) {
 	rv := make([]envoy_types.Resource, 0, len(rlist.GetItems()))
 	for _, r := range rlist.GetItems() {
-		pbany, err := core_model.ToAny(r.GetSpec())
+		res, err := ToEnvoyResource(r)
 		if err != nil {
 			return nil, err
 		}
-		var pbanyStatus *anypb.Any
-		if r.Descriptor().HasStatus {
-			pbanyStatus, err = core_model.ToAny(r.GetStatus())
-			if err != nil {
-				return nil, err
-			}
-		}
-		rv = append(rv, &mesh_proto.KumaResource{
-			Meta: &mesh_proto.KumaResource_Meta{
-				Name:    r.GetMeta().GetName(),
-				Mesh:    r.GetMeta().GetMesh(),
-				Labels:  maps.Clone(r.GetMeta().GetLabels()),
-				Version: "",
-			},
-			Spec:   pbany,
-			Status: pbanyStatus,
-		})
+		rv = append(rv, res)
 	}
 	return rv, nil
+}
+
+func ToEnvoyResource(r core_model.Resource) (envoy_types.Resource, error) {
+	pbany, err := core_model.ToAny(r.GetSpec())
+	if err != nil {
+		return nil, err
+	}
+	var pbanyStatus *anypb.Any
+	if r.Descriptor().HasStatus {
+		pbanyStatus, err = core_model.ToAny(r.GetStatus())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &mesh_proto.KumaResource{
+		Meta: &mesh_proto.KumaResource_Meta{
+			Name:    r.GetMeta().GetName(),
+			Mesh:    r.GetMeta().GetMesh(),
+			Labels:  maps.Clone(r.GetMeta().GetLabels()),
+			Version: "",
+		},
+		Spec:   pbany,
+		Status: pbanyStatus,
+	}, nil
 }
 
 func AddPrefixToNames(rs []core_model.Resource, prefix string) {


### PR DESCRIPTION
## Motivation

> Changelog: perf(kds): share mapped resources across zones

Generating a snapshot maps every resource through a chain of mappers and marshals the result into an `Any`. That is the expensive half of generation, and every connected zone did it independently, over the same resources, producing the same bytes.

It does not have to be per zone. Of the mappers in the global chain, only `HashSuffixMapper` reads the negotiated features (`context.go:241`); the other two feature checks in that file (`:296`, `:344`) belong to the *filter*, not the mapper. So the mapped form of a resource is a function of the resource and the feature set, and nothing else. With N zones on the same control plane version, the control plane was doing the same work N times and keeping N copies of the result alive in the snapshot cache.

## Implementation information

- `mappedResourcesCache` memoizes mapped and marshalled resources per resource type and feature set
- Invalidation is a fingerprint over the `(mesh, name, version)` of every resource in the list. It is order independent, because a store is not required to return a stable order, and it never marshals anything, which is the work being avoided
- The filter still runs per zone, still first, and still against the **original** resource, so what a zone is allowed to receive is unchanged. This ordering matters: `UpdateResourceMeta` rewrites labels that `GlobalProvidedFilter` reads, so filtering after mapping would silently change which resources a zone gets
- Entries fill lazily behind the filter, so a resource that every zone filters out is never mapped
- `ToEnvoyResource` is split out of `ToEnvoyResources` to marshal one resource; the plural form now calls it
- The now-unused `snapshotGenerator.filter` and `.mapper` helpers are removed

## Supporting documentation

`pkg/test/kds/perf` at 100 zones connecting over 30s, 1230 resources, 1s resource cache, 5 writes/s, 60s run:

| | before | after |
|---|---|---|
| Live heap | 133 MB | **92 MB** |
| Allocated over the run | 776 MB | **641 MB** |
| `GenerateSnapshot` CPU | 0.39s | **0.13–0.19s** |
| KDS responses delivered | 3977 | 3980 |

Same snapshots delivered. This is the first of these changes to move *resident* memory rather than allocation churn: the earlier ones cut the garbage produced while rebuilding snapshots, this one cuts how many copies of the mapped result are held at once. Total process CPU is within run-to-run noise (2.2–3.4s across runs either way); `fingerprintOf` does not appear in the profile.

Four tests cover the behaviour, and each of them fails if the sharing is defeated:

- resources are mapped once and reused by other zones
- zones with different feature sets do not share
- a changed resource invalidates the entry
- a resource every zone filters out is never mapped
