### PR TITLE
ci(runners): select runners by size from JSON vars

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,10 +1,6 @@
 # Choosing runners
 
-Almost every job picks its runner through two repository variables, so a fork or a downstream
-repository can move CI onto its own runners without editing any workflow. Nothing here is
-required: with both variables unset, every job keeps the runner it had, which is a
-GitHub-hosted label for most of them and the shared `ubuntu-latest-kong` pool for the e2e
-legs.
+Almost every job picks its runner through two repository variables, so a fork or a downstream repository can move CI onto its own runners without editing any workflow. Nothing here is required: with both variables unset, every job keeps the runner it had, which is a GitHub-hosted label for most of them and the shared `ubuntu-latest-kong` pool for the e2e legs.
 
 ## The variables
 
@@ -14,12 +10,9 @@ legs.
 | `RUNNERS_<BRANCH_SLUG>_<ARCH>` | one branch, one architecture | the global variable |
 | `RUNNERS_<ARCH>` | one architecture, every branch | the built-in default |
 
-`RUNNERS_PR_<ARCH>` exists so pull requests can run somewhere other than pushes to the same
-branch, on a smaller or cheaper pool, without giving up the per-branch override for pushes.
-Leave it unset and pull requests follow the branch.
+`RUNNERS_PR_<ARCH>` exists so pull requests can run somewhere other than pushes to the same branch, on a smaller or cheaper pool, without giving up the per-branch override for pushes. Leave it unset and pull requests follow the branch.
 
-`<ARCH>` is `AMD64` or `ARM64`. `<BRANCH_SLUG>` is the branch name uppercased with `-` and
-`.` replaced by `_`, so `master` is `MASTER` and `release-2.14` is `RELEASE_2_14`.
+`<ARCH>` is `AMD64` or `ARM64`. `<BRANCH_SLUG>` is the branch name uppercased with `-` and `.` replaced by `_`, so `master` is `MASTER` and `release-2.14` is `RELEASE_2_14`.
 
 The value is a JSON object mapping a size to the labels a runner must carry:
 
@@ -31,25 +24,17 @@ The value is a JSON object mapping a size to the labels a runner must carry:
 }
 ```
 
-A job runs only on a runner that has **all** the labels listed for its size. A repository
-without a pool for one of the sizes points that key at a pool it does have; nothing
-requires three distinct pools.
+A job runs only on a runner that has **all** the labels listed for its size. A repository without a pool for one of the sizes points that key at a pool it does have; nothing requires three distinct pools.
 
 ## Sizes
 
 Jobs declare the size they need, not a pool. The rule:
 
-- **sm** for a job with no checkout, or a checkout plus only `gh`, `jq`, `git` or `curl`.
-  Gates, dispatchers, matrix generators, comment posters, and the pollers that spend hours
-  waiting on another workflow.
-- **md** for a job that needs the mise toolchain and does network, artifact or git work, but
-  compiles no Go, builds no container image and starts no cluster. Publishing, SBOM
-  generation, backports, doc generation.
-- **lg** for a job that compiles Go, runs `go test -race` or golangci-lint, builds images
-  with buildx, starts a k3d or kind cluster, or builds a CodeQL database.
+- **sm** for a job with no checkout, or a checkout plus only `gh`, `jq`, `git` or `curl`. Gates, dispatchers, matrix generators, comment posters, and the pollers that spend hours waiting on another workflow.
+- **md** for a job that needs the mise toolchain and does network, artifact or git work, but compiles no Go, builds no container image and starts no cluster. Publishing, SBOM generation, backports, doc generation.
+- **lg** for a job that compiles Go, runs `go test -race` or golangci-lint, builds images with buildx, starts a k3d or kind cluster, or builds a CodeQL database.
 
-When a job's steps change, revisit its size. Overshooting wastes a large slot. Undershooting
-gets the job OOM-killed on a small one.
+When a job's steps change, revisit its size. Overshooting wastes a large slot. Undershooting gets the job OOM-killed on a small one.
 
 ## The expression
 
@@ -62,18 +47,11 @@ runs-on: >-
   || 'ubuntu-24.04' }}
 ```
 
-`>-` folds the newlines into single spaces, so the expression GitHub evaluates is the same
-one-line string. Every continuation line has to sit at the same indentation, or YAML keeps
-the newline instead of folding it.
+`>-` folds the newlines into single spaces, so the expression GitHub evaluates is the same one-line string. Every continuation line has to sit at the same indentation, or YAML keeps the newline instead of folding it.
 
-Reading it: on a pull request take the PR variable, otherwise the per-branch one, otherwise
-the global one, otherwise an empty object. Then look up the size. If any step yields
-nothing, fall back to the GitHub-hosted label. Only one possibly-missing property is ever
-dereferenced, because `'{}'` guarantees the object exists.
+Reading it: on a pull request take the PR variable, otherwise the per-branch one, otherwise the global one, otherwise an empty object. Then look up the size. If any step yields nothing, fall back to the GitHub-hosted label. Only one possibly-missing property is ever dereferenced, because `'{}'` guarantees the object exists.
 
-Workflows that a `pull_request` event can reach, directly or as a reusable workflow called
-from one, add a fork guard in front, so code from a fork never runs on a self-hosted
-runner:
+Workflows that a `pull_request` event can reach, directly or as a reusable workflow called from one, add a fork guard in front, so code from a fork never runs on a self-hosted runner:
 
 ```yaml
 runs-on: >-
@@ -87,51 +65,26 @@ runs-on: >-
   || 'ubuntu-24.04' }}
 ```
 
-The `env` context is not available in `runs-on`, which is why the default label is written
-inline at every site rather than defined once.
+The `env` context is not available in `runs-on`, which is why the default label is written inline at every site rather than defined once.
 
 ### The e2e jobs
 
-`_test.yaml` runs the same job across architectures, so it cannot read `vars` per leg.
-`build-test-distribute.yaml` splices both variables into its `RUNNERS_BY_ARCH` input, and
-each leg indexes the result by `matrix.arch` and then by size. That path additionally sends
-`master` to GitHub-hosted runners; the per-job sites above do not.
+`_test.yaml` runs the same job across architectures, so it cannot read `vars` per leg. `build-test-distribute.yaml` splices both variables into its `RUNNERS_BY_ARCH` input, and each leg indexes the result by `matrix.arch` and then by size. That path additionally sends `master` to GitHub-hosted runners; the per-job sites above do not.
 
 ## Adding an architecture
 
-Set `RUNNERS_ARM64` (or the `PR` or per-branch form) to the same size-to-labels object, with
-labels that name an arm64 pool. Nothing else changes: `build-test-distribute.yaml` resolves
-both architectures into one `RUNNERS_BY_ARCH` map, hands it to every reusable workflow it
-calls, and the jobs with an architecture matrix index it by `matrix.arch`. An architecture
-nobody has set resolves to an empty object, so those jobs keep falling back to the runner
-they use now.
+Set `RUNNERS_ARM64` (or the `PR` or per-branch form) to the same size-to-labels object, with labels that name an arm64 pool. Nothing else changes: `build-test-distribute.yaml` resolves both architectures into one `RUNNERS_BY_ARCH` map, hands it to every reusable workflow it calls, and the jobs with an architecture matrix index it by `matrix.arch`. An architecture nobody has set resolves to an empty object, so those jobs keep falling back to the runner they use now.
 
-Today that means the arm64 e2e legs in `_test.yaml` and the `linux/arm64` leg of
-`build-binaries`, which cross-compiles on an amd64 host while `RUNNERS_ARM64` is unset and
-builds natively once it is. Binaries are unaffected either way, since `CGO_ENABLED=0` makes
-the two byte-identical. A `darwin` leg cross-compiles wherever it lands, so it always asks
-for amd64.
+Today that means the arm64 e2e legs in `_test.yaml` and the `linux/arm64` leg of `build-binaries`, which cross-compiles on an amd64 host while `RUNNERS_ARM64` is unset and builds natively once it is. Binaries are unaffected either way, since `CGO_ENABLED=0` makes the two byte-identical. A `darwin` leg cross-compiles wherever it lands, so it always asks for amd64.
 
-`build-images` still builds every architecture on one host through qemu, so an arm64 pool
-does not speed it up without splitting that job per architecture first.
+`build-images` still builds every architecture on one host through qemu, so an arm64 pool does not speed it up without splitting that job per architecture first.
 
 ## Exceptions
 
-- `scorecard.yml` must keep a literal label, because `scorecard-action` rejects an
-  expression-based `runs-on` during workflow verification.
-- `pr-comments.yaml` must stay GitHub-hosted. It checks out the head of the PR a
-  maintainer commented on, which is a fork on most pull requests, and runs `make` against
-  it. `runs-on` cannot read the step that resolves `isCrossRepository`, so the runner is
-  chosen before the workflow knows whose code it is about to run.
-- `_provenance.yaml` and `lifecycle.yml` have no `runs-on`. They call reusable workflows
-  that choose their own runner.
+- `scorecard.yml` must keep a literal label, because `scorecard-action` rejects an expression-based `runs-on` during workflow verification.
+- `pr-comments.yaml` must stay GitHub-hosted. It checks out the head of the PR a maintainer commented on, which is a fork on most pull requests, and runs `make` against it. `runs-on` cannot read the step that resolves `isCrossRepository`, so the runner is chosen before the workflow knows whose code it is about to run.
+- `_provenance.yaml` and `lifecycle.yml` have no `runs-on`. They call reusable workflows that choose their own runner.
 
 ## Cutting a release branch
 
-Variable names cannot contain `-` or `.`, and an inline expression cannot sanitize
-`github.ref_name`, so the branch slug is written into the workflows by hand. After cutting
-`release-X.Y`, replace `RUNNERS_MASTER_` with `RUNNERS_RELEASE_X_Y_` across
-`.github/workflows/` on the new branch, comments included, and set the matching variables.
-A missed rename would silently fall back to the global variable, so `validate-workflows-and-scripts.yaml`
-fails when a slug in the workflows does not match the branch. `PR` is exempt, since it names
-a tier rather than a branch.
+Variable names cannot contain `-` or `.`, and an inline expression cannot sanitize `github.ref_name`, so the branch slug is written into the workflows by hand. After cutting `release-X.Y`, replace `RUNNERS_MASTER_` with `RUNNERS_RELEASE_X_Y_` across `.github/workflows/` on the new branch, comments included, and set the matching variables. A missed rename would silently fall back to the global variable, so `validate-workflows-and-scripts.yaml` fails when a slug in the workflows does not match the branch. `PR` is exempt, since it names a tier rather than a branch.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -54,8 +54,17 @@ gets the job OOM-killed on a small one.
 ## The expression
 
 ```yaml
-runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+runs-on: >-
+  ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+  || vars.RUNNERS_MASTER_AMD64
+  || vars.RUNNERS_AMD64
+  || '{}').lg
+  || 'ubuntu-24.04' }}
 ```
+
+`>-` folds the newlines into single spaces, so the expression GitHub evaluates is the same
+one-line string. Every continuation line has to sit at the same indentation, or YAML keeps
+the newline instead of folding it.
 
 Reading it: on a pull request take the PR variable, otherwise the per-branch one, otherwise
 the global one, otherwise an empty object. Then look up the size. If any step yields
@@ -67,7 +76,15 @@ from one, add a fork guard in front, so code from a fork never runs on a self-ho
 runner:
 
 ```yaml
-runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+runs-on: >-
+  ${{ (github.event_name == 'pull_request'
+  && github.event.pull_request.head.repo.full_name != github.repository)
+  && 'ubuntu-24.04'
+  || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+  || vars.RUNNERS_MASTER_AMD64
+  || vars.RUNNERS_AMD64
+  || '{}').lg
+  || 'ubuntu-24.04' }}
 ```
 
 The `env` context is not available in `runs-on`, which is why the default label is written

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,9 +1,10 @@
 # Choosing runners
 
-Every job picks its runner through two repository variables, so a fork or a downstream
+Almost every job picks its runner through two repository variables, so a fork or a downstream
 repository can move CI onto its own runners without editing any workflow. Nothing here is
-required: with both variables unset, every job runs on the GitHub-hosted default it has
-always used.
+required: with both variables unset, every job keeps the runner it had, which is a
+GitHub-hosted label for most of them and the shared `ubuntu-latest-kong` pool for the e2e
+legs.
 
 ## The variables
 
@@ -33,16 +34,16 @@ requires three distinct pools.
 
 Jobs declare the size they need, not a pool. The rule:
 
-- **sm** — no checkout, or a checkout plus only `gh`, `jq`, `git` or `curl`. Gates,
-  dispatchers, matrix generators, comment posters, and the pollers that spend hours waiting
-  on another workflow.
-- **md** — needs the mise toolchain and does network, artifact or git work, but compiles no
-  Go, builds no container image and starts no cluster. Publishing, SBOM generation,
-  backports, doc generation.
-- **lg** — compiles Go, runs `go test -race` or golangci-lint, builds images with buildx,
-  starts a k3d or kind cluster, or builds a CodeQL database.
+- **sm** for a job with no checkout, or a checkout plus only `gh`, `jq`, `git` or `curl`.
+  Gates, dispatchers, matrix generators, comment posters, and the pollers that spend hours
+  waiting on another workflow.
+- **md** for a job that needs the mise toolchain and does network, artifact or git work, but
+  compiles no Go, builds no container image and starts no cluster. Publishing, SBOM
+  generation, backports, doc generation.
+- **lg** for a job that compiles Go, runs `go test -race` or golangci-lint, builds images
+  with buildx, starts a k3d or kind cluster, or builds a CodeQL database.
 
-When a job's steps change, revisit its size. Overshooting wastes a large slot; undershooting
+When a job's steps change, revisit its size. Overshooting wastes a large slot. Undershooting
 gets the job OOM-killed on a small one.
 
 ## The expression
@@ -55,8 +56,8 @@ Reading it: take the per-branch variable, else the global one, else an empty obj
 the size; if any step yields nothing, fall back to the GitHub-hosted label. Only one
 possibly-missing property is ever dereferenced, because `'{}'` guarantees the object exists.
 
-Workflows that a `pull_request` event can reach — directly, or as a reusable workflow called
-from one — add a fork guard in front, so code from a fork never runs on a self-hosted
+Workflows that a `pull_request` event can reach, directly or as a reusable workflow called
+from one, add a fork guard in front, so code from a fork never runs on a self-hosted
 runner:
 
 ```yaml
@@ -75,9 +76,13 @@ each leg indexes the result by `matrix.arch` and then by size. That path additio
 
 ## Exceptions
 
-- `scorecard.yml` must keep a literal label — `scorecard-action` rejects an
+- `scorecard.yml` must keep a literal label, because `scorecard-action` rejects an
   expression-based `runs-on` during workflow verification.
-- `_provenance.yaml` and `lifecycle.yml` have no `runs-on`; they call reusable workflows
+- `pr-comments.yaml` must stay GitHub-hosted. It checks out the head of the PR a
+  maintainer commented on, which is a fork on most pull requests, and runs `make` against
+  it. `runs-on` cannot read the step that resolves `isCrossRepository`, so the runner is
+  chosen before the workflow knows whose code it is about to run.
+- `_provenance.yaml` and `lifecycle.yml` have no `runs-on`. They call reusable workflows
   that choose their own runner.
 
 ## Cutting a release branch

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,10 +8,15 @@ legs.
 
 ## The variables
 
-| name | scope |
-| --- | --- |
-| `RUNNERS_<BRANCH_SLUG>_<ARCH>` | one branch, one architecture |
-| `RUNNERS_<ARCH>` | one architecture, every branch |
+| name | scope | wins over |
+| --- | --- | --- |
+| `RUNNERS_PR_<ARCH>` | `pull_request` runs only | everything below |
+| `RUNNERS_<BRANCH_SLUG>_<ARCH>` | one branch, one architecture | the global variable |
+| `RUNNERS_<ARCH>` | one architecture, every branch | the built-in default |
+
+`RUNNERS_PR_<ARCH>` exists so pull requests can run somewhere other than pushes to the same
+branch, on a smaller or cheaper pool, without giving up the per-branch override for pushes.
+Leave it unset and pull requests follow the branch.
 
 `<ARCH>` is `AMD64` or `ARM64`. `<BRANCH_SLUG>` is the branch name uppercased with `-` and
 `.` replaced by `_`, so `master` is `MASTER` and `release-2.14` is `RELEASE_2_14`.
@@ -49,19 +54,20 @@ gets the job OOM-killed on a small one.
 ## The expression
 
 ```yaml
-runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
 ```
 
-Reading it: take the per-branch variable, else the global one, else an empty object; look up
-the size; if any step yields nothing, fall back to the GitHub-hosted label. Only one
-possibly-missing property is ever dereferenced, because `'{}'` guarantees the object exists.
+Reading it: on a pull request take the PR variable, otherwise the per-branch one, otherwise
+the global one, otherwise an empty object. Then look up the size. If any step yields
+nothing, fall back to the GitHub-hosted label. Only one possibly-missing property is ever
+dereferenced, because `'{}'` guarantees the object exists.
 
 Workflows that a `pull_request` event can reach, directly or as a reusable workflow called
 from one, add a fork guard in front, so code from a fork never runs on a self-hosted
 runner:
 
 ```yaml
-runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
 ```
 
 The `env` context is not available in `runs-on`, which is why the default label is written
@@ -92,4 +98,5 @@ Variable names cannot contain `-` or `.`, and an inline expression cannot saniti
 `release-X.Y`, replace `RUNNERS_MASTER_` with `RUNNERS_RELEASE_X_Y_` across
 `.github/workflows/` on the new branch, comments included, and set the matching variables.
 A missed rename would silently fall back to the global variable, so `validate-workflows-and-scripts.yaml`
-fails when a slug in the workflows does not match the branch.
+fails when a slug in the workflows does not match the branch. `PR` is exempt, since it names
+a tier rather than a branch.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # Choosing runners
 
-Almost every job picks its runner through two repository variables, so a fork or a downstream repository can move CI onto its own runners without editing any workflow. Nothing here is required: with both variables unset, every job keeps the runner it had, which is a GitHub-hosted label for most of them and the shared `ubuntu-latest-kong` pool for the e2e legs.
+Almost every job picks its runner through repository variables, so a fork or a downstream repository can move CI onto its own runners without editing any workflow. Three of them apply to one architecture: a pull-request tier, a per-branch one and a global one, each set independently. Nothing here is required: with all three unset, every job keeps the runner it had, which is a GitHub-hosted label for most of them and the shared `ubuntu-latest-kong` pool for the e2e legs.
 
 ## The variables
 
@@ -69,7 +69,7 @@ The `env` context is not available in `runs-on`, which is why the default label 
 
 ### The e2e jobs
 
-`_test.yaml` runs the same job across architectures, so it cannot read `vars` per leg. `build-test-distribute.yaml` splices both variables into its `RUNNERS_BY_ARCH` input, and each leg indexes the result by `matrix.arch` and then by size. That path additionally sends `master` to GitHub-hosted runners; the per-job sites above do not.
+`_test.yaml` runs the same job across architectures, so it cannot read `vars` per leg. `build-test-distribute.yaml` resolves the tiers for both architectures into one `RUNNERS_BY_ARCH` map, and each leg indexes the result by `matrix.arch` and then by size. That path additionally sends `master` to GitHub-hosted runners; the per-job sites above do not.
 
 ## Adding an architecture
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -86,4 +86,5 @@ Variable names cannot contain `-` or `.`, and an inline expression cannot saniti
 `github.ref_name`, so the branch slug is written into the workflows by hand. After cutting
 `release-X.Y`, replace `RUNNERS_MASTER_` with `RUNNERS_RELEASE_X_Y_` across
 `.github/workflows/` on the new branch, comments included, and set the matching variables.
-Nothing verifies this, so a missed rename silently falls back to the global variable.
+A missed rename would silently fall back to the global variable, so `validate-workflows-and-scripts.yaml`
+fails when a slug in the workflows does not match the branch.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,89 @@
+# Choosing runners
+
+Every job picks its runner through two repository variables, so a fork or a downstream
+repository can move CI onto its own runners without editing any workflow. Nothing here is
+required: with both variables unset, every job runs on the GitHub-hosted default it has
+always used.
+
+## The variables
+
+| name | scope |
+| --- | --- |
+| `RUNNERS_<BRANCH_SLUG>_<ARCH>` | one branch, one architecture |
+| `RUNNERS_<ARCH>` | one architecture, every branch |
+
+`<ARCH>` is `AMD64` or `ARM64`. `<BRANCH_SLUG>` is the branch name uppercased with `-` and
+`.` replaced by `_`, so `master` is `MASTER` and `release-2.14` is `RELEASE_2_14`.
+
+The value is a JSON object mapping a size to the labels a runner must carry:
+
+```json
+{
+  "sm": ["self-hosted", "linux", "x64", "size-sm"],
+  "md": ["self-hosted", "linux", "x64", "size-md"],
+  "lg": ["self-hosted", "linux", "x64", "size-lg"]
+}
+```
+
+A job runs only on a runner that has **all** the labels listed for its size. A repository
+without a pool for one of the sizes points that key at a pool it does have; nothing
+requires three distinct pools.
+
+## Sizes
+
+Jobs declare the size they need, not a pool. The rule:
+
+- **sm** — no checkout, or a checkout plus only `gh`, `jq`, `git` or `curl`. Gates,
+  dispatchers, matrix generators, comment posters, and the pollers that spend hours waiting
+  on another workflow.
+- **md** — needs the mise toolchain and does network, artifact or git work, but compiles no
+  Go, builds no container image and starts no cluster. Publishing, SBOM generation,
+  backports, doc generation.
+- **lg** — compiles Go, runs `go test -race` or golangci-lint, builds images with buildx,
+  starts a k3d or kind cluster, or builds a CodeQL database.
+
+When a job's steps change, revisit its size. Overshooting wastes a large slot; undershooting
+gets the job OOM-killed on a small one.
+
+## The expression
+
+```yaml
+runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+```
+
+Reading it: take the per-branch variable, else the global one, else an empty object; look up
+the size; if any step yields nothing, fall back to the GitHub-hosted label. Only one
+possibly-missing property is ever dereferenced, because `'{}'` guarantees the object exists.
+
+Workflows that a `pull_request` event can reach — directly, or as a reusable workflow called
+from one — add a fork guard in front, so code from a fork never runs on a self-hosted
+runner:
+
+```yaml
+runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+```
+
+The `env` context is not available in `runs-on`, which is why the default label is written
+inline at every site rather than defined once.
+
+### The e2e jobs
+
+`_test.yaml` runs the same job across architectures, so it cannot read `vars` per leg.
+`build-test-distribute.yaml` splices both variables into its `RUNNERS_BY_ARCH` input, and
+each leg indexes the result by `matrix.arch` and then by size. That path additionally sends
+`master` to GitHub-hosted runners; the per-job sites above do not.
+
+## Exceptions
+
+- `scorecard.yml` must keep a literal label — `scorecard-action` rejects an
+  expression-based `runs-on` during workflow verification.
+- `_provenance.yaml` and `lifecycle.yml` have no `runs-on`; they call reusable workflows
+  that choose their own runner.
+
+## Cutting a release branch
+
+Variable names cannot contain `-` or `.`, and an inline expression cannot sanitize
+`github.ref_name`, so the branch slug is written into the workflows by hand. After cutting
+`release-X.Y`, replace `RUNNERS_MASTER_` with `RUNNERS_RELEASE_X_Y_` across
+`.github/workflows/` on the new branch, comments included, and set the matching variables.
+Nothing verifies this, so a missed rename silently falls back to the global variable.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -97,6 +97,24 @@ inline at every site rather than defined once.
 each leg indexes the result by `matrix.arch` and then by size. That path additionally sends
 `master` to GitHub-hosted runners; the per-job sites above do not.
 
+## Adding an architecture
+
+Set `RUNNERS_ARM64` (or the `PR` or per-branch form) to the same size-to-labels object, with
+labels that name an arm64 pool. Nothing else changes: `build-test-distribute.yaml` resolves
+both architectures into one `RUNNERS_BY_ARCH` map, hands it to every reusable workflow it
+calls, and the jobs with an architecture matrix index it by `matrix.arch`. An architecture
+nobody has set resolves to an empty object, so those jobs keep falling back to the runner
+they use now.
+
+Today that means the arm64 e2e legs in `_test.yaml` and the `linux/arm64` leg of
+`build-binaries`, which cross-compiles on an amd64 host while `RUNNERS_ARM64` is unset and
+builds natively once it is. Binaries are unaffected either way, since `CGO_ENABLED=0` makes
+the two byte-identical. A `darwin` leg cross-compiles wherever it lands, so it always asks
+for amd64.
+
+`build-images` still builds every architecture on one host through qemu, so an arm64 pool
+does not speed it up without splitting that job per architecture first.
+
 ## Exceptions
 
 - `scorecard.yml` must keep a literal label, because `scorecard-action` rejects an

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -55,10 +55,8 @@ jobs:
   # repository cache budget is shared with every branch.
   build-binaries:
     timeout-minutes: 70
-    # A linux leg builds for the host it runs on when a pool for that arch exists, so it
-    # asks for matrix.arch. A darwin leg cross-compiles wherever it lands, so it stays on
-    # amd64. An arch with no pool resolves to nothing here and falls back, which is what
-    # every arm64 leg does until RUNNERS_ARM64 is set.
+    # A darwin leg cross-compiles wherever it lands, so it stays on amd64. An arch with no
+    # pool set falls back, which is every arm64 leg today.
     runs-on: >-
       ${{ (github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name != github.repository)

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -52,7 +52,7 @@ jobs:
   # repository cache budget is shared with every branch.
   build-binaries:
     timeout-minutes: 70
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     permissions:
       contents: read
     strategy:
@@ -146,7 +146,7 @@ jobs:
   publish-binaries:
     needs: [build-binaries]
     timeout-minutes: 30
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -225,7 +225,7 @@ jobs:
           make publish/pulp
   build-images:
     needs: [build-binaries] # consumes the linux_binaries artifact
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -393,7 +393,7 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -414,7 +414,7 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -25,6 +25,9 @@ on:
       NOTARY_REPOSITORY:
         required: true
         type: string
+      RUNNERS_BY_ARCH:
+        required: true
+        type: string
     outputs:
       BINARY_ARTIFACT_DIGEST_BASE64:
         value: ${{ jobs.publish-binaries.outputs.BINARY_ARTIFACT_DIGEST_BASE64 }}
@@ -52,14 +55,15 @@ jobs:
   # repository cache budget is shared with every branch.
   build-binaries:
     timeout-minutes: 70
+    # A linux leg builds for the host it runs on when a pool for that arch exists, so it
+    # asks for matrix.arch. A darwin leg cross-compiles wherever it lands, so it stays on
+    # amd64. An arch with no pool resolves to nothing here and falls back, which is what
+    # every arm64 leg does until RUNNERS_ARM64 is set.
     runs-on: >-
       ${{ (github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name != github.repository)
       && 'ubuntu-24.04'
-      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
-      || vars.RUNNERS_MASTER_AMD64
-      || vars.RUNNERS_AMD64
-      || '{}').lg
+      || fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.os == 'linux' && matrix.arch || 'amd64'].lg
       || 'ubuntu-24.04' }}
     permissions:
       contents: read

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -52,7 +52,15 @@ jobs:
   # repository cache budget is shared with every branch.
   build-binaries:
     timeout-minutes: 70
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     permissions:
       contents: read
     strategy:
@@ -146,7 +154,15 @@ jobs:
   publish-binaries:
     needs: [build-binaries]
     timeout-minutes: 30
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -225,7 +241,15 @@ jobs:
           make publish/pulp
   build-images:
     needs: [build-binaries] # consumes the linux_binaries artifact
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -393,7 +417,15 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -414,7 +446,15 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -52,7 +52,7 @@ jobs:
   # repository cache budget is shared with every branch.
   build-binaries:
     timeout-minutes: 70
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     permissions:
       contents: read
     strategy:
@@ -146,7 +146,7 @@ jobs:
   publish-binaries:
     needs: [build-binaries]
     timeout-minutes: 30
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -225,7 +225,7 @@ jobs:
           make publish/pulp
   build-images:
     needs: [build-binaries] # consumes the linux_binaries artifact
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -393,7 +393,7 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -414,7 +414,7 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -33,7 +33,7 @@ on:
 permissions:
   contents: read
 env:
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
   ALLOW_PUSH: ${{ inputs.ALLOW_PUSH }}
   GH_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/_get-active-branches.yaml
+++ b/.github/workflows/_get-active-branches.yaml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   get:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     outputs:
       out: ${{ steps.main.outputs.out }}
     steps:

--- a/.github/workflows/_get-active-branches.yaml
+++ b/.github/workflows/_get-active-branches.yaml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   get:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     outputs:
       out: ${{ steps.main.outputs.out }}
     steps:

--- a/.github/workflows/_get-active-branches.yaml
+++ b/.github/workflows/_get-active-branches.yaml
@@ -31,7 +31,12 @@ permissions:
 
 jobs:
   get:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     outputs:
       out: ${{ steps.main.outputs.out }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -25,7 +25,7 @@ jobs:
   test_unit:
     timeout-minutes: 30
     if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     env:
       UNIT_CLEAN_TESTCACHE: ${{ inputs.IS_PULL_REQUEST && 'false' || 'true' }}
     steps:
@@ -65,7 +65,7 @@ jobs:
           key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -143,13 +143,13 @@ jobs:
     name: "e2e (default, ${{ matrix.k8sVersion }}, ${{ matrix.arch }})"
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
+    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
     strategy:
       max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e }}
       fail-fast: false
     env:
-      CI_TOOLS_DIR: ${{ contains(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch], '-kong') && '/work/kuma/kuma/.ci_tools' || '/home/runner/work/kuma/kuma/.ci_tools' }}
+      CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
       MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
       DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
     steps:
@@ -170,13 +170,13 @@ jobs:
     name: "e2e (gatewayapi, ${{ matrix.k8sVersion }}, ${{ matrix.arch }})"
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
+    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
     strategy:
       max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi }}
       fail-fast: false
     env:
-      CI_TOOLS_DIR: ${{ contains(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch], '-kong') && '/work/kuma/kuma/.ci_tools' || '/home/runner/work/kuma/kuma/.ci_tools' }}
+      CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
       MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
       DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
     steps:
@@ -197,13 +197,13 @@ jobs:
     name: "e2e (${{ matrix.target }}, ${{ matrix.k8sVersion }}, ${{ matrix.arch }}${{ matrix.cniNetworkPlugin != 'flannel' && format(', {0}', matrix.cniNetworkPlugin) || '' }})"
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
+    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
     strategy:
       max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env }}
       fail-fast: false
     env:
-      CI_TOOLS_DIR: ${{ contains(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch], '-kong') && '/work/kuma/kuma/.ci_tools' || '/home/runner/work/kuma/kuma/.ci_tools' }}
+      CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
       MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
       DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -16,7 +16,7 @@ on:
 permissions:
   contents: read
 env:
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   # This is automatically managed by CI
   K8S_MIN_VERSION: v1.34.9-k3s1
   K8S_MAX_VERSION: v1.35.3-k3s1
@@ -149,7 +149,6 @@ jobs:
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e }}
       fail-fast: false
     env:
-      CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
       MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
       DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
     steps:
@@ -176,7 +175,6 @@ jobs:
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi }}
       fail-fast: false
     env:
-      CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
       MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
       DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
     steps:
@@ -203,7 +201,6 @@ jobs:
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env }}
       fail-fast: false
     env:
-      CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
       MISE_DISABLE_TOOLS: "golangci-lint,skaffold,aqua:stackrox/kube-linter"
       DOCKERHUB_PULL_CREDENTIAL: ${{ secrets.DOCKERHUB_PULL_CREDENTIAL }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -25,7 +25,7 @@ jobs:
   test_unit:
     timeout-minutes: 30
     if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     env:
       UNIT_CLEAN_TESTCACHE: ${{ inputs.IS_PULL_REQUEST && 'false' || 'true' }}
     steps:
@@ -65,7 +65,7 @@ jobs:
           key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -25,7 +25,15 @@ jobs:
   test_unit:
     timeout-minutes: 30
     if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     env:
       UNIT_CLEAN_TESTCACHE: ${{ inputs.IS_PULL_REQUEST && 'false' || 'true' }}
     steps:
@@ -65,7 +73,15 @@ jobs:
           key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -143,7 +159,9 @@ jobs:
     name: "e2e (default, ${{ matrix.k8sVersion }}, ${{ matrix.arch }})"
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
+    runs-on: >-
+      ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg
+      || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
     strategy:
       max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e }}
@@ -169,7 +187,9 @@ jobs:
     name: "e2e (gatewayapi, ${{ matrix.k8sVersion }}, ${{ matrix.arch }})"
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
+    runs-on: >-
+      ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg
+      || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
     strategy:
       max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_gatewayapi }}
@@ -195,7 +215,9 @@ jobs:
     name: "e2e (${{ matrix.target }}, ${{ matrix.k8sVersion }}, ${{ matrix.arch }}${{ matrix.cniNetworkPlugin != 'flannel' && format(', {0}', matrix.cniNetworkPlugin) || '' }})"
     if: fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
+    runs-on: >-
+      ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg
+      || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong') }}
     strategy:
       max-parallel: ${{ inputs.IS_PULL_REQUEST && 12 || 5 }}
       matrix: ${{ fromJSON(needs.gen_e2e_matrix.outputs.matrix).test_e2e_env }}

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,7 +13,15 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -22,7 +22,12 @@ env:
   GH_REPO: ${{ github.repository }}
 jobs:
   pr-info:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     outputs:
       pr_title: ${{ steps.get-pr-info.outputs.pr_title }}
       pr_change_log: ${{ steps.get-pr-info.outputs.pr_change_log }}
@@ -109,7 +114,12 @@ jobs:
       branches: ${{ inputs.branches }}
   open-prs:
     needs: [pr-info, active-branches]
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -22,7 +22,7 @@ env:
   GH_REPO: ${{ github.repository }}
 jobs:
   pr-info:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     outputs:
       pr_title: ${{ steps.get-pr-info.outputs.pr_title }}
       pr_change_log: ${{ steps.get-pr-info.outputs.pr_change_log }}
@@ -109,7 +109,7 @@ jobs:
       branches: ${{ inputs.branches }}
   open-prs:
     needs: [pr-info, active-branches]
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -22,7 +22,7 @@ env:
   GH_REPO: ${{ github.repository }}
 jobs:
   pr-info:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     outputs:
       pr_title: ${{ steps.get-pr-info.outputs.pr_title }}
       pr_change_log: ${{ steps.get-pr-info.outputs.pr_change_log }}
@@ -109,7 +109,7 @@ jobs:
       branches: ${{ inputs.branches }}
   open-prs:
     needs: [pr-info, active-branches]
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,7 +7,12 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,7 +7,7 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   release_sha_gate:
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: read
@@ -110,7 +110,7 @@ jobs:
   meta:
     needs: ["release_sha_gate"]
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
     outputs:
@@ -120,7 +120,7 @@ jobs:
   build_check:
     needs: ["release_sha_gate"]
     timeout-minutes: 20
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -147,7 +147,7 @@ jobs:
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
       pull-requests: read # needed by paths-filter to access PR file list
     timeout-minutes: 40
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -281,17 +281,20 @@ jobs:
       FULL_MATRIX: ${{ needs.meta.outputs.FULL_MATRIX }}
       IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
-      # Per-arch lookup (each side independent):
-      #   1. fork PR                    -> free GitHub-hosted runners (security)
-      #   2. master (push, or PR targeting it) -> free GitHub-hosted runners
-      #   3. vars.RUNS_ON_MASTER_<ARCH> -> per-branch + per-arch override
-      #   4. vars.RUNS_ON_<ARCH>        -> global per-arch override
-      #   5. default                    -> the standard self-hosted Kong pool
+      # Per-arch lookup, each side independent. See .github/workflows/README.md.
+      #   1. fork PR                            -> free GitHub-hosted runners (security)
+      #   2. master (push, or PR targeting it)  -> free GitHub-hosted runners
+      #   3. vars.RUNNERS_MASTER_<ARCH>         -> per-branch + per-arch override
+      #   4. vars.RUNNERS_<ARCH>                -> global per-arch override
+      #   5. default                            -> the standard self-hosted Kong pool
+      # Both variables hold a JSON object of size to label array, and the raw strings are
+      # spliced in, so _test.yaml receives {"<arch>":{"<size>":[labels]}} and indexes it by
+      # arch and by the size that job needs.
       # `github.base_ref` is the PR target branch and is empty outside pull_request,
       # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.base_ref || github.ref_name) == 'master') && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_MASTER_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.base_ref || github.ref_name) == 'master') && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}' || format('{{"amd64":{0},"arm64":{1}}}', vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}', vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
     secrets: inherit
   build_publish:
     permissions:
@@ -332,7 +335,7 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   release_sha_gate:
     timeout-minutes: 5
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: read
@@ -111,7 +111,7 @@ jobs:
   meta:
     needs: ["release_sha_gate"]
     timeout-minutes: 5
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
     outputs:
@@ -121,7 +121,7 @@ jobs:
   build_check:
     needs: ["release_sha_gate"]
     timeout-minutes: 20
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -148,7 +148,7 @@ jobs:
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
       pull-requests: read # needed by paths-filter to access PR file list
     timeout-minutes: 40
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -294,9 +294,10 @@ jobs:
       # Per-arch lookup, each side independent. See .github/workflows/README.md.
       #   1. fork PR                            -> free GitHub-hosted runners (security)
       #   2. master (push, or PR targeting it)  -> free GitHub-hosted runners
-      #   3. vars.RUNNERS_MASTER_<ARCH>         -> per-branch + per-arch override
-      #   4. vars.RUNNERS_<ARCH>                -> global per-arch override
-      #   5. default                            -> the standard self-hosted Kong pool
+      #   3. vars.RUNNERS_PR_<ARCH>             -> pull_request runs, per-arch
+      #   4. vars.RUNNERS_MASTER_<ARCH>         -> per-branch + per-arch override
+      #   5. vars.RUNNERS_<ARCH>                -> global per-arch override
+      #   6. default                            -> the standard self-hosted Kong pool
       # Both variables hold a JSON object of size to label array, and the raw strings are
       # spliced in, so _test.yaml receives {"<arch>":{"<size>":[labels]}} and indexes it by
       # arch and by the size that job needs.
@@ -304,7 +305,7 @@ jobs:
       # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.base_ref || github.ref_name) == 'master') && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}' || format('{{"amd64":{0},"arm64":{1}}}', vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}', vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
+      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.base_ref || github.ref_name) == 'master') && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}' || format('{{"amd64":{0},"arm64":{1}}}', (github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}', (github.event_name == 'pull_request' && vars.RUNNERS_PR_ARM64) || vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
     secrets: inherit
   build_publish:
     permissions:
@@ -345,7 +346,7 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -24,7 +24,15 @@ concurrency:
 jobs:
   release_sha_gate:
     timeout-minutes: 5
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: read
@@ -111,7 +119,15 @@ jobs:
   meta:
     needs: ["release_sha_gate"]
     timeout-minutes: 5
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
     outputs:
@@ -121,7 +137,15 @@ jobs:
   build_check:
     needs: ["release_sha_gate"]
     timeout-minutes: 20
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -148,7 +172,15 @@ jobs:
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
       pull-requests: read # needed by paths-filter to access PR file list
     timeout-minutes: 40
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -305,7 +337,16 @@ jobs:
       # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
       # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
       # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.base_ref || github.ref_name) == 'master') && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}' || format('{{"amd64":{0},"arm64":{1}}}', (github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}', (github.event_name == 'pull_request' && vars.RUNNERS_PR_ARM64) || vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
+      RUNNERS_BY_ARCH: >-
+        ${{ ((github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository)
+        || (github.base_ref || github.ref_name) == 'master')
+        && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}'
+        || format('{{"amd64":{0},"arm64":{1}}}',
+        (github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+        || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}',
+        (github.event_name == 'pull_request' && vars.RUNNERS_PR_ARM64)
+        || vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
     secrets: inherit
   build_publish:
     permissions:
@@ -346,7 +387,15 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -10,10 +10,11 @@ permissions:
   contents: read
 env:
   KUMA_DIR: "."
-  # To keep CI tools out of the SBOM, we use a `.ci_tools` directory in the parent
-  # of the code checkout path (typically /home/runner/work/<repo-name>/<repo-name>
-  # on the runner).
-  CI_TOOLS_DIR: "/home/runner/work/kuma/.ci_tools"
+  # To keep CI tools out of the SBOM, `.ci_tools` sits in the parent of the code
+  # checkout path. Hardcoding that path assumed a GitHub-hosted runner, where the
+  # checkout is /home/runner/work/<repo>/<repo>; a self-hosted runner puts its work
+  # directory elsewhere.
+  CI_TOOLS_DIR: ${{ github.workspace }}/../.ci_tools
   # renovate: datasource=github-tags depName=golangci-lint packageName=golangci/golangci-lint versioning=semver
   GOLANGCI_LINT_VERSION: "v2.13.2"
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
@@ -203,11 +204,20 @@ jobs:
       - name: Set GOMEMLIMIT dynamically based on available memory
         id: set-gomemlimit
         run: |
-          # Get total memory in bytes
           set -e
-          mem_total_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-          mem_total_bytes=$((mem_total_kb * 1024))
-          gomemlimit=$((mem_total_bytes * 8 / 10))
+          # /proc/meminfo reports the host, so inside a container it names memory this job
+          # cannot have. Prefer the cgroup cap when one is set.
+          available=$(($(grep MemTotal /proc/meminfo | awk '{print $2}') * 1024))
+          for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+            [ -r "$f" ] || continue
+            limit=$(cat "$f")
+            case "$limit" in ''|*[!0-9]*) continue ;; esac
+            if [ "$limit" -lt "$available" ]; then
+              available=$limit
+            fi
+            break
+          done
+          gomemlimit=$((available * 8 / 10))
           echo "GOMEMLIMIT=${gomemlimit}" >> "$GITHUB_ENV"
           echo "Setting GOMEMLIMIT to $(numfmt --to=iec "$gomemlimit")"
       - name: Cache Go build

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -10,10 +10,7 @@ permissions:
   contents: read
 env:
   KUMA_DIR: "."
-  # To keep CI tools out of the SBOM, `.ci_tools` sits in the parent of the code
-  # checkout path. Hardcoding that path assumed a GitHub-hosted runner, where the
-  # checkout is /home/runner/work/<repo>/<repo>; a self-hosted runner puts its work
-  # directory elsewhere.
+  # Parent of the checkout, to keep CI tools out of the SBOM.
   CI_TOOLS_DIR: ${{ github.workspace }}/../.ci_tools
   # renovate: datasource=github-tags depName=golangci-lint packageName=golangci/golangci-lint versioning=semver
   GOLANGCI_LINT_VERSION: "v2.13.2"
@@ -139,15 +136,12 @@ jobs:
       #   4. vars.RUNNERS_MASTER_<ARCH>         -> per-branch + per-arch override
       #   5. vars.RUNNERS_<ARCH>                -> global per-arch override
       #   6. default                            -> the standard self-hosted Kong pool
-      # Both variables hold a JSON object of size to label array, and the raw strings are
-      # spliced in, so a caller receives {"<arch>":{"<size>":[labels]}} and indexes it by
-      # arch and by the size that job needs. An arch nobody has set resolves to an empty
-      # object, and each consumer falls back to its own default, so adding an architecture
-      # is setting a variable rather than editing a workflow.
-      # `github.base_ref` is the PR target branch and is empty outside pull_request,
-      # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
-      # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
-      # and inline expressions can't sanitize `github.ref_name`.
+      # Each variable is a JSON object of size to label array, spliced in raw, so a caller
+      # gets {"<arch>":{"<size>":[labels]}}. An unset arch resolves to {} and the consumer
+      # falls back, so adding an arch is setting a variable.
+      # `github.base_ref` is empty outside pull_request, where `github.ref_name` is
+      # '<number>/merge'. The slug is hardcoded: var names take no '-' or '.', and an
+      # inline expression cannot sanitize `github.ref_name`.
       RUNNERS_BY_ARCH: >-
         ${{ ((github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name != github.repository)
@@ -263,8 +257,7 @@ jobs:
         id: set-gomemlimit
         run: |
           set -e
-          # /proc/meminfo reports the host, so inside a container it names memory this job
-          # cannot have. Prefer the cgroup cap when one is set.
+          # /proc/meminfo reports the host, not the cgroup a containerised runner gets.
           available=$(($(grep MemTotal /proc/meminfo | awk '{print $2}') * 1024))
           for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
             [ -r "$f" ] || continue

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -132,6 +132,32 @@ jobs:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
     outputs:
       FULL_MATRIX: ${{ env.FULL_MATRIX }}
+      # Per-arch lookup, each side independent. See .github/workflows/README.md.
+      #   1. fork PR                            -> free GitHub-hosted runners (security)
+      #   2. master (push, or PR targeting it)  -> free GitHub-hosted runners
+      #   3. vars.RUNNERS_PR_<ARCH>             -> pull_request runs, per-arch
+      #   4. vars.RUNNERS_MASTER_<ARCH>         -> per-branch + per-arch override
+      #   5. vars.RUNNERS_<ARCH>                -> global per-arch override
+      #   6. default                            -> the standard self-hosted Kong pool
+      # Both variables hold a JSON object of size to label array, and the raw strings are
+      # spliced in, so a caller receives {"<arch>":{"<size>":[labels]}} and indexes it by
+      # arch and by the size that job needs. An arch nobody has set resolves to an empty
+      # object, and each consumer falls back to its own default, so adding an architecture
+      # is setting a variable rather than editing a workflow.
+      # `github.base_ref` is the PR target branch and is empty outside pull_request,
+      # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
+      # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
+      # and inline expressions can't sanitize `github.ref_name`.
+      RUNNERS_BY_ARCH: >-
+        ${{ ((github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository)
+        || (github.base_ref || github.ref_name) == 'master')
+        && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}'
+        || format('{{"amd64":{0},"arm64":{1}}}',
+        (github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+        || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}',
+        (github.event_name == 'pull_request' && vars.RUNNERS_PR_ARM64)
+        || vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
     steps:
       - run: echo "FULL_MATRIX=${{ env.FULL_MATRIX }}"
   build_check:
@@ -323,36 +349,13 @@ jobs:
       FULL_MATRIX: ${{ needs.meta.outputs.FULL_MATRIX }}
       IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
-      # Per-arch lookup, each side independent. See .github/workflows/README.md.
-      #   1. fork PR                            -> free GitHub-hosted runners (security)
-      #   2. master (push, or PR targeting it)  -> free GitHub-hosted runners
-      #   3. vars.RUNNERS_PR_<ARCH>             -> pull_request runs, per-arch
-      #   4. vars.RUNNERS_MASTER_<ARCH>         -> per-branch + per-arch override
-      #   5. vars.RUNNERS_<ARCH>                -> global per-arch override
-      #   6. default                            -> the standard self-hosted Kong pool
-      # Both variables hold a JSON object of size to label array, and the raw strings are
-      # spliced in, so _test.yaml receives {"<arch>":{"<size>":[labels]}} and indexes it by
-      # arch and by the size that job needs.
-      # `github.base_ref` is the PR target branch and is empty outside pull_request,
-      # where `github.ref_name` is the branch/tag ('<number>/merge' on a PR).
-      # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
-      # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: >-
-        ${{ ((github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name != github.repository)
-        || (github.base_ref || github.ref_name) == 'master')
-        && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}'
-        || format('{{"amd64":{0},"arm64":{1}}}',
-        (github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
-        || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}',
-        (github.event_name == 'pull_request' && vars.RUNNERS_PR_ARM64)
-        || vars.RUNNERS_MASTER_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
+      RUNNERS_BY_ARCH: ${{ needs.meta.outputs.RUNNERS_BY_ARCH }}
     secrets: inherit
   build_publish:
     permissions:
       contents: write # needed to upload SBOM assets to GitHub releases
       id-token: write # Required for image signing
-    needs: ["check", "test"]
+    needs: ["check", "meta", "test"]
     uses: ./.github/workflows/_build_publish.yaml
     if: ${{ fromJSON(needs.check.outputs.BUILD) }}
     with:
@@ -364,6 +367,7 @@ jobs:
       REGISTRY: ${{ needs.check.outputs.REGISTRY }}
       NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
       VERSION_NAME: ${{ needs.check.outputs.VERSION_NAME }}
+      RUNNERS_BY_ARCH: ${{ needs.meta.outputs.RUNNERS_BY_ARCH }}
     secrets: inherit
   provenance:
     needs: ["check", "build_publish"]

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,7 @@ permissions: {}
 jobs:
   pr-check:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - name: Check PR title
         # Check PR title against the Conventional Commits format using commitlint.

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,7 @@ permissions: {}
 jobs:
   pr-check:
     timeout-minutes: 10
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - name: Check PR title
         # Check PR title against the Conventional Commits format using commitlint.

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,15 @@ permissions: {}
 jobs:
   pr-check:
     timeout-minutes: 10
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     steps:
       - name: Check PR title
         # Check PR title against the Conventional Commits format using commitlint.

--- a/.github/workflows/ci-stability-master.yaml
+++ b/.github/workflows/ci-stability-master.yaml
@@ -24,7 +24,12 @@ env:
 
 jobs:
   trigger-build-test-distribute:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-master.yaml
+++ b/.github/workflows/ci-stability-master.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   trigger-build-test-distribute:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-master.yaml
+++ b/.github/workflows/ci-stability-master.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   trigger-build-test-distribute:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -25,7 +25,12 @@ jobs:
 
   trigger-build-test-distribute:
     needs: active-branches
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -25,7 +25,7 @@ jobs:
 
   trigger-build-test-distribute:
     needs: active-branches
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability-release-branches.yaml
+++ b/.github/workflows/ci-stability-release-branches.yaml
@@ -25,7 +25,7 @@ jobs:
 
   trigger-build-test-distribute:
     needs: active-branches
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       actions: write # required to trigger workflows
       checks: read # required to list workflow runs

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   trigger-ci:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - name: Generate GitHub app token

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   trigger-ci:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - name: Generate GitHub app token

--- a/.github/workflows/ci-stability.yaml
+++ b/.github/workflows/ci-stability.yaml
@@ -29,7 +29,12 @@ env:
 
 jobs:
   trigger-ci:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - name: Generate GitHub app token

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,7 +9,12 @@ permissions: {}
 
 jobs:
   analyze:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analyze:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   analyze:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/e2e-v3-readiness.yml
+++ b/.github/workflows/e2e-v3-readiness.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         env: [universal, kubernetes, multizone]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -71,7 +71,7 @@ jobs:
   report:
     needs: audit
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/e2e-v3-readiness.yml
+++ b/.github/workflows/e2e-v3-readiness.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         env: [universal, kubernetes, multizone]
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -71,7 +71,7 @@ jobs:
   report:
     needs: audit
     if: always()
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/e2e-v3-readiness.yml
+++ b/.github/workflows/e2e-v3-readiness.yml
@@ -29,7 +29,12 @@ jobs:
       fail-fast: false
       matrix:
         env: [universal, kubernetes, multizone]
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -71,7 +76,12 @@ jobs:
   report:
     needs: audit
     if: always()
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -18,7 +18,7 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   release:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -18,7 +18,12 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   release:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/merge-release-to-master.yaml
+++ b/.github/workflows/merge-release-to-master.yaml
@@ -18,7 +18,7 @@ env:
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 jobs:
   release:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,7 +12,7 @@ jobs:
   pr_comments:
     timeout-minutes: 120
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files') || contains(github.event.comment.body, '/golden_files_e2e') || contains(github.event.comment.body, '/tproxy_golden_files'))
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       # Commands are additive: one comment can request multiple actions, and all
       # matching steps below will run in order.

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,10 +12,8 @@ jobs:
   pr_comments:
     timeout-minutes: 120
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files') || contains(github.event.comment.body, '/golden_files_e2e') || contains(github.event.comment.body, '/tproxy_golden_files'))
-    # Stays GitHub-hosted. A maintainer's /format or /golden_files checks out the PR head,
-    # which is a fork on most PRs, and runs make against it. runs-on cannot read the step
-    # that resolves isCrossRepository, so the runner is picked before we know whose code
-    # this is. See .github/workflows/README.md.
+    # Checks out the PR head, a fork on most PRs, and runs make against it. runs-on cannot
+    # read the step that resolves isCrossRepository, so this stays GitHub-hosted.
     runs-on: ubuntu-24.04
     steps:
       # Commands are additive: one comment can request multiple actions, and all

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,7 +12,11 @@ jobs:
   pr_comments:
     timeout-minutes: 120
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files') || contains(github.event.comment.body, '/golden_files_e2e') || contains(github.event.comment.body, '/tproxy_golden_files'))
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    # Stays GitHub-hosted. A maintainer's /format or /golden_files checks out the PR head,
+    # which is a fork on most PRs, and runs make against it. runs-on cannot read the step
+    # that resolves isCrossRepository, so the runner is picked before we know whose code
+    # this is. See .github/workflows/README.md.
+    runs-on: ubuntu-24.04
     steps:
       # Commands are additive: one comment can request multiple actions, and all
       # matching steps below will run in order.

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,7 +12,7 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,7 +12,7 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,7 +12,12 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   tag:
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - name: "Generate GitHub app token"
         id: app-token

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   tag:
     timeout-minutes: 60
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     steps:
       - name: "Generate GitHub app token"
         id: app-token

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -33,7 +33,12 @@ concurrency:
 jobs:
   tag:
     timeout-minutes: 60
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     steps:
       - name: "Generate GitHub app token"
         id: app-token

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
   release:
     # Headroom for the retried checks below (up to 5 attempts x 3 checks).
     timeout-minutes: 45
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
   release:
     # Headroom for the retried checks below (up to 5 attempts x 3 checks).
     timeout-minutes: 45
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,12 @@ jobs:
   release:
     # Headroom for the retried checks below (up to 5 attempts x 3 checks).
     timeout-minutes: 45
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
+++ b/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   dispatch-event:
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 10
     env:
       TARGET_REPO: kuma-gui

--- a/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
+++ b/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   dispatch-event:
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 10
     env:
       TARGET_REPO: kuma-gui

--- a/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
+++ b/.github/workflows/sync_kuma_oas_to_kuma-gui.yaml
@@ -17,7 +17,12 @@ permissions: {}
 
 jobs:
   dispatch-event:
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     timeout-minutes: 10
     env:
       TARGET_REPO: kuma-gui

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -12,7 +12,12 @@ permissions:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: 0 2 * * *
 env:
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   IPV6: "true"
   MISE_DISABLE_TOOLS: "golangci-lint,skaffold"
 permissions:

--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -65,7 +65,12 @@ jobs:
         !startsWith(github.event.workflow_run.head_branch, 'release-')
       )
     timeout-minutes: 5
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       contents: read # to confirm the ref is really a tag, via the git refs API
     outputs:
@@ -135,7 +140,12 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_smoke)
     timeout-minutes: 5
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Trigger downstream smoke test"
@@ -182,7 +192,12 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_verify)
     timeout-minutes: 5
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       # same-repo dispatch needs no cross-org token, unlike smoke; the default
       # GITHUB_TOKEN only gains workflow_dispatch rights with actions:write.
@@ -214,7 +229,12 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_installer)
     timeout-minutes: 5
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Run installer.sh for the released version"

--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -65,7 +65,7 @@ jobs:
         !startsWith(github.event.workflow_run.head_branch, 'release-')
       )
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       contents: read # to confirm the ref is really a tag, via the git refs API
     outputs:
@@ -135,7 +135,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_smoke)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Trigger downstream smoke test"
@@ -182,7 +182,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_verify)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       # same-repo dispatch needs no cross-org token, unlike smoke; the default
       # GITHUB_TOKEN only gains workflow_dispatch rights with actions:write.
@@ -214,7 +214,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_installer)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Run installer.sh for the released version"

--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -65,7 +65,7 @@ jobs:
         !startsWith(github.event.workflow_run.head_branch, 'release-')
       )
     timeout-minutes: 5
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       contents: read # to confirm the ref is really a tag, via the git refs API
     outputs:
@@ -135,7 +135,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_smoke)
     timeout-minutes: 5
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Trigger downstream smoke test"
@@ -182,7 +182,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_verify)
     timeout-minutes: 5
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions:
       # same-repo dispatch needs no cross-org token, unlike smoke; the default
       # GITHUB_TOKEN only gains workflow_dispatch rights with actions:write.
@@ -214,7 +214,7 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_installer)
     timeout-minutes: 5
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Run installer.sh for the released version"

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -23,7 +23,7 @@ jobs:
   generate-docs:
     needs: active-branches
     timeout-minutes: 10
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -23,7 +23,12 @@ jobs:
   generate-docs:
     needs: active-branches
     timeout-minutes: 10
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -23,7 +23,7 @@ jobs:
   generate-docs:
     needs: active-branches
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').md || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # master

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
-    runs-on: ${{ fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # master

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -19,7 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.active-branches.outputs.out) }}
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').lg || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # master

--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   workflows:
     name: "Validate Workflows"
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_actionlint ||
@@ -80,7 +80,8 @@ jobs:
           found=$(grep -rhoE 'vars\.RUNNERS_[A-Z0-9_]+_(AMD64|ARM64)' \
             --include='*.yaml' --include='*.yml' .github/workflows \
             | sed -E 's/^vars\.RUNNERS_(.+)_(AMD64|ARM64)$/\1/' | sort -u)
-          wrong=$(printf '%s\n' "$found" | grep -vxF "$expected" || true)
+          # PR is a tier, not a branch: it names the variable a pull_request run prefers.
+          wrong=$(printf '%s\n' "$found" | grep -vxF "$expected" | grep -vxF PR || true)
           if [ -n "$wrong" ]; then
             echo "::error title=Runner variable slug does not match the branch::expected RUNNERS_${expected}_<ARCH>, found $(printf '%s' "$wrong" | tr '\n' ' ')"
             exit 1
@@ -99,7 +100,7 @@ jobs:
 
   shellcheck:
     name: "Validate Shell Scripts"
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_shellcheck ||

--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   workflows:
     name: "Validate Workflows"
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_actionlint ||
@@ -76,7 +76,7 @@ jobs:
 
   shellcheck:
     name: "Validate Shell Scripts"
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON(vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_shellcheck ||

--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -81,14 +81,13 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -e
-          # Variable names take no '-' or '.', and an inline expression cannot sanitize a
-          # branch name, so the slug is written by hand at every branch cut. Nothing else
-          # catches a missed rename: it silently falls back to the global variable.
+          # The slug is written by hand at every branch cut, and a missed rename silently
+          # falls back to the global variable.
           expected=$(printf '%s' "${BASE_REF:-$REF_NAME}" | tr '[:lower:]' '[:upper:]' | tr '.-' '__')
           found=$(grep -rhoE 'vars\.RUNNERS_[A-Z0-9_]+_(AMD64|ARM64)' \
             --include='*.yaml' --include='*.yml' .github/workflows \
             | sed -E 's/^vars\.RUNNERS_(.+)_(AMD64|ARM64)$/\1/' | sort -u)
-          # PR is a tier, not a branch: it names the variable a pull_request run prefers.
+          # PR is a tier, not a branch.
           wrong=$(printf '%s\n' "$found" | grep -vxF "$expected" | grep -vxF PR || true)
           if [ -n "$wrong" ]; then
             echo "::error title=Runner variable slug does not match the branch::expected RUNNERS_${expected}_<ARCH>, found $(printf '%s' "$wrong" | tr '\n' ' ')"

--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -43,7 +43,15 @@ concurrency:
 jobs:
   workflows:
     name: "Validate Workflows"
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_actionlint ||
@@ -100,7 +108,15 @@ jobs:
 
   shellcheck:
     name: "Validate Shell Scripts"
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-24.04' || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64) || vars.RUNNERS_MASTER_AMD64 || vars.RUNNERS_AMD64 || '{}').sm || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_MASTER_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     timeout-minutes: 10
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.run_shellcheck ||

--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -64,6 +64,29 @@ jobs:
             workflows:
               - '.github/workflows/**'
 
+      - name: "Check the runner variable slug matches the branch"
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outputs.workflows == 'true'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -e
+          # Variable names take no '-' or '.', and an inline expression cannot sanitize a
+          # branch name, so the slug is written by hand at every branch cut. Nothing else
+          # catches a missed rename: it silently falls back to the global variable.
+          expected=$(printf '%s' "${BASE_REF:-$REF_NAME}" | tr '[:lower:]' '[:upper:]' | tr '.-' '__')
+          found=$(grep -rhoE 'vars\.RUNNERS_[A-Z0-9_]+_(AMD64|ARM64)' \
+            --include='*.yaml' --include='*.yml' .github/workflows \
+            | sed -E 's/^vars\.RUNNERS_(.+)_(AMD64|ARM64)$/\1/' | sort -u)
+          wrong=$(printf '%s\n' "$found" | grep -vxF "$expected" || true)
+          if [ -n "$wrong" ]; then
+            echo "::error title=Runner variable slug does not match the branch::expected RUNNERS_${expected}_<ARCH>, found $(printf '%s' "$wrong" | tr '\n' ' ')"
+            exit 1
+          fi
+          echo "Runner variables use RUNNERS_${expected}_<ARCH>"
+
       - uses: reviewdog/action-actionlint@d290e336d5a743810aef4404f757dc862276d2ae # v1.73.4
         if: >-
           github.event_name == 'workflow_dispatch' ||

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -30,8 +30,13 @@ else
 endif
 
 .PHONY: fmt/ci
+# Two scalars, edited in place. `yq -i` reserializes the whole document, which drops the
+# folded block scalars the runs-on expressions use, and `check` then fails on the diff.
+# No `sed -i`, since GNU and BSD disagree on its argument.
 fmt/ci:
-	$(YQ) -i '.env.K8S_MIN_VERSION = "$(K8S_MIN_VERSION)" | .env.K8S_MAX_VERSION = "$(K8S_MAX_VERSION)"' .github/workflows/"$(ACTION_PREFIX)"_test.yaml
+	@f=.github/workflows/"$(ACTION_PREFIX)"_test.yaml; t=$$(mktemp); \
+	sed -E -e 's|^(  K8S_MIN_VERSION: ).*|\1$(K8S_MIN_VERSION)|' \
+	       -e 's|^(  K8S_MAX_VERSION: ).*|\1$(K8S_MAX_VERSION)|' "$$f" > "$$t" && mv "$$t" "$$f"
 
 .PHONY: helm-lint
 helm-lint:

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -30,9 +30,8 @@ else
 endif
 
 .PHONY: fmt/ci
-# Two scalars, edited in place. `yq -i` reserializes the whole document, which drops the
-# folded block scalars the runs-on expressions use, and `check` then fails on the diff.
-# No `sed -i`, since GNU and BSD disagree on its argument.
+# `yq -i` reserializes the document and drops the folded runs-on scalars, so `check` fails
+# on its own diff. No `sed -i`: GNU and BSD disagree on its argument.
 fmt/ci:
 	@f=.github/workflows/"$(ACTION_PREFIX)"_test.yaml; t=$$(mktemp); \
 	sed -E -e 's|^(  K8S_MIN_VERSION: ).*|\1$(K8S_MIN_VERSION)|' \


### PR DESCRIPTION
## Motivation

Runner selection resolved to a single label, so a job could name only one of a pool's labels. `size-lg` on its own is ambiguous once more than one pool carries it, and no job could require `self-hosted`, `size-lg` and `amd64` together. All 43 `runs-on` sites read that same variable, so a `gh api` one-liner and a `gh run watch` poller that idles for four hours took the same slot as a k3d e2e leg.

Two values nearby assumed a GitHub-hosted runner as well: `CI_TOOLS_DIR` was a literal `/home/runner/...` path, and `GOMEMLIMIT` came from `/proc/meminfo`, which reports the host rather than the cgroup a containerised runner lives in. On a 64 GB host with an 8 GB cap that sets a limit six times what the job can have, so Go never applies GC pressure and gets OOM killed instead.

## Implementation information

- `RUNNERS_PR_<ARCH>`, `RUNNERS_<BRANCH_SLUG>_<ARCH>` and `RUNNERS_<ARCH>` hold a JSON object of size to label array, so a job asks for `sm`, `md` or `lg` and runs only on a runner carrying every label listed for that size. New names rather than a new format on `RUNS_ON_*`, so a downstream repository sets the new ones before it picks up these workflows.
- Adding an architecture is setting a variable, not editing a workflow. `meta` resolves both architectures into one map and hands it to every reusable workflow it calls, so the jobs with an architecture matrix index it by `matrix.arch`. An architecture nobody has set resolves to an empty object and those jobs keep the runner they use now, which is every arm64 leg today. The `linux/arm64` leg of `build-binaries` builds natively the day `RUNNERS_ARM64` exists, and `CGO_ENABLED=0` makes that binary identical to the cross-compiled one.
- Jobs split 21 `sm`, 8 `md`, 12 `lg`, by what their steps do. `sm` runs only `gh`, `jq`, `git` or `curl`. `md` needs mise and does network, artifact or git work. `lg` compiles Go, runs `go test -race` or golangci-lint, builds images, starts a cluster, or builds a CodeQL database.
- The fork-PR carve-out that only the e2e path had now covers all 16 sites a `pull_request` reaches, so code from a fork cannot run on a self-hosted runner.
- `CI_TOOLS_DIR` comes from `github.workspace` and `GOMEMLIMIT` from the cgroup cap when one is set. The e2e jobs picked their tools directory with `contains(<runner label>, '-kong')`, which matches whole elements rather than substrings once the value is an array, and both of its branches resolved to `github.workspace` anyway.
- Both `e2e-v3-readiness` jobs and the `sync_kuma_oas_to_kuma-gui` fallback join the scheme. `scorecard.yml` keeps its literal label because `scorecard-action` rejects an expression-based `runs-on`, and `pr-comments.yaml` keeps one because it checks out the head of the PR a maintainer commented on, which is a fork on most pull requests, before anything can tell `runs-on` whose code it is.
- `validate-workflows-and-scripts.yaml` fails when the branch slug in the workflows does not match the branch, which a release cut used to get wrong in silence. `actionlint` over `.github/workflows` is clean, neither variable is set in this repository, so every site resolves to the GitHub-hosted label it used before and this PR's own run exercises the rewritten expressions.

## Supporting documentation

`.github/workflows/README.md`, added here, documents the variable names, the JSON shape, the size rule, and the branch-slug rename each release cut needs.
