### PR TITLE
refactor(otel)!: always export otel backendRefs through kuma-dp

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,14 @@ does not have any particular instructions.
 - If a workload relies on `KUMA_DATAPLANE_RUNTIME_STRICT_INBOUND_PORTS_ENABLED=false` to receive traffic on ports it does not declare, declare those ports as inbounds before you upgrade.
 - Restart data planes that run with `KUMA_DATAPLANE_RUNTIME_REUSE_PORT_ENABLED=false` after you upgrade the control plane. Envoy cannot change `enable_reuse_port` on a running listener, so it rejects listener updates until the data plane restarts.
 
+### OpenTelemetry backends referenced by `backendRef` always export through `kuma-dp`
+
+`MeshTrace`, `MeshAccessLog`, and `MeshMetric` send data for a `backendRef` to a `MeshOpenTelemetryBackend` through `kuma-dp`: Envoy exports to a Unix socket and `kuma-dp` forwards to the collector. Setting `runtime.kubernetes.injector.otelPipeEnabled` (`KUMA_RUNTIME_KUBERNETES_INJECTOR_OTEL_PIPE_ENABLED`) or `KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED` to `false` used to make Envoy export to the collector directly. Both settings are removed.
+
+**Action required**
+
+None unless you set either setting to `false`. The control plane and `kuma-dp` now ignore both, so remove them from your control plane configuration and sidecar environment.
+
 ### KDS full resync is periodic again, not every second
 
 Removing the polling KDS watchdog carried the poll loop's `refreshInterval` of

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -218,10 +218,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 
 			rootCtx.Features = nil
-			if cfg.DataplaneRuntime.OtelPipeEnabled {
-				rootCtx.Features = append(rootCtx.Features, xds_types.FeatureOtelViaKumaDp)
-			}
-
 			if cfg.DataplaneRuntime.TransparentProxy != nil {
 				rootCtx.Features = append(rootCtx.Features, xds_types.FeatureTransparentProxyInDataplaneMetadata)
 			}
@@ -236,7 +232,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			if hostIP := os.Getenv("HOST_IP"); hostIP != "" {
 				rootCtx.BootstrapDynamicMetadata[core_xds.FieldDynamicHostIP] = hostIP
 			}
-			discoveredEnv := otelenv.Discover(cfg.DataplaneRuntime.OtelPipeEnabled)
+			discoveredEnv := otelenv.Discover()
 			rootCtx.DiscoveredOtelEnv = discoveredEnv
 			rootCtx.BootstrapOtelEnv = &discoveredEnv.Inventory
 

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -195,7 +195,6 @@ var _ = Describe("Remote Bootstrap", func() {
 		defer server.Close()
 
 		inventory := &core_xds.OtelBootstrapInventory{
-			PipeEnabled: true,
 			Shared: &core_xds.OtelSignalEnvInventory{
 				EndpointPresent:   true,
 				HeadersPresent:    true,
@@ -213,7 +212,6 @@ var _ = Describe("Remote Bootstrap", func() {
 			var request types.BootstrapRequest
 			Expect(json.NewDecoder(req.Body).Decode(&request)).To(Succeed())
 			Expect(request.OtelEnv).ToNot(BeNil())
-			Expect(request.OtelEnv.PipeEnabled).To(BeTrue())
 			Expect(request.OtelEnv.Shared).ToNot(BeNil())
 			Expect(request.OtelEnv.Shared.EffectiveProtocol).To(Equal(core_xds.OtelProtocolHTTPProtobuf))
 			Expect(request.OtelEnv.Traces).ToNot(BeNil())

--- a/app/kuma-dp/pkg/dataplane/otelenv/discovery.go
+++ b/app/kuma-dp/pkg/dataplane/otelenv/discovery.go
@@ -16,12 +16,12 @@ var envPrefix = map[core_xds.OtelSignal]string{
 	core_xds.OtelSignalMetrics: "OTEL_EXPORTER_OTLP_METRICS",
 }
 
-func Discover(pipeEnabled bool) Config {
-	return discoverWithLookup(pipeEnabled, OSEnvReader{})
+func Discover() Config {
+	return discoverWithLookup(OSEnvReader{})
 }
 
-func discoverWithLookup(pipeEnabled bool, reader EnvReader) Config {
-	return NewConfig(pipeEnabled,
+func discoverWithLookup(reader EnvReader) Config {
+	return NewConfig(
 		readLayer(core_xds.OtelSignalShared, reader),
 		readLayer(core_xds.OtelSignalTraces, reader),
 		readLayer(core_xds.OtelSignalLogs, reader),
@@ -29,24 +29,22 @@ func discoverWithLookup(pipeEnabled bool, reader EnvReader) Config {
 	)
 }
 
-func NewConfig(pipeEnabled bool, shared, traces, logs, metrics Layer) Config {
+func NewConfig(shared, traces, logs, metrics Layer) Config {
 	sharedInv := shared.analyze(nil)
 	tracesInv := traces.analyze(&shared)
 	logsInv := logs.analyze(&shared)
 	metricsInv := metrics.analyze(&shared)
 
 	return Config{
-		PipeEnabled: pipeEnabled,
-		Shared:      shared,
-		Traces:      traces,
-		Logs:        logs,
-		Metrics:     metrics,
+		Shared:  shared,
+		Traces:  traces,
+		Logs:    logs,
+		Metrics: metrics,
 		Inventory: core_xds.OtelBootstrapInventory{
-			PipeEnabled: pipeEnabled,
-			Shared:      sharedInv,
-			Traces:      tracesInv,
-			Logs:        logsInv,
-			Metrics:     metricsInv,
+			Shared:  sharedInv,
+			Traces:  tracesInv,
+			Logs:    logsInv,
+			Metrics: metricsInv,
 			ValidationErrors: slices.Concat(
 				sharedInv.GetValidationErrors(),
 				tracesInv.GetValidationErrors(),

--- a/app/kuma-dp/pkg/dataplane/otelenv/discovery_test.go
+++ b/app/kuma-dp/pkg/dataplane/otelenv/discovery_test.go
@@ -18,9 +18,8 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "grpc",
 		}
 
-		cfg := discoverWithLookup(true, env)
+		cfg := discoverWithLookup(env)
 
-		Expect(cfg.Inventory.PipeEnabled).To(BeTrue())
 		Expect(cfg.Inventory.Shared).ToNot(BeNil())
 		Expect(cfg.Inventory.Shared.EndpointPresent).To(BeTrue())
 		Expect(cfg.Inventory.Shared.EndpointParsedAsURL).To(BeTrue())
@@ -43,7 +42,7 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE": "/cert",
 		}
 
-		cfg := discoverWithLookup(false, env)
+		cfg := discoverWithLookup(env)
 
 		Expect(cfg.Inventory.ValidationErrors).To(ConsistOf("shared.protocol", "shared.timeout", "shared.compression", "traces.mtls"))
 		Expect(cfg.Inventory.Shared).ToNot(BeNil())
@@ -57,7 +56,7 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_COMPRESSION": "none",
 		}
 
-		cfg := discoverWithLookup(false, env)
+		cfg := discoverWithLookup(env)
 
 		Expect(cfg.Inventory.ValidationErrors).To(BeEmpty())
 		Expect(cfg.Inventory.Shared).ToNot(BeNil())
@@ -69,7 +68,7 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_ENDPOINT": "   ",
 		}
 
-		cfg := discoverWithLookup(false, env)
+		cfg := discoverWithLookup(env)
 
 		Expect(cfg.Inventory.Shared).To(BeNil())
 		Expect(cfg.Inventory.ValidationErrors).To(BeEmpty())
@@ -80,7 +79,7 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_ENDPOINT": "https://collector.example:4317/custom",
 		}
 
-		cfg := discoverWithLookup(false, env)
+		cfg := discoverWithLookup(env)
 
 		Expect(cfg.Inventory.ValidationErrors).To(ContainElement("shared.endpoint"))
 	})
@@ -91,7 +90,7 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "https://collector.example:4317/traces",
 		}
 
-		cfg := discoverWithLookup(false, env)
+		cfg := discoverWithLookup(env)
 
 		Expect(cfg.Inventory.ValidationErrors).To(ContainElement("traces.endpoint"))
 	})
@@ -101,7 +100,7 @@ var _ = Describe("DiscoverWithLookup", func() {
 			"OTEL_EXPORTER_OTLP_PROTOCOL": " http/protobuf ",
 		}
 
-		cfg := discoverWithLookup(false, env)
+		cfg := discoverWithLookup(env)
 
 		Expect(cfg.Inventory.ValidationErrors).To(BeEmpty())
 		Expect(cfg.Inventory.Shared).ToNot(BeNil())

--- a/app/kuma-dp/pkg/dataplane/otelenv/types.go
+++ b/app/kuma-dp/pkg/dataplane/otelenv/types.go
@@ -8,12 +8,11 @@ import (
 )
 
 type Config struct {
-	PipeEnabled bool
-	Shared      Layer
-	Traces      Layer
-	Logs        Layer
-	Metrics     Layer
-	Inventory   core_xds.OtelBootstrapInventory
+	Shared    Layer
+	Traces    Layer
+	Logs      Layer
+	Metrics   Layer
+	Inventory core_xds.OtelBootstrapInventory
 }
 
 type Layer struct {

--- a/docs/generated/raw/kuma-cp.yaml
+++ b/docs/generated/raw/kuma-cp.yaml
@@ -408,9 +408,6 @@ runtime:
       # transparent proxy configuration. The sidecar injector reads it, merges it with pod annotations and injects the
       # result. It defaults to "kuma-transparent-proxy-config" and the ConfigMap is expected to exist.
       transparentProxyConfigMap: "kuma-transparent-proxy-config" # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_TRANSPARENT_PROXY_CONFIGMAP_NAME
-      # OtelPipeEnabled controls whether kuma-dp pipe mode is enabled for OTel backends.
-      # When true (default), kuma-dp proxies OTel traffic through a Unix socket.
-      otelPipeEnabled: true # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_OTEL_PIPE_ENABLED
       # Spire is used to specify spire integration configuration.
       spire:
         # If true, enables mounting of SPIRE-related resources.

--- a/docs/madr/decisions/095-mesh-opentelemetry-backend.md
+++ b/docs/madr/decisions/095-mesh-opentelemetry-backend.md
@@ -2,6 +2,8 @@
 
 - Status: accepted
 
+> Note: Kuma 3.0.0 removed `FeatureOtelViaKumaDp`. The control plane routes every `backendRef` backend through the `kuma-dp` pipe and writes `/otel` without checking data plane features, so the feature checks described below no longer apply.
+
 ## Context and problem statement
 
 Kuma has three observability policies that can export telemetry to an OpenTelemetry collector: MeshMetric, MeshTrace, and MeshAccessLog. Each policy defines the OTel collector endpoint independently in its own spec.

--- a/docs/madr/decisions/100-otel-env-bootstrap-runtime.md
+++ b/docs/madr/decisions/100-otel-env-bootstrap-runtime.md
@@ -2,6 +2,8 @@
 
 * Status: accepted
 
+> Note: Kuma 3.0.0 removed `FeatureOtelViaKumaDp`. Pipe mode has no feature gate, so the compatibility path described below for data planes without the feature no longer exists.
+
 Technical Story: none
 
 ## Context and problem statement

--- a/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
+++ b/pkg/config/app/kuma-cp/kuma-cp.defaults.yaml
@@ -408,9 +408,6 @@ runtime:
       # transparent proxy configuration. The sidecar injector reads it, merges it with pod annotations and injects the
       # result. It defaults to "kuma-transparent-proxy-config" and the ConfigMap is expected to exist.
       transparentProxyConfigMap: "kuma-transparent-proxy-config" # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_TRANSPARENT_PROXY_CONFIGMAP_NAME
-      # OtelPipeEnabled controls whether kuma-dp pipe mode is enabled for OTel backends.
-      # When true (default), kuma-dp proxies OTel traffic through a Unix socket.
-      otelPipeEnabled: true # ENV: KUMA_RUNTIME_KUBERNETES_INJECTOR_OTEL_PIPE_ENABLED
       # Spire is used to specify spire integration configuration.
       spire:
         # If true, enables mounting of SPIRE-related resources.

--- a/pkg/config/app/kuma-dp/config.go
+++ b/pkg/config/app/kuma-dp/config.go
@@ -40,8 +40,7 @@ var DefaultConfig = func() Config {
 			DynamicConfiguration: DynamicConfiguration{
 				RefreshInterval: config_types.Duration{Duration: 1 * time.Second},
 			},
-			IPv6Enabled:     true,
-			OtelPipeEnabled: true,
+			IPv6Enabled: true,
 		},
 		DNS: DNS{
 			Enabled:   true,
@@ -231,10 +230,6 @@ type DataplaneRuntime struct {
 	IPv6Enabled bool `json:"IPv6Enabled" envconfig:"kuma_dataplane_runtime_ipv6_enabled"`
 	// Spire defines properties for Spire integration
 	Spire Spire `json:"spire,omitempty"`
-	// OtelPipeEnabled controls whether kuma-dp advertises FeatureOtelViaKumaDp to the CP.
-	// When false, observability policy backendRefs (MeshTrace, MeshAccessLog, MeshMetric)
-	// use direct Envoy clusters instead of routing through kuma-dp Unix sockets. Default: true.
-	OtelPipeEnabled bool `json:"otelPipeEnabled" envconfig:"kuma_dataplane_runtime_otel_pipe_enabled"`
 }
 
 type Spire struct {

--- a/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
+++ b/pkg/config/app/kuma-dp/testdata/default-config.golden.yaml
@@ -19,7 +19,6 @@ dataplaneRuntime:
   dynamicConfiguration:
     refreshInterval: 1s
   metrics: {}
-  otelPipeEnabled: true
   resources: {}
   spire: {}
 dns:

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -223,7 +223,6 @@ var _ = Describe("Config loader", func() {
 			Expect(cfg.Runtime.Kubernetes.Injector.IgnoredServiceSelectorLabels).To(Equal([]string{"x", "y"}))
 			Expect(cfg.Runtime.Kubernetes.Injector.NodeLabelsToCopy).To(Equal([]string{"label-1", "label-2"}))
 			Expect(cfg.Runtime.Kubernetes.Injector.TransparentProxyConfigMapName).To(Equal("foo"))
-			Expect(cfg.Runtime.Kubernetes.Injector.OtelPipeEnabled).To(BeFalse())
 			Expect(cfg.Runtime.Kubernetes.Injector.Spire.Enabled).To(BeTrue())
 			Expect(cfg.Runtime.Kubernetes.Injector.Spire.MountPath).To(Equal("/run/test"))
 			Expect(cfg.Runtime.Kubernetes.Injector.Spire.SocketFileName).To(Equal("my-socket"))
@@ -596,7 +595,6 @@ runtime:
       ignoredServiceSelectorLabels: ["x", "y"]
       nodeLabelsToCopy: ["label-1", "label-2"]
       transparentProxyConfigMap: foo
-      otelPipeEnabled: false
       spire:
         enabled: true
         mountPath: "/run/test"
@@ -965,7 +963,6 @@ meshService:
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_IGNORED_SERVICE_SELECTOR_LABELS":                         "x,y",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_TRANSPARENT_PROXY_CONFIGMAP_NAME":                        "foo",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_NODE_LABELS_TO_COPY":                                     "label-1,label-2",
-				"KUMA_RUNTIME_KUBERNETES_INJECTOR_OTEL_PIPE_ENABLED":                                       "false",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SPIRE_ENABLED":                                           "true",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SPIRE_MOUNT_PATH":                                        "/run/test",
 				"KUMA_RUNTIME_KUBERNETES_INJECTOR_SPIRE_SOCKET_FILE_NAME":                                  "my-socket",

--- a/pkg/config/plugins/runtime/k8s/config.go
+++ b/pkg/config/plugins/runtime/k8s/config.go
@@ -108,7 +108,6 @@ func DefaultKubernetesRuntimeConfig() *KubernetesRuntimeConfig {
 			// topology labels that are useful for, for example, MeshLoadBalancingStrategy policy.
 			NodeLabelsToCopy:              []string{"topology.kubernetes.io/zone", "topology.kubernetes.io/region", "kubernetes.io/hostname"},
 			TransparentProxyConfigMapName: "kuma-transparent-proxy-config",
-			OtelPipeEnabled:               true,
 			Spire: Spire{
 				Enabled:        false,
 				MountPath:      "/run/spire/sockets",
@@ -251,9 +250,6 @@ type Injector struct {
 	// transparent proxy configuration. The sidecar injector reads it, merges it with pod annotations and injects the
 	// result. It defaults to "kuma-transparent-proxy-config" and the ConfigMap is expected to exist.
 	TransparentProxyConfigMapName string `json:"transparentProxyConfigMap" envconfig:"kuma_runtime_kubernetes_injector_transparent_proxy_configmap_name"`
-	// OtelPipeEnabled controls whether kuma-dp pipe mode is enabled for OTel backends.
-	// When true (default), kuma-dp proxies OTel traffic through a Unix socket.
-	OtelPipeEnabled bool `json:"otelPipeEnabled" envconfig:"kuma_runtime_kubernetes_injector_otel_pipe_enabled"`
 	// Spire is used to specify spire integration configuration.
 	Spire Spire `json:"spire"`
 }

--- a/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
+++ b/pkg/config/plugins/runtime/k8s/testdata/default-config.golden.yaml
@@ -35,7 +35,6 @@ injector:
   - topology.kubernetes.io/zone
   - topology.kubernetes.io/region
   - kubernetes.io/hostname
-  otelPipeEnabled: true
   sidecarContainer:
     drainTime: 30s
     envVars: {}

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -115,17 +115,21 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 				IPv6Enabled: true,
 			},
 		}),
-		Entry("should parse OTEL env inventory", testCase{
+		Entry("should parse OTEL env inventory and ignore pipeEnabled sent by 2.14 data planes", testCase{
 			node: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"otelEnvInventory": {
 						Kind: &structpb.Value_StructValue{
-							StructValue: util_proto.MustStructToProtoStruct(&xds.OtelBootstrapInventory{
-								Shared: &xds.OtelSignalEnvInventory{
-									EndpointPresent:   true,
-									EffectiveProtocol: xds.OtelProtocolHTTPProtobuf,
-								},
-							}),
+							StructValue: func() *structpb.Struct {
+								s := util_proto.MustStructToProtoStruct(&xds.OtelBootstrapInventory{
+									Shared: &xds.OtelSignalEnvInventory{
+										EndpointPresent:   true,
+										EffectiveProtocol: xds.OtelProtocolHTTPProtobuf,
+									},
+								})
+								s.Fields["pipeEnabled"] = structpb.NewBoolValue(true)
+								return s
+							}(),
 						},
 					},
 				},

--- a/pkg/core/xds/metadata_test.go
+++ b/pkg/core/xds/metadata_test.go
@@ -121,7 +121,6 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 					"otelEnvInventory": {
 						Kind: &structpb.Value_StructValue{
 							StructValue: util_proto.MustStructToProtoStruct(&xds.OtelBootstrapInventory{
-								PipeEnabled: true,
 								Shared: &xds.OtelSignalEnvInventory{
 									EndpointPresent:   true,
 									EffectiveProtocol: xds.OtelProtocolHTTPProtobuf,
@@ -134,7 +133,6 @@ var _ = Describe("DataplaneMetadataFromXdsMetadata", func() {
 			expected: xds.DataplaneMetadata{
 				IPv6Enabled: true,
 				OtelEnvInventory: &xds.OtelBootstrapInventory{
-					PipeEnabled: true,
 					Shared: &xds.OtelSignalEnvInventory{
 						EndpointPresent:   true,
 						EffectiveProtocol: xds.OtelProtocolHTTPProtobuf,

--- a/pkg/core/xds/otel_env.go
+++ b/pkg/core/xds/otel_env.go
@@ -27,7 +27,6 @@ const (
 )
 
 type OtelBootstrapInventory struct {
-	PipeEnabled      bool                    `json:"pipeEnabled,omitempty"`
 	Shared           *OtelSignalEnvInventory `json:"shared,omitempty"`
 	Traces           *OtelSignalEnvInventory `json:"traces,omitempty"`
 	Logs             *OtelSignalEnvInventory `json:"logs,omitempty"`

--- a/pkg/core/xds/types/features.go
+++ b/pkg/core/xds/types/features.go
@@ -19,8 +19,3 @@ const FeatureBindOutbounds string = "feature-bind-outbounds"
 // FeatureSpire indicates whether the sidecar has mounted a volume that includes the socket for the Spire agent to retrieve its identity.
 // Currently supported only on Kubernetes.
 const FeatureSpire string = "feature-spire"
-
-// FeatureOtelViaKumaDp indicates that kuma-dp can act as a gRPC proxy for OTel
-// traces and access logs. When present, the CP routes the OTel cluster to a Unix
-// socket instead of connecting directly to the collector.
-const FeatureOtelViaKumaDp = "feature-otel-via-kuma-dp"

--- a/pkg/plugins/policies/core/generator/generator.go
+++ b/pkg/plugins/policies/core/generator/generator.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kumahq/kuma/v3/pkg/core/plugins"
 	"github.com/kumahq/kuma/v3/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	"github.com/kumahq/kuma/v3/pkg/xds/dynconf"
 	generator_core "github.com/kumahq/kuma/v3/pkg/xds/generator/core"
@@ -38,10 +37,6 @@ func (g generator) Generate(ctx context.Context, rs *xds.ResourceSet, xdsCtx xds
 
 func writeUnifiedOtelRoute(rs *xds.ResourceSet, proxy *xds.Proxy) error {
 	if proxy.OtelPipeBackends.Empty() {
-		return nil
-	}
-
-	if !proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) {
 		return nil
 	}
 

--- a/pkg/plugins/policies/core/generator/generator_internal_test.go
+++ b/pkg/plugins/policies/core/generator/generator_internal_test.go
@@ -1,0 +1,61 @@
+package generator
+
+import (
+	"encoding/json"
+
+	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/samples"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
+)
+
+var _ = Describe("writeUnifiedOtelRoute", func() {
+	It("should write the /otel route for a proxy that advertises no features", func() {
+		// given
+		socketPath := core_xds.OpenTelemetrySocketName("/tmp", "otel-backend")
+		proxy := xds_builders.Proxy().
+			WithID(*core_xds.BuildProxyId("default", "backend")).
+			WithDataplane(samples.DataplaneBackendBuilder()).
+			WithMetadata(&core_xds.DataplaneMetadata{WorkDir: "/tmp"}).
+			Build()
+		proxy.OtelPipeBackends = &core_xds.OtelPipeBackends{}
+		proxy.OtelPipeBackends.AddSignal("otel-backend", core_xds.OtelPipeBackend{
+			Name:       "otel-backend",
+			SocketPath: socketPath,
+			Endpoint:   "collector.mesh:4317",
+		}, core_xds.OtelSignalTraces, core_xds.OtelSignalRuntimePlan{Enabled: true})
+		rs := core_xds.NewResourceSet()
+
+		// when
+		Expect(writeUnifiedOtelRoute(rs, proxy)).To(Succeed())
+
+		// then
+		listeners := rs.Resources(envoy_resource.ListenerType)
+		Expect(listeners).To(HaveLen(1))
+		var listener *envoy_listener.Listener
+		for _, res := range listeners {
+			listener = res.Resource.(*envoy_listener.Listener)
+		}
+		hcm := &envoy_hcm.HttpConnectionManager{}
+		filter := listener.GetFilterChains()[0].GetFilters()[0]
+		Expect(filter.GetTypedConfig().UnmarshalTo(hcm)).To(Succeed())
+
+		var body string
+		for _, route := range hcm.GetRouteConfig().GetVirtualHosts()[0].GetRoutes() {
+			if route.GetMatch().GetPath() == core_xds.OtelDynconfPath && route.GetDirectResponse().GetStatus() == 200 {
+				body = route.GetDirectResponse().GetBody().GetInlineString()
+			}
+		}
+		var dpConfig core_xds.OtelDpConfig
+		Expect(json.Unmarshal([]byte(body), &dpConfig)).To(Succeed())
+		Expect(dpConfig.Backends).To(HaveLen(1))
+		Expect(dpConfig.Backends[0].SocketPath).To(Equal(socketPath))
+		Expect(dpConfig.Backends[0].Endpoint).To(Equal("collector.mesh:4317"))
+		Expect(dpConfig.Backends[0].Traces.Enabled).To(BeTrue())
+	})
+})

--- a/pkg/plugins/policies/core/generator/generator_suite_test.go
+++ b/pkg/plugins/policies/core/generator/generator_suite_test.go
@@ -1,0 +1,11 @@
+package generator_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestGenerator(t *testing.T) {
+	test.RunSpecs(t, "Policies Generator Suite")
+}

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin.go
@@ -19,7 +19,6 @@ import (
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	workload_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/api/v1alpha1"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	bldrs_accesslog "github.com/kumahq/kuma/v3/pkg/envoy/builders/accesslog"
 	. "github.com/kumahq/kuma/v3/pkg/envoy/builders/common"
 	"github.com/kumahq/kuma/v3/pkg/envoy/builders/filter/network/hcm"
@@ -79,9 +78,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	endpoints := &EndpointAccumulator{
 		OtelPipe: &OtelPipeResolver{
 			Resources:        ctx.Mesh.Resources,
-			NodeHostIP:       proxy.Metadata.GetDynamicMetadata(core_xds.FieldDynamicHostIP),
 			OtelEnvInventory: proxy.Metadata.GetOtelEnvInventory(),
-			Enabled:          proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp),
 			WorkDir:          proxy.Metadata.WorkDir,
 		},
 	}
@@ -118,7 +115,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 		return errors.Wrap(err, "unable to add configuration for MeshAccessLog backends")
 	}
 
-	if proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) && proxy.OtelPipeBackends != nil && endpoints.OtelPipe != nil {
+	if proxy.OtelPipeBackends != nil && endpoints.OtelPipe != nil {
 		for name, info := range endpoints.OtelPipe.PipeBackends() {
 			plan := policies_xds.BuildSignalRuntimePlan(
 				endpoints.OtelPipe.OtelEnvInventory,

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/plugin_test.go
@@ -964,7 +964,7 @@ var _ = Describe("MeshAccessLog", func() {
 		}),
 	)
 
-	It("should route opentelemetry backendRef via kuma-dp when feature is enabled", func() {
+	It("should route opentelemetry backendRef via kuma-dp", func() {
 		const (
 			workDir     = "/tmp"
 			backendName = "otel-backend"
@@ -1005,9 +1005,6 @@ var _ = Describe("MeshAccessLog", func() {
 			WithID(*core_xds.BuildProxyId("default", "backend")).
 			WithMetadata(&core_xds.DataplaneMetadata{
 				WorkDir: workDir,
-				Features: xds_types.Features{
-					xds_types.FeatureOtelViaKumaDp: true,
-				},
 			}).
 			WithDataplane(
 				builders.Dataplane().
@@ -1092,9 +1089,6 @@ var _ = Describe("MeshAccessLog", func() {
 			WithID(*core_xds.BuildProxyId("default", "backend")).
 			WithMetadata(&core_xds.DataplaneMetadata{
 				WorkDir: "/tmp",
-				Features: xds_types.Features{
-					xds_types.FeatureOtelViaKumaDp: true,
-				},
 			}).
 			WithDataplane(
 				builders.Dataplane().

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.cluster.golden.yaml
@@ -1,16 +1,14 @@
 connectTimeout: 5s
-dnsLookupFamily: V4_ONLY
 loadAssignment:
-  clusterName: system_meshaccesslog_otel-collector-4317
+  clusterName: system_meshaccesslog_otel_otel-collector
   endpoints:
   - lbEndpoints:
     - endpoint:
         address:
-          socketAddress:
-            address: otel-collector
-            portValue: 4317
-name: system_meshaccesslog_otel-collector-4317
-type: STRICT_DNS
+          pipe:
+            path: /tmp/kuma-otel-otel-collector.sock
+name: system_meshaccesslog_otel_otel-collector
+type: STATIC
 typedExtensionProtocolOptions:
   envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format.listener.golden.yaml
@@ -20,7 +20,7 @@ filterChains:
                   stringValue: default
           grpcService:
             envoyGrpc:
-              clusterName: system_meshaccesslog_other-otel-collector-5317
+              clusterName: system_meshaccesslog_otel_other-otel-collector
           logName: MeshAccessLog
           resourceAttributes:
             values:

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.cluster.golden.yaml
@@ -1,16 +1,14 @@
 connectTimeout: 5s
-dnsLookupFamily: V4_ONLY
 loadAssignment:
-  clusterName: system_meshaccesslog_other-otel-collector-5317
+  clusterName: system_meshaccesslog_otel_other-otel-collector
   endpoints:
   - lbEndpoints:
     - endpoint:
         address:
-          socketAddress:
-            address: other-otel-collector
-            portValue: 5317
-name: system_meshaccesslog_other-otel-collector-5317
-type: STRICT_DNS
+          pipe:
+            path: /tmp/kuma-otel-other-otel-collector.sock
+name: system_meshaccesslog_otel_other-otel-collector
+type: STATIC
 typedExtensionProtocolOptions:
   envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_1.listener.golden.yaml
@@ -16,7 +16,7 @@ filterChains:
             stringValue: default
           grpcService:
             envoyGrpc:
-              clusterName: system_meshaccesslog_otel-collector-4317
+              clusterName: system_meshaccesslog_otel_otel-collector
           logName: MeshAccessLog
           resourceAttributes:
             values:

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_2.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_backend_plain_format_2.listener.golden.yaml
@@ -18,7 +18,7 @@ filterChains:
               bytes'
           grpcService:
             envoyGrpc:
-              clusterName: system_meshaccesslog_otel-collector-4317
+              clusterName: system_meshaccesslog_otel_otel-collector
           logName: MeshAccessLog
           resourceAttributes:
             values:

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.cluster.golden.yaml
@@ -1,16 +1,14 @@
 connectTimeout: 5s
-dnsLookupFamily: V4_ONLY
 loadAssignment:
-  clusterName: system_meshaccesslog_otel-collector-4317
+  clusterName: system_meshaccesslog_otel_otel-collector
   endpoints:
   - lbEndpoints:
     - endpoint:
         address:
-          socketAddress:
-            address: otel-collector
-            portValue: 4317
-name: system_meshaccesslog_otel-collector-4317
-type: STRICT_DNS
+          pipe:
+            path: /tmp/kuma-otel-otel-collector.sock
+name: system_meshaccesslog_otel_otel-collector
+type: STATIC
 typedExtensionProtocolOptions:
   envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
+++ b/pkg/plugins/policies/meshaccesslog/plugin/v1alpha1/testdata/outbound_otel_workload_identity.listener.golden.yaml
@@ -41,7 +41,7 @@ filterChains:
             stringValue: default zone-1 kri_wl_default_zone-1_kuma-demo_backend_
           grpcService:
             envoyGrpc:
-              clusterName: system_meshaccesslog_otel-collector-4317
+              clusterName: system_meshaccesslog_otel_otel-collector
           logName: MeshAccessLog
           resourceAttributes:
             values:

--- a/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshaccesslog/plugin/xds/configurer.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	core_meta "github.com/kumahq/kuma/v3/pkg/core/metadata"
-	motb_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
 	core_system_names "github.com/kumahq/kuma/v3/pkg/core/system_names"
 	"github.com/kumahq/kuma/v3/pkg/core/validators"
 	"github.com/kumahq/kuma/v3/pkg/core/xds"
@@ -97,9 +96,7 @@ func BaseAccessLogBuilder(
 // endpoints and accumulate pipe backends during access log configuration.
 type OtelPipeResolver struct {
 	Resources        xds_context.Resources
-	NodeHostIP       string
 	OtelEnvInventory *xds.OtelBootstrapInventory
-	Enabled          bool
 	WorkDir          string
 	backends         map[string]xds.OtelPipeBackend
 }
@@ -152,23 +149,15 @@ func resolveOtelLoggingEndpoint(otelBackend *api.OtelBackend, acc *EndpointAccum
 		return nil
 	}
 
-	if otelBackend.BackendRef != nil && pipe.Enabled {
-		if pipe.backends == nil {
-			pipe.backends = map[string]xds.OtelPipeBackend{}
-		}
-		base := policies_xds.BuildResolvedPipeBackend(pipe.WorkDir, resolved)
-		pipe.backends[resolved.Name] = base
-		return &LoggingEndpoint{
-			SocketPath:  base.SocketPath,
-			BackendName: resolved.Name,
-			UseHTTP2:    true, // Envoy→kuma-dp leg is always gRPC
-		}
+	if pipe.backends == nil {
+		pipe.backends = map[string]xds.OtelPipeBackend{}
 	}
-
+	base := policies_xds.BuildResolvedPipeBackend(pipe.WorkDir, resolved)
+	pipe.backends[resolved.Name] = base
 	return &LoggingEndpoint{
-		Address:  policies_xds.ResolveAddressForDirectExport(resolved.Endpoint.Target, pipe.NodeHostIP),
-		Port:     resolved.Endpoint.Port,
-		UseHTTP2: resolved.Protocol != motb_api.ProtocolHTTP,
+		SocketPath:  base.SocketPath,
+		BackendName: resolved.Name,
+		UseHTTP2:    true, // Envoy->kuma-dp leg is always gRPC
 	}
 }
 

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin.go
@@ -14,7 +14,6 @@ import (
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
 	core_system_names "github.com/kumahq/kuma/v3/pkg/core/system_names"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	policies_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/api/v1alpha1"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/dpapi"
@@ -111,7 +110,7 @@ func (p plugin) Apply(rs *core_xds.ResourceSet, ctx xds_context.Context, proxy *
 	if err != nil {
 		return err
 	}
-	if proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) && proxy.OtelPipeBackends != nil {
+	if proxy.OtelPipeBackends != nil {
 		addOtelToAccumulator(proxy, openTelemetryBackends, ctx)
 	}
 	// configureOpenTelemetry creates Envoy-side OTel resources (listener + cluster).
@@ -357,10 +356,10 @@ func filterPrometheusBackends(backends *[]api.Backend) []*api.PrometheusBackend 
 }
 
 // filterOtelBackendsForEnvoy returns backends that need Envoy-side OTel resources.
-// In pipe mode, backendRef backends go through the unified pipe so only inline
-// backends need Envoy config. Without pipe mode, all backends need it.
+// backendRef backends go through the unified pipe so only inline backends need
+// Envoy config. Without a pipe accumulator, all backends need it.
 func filterOtelBackendsForEnvoy(proxy *core_xds.Proxy, backends []*api.OpenTelemetryBackend) []*api.OpenTelemetryBackend {
-	if !proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) || proxy.OtelPipeBackends == nil {
+	if proxy.OtelPipeBackends == nil {
 		return backends
 	}
 

--- a/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshmetric/plugin/v1alpha1/plugin_test.go
@@ -16,7 +16,6 @@ import (
 	motb_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/subsetutils"
 	api "github.com/kumahq/kuma/v3/pkg/plugins/policies/meshmetric/api/v1alpha1"
@@ -566,7 +565,7 @@ var _ = Describe("MeshMetric", func() {
 		})
 	})
 
-	Describe("pipe mode (FeatureOtelViaKumaDp)", func() {
+	Describe("pipe mode", func() {
 		const (
 			workDir     = "/tmp"
 			backendName = "otel-backend"
@@ -596,9 +595,6 @@ var _ = Describe("MeshMetric", func() {
 				).
 				WithMetadata(&core_xds.DataplaneMetadata{
 					WorkDir: workDir,
-					Features: xds_types.Features{
-						xds_types.FeatureOtelViaKumaDp: true,
-					},
 				}).
 				WithPolicies(xds_builders.MatchedPolicies().
 					WithProxyConfPolicy(api.MeshMetricType, mergedPolicyConf(core_rules.Rules{

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-	"net"
 	net_url "net/url"
 	"strconv"
 
@@ -18,12 +16,10 @@ import (
 	core_plugins "github.com/kumahq/kuma/v3/pkg/core/plugins"
 	"github.com/kumahq/kuma/v3/pkg/core/resources/apis/core/destinationname"
 	core_mesh "github.com/kumahq/kuma/v3/pkg/core/resources/apis/mesh"
-	motb_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/meshopentelemetrybackend/api/v1alpha1"
 	workload_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/workload/api/v1alpha1"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	core_system_names "github.com/kumahq/kuma/v3/pkg/core/system_names"
 	"github.com/kumahq/kuma/v3/pkg/core/xds"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	core_rules "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules"
 	"github.com/kumahq/kuma/v3/pkg/plugins/policies/core/rules/resolve"
 	policies_xds "github.com/kumahq/kuma/v3/pkg/plugins/policies/core/xds"
@@ -69,7 +65,7 @@ func (p plugin) Apply(rs *xds.ResourceSet, ctx xds_context.Context, proxy *xds.P
 	if err := applyToRealResources(ctx, policies.ProxyConf, rs, proxy); err != nil {
 		return err
 	}
-	if proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) && proxy.OtelPipeBackends != nil {
+	if proxy.OtelPipeBackends != nil {
 		addToOtelPipeBackends(ctx, policies.ProxyConf, proxy)
 	}
 
@@ -235,19 +231,6 @@ func configureListener(ctx xds_context.Context, policyConf *core_rules.ProxyConf
 	}
 	if resolved != nil {
 		configurer.ResolvedOtelName = resolved.Name
-		// When kuma-dp acts as intermediary for the resolved backend, Envoy
-		// always speaks gRPC to the pipe cluster. Only fall back to HTTP config
-		// when using direct-to-collector mode (FeatureOtelViaKumaDp not enabled).
-		usePipe := hasOtelBackendRef(conf) && proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp)
-		if !usePipe && resolved.Protocol == motb_api.ProtocolHTTP {
-			configurer.ResolvedOtelUseHTTP = true
-			host := net.JoinHostPort(resolved.Endpoint.Target, strconv.Itoa(int(resolved.Endpoint.Port)))
-			scheme := "http"
-			if resolved.UseHTTPS {
-				scheme = "https"
-			}
-			configurer.ResolvedOtelURI = fmt.Sprintf("%s://%s%s", scheme, host, resolved.FullPath(policies_xds.OtelTracesPathSuffix))
-		}
 	}
 
 	for _, chain := range listener.FilterChains {
@@ -318,15 +301,10 @@ func applyToClusters(ctx xds_context.Context, policyConf *core_rules.ProxyConf, 
 			return nil
 		}
 
-		if backend.OpenTelemetry.BackendRef != nil && proxy.Metadata.HasFeature(xds_types.FeatureOtelViaKumaDp) {
-			// Route through kuma-dp Unix socket; kuma-dp forwards to the real collector.
-			socketPath := xds.OpenTelemetrySocketName(proxy.Metadata.WorkDir, resolved.Name)
-			endpoint = &xds.Endpoint{UnixDomainPath: socketPath}
-			useHTTP2 = true // Envoy→kuma-dp leg is always gRPC
-		} else {
-			endpoint = policies_xds.EndpointForDirectOtelExport(resolved, proxy.Metadata.GetDynamicMetadata(xds.FieldDynamicHostIP))
-			useHTTP2 = resolved.Protocol != motb_api.ProtocolHTTP
-		}
+		// Route through kuma-dp Unix socket; kuma-dp forwards to the real collector.
+		socketPath := xds.OpenTelemetrySocketName(proxy.Metadata.WorkDir, resolved.Name)
+		endpoint = &xds.Endpoint{UnixDomainPath: socketPath}
+		useHTTP2 = true // Envoy->kuma-dp leg is always gRPC
 
 		name = core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_otel", core_system_names.CleanName(resolved.Name)))
 	}

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -524,7 +524,7 @@ var _ = Describe("MeshTrace", func() {
 		Expect(strings.TrimSpace(string(clusterResources))).To(Equal("{}"))
 	})
 
-	It("should route opentelemetry via kuma-dp when feature is enabled", func() {
+	It("should route opentelemetry via kuma-dp", func() {
 		const (
 			workDir     = "/tmp"
 			backendName = "otel-backend"
@@ -571,9 +571,6 @@ var _ = Describe("MeshTrace", func() {
 			).
 			WithMetadata(&core_xds.DataplaneMetadata{
 				WorkDir: workDir,
-				Features: xds_types.Features{
-					xds_types.FeatureOtelViaKumaDp: true,
-				},
 			}).
 			WithOutbounds(xds_types.Outbounds{
 				{

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/plugin_test.go
@@ -524,7 +524,7 @@ var _ = Describe("MeshTrace", func() {
 		Expect(strings.TrimSpace(string(clusterResources))).To(Equal("{}"))
 	})
 
-	It("should route opentelemetry via kuma-dp", func() {
+	DescribeTable("should route opentelemetry via kuma-dp", func(protocol motb_api.Protocol, endpoint *motb_api.Endpoint, expected core_xds.OtelPipeBackend) {
 		const (
 			workDir     = "/tmp"
 			backendName = "otel-backend"
@@ -542,11 +542,8 @@ var _ = Describe("MeshTrace", func() {
 			Name:   backendName,
 			Labels: map[string]string{mesh_proto.DisplayName: backendName},
 		})
-		motb.Spec.Endpoint = &motb_api.Endpoint{
-			Address: pointer.To("collector.mesh"),
-			Port:    pointer.To(int32(4317)),
-		}
-		motb.Spec.Protocol = pointer.To(motb_api.ProtocolGRPC)
+		motb.Spec.Endpoint = endpoint
+		motb.Spec.Protocol = &protocol
 
 		meshResources := xds_context.NewResources()
 		meshResources.MeshLocalResources[motb_api.MeshOpenTelemetryBackendType] = &motb_api.MeshOpenTelemetryBackendResourceList{
@@ -605,9 +602,16 @@ var _ = Describe("MeshTrace", func() {
 
 		expectedSocket := core_xds.OpenTelemetrySocketName(workDir, backendName)
 
+		// Envoy speaks gRPC to kuma-dp over the Unix socket whatever the collector protocol is.
+		listenerResources, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ListenerType)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(listenerResources)).To(ContainSubstring("grpcService"))
+		Expect(string(listenerResources)).ToNot(ContainSubstring("httpService"))
+
 		clusterResources, err := util_yaml.GetResourcesToYaml(resources, envoy_resource.ClusterType)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(clusterResources)).To(ContainSubstring(expectedSocket))
+		Expect(string(clusterResources)).To(ContainSubstring("http2ProtocolOptions"))
 		Expect(string(clusterResources)).ToNot(ContainSubstring("collector.mesh"))
 
 		// Plugin adds to OtelPipeBackends accumulator instead of writing dynconf directly.
@@ -616,11 +620,23 @@ var _ = Describe("MeshTrace", func() {
 		backends := proxy.OtelPipeBackends.All()
 		Expect(backends).To(HaveLen(1))
 		Expect(backends[0].SocketPath).To(Equal(expectedSocket))
-		Expect(backends[0].Endpoint).To(Equal("collector.mesh:4317"))
-		Expect(backends[0].UseHTTP).To(BeFalse())
+		Expect(backends[0].Endpoint).To(Equal(expected.Endpoint))
+		Expect(backends[0].UseHTTP).To(Equal(expected.UseHTTP))
+		Expect(backends[0].UseHTTPS).To(Equal(expected.UseHTTPS))
+		Expect(backends[0].Path).To(Equal(expected.Path))
 		Expect(backends[0].Traces).ToNot(BeNil())
 		Expect(backends[0].Traces.Enabled).To(BeTrue())
-	})
+	},
+		Entry("grpc backend", motb_api.ProtocolGRPC, &motb_api.Endpoint{
+			Address: new("collector.mesh"),
+			Port:    new(int32(4317)),
+		}, core_xds.OtelPipeBackend{Endpoint: "collector.mesh:4317"}),
+		Entry("https backend with a path", motb_api.ProtocolHTTP, &motb_api.Endpoint{
+			Address: new("collector.mesh"),
+			Port:    new(int32(443)),
+			Path:    new("/otlp"),
+		}, core_xds.OtelPipeBackend{Endpoint: "collector.mesh:443", UseHTTP: true, UseHTTPS: true, Path: "/otlp"}),
+	)
 })
 
 func zoneEgressOnlyDataplane() *builders.DataplaneBuilder {

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-otel-ipv6.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-otel-ipv6.cluster.golden.yaml
@@ -9,9 +9,8 @@ resources:
       - lbEndpoints:
         - endpoint:
             address:
-              socketAddress:
-                address: 2001:db8::1
-                portValue: 4317
+              pipe:
+                path: kuma-otel-otel-collector-ipv6.sock
     name: system_meshtrace_otel_otel-collector-ipv6
     type: STATIC
     typedExtensionProtocolOptions:

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/inbound-outbound-otel.cluster.golden.yaml
@@ -3,18 +3,16 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
-    dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: system_meshtrace_otel_otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
-              socketAddress:
-                address: jaeger-collector.mesh-observability
-                portValue: 4317
+              pipe:
+                path: kuma-otel-otel-collector.sock
     name: system_meshtrace_otel_otel-collector
-    type: STRICT_DNS
+    type: STATIC
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/mixed-inbound-and-zone-egress-otel.cluster.golden.yaml
@@ -3,18 +3,16 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
-    dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: system_meshtrace_otel_otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
-              socketAddress:
-                address: jaeger-collector.mesh-observability
-                portValue: 4317
+              pipe:
+                path: kuma-otel-otel-collector.sock
     name: system_meshtrace_otel_otel-collector
-    type: STRICT_DNS
+    type: STATIC
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-egress-only-otel.cluster.golden.yaml
@@ -3,18 +3,16 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
-    dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: system_meshtrace_otel_otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
-              socketAddress:
-                address: jaeger-collector.mesh-observability
-                portValue: 4317
+              pipe:
+                path: kuma-otel-otel-collector.sock
     name: system_meshtrace_otel_otel-collector
-    type: STRICT_DNS
+    type: STATIC
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-otel.cluster.golden.yaml
+++ b/pkg/plugins/policies/meshtrace/plugin/v1alpha1/testdata/zone-ingress-only-otel.cluster.golden.yaml
@@ -3,18 +3,16 @@ resources:
   resource:
     '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 5s
-    dnsLookupFamily: V4_ONLY
     loadAssignment:
       clusterName: system_meshtrace_otel_otel-collector
       endpoints:
       - lbEndpoints:
         - endpoint:
             address:
-              socketAddress:
-                address: jaeger-collector.mesh-observability
-                portValue: 4317
+              pipe:
+                path: kuma-otel-otel-collector.sock
     name: system_meshtrace_otel_otel-collector
-    type: STRICT_DNS
+    type: STATIC
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/pkg/plugins/policies/meshtrace/plugin/xds/configurer.go
+++ b/pkg/plugins/policies/meshtrace/plugin/xds/configurer.go
@@ -3,7 +3,6 @@ package xds
 import (
 	net_url "net/url"
 	"strings"
-	"time"
 
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -12,7 +11,6 @@ import (
 	tracingv3 "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -38,10 +36,6 @@ type Configurer struct {
 	WorkloadKRI      string
 	// ResolvedOtelName is the resolved MeshOpenTelemetryBackend name for OTel, used for naming.
 	ResolvedOtelName string
-	// ResolvedOtelUseHTTP is true when the resolved backend uses HTTP protocol.
-	ResolvedOtelUseHTTP bool
-	// ResolvedOtelURI is the full HTTP URI for the OTel collector (only used when ResolvedOtelUseHTTP is true).
-	ResolvedOtelURI string
 	// SkipOpenTelemetry prevents injecting an OTel tracing provider when backend resolution fails.
 	SkipOpenTelemetry bool
 }
@@ -135,13 +129,7 @@ func (c *Configurer) Configure(filterChain *envoy_listener.FilterChain) error {
 
 		if backend.OpenTelemetry != nil && !c.SkipOpenTelemetry {
 			name := core_system_names.AsSystemName(core_system_names.JoinSections("meshtrace_otel", core_system_names.CleanName(c.ResolvedOtelName)))
-			var tracing *envoy_trace.Tracing_Http
-			var err error
-			if c.ResolvedOtelUseHTTP {
-				tracing, err = openTelemetryHTTPConfig(name, c.Service, c.ResolvedOtelURI)
-			} else {
-				tracing, err = c.opentelemetryConfig(name)
-			}
+			tracing, err := c.opentelemetryConfig(name)
 			if err != nil {
 				return err
 			}
@@ -189,33 +177,6 @@ func (c *Configurer) opentelemetryConfig(clusterName string) (*envoy_trace.Traci
 				EnvoyGrpc: &envoy_core.GrpcService_EnvoyGrpc{
 					ClusterName: clusterName,
 				},
-			},
-		},
-	}
-	otelConfigAny, err := proto.MarshalAnyDeterministic(&otelConfig)
-	if err != nil {
-		return nil, err
-	}
-	return &envoy_trace.Tracing_Http{
-		Name: "envoy.tracers.opentelemetry",
-		ConfigType: &envoy_trace.Tracing_Http_TypedConfig{
-			TypedConfig: otelConfigAny,
-		},
-	}, nil
-}
-
-// openTelemetryHTTPConfig builds the Envoy OTel tracer config for an HTTP/HTTPS endpoint.
-// Used when resolving a MeshOpenTelemetryBackend with HTTP protocol.
-func openTelemetryHTTPConfig(clusterName, serviceName, uri string) (*envoy_trace.Tracing_Http, error) {
-	otelConfig := envoy_trace.OpenTelemetryConfig{
-		ServiceName: serviceName,
-		HttpService: &envoy_core.HttpService{
-			HttpUri: &envoy_core.HttpUri{
-				Uri: uri,
-				HttpUpstreamType: &envoy_core.HttpUri_Cluster{
-					Cluster: clusterName,
-				},
-				Timeout: durationpb.New(10 * time.Second),
 			},
 		},
 	}

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -36,7 +36,6 @@ type DataplaneProxyFactory struct {
 	WaitForDataplane          bool
 	sidecarContainersEnabled  bool
 	applicationProbeProxyPort uint32
-	otelPipeEnabled           bool
 	spireEnabled              bool
 }
 
@@ -50,7 +49,6 @@ func NewDataplaneProxyFactory(
 	waitForDataplane bool,
 	sidecarContainersEnabled bool,
 	applicationProbeProxyPort uint32,
-	otelPipeEnabled bool,
 	spireEnabled bool,
 ) *DataplaneProxyFactory {
 	return &DataplaneProxyFactory{
@@ -63,7 +61,6 @@ func NewDataplaneProxyFactory(
 		WaitForDataplane:          waitForDataplane,
 		sidecarContainersEnabled:  sidecarContainersEnabled,
 		applicationProbeProxyPort: applicationProbeProxyPort,
-		otelPipeEnabled:           otelPipeEnabled,
 		spireEnabled:              spireEnabled,
 	}
 }
@@ -314,21 +311,14 @@ func (i *DataplaneProxyFactory) sidecarEnvVars(mesh string, podAnnotations map[s
 		}
 	}
 
-	if i.otelPipeEnabled {
-		envVars["HOST_IP"] = kube_core.EnvVar{
-			Name: "HOST_IP",
-			ValueFrom: &kube_core.EnvVarSource{
-				FieldRef: &kube_core.ObjectFieldSelector{
-					APIVersion: "v1",
-					FieldPath:  "status.hostIP",
-				},
+	envVars["HOST_IP"] = kube_core.EnvVar{
+		Name: "HOST_IP",
+		ValueFrom: &kube_core.EnvVarSource{
+			FieldRef: &kube_core.ObjectFieldSelector{
+				APIVersion: "v1",
+				FieldPath:  "status.hostIP",
 			},
-		}
-	} else {
-		envVars["KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED"] = kube_core.EnvVar{
-			Name:  "KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED",
-			Value: "false",
-		}
+		},
 	}
 	if enabled, _, err := metadata.Annotations(podAnnotations).GetEnabledWithDefault(i.spireEnabled, metadata.KumaSpireSupport); err != nil {
 		return nil, errors.Wrapf(err, "getting %s annotation failed", metadata.KumaSpireSupport)

--- a/pkg/plugins/runtime/k8s/containers/factory_test.go
+++ b/pkg/plugins/runtime/k8s/containers/factory_test.go
@@ -29,8 +29,7 @@ var _ = Describe("DataplaneProxyFactory", func() {
 					DrainTime: config_types.Duration{Duration: 30 * time.Second},
 					EnvVars:   map[string]string{},
 				},
-				BuiltinDNS:      runtime_k8s.BuiltinDNS{},
-				otelPipeEnabled: true,
+				BuiltinDNS: runtime_k8s.BuiltinDNS{},
 			}
 			envVars, err := factory.sidecarEnvVars("default", nil)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector.go
@@ -131,7 +131,7 @@ func New(
 			cfg.BuiltinDNS, cfg.SidecarContainer.WaitForDataplaneReady,
 			sidecarContainersEnabled,
 			cfg.ApplicationProbeProxyPort,
-			cfg.OtelPipeEnabled, cfg.Spire.Enabled,
+			cfg.Spire.Enabled,
 		),
 		systemNamespace: systemNamespace,
 		metrics:         im,

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.01.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.02.golden.yaml
@@ -85,6 +85,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -120,8 +125,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.03.golden.yaml
@@ -165,6 +165,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -200,8 +205,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.04.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: demo
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.05.golden.yaml
@@ -81,6 +81,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -116,8 +121,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.06.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.07.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.08.golden.yaml
@@ -87,6 +87,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -122,8 +127,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.09.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.10.golden.yaml
@@ -85,6 +85,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -120,8 +125,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.11.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: mesh-name-from-ns
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.12.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: mesh-name-from-pod
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.13.golden.yaml
@@ -96,6 +96,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -131,8 +136,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.14.golden.yaml
@@ -96,6 +96,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -131,8 +136,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.15.golden.yaml
@@ -97,6 +97,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -132,8 +137,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.16.golden.yaml
@@ -90,6 +90,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -125,8 +130,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.17.golden.yaml
@@ -88,6 +88,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -123,8 +128,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.18.golden.yaml
@@ -90,6 +90,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -125,8 +130,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.19.golden.yaml
@@ -103,6 +103,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -138,8 +143,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.20.golden.yaml
@@ -104,6 +104,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -139,8 +144,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.21.golden.yaml
@@ -109,6 +109,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -144,8 +149,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.22.golden.yaml
@@ -85,6 +85,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -120,8 +125,6 @@ spec:
       value: 5s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /some/other/path
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.23.golden.yaml
@@ -85,6 +85,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -120,8 +125,6 @@ spec:
       value: 5s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.24.golden.yaml
@@ -86,6 +86,11 @@ spec:
     - --concurrency=99
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -121,8 +126,6 @@ spec:
       value: 5s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.25.golden.yaml
@@ -85,6 +85,11 @@ spec:
     - --concurrency=8
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -120,8 +125,6 @@ spec:
       value: 5s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.26.golden.yaml
@@ -82,6 +82,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -117,8 +122,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.27.golden.yaml
@@ -81,6 +81,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -116,8 +121,6 @@ spec:
       value: 10s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.28.golden.yaml
@@ -82,6 +82,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: default
     - name: KUMA_DATAPLANE_RUNTIME_ENVOY_LOG_LEVEL
       value: trace
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.29.golden.yaml
@@ -79,6 +79,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -114,8 +119,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.31.golden.yaml
@@ -82,6 +82,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -117,8 +122,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.32.golden.yaml
@@ -81,6 +81,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -116,8 +121,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.33.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.34.golden.yaml
@@ -83,6 +83,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -118,8 +123,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.35.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.36.golden.yaml
@@ -86,6 +86,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -121,8 +126,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.37.golden.yaml
@@ -88,6 +88,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -123,8 +128,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.38.golden.yaml
@@ -90,6 +90,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -125,8 +130,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.39.golden.yaml
@@ -90,6 +90,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -125,8 +130,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.40.golden.yaml
@@ -105,6 +105,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -140,8 +145,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.41.golden.yaml
@@ -52,6 +52,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -87,8 +92,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.43.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.43.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_SPIRE_SUPPORTED
       value: "true"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.44.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.44.golden.yaml
@@ -84,6 +84,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -119,8 +124,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.45.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.45.golden.yaml
@@ -97,6 +97,11 @@ spec:
     - --concurrency=2
     - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
     env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
     - name: INSTANCE_IP
       valueFrom:
         fieldRef:
@@ -132,8 +137,6 @@ spec:
       value: 31s
     - name: KUMA_DATAPLANE_MESH
       value: default
-    - name: KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED
-      value: "false"
     - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
       value: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: KUMA_DNS_ENABLED


### PR DESCRIPTION
## Motivation

`feature-otel-via-kuma-dp` tells the control plane to point OpenTelemetry clusters for `backendRef` backends at `kuma-dp` Unix sockets instead of the collector. It reads like a capability, but `kuma-dp` always builds the receiver, so the flag only mirrors `KUMA_DATAPLANE_RUNTIME_OTEL_PIPE_ENABLED`, which the injector sets from `runtime.kubernetes.injector.otelPipeEnabled`. Every data plane that 3.0 supports is 2.14 or newer and ships the receiver, so the flag and both settings can go.

## Implementation information

- MeshTrace, MeshAccessLog, and MeshMetric always route `backendRef` backends to the `kuma-dp` socket, and the policy generator always writes the `/otel` dynamic config route when a backend needs it
- The direct-to-collector branches these plugins took without the flag are gone, including the MeshTrace HTTP tracer config
- `OtelPipeEnabled` is gone from the `kuma-dp` and injector configuration, and the injector always sets `HOST_IP` on the sidecar, as it did with the default
- The bootstrap OpenTelemetry inventory drops `pipeEnabled`, which the control plane never read and ignores when an older data plane sends it
- `UPGRADE.md` tells users who set either setting to `false` to remove it
- `make format` and `golangci-lint` on the touched packages are clean, and `make test` passes for them after regenerating the injector, config, MeshTrace, and MeshAccessLog goldens

## Supporting documentation

Closes #18596

Part of #18593
