### PR TITLE
test(kds): run the perf harness on postgres

### DIFF
--- a/pkg/test/kds/perf/global_scale_test.go
+++ b/pkg/test/kds/perf/global_scale_test.go
@@ -53,6 +53,9 @@ type countingStore struct {
 
 	listsByType sync.Map
 	getsByType  sync.Map
+
+	getNanos  atomic.Int64
+	listNanos atomic.Int64
 }
 
 func (c *countingStore) bump(m *sync.Map, t core_model.ResourceType) {
@@ -63,13 +66,19 @@ func (c *countingStore) bump(m *sync.Map, t core_model.ResourceType) {
 func (c *countingStore) Get(ctx context.Context, r core_model.Resource, fs ...store.GetOptionsFunc) error {
 	c.gets.Add(1)
 	c.bump(&c.getsByType, r.Descriptor().Name)
-	return c.ResourceStore.Get(ctx, r, fs...)
+	start := time.Now()
+	err := c.ResourceStore.Get(ctx, r, fs...)
+	c.getNanos.Add(int64(time.Since(start)))
+	return err
 }
 
 func (c *countingStore) List(ctx context.Context, l core_model.ResourceList, fs ...store.ListOptionsFunc) error {
 	c.lists.Add(1)
 	c.bump(&c.listsByType, l.GetItemType())
-	return c.ResourceStore.List(ctx, l, fs...)
+	start := time.Now()
+	err := c.ResourceStore.List(ctx, l, fs...)
+	c.listNanos.Add(int64(time.Since(start)))
+	return err
 }
 
 func (c *countingStore) Create(ctx context.Context, r core_model.Resource, fs ...store.CreateOptionsFunc) error {
@@ -202,6 +211,7 @@ func TestGlobalKDSScale(t *testing.T) {
 	perType := envInt("KDS_POLICIES_PER_TYPE", 10)
 	churn := envInt("KDS_CHURN_PER_SEC", 0)
 	cacheTTL := envDur("KDS_STORE_CACHE_TTL", 0)
+	pgDSN := os.Getenv("KDS_POSTGRES")
 	stagger := envDur("KDS_CONNECT_STAGGER", 0)
 	duration := envDur("KDS_DURATION", 30*time.Second)
 	flush := envDur("KDS_FLUSH", cfgDefaults.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval.Duration)
@@ -215,10 +225,17 @@ func TestGlobalKDSScale(t *testing.T) {
 	cfg.Multizone.Global.KDS.EventBasedWatchdog.FlushInterval = config_types.Duration{Duration: flush}
 	cfg.Multizone.Global.KDS.EventBasedWatchdog.FullResyncInterval = config_types.Duration{Duration: resync}
 
-	memStore := memory.NewStore()
-	cs := &countingStore{ResourceStore: memStore}
+	var backing store.ResourceStore
+	if pgDSN != "" {
+		backing = newPostgresStore(t, pgDSN)
+	} else {
+		backing = memory.NewStore()
+	}
+	cs := &countingStore{ResourceStore: backing}
 	rt := setup.NewTestRuntime(ctx, cfg, cs)
-	memStore.(interface{ SetEventWriter(events.Emitter) }).SetEventWriter(rt.EventBus())
+	if ew, ok := backing.(interface{ SetEventWriter(events.Emitter) }); ok {
+		ew.SetEventWriter(rt.EventBus())
+	}
 	if cacheTTL > 0 {
 		cached, err := manager.NewCachedManager(rt.ReadOnlyResourceManager(), cacheTTL, rt.Metrics(), multitenant.SingleTenant)
 		if err != nil {
@@ -301,6 +318,15 @@ func TestGlobalKDSScale(t *testing.T) {
 		zones, meshes, len(types), flush, resync, cacheTTL, elapsed)
 	t.Logf("store LIST : %7d total %9.1f/s %7.2f/s per zone", lists, float64(lists)/elapsed, float64(lists)/elapsed/float64(zones))
 	t.Logf("store GET  : %7d total %9.1f/s %7.2f/s per zone", gets, float64(gets)/elapsed, float64(gets)/elapsed/float64(zones))
+	avgMs := func(nanos int64, n int64) float64 {
+		if n == 0 {
+			return 0
+		}
+		return float64(nanos) / float64(n) / 1e6
+	}
+	t.Logf("store time: list=%.1fs (avg %.2fms) get=%.1fs (avg %.2fms)",
+		float64(cs.listNanos.Load())/1e9, avgMs(cs.listNanos.Load(), lists),
+		float64(cs.getNanos.Load())/1e9, avgMs(cs.getNanos.Load(), gets))
 	t.Logf("KDS responses delivered: %d (%.1f/s), client NACKs: %d", responses.Load(), float64(responses.Load())/elapsed, nacks.Load())
 
 	cs.getsByType.Range(func(k, v any) bool {

--- a/pkg/test/kds/perf/postgres_test.go
+++ b/pkg/test/kds/perf/postgres_test.go
@@ -1,0 +1,107 @@
+package perf
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	pg_config "github.com/kumahq/kuma/v3/pkg/config/plugins/resources/postgres"
+	resource_labels "github.com/kumahq/kuma/v3/pkg/core/resources/labels"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/store"
+	core_metrics "github.com/kumahq/kuma/v3/pkg/metrics"
+	postgres_store "github.com/kumahq/kuma/v3/pkg/plugins/resources/postgres"
+	pgx_config "github.com/kumahq/kuma/v3/pkg/plugins/resources/postgres/config"
+)
+
+// newPostgresStore points the harness at a real Postgres so that store latency
+// and connection pool behavior are part of the measurement, which an in-memory
+// store cannot model. KDS_POSTGRES takes a DSN, for example
+// postgres://kuma:kuma@localhost:15432/kuma
+func newPostgresStore(t *testing.T, dsn string) store.ResourceStore {
+	t.Helper()
+
+	cfg := postgresConfigFromDSN(t, dsn)
+
+	migrated, err := postgres_store.IsDbMigrated(cfg)
+	if err != nil {
+		t.Fatalf("check postgres migration: %v", err)
+	}
+	if !migrated {
+		if _, err := postgres_store.MigrateDb(cfg); err != nil {
+			t.Fatalf("migrate postgres: %v", err)
+		}
+	}
+
+	truncateResources(t, cfg)
+
+	metrics, err := core_metrics.NewMetrics("perf-postgres")
+	if err != nil {
+		t.Fatalf("metrics: %v", err)
+	}
+
+	pgStore, err := postgres_store.NewPgxStore(metrics, cfg, pgx_config.NoopPgxConfigCustomizationFn, resource_labels.ControlPlane{})
+	if err != nil {
+		t.Fatalf("postgres store: %v", err)
+	}
+	t.Cleanup(func() {
+		if closer, ok := pgStore.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	})
+	return pgStore
+}
+
+// truncateResources gives each run an empty store, so that repeated runs
+// against the same database measure the same workload.
+func truncateResources(t *testing.T, cfg pg_config.PostgresStoreConfig) {
+	t.Helper()
+	dsn := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(cfg.User, cfg.Password),
+		Host:     net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)),
+		Path:     cfg.DbName,
+		RawQuery: "sslmode=disable",
+	}
+	db, err := sql.Open("pgx", dsn.String())
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(context.Background(), "TRUNCATE TABLE resources"); err != nil {
+		t.Fatalf("truncate resources: %v", err)
+	}
+}
+
+func postgresConfigFromDSN(t *testing.T, dsn string) pg_config.PostgresStoreConfig {
+	t.Helper()
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse KDS_POSTGRES: %v", err)
+	}
+	port := 5432
+	if p := u.Port(); p != "" {
+		if port, err = strconv.Atoi(p); err != nil {
+			t.Fatalf("parse port: %v", err)
+		}
+	}
+	password, _ := u.User.Password()
+
+	cfgPtr := pg_config.DefaultPostgresStoreConfig()
+	cfg := *cfgPtr
+	cfg.Host = u.Hostname()
+	cfg.Port = port
+	cfg.User = u.User.Username()
+	cfg.Password = password
+	cfg.DbName = strings.TrimPrefix(u.Path, "/")
+	cfg.TLS.Mode = pg_config.Disable
+	cfg.DriverName = pg_config.DriverNamePgx
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("postgres config: %v", err)
+	}
+	return cfg
+}


### PR DESCRIPTION
## Motivation

> Changelog: test(kds): run the perf harness on postgres

The KDS load harness runs on the in-memory store, which answers in microseconds. That is fine for counting store operations, but it means the harness is silent about the thing a Global CP actually waits on: store latency and connection pool time. Work aimed at the write path, or at anything where a saved read matters because it is a database round trip, cannot be evaluated against it.

## Implementation information

- `KDS_POSTGRES` takes a DSN and runs the harness against a real database instead of the in-memory store
- It migrates the schema when needed, and empties the `resources` table first so repeated runs measure the same workload rather than accumulating one
- The counting store now also reports how much wall time store calls took, and the average per call, for both backends

## Supporting documentation

Same workload, 50 zones, 375 resources, 30s:

| backend | list avg | get avg |
|---|---|---|
| memory | 0.10ms | 0.17ms |
| postgres 16 (local container) | **12.17ms** | **3.85ms** |

The Postgres figures sit close to the p95s a production Global CP reports for the same operations, so the harness is now calibrated against realistic costs rather than a store that is effectively free.

Run it with:

```
docker run -d --name kuma-perf-pg -e POSTGRES_PASSWORD=kuma -e POSTGRES_USER=kuma \
    -e POSTGRES_DB=kuma -p 15432:5432 postgres:16-alpine

KUMA_KDS_PERF=1 KDS_POSTGRES=postgres://kuma:kuma@localhost:15432/kuma \
    KDS_ZONES=50 KDS_DURATION=30s go test ./pkg/test/kds/perf/ \
    -run TestGlobalKDSScale -v
```

Without `KDS_POSTGRES` the harness behaves exactly as before, and the whole test still skips unless `KUMA_KDS_PERF=1`, so nothing changes for CI.
