### PR TITLE
refactor(api)!: drop legacy transparent proxy fields from Dataplane

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,7 +67,7 @@ kuma-dp run --dataplane-file=backend.yaml --transparent-proxy
 
 **Action required**
 
-On Universal, drop `redirectPortInbound`, `redirectPortOutbound`, and `ipFamilyMode` from your `Dataplane` manifests and `kuma-dp` dataplane files, and start `kuma-dp` with `--transparent-proxy`. If you installed the transparent proxy with non-default redirect ports or IP family mode, pass the same values to `kuma-dp` in a file with `--transparent-proxy-config` instead:
+On Universal, drop `redirectPortInbound`, `redirectPortOutbound`, and `ipFamilyMode` from your `Dataplane` manifests and `kuma-dp` dataplane files, and start `kuma-dp` with `--transparent-proxy`. If you installed the transparent proxy with a non-default IP family mode, redirect ports, inbound redirection, or virtual networks, pass the same values to `kuma-dp` in a file with `--transparent-proxy-config` instead:
 
 ```yaml
 ipFamilyMode: ipv4

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -78,7 +78,7 @@ redirect:
     port: 15001
 ```
 
-Do this before you upgrade the control plane. `kuma-dp` 2.14 already supports both flags.
+Do this before you upgrade the control plane. `kuma-dp` 2.14 already supports both flags. On hosts with IPv6 disabled, `kuma-dp` 2.14 cannot start its DNS proxy in the default dual-stack mode, so use `--transparent-proxy-config` with `ipFamilyMode: ipv4` there.
 
 On Kubernetes, if your 2.14 control plane runs with `transparentProxy.configMap.enabled` set to `false`, set it to `true` and restart your workloads before you upgrade the control plane.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,7 +32,7 @@ None unless you set either setting to `false`. The control plane and `kuma-dp` n
 
 Kuma 3.0 removes `redirectPortInbound`, `redirectPortOutbound`, and `ipFamilyMode` from `Dataplane.networking.transparentProxying` and reserves their field numbers. `directAccessServices` and `reachableBackends` stay. The control plane reads redirect ports and the IP family mode only from `kuma-dp`, which sends them when it runs with `--transparent-proxy` or `--transparent-proxy-config`.
 
-On Kubernetes nothing changes for you. The sidecar injector already passes the transparent proxy configuration to `kuma-dp`.
+On Kubernetes, sidecars injected by a 3.0 control plane always pass the transparent proxy configuration to `kuma-dp`. Sidecars injected by 2.14 with `transparentProxy.configMap.enabled` set to `false`, the 2.14 default, do not. After you upgrade the control plane, they get no transparent proxy listeners until they restart.
 
 On Universal this is a breaking change. The control plane ignores the removed fields on input, so a `Dataplane` that still sets them loads without an error but gets no transparent proxy listeners. Envoy then has no listener on the redirect ports, and the traffic iptables sends there fails.
 
@@ -79,6 +79,8 @@ redirect:
 ```
 
 Do this before you upgrade the control plane. `kuma-dp` 2.14 already supports both flags.
+
+On Kubernetes, if your 2.14 control plane runs with `transparentProxy.configMap.enabled` set to `false`, set it to `true` and restart your workloads before you upgrade the control plane.
 
 ### KDS full resync is periodic again, not every second
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -28,6 +28,58 @@ does not have any particular instructions.
 
 None unless you set either setting to `false`. The control plane and `kuma-dp` now ignore both, so remove them from your control plane configuration and sidecar environment.
 
+### Redirect ports and IP family mode removed from `Dataplane`
+
+Kuma 3.0 removes `redirectPortInbound`, `redirectPortOutbound`, and `ipFamilyMode` from `Dataplane.networking.transparentProxying` and reserves their field numbers. `directAccessServices` and `reachableBackends` stay. The control plane reads redirect ports and the IP family mode only from `kuma-dp`, which sends them when it runs with `--transparent-proxy` or `--transparent-proxy-config`.
+
+On Kubernetes nothing changes for you. The sidecar injector already passes the transparent proxy configuration to `kuma-dp`.
+
+On Universal this is a breaking change. The control plane ignores the removed fields on input, so a `Dataplane` that still sets them loads without an error but gets no transparent proxy listeners. Envoy then has no listener on the redirect ports, and the traffic iptables sends there fails.
+
+Before:
+
+```yaml
+networking:
+  address: 192.168.0.1
+  inbound:
+    - port: 8080
+  transparentProxying:
+    redirectPortInbound: 15006
+    redirectPortOutbound: 15001
+```
+
+```sh
+kuma-dp run --dataplane-file=backend.yaml
+```
+
+After:
+
+```yaml
+networking:
+  address: 192.168.0.1
+  inbound:
+    - port: 8080
+```
+
+```sh
+kuma-dp run --dataplane-file=backend.yaml --transparent-proxy
+```
+
+**Action required**
+
+On Universal, drop `redirectPortInbound`, `redirectPortOutbound`, and `ipFamilyMode` from your `Dataplane` manifests and `kuma-dp` dataplane files, and start `kuma-dp` with `--transparent-proxy`. If you installed the transparent proxy with non-default redirect ports or IP family mode, pass the same values to `kuma-dp` in a file with `--transparent-proxy-config` instead:
+
+```yaml
+ipFamilyMode: ipv4
+redirect:
+  inbound:
+    port: 15006
+  outbound:
+    port: 15001
+```
+
+Do this before you upgrade the control plane. `kuma-dp` 2.14 already supports both flags.
+
 ### KDS full resync is periodic again, not every second
 
 Removing the polling KDS watchdog carried the poll loop's `refreshInterval` of

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -7,7 +7,6 @@
 package v1alpha1
 
 import (
-	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/kumahq/kuma/v3/api/mesh"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -79,65 +78,6 @@ func (Dataplane_Networking_Inbound_State) EnumDescriptor() ([]byte, []int) {
 	return file_api_mesh_v1alpha1_dataplane_proto_rawDescGZIP(), []int{0, 0, 0, 0}
 }
 
-type Dataplane_Networking_TransparentProxying_IpFamilyMode int32
-
-const (
-	// This value is to support backward compatibility and should not be
-	// used in new data plane objects.
-	Dataplane_Networking_TransparentProxying_UnSpecified Dataplane_Networking_TransparentProxying_IpFamilyMode = 0
-	// Enables transparent proxying for both IPv4 and IPv6 traffic, This is
-	// the default.
-	Dataplane_Networking_TransparentProxying_DualStack Dataplane_Networking_TransparentProxying_IpFamilyMode = 1
-	// Enables transparent proxying for IPv4 traffic only.
-	Dataplane_Networking_TransparentProxying_IPv4 Dataplane_Networking_TransparentProxying_IpFamilyMode = 2
-	// Enables transparent proxying for IPv6 traffic only. This mode is to
-	// be supported in the future.
-	Dataplane_Networking_TransparentProxying_IPv6 Dataplane_Networking_TransparentProxying_IpFamilyMode = 3
-)
-
-// Enum value maps for Dataplane_Networking_TransparentProxying_IpFamilyMode.
-var (
-	Dataplane_Networking_TransparentProxying_IpFamilyMode_name = map[int32]string{
-		0: "UnSpecified",
-		1: "DualStack",
-		2: "IPv4",
-		3: "IPv6",
-	}
-	Dataplane_Networking_TransparentProxying_IpFamilyMode_value = map[string]int32{
-		"UnSpecified": 0,
-		"DualStack":   1,
-		"IPv4":        2,
-		"IPv6":        3,
-	}
-)
-
-func (x Dataplane_Networking_TransparentProxying_IpFamilyMode) Enum() *Dataplane_Networking_TransparentProxying_IpFamilyMode {
-	p := new(Dataplane_Networking_TransparentProxying_IpFamilyMode)
-	*p = x
-	return p
-}
-
-func (x Dataplane_Networking_TransparentProxying_IpFamilyMode) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (Dataplane_Networking_TransparentProxying_IpFamilyMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_mesh_v1alpha1_dataplane_proto_enumTypes[1].Descriptor()
-}
-
-func (Dataplane_Networking_TransparentProxying_IpFamilyMode) Type() protoreflect.EnumType {
-	return &file_api_mesh_v1alpha1_dataplane_proto_enumTypes[1]
-}
-
-func (x Dataplane_Networking_TransparentProxying_IpFamilyMode) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use Dataplane_Networking_TransparentProxying_IpFamilyMode.Descriptor instead.
-func (Dataplane_Networking_TransparentProxying_IpFamilyMode) EnumDescriptor() ([]byte, []int) {
-	return file_api_mesh_v1alpha1_dataplane_proto_rawDescGZIP(), []int{0, 0, 2, 0}
-}
-
 type Dataplane_Networking_Listener_Type int32
 
 const (
@@ -178,11 +118,11 @@ func (x Dataplane_Networking_Listener_Type) String() string {
 }
 
 func (Dataplane_Networking_Listener_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_mesh_v1alpha1_dataplane_proto_enumTypes[2].Descriptor()
+	return file_api_mesh_v1alpha1_dataplane_proto_enumTypes[1].Descriptor()
 }
 
 func (Dataplane_Networking_Listener_Type) Type() protoreflect.EnumType {
-	return &file_api_mesh_v1alpha1_dataplane_proto_enumTypes[2]
+	return &file_api_mesh_v1alpha1_dataplane_proto_enumTypes[1]
 }
 
 func (x Dataplane_Networking_Listener_Type) Number() protoreflect.EnumNumber {
@@ -226,11 +166,11 @@ func (x Dataplane_Networking_Listener_State) String() string {
 }
 
 func (Dataplane_Networking_Listener_State) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_mesh_v1alpha1_dataplane_proto_enumTypes[3].Descriptor()
+	return file_api_mesh_v1alpha1_dataplane_proto_enumTypes[2].Descriptor()
 }
 
 func (Dataplane_Networking_Listener_State) Type() protoreflect.EnumType {
-	return &file_api_mesh_v1alpha1_dataplane_proto_enumTypes[3]
+	return &file_api_mesh_v1alpha1_dataplane_proto_enumTypes[2]
 }
 
 func (x Dataplane_Networking_Listener_State) Number() protoreflect.EnumNumber {
@@ -614,17 +554,11 @@ func (x *Dataplane_Networking_Outbound) GetBackendRef() *Dataplane_Networking_Ou
 // TransparentProxying describes configuration for transparent proxying.
 type Dataplane_Networking_TransparentProxying struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Port on which all inbound traffic is being transparently redirected.
-	RedirectPortInbound uint32 `protobuf:"varint,1,opt,name=redirect_port_inbound,json=redirectPortInbound,proto3" json:"redirect_port_inbound,omitempty"`
-	// Port on which all outbound traffic is being transparently redirected.
-	RedirectPortOutbound uint32 `protobuf:"varint,2,opt,name=redirect_port_outbound,json=redirectPortOutbound,proto3" json:"redirect_port_outbound,omitempty"`
 	// List of services that will be accessed directly via IP:PORT
 	// Use `*` to indicate direct access to every service in the Mesh.
 	// Using `*` to directly access every service is a resource-intensive
 	// operation, use it only if needed.
 	DirectAccessServices []string `protobuf:"bytes,3,rep,name=direct_access_services,json=directAccessServices,proto3" json:"direct_access_services,omitempty"`
-	// The IP family mode to enable for. Can be "IPv4" or "DualStack".
-	IpFamilyMode Dataplane_Networking_TransparentProxying_IpFamilyMode `protobuf:"varint,6,opt,name=ip_family_mode,json=ipFamilyMode,proto3,enum=kuma.mesh.v1alpha1.Dataplane_Networking_TransparentProxying_IpFamilyMode" json:"ip_family_mode,omitempty"`
 	// Reachable backend via transparent proxy when running with
 	// MeshExternalService, MeshService and MeshMultiZoneService. Setting an
 	// explicit list of refs can dramatically improve the performance of the
@@ -664,32 +598,11 @@ func (*Dataplane_Networking_TransparentProxying) Descriptor() ([]byte, []int) {
 	return file_api_mesh_v1alpha1_dataplane_proto_rawDescGZIP(), []int{0, 0, 2}
 }
 
-func (x *Dataplane_Networking_TransparentProxying) GetRedirectPortInbound() uint32 {
-	if x != nil {
-		return x.RedirectPortInbound
-	}
-	return 0
-}
-
-func (x *Dataplane_Networking_TransparentProxying) GetRedirectPortOutbound() uint32 {
-	if x != nil {
-		return x.RedirectPortOutbound
-	}
-	return 0
-}
-
 func (x *Dataplane_Networking_TransparentProxying) GetDirectAccessServices() []string {
 	if x != nil {
 		return x.DirectAccessServices
 	}
 	return nil
-}
-
-func (x *Dataplane_Networking_TransparentProxying) GetIpFamilyMode() Dataplane_Networking_TransparentProxying_IpFamilyMode {
-	if x != nil {
-		return x.IpFamilyMode
-	}
-	return Dataplane_Networking_TransparentProxying_UnSpecified
 }
 
 func (x *Dataplane_Networking_TransparentProxying) GetReachableBackends() *Dataplane_Networking_TransparentProxying_ReachableBackends {
@@ -1167,11 +1080,11 @@ var File_api_mesh_v1alpha1_dataplane_proto protoreflect.FileDescriptor
 
 const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\n" +
-	"!api/mesh/v1alpha1/dataplane.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a#api/mesh/v1alpha1/envoy_admin.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x17validate/validate.proto\"\xf9\x19\n" +
+	"!api/mesh/v1alpha1/dataplane.proto\x12\x12kuma.mesh.v1alpha1\x1a\x16api/mesh/options.proto\x1a#api/mesh/v1alpha1/envoy_admin.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\x95\x18\n" +
 	"\tDataplane\x12H\n" +
 	"\n" +
 	"networking\x18\x01 \x01(\v2(.kuma.mesh.v1alpha1.Dataplane.NetworkingR\n" +
-	"networking\x1a\xa3\x18\n" +
+	"networking\x1a\xbf\x16\n" +
 	"\n" +
 	"Networking\x12\x18\n" +
 	"\aaddress\x18\x05 \x01(\tR\aaddress\x12J\n" +
@@ -1218,12 +1131,9 @@ const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\x06labels\x18\x04 \x03(\v2H.kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.LabelsEntryR\x06labels\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x05\x10\x06R\x04tags\x1a\xf5\a\n" +
-	"\x13TransparentProxying\x12=\n" +
-	"\x15redirect_port_inbound\x18\x01 \x01(\rB\t\xfaB\x06*\x04\x18\xff\xff\x03R\x13redirectPortInbound\x12?\n" +
-	"\x16redirect_port_outbound\x18\x02 \x01(\rB\t\xfaB\x06*\x04\x18\xff\xff\x03R\x14redirectPortOutbound\x124\n" +
-	"\x16direct_access_services\x18\x03 \x03(\tR\x14directAccessServices\x12o\n" +
-	"\x0eip_family_mode\x18\x06 \x01(\x0e2I.kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.IpFamilyModeR\fipFamilyMode\x12}\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x05\x10\x06R\x04tags\x1a\x91\x06\n" +
+	"\x13TransparentProxying\x124\n" +
+	"\x16direct_access_services\x18\x03 \x03(\tR\x14directAccessServices\x12}\n" +
 	"\x12reachable_backends\x18\a \x01(\v2N.kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendsR\x11reachableBackends\x1a\xbe\x02\n" +
 	"\x13ReachableBackendRef\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
@@ -1235,12 +1145,7 @@ const file_api_mesh_v1alpha1_dataplane_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1ay\n" +
 	"\x11ReachableBackends\x12d\n" +
-	"\x04refs\x18\x01 \x03(\v2P.kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRefR\x04refs\"B\n" +
-	"\fIpFamilyMode\x12\x0f\n" +
-	"\vUnSpecified\x10\x00\x12\r\n" +
-	"\tDualStack\x10\x01\x12\b\n" +
-	"\x04IPv4\x10\x02\x12\b\n" +
-	"\x04IPv6\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\x18redirect_port_inbound_v6R\x12reachable_services\x1a\xc3\x02\n" +
+	"\x04refs\x18\x01 \x03(\v2P.kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRefR\x04refsJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aR\x15redirect_port_inboundR\x16redirect_port_outboundR\x18redirect_port_inbound_v6R\x12reachable_servicesR\x0eip_family_mode\x1a\xc3\x02\n" +
 	"\bListener\x12J\n" +
 	"\x04type\x18\x01 \x01(\x0e26.kuma.mesh.v1alpha1.Dataplane.Networking.Listener.TypeR\x04type\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\x12\n" +
@@ -1270,60 +1175,58 @@ func file_api_mesh_v1alpha1_dataplane_proto_rawDescGZIP() []byte {
 	return file_api_mesh_v1alpha1_dataplane_proto_rawDescData
 }
 
-var file_api_mesh_v1alpha1_dataplane_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_api_mesh_v1alpha1_dataplane_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_api_mesh_v1alpha1_dataplane_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_api_mesh_v1alpha1_dataplane_proto_goTypes = []any{
-	(Dataplane_Networking_Inbound_State)(0),                    // 0: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.State
-	(Dataplane_Networking_TransparentProxying_IpFamilyMode)(0), // 1: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.IpFamilyMode
-	(Dataplane_Networking_Listener_Type)(0),                    // 2: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.Type
-	(Dataplane_Networking_Listener_State)(0),                   // 3: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.State
-	(*Dataplane)(nil),                                          // 4: kuma.mesh.v1alpha1.Dataplane
-	(*Dataplane_Networking)(nil),                               // 5: kuma.mesh.v1alpha1.Dataplane.Networking
-	(*Dataplane_Networking_Inbound)(nil),                       // 6: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound
-	(*Dataplane_Networking_Outbound)(nil),                      // 7: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound
-	(*Dataplane_Networking_TransparentProxying)(nil),           // 8: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying
-	(*Dataplane_Networking_Listener)(nil),                      // 9: kuma.mesh.v1alpha1.Dataplane.Networking.Listener
-	(*Dataplane_Networking_Inbound_Health)(nil),                // 10: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.Health
-	(*Dataplane_Networking_Inbound_ServiceProbe)(nil),          // 11: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe
-	(*Dataplane_Networking_Inbound_ServiceProbe_Tcp)(nil),      // 12: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.Tcp
-	(*Dataplane_Networking_Outbound_BackendRef)(nil),           // 13: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef
-	nil, // 14: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.LabelsEntry
-	(*Dataplane_Networking_TransparentProxying_ReachableBackendRef)(nil), // 15: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef
-	(*Dataplane_Networking_TransparentProxying_ReachableBackends)(nil),   // 16: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends
-	nil,                            // 17: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.LabelsEntry
-	(*EnvoyAdmin)(nil),             // 18: kuma.mesh.v1alpha1.EnvoyAdmin
-	(*durationpb.Duration)(nil),    // 19: google.protobuf.Duration
-	(*wrapperspb.UInt32Value)(nil), // 20: google.protobuf.UInt32Value
+	(Dataplane_Networking_Inbound_State)(0),               // 0: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.State
+	(Dataplane_Networking_Listener_Type)(0),               // 1: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.Type
+	(Dataplane_Networking_Listener_State)(0),              // 2: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.State
+	(*Dataplane)(nil),                                     // 3: kuma.mesh.v1alpha1.Dataplane
+	(*Dataplane_Networking)(nil),                          // 4: kuma.mesh.v1alpha1.Dataplane.Networking
+	(*Dataplane_Networking_Inbound)(nil),                  // 5: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound
+	(*Dataplane_Networking_Outbound)(nil),                 // 6: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound
+	(*Dataplane_Networking_TransparentProxying)(nil),      // 7: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying
+	(*Dataplane_Networking_Listener)(nil),                 // 8: kuma.mesh.v1alpha1.Dataplane.Networking.Listener
+	(*Dataplane_Networking_Inbound_Health)(nil),           // 9: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.Health
+	(*Dataplane_Networking_Inbound_ServiceProbe)(nil),     // 10: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe
+	(*Dataplane_Networking_Inbound_ServiceProbe_Tcp)(nil), // 11: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.Tcp
+	(*Dataplane_Networking_Outbound_BackendRef)(nil),      // 12: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef
+	nil, // 13: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.LabelsEntry
+	(*Dataplane_Networking_TransparentProxying_ReachableBackendRef)(nil), // 14: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef
+	(*Dataplane_Networking_TransparentProxying_ReachableBackends)(nil),   // 15: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends
+	nil,                            // 16: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.LabelsEntry
+	(*EnvoyAdmin)(nil),             // 17: kuma.mesh.v1alpha1.EnvoyAdmin
+	(*durationpb.Duration)(nil),    // 18: google.protobuf.Duration
+	(*wrapperspb.UInt32Value)(nil), // 19: google.protobuf.UInt32Value
 }
 var file_api_mesh_v1alpha1_dataplane_proto_depIdxs = []int32{
-	5,  // 0: kuma.mesh.v1alpha1.Dataplane.networking:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking
-	6,  // 1: kuma.mesh.v1alpha1.Dataplane.Networking.inbound:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound
-	7,  // 2: kuma.mesh.v1alpha1.Dataplane.Networking.outbound:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Outbound
-	8,  // 3: kuma.mesh.v1alpha1.Dataplane.Networking.transparent_proxying:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying
-	18, // 4: kuma.mesh.v1alpha1.Dataplane.Networking.admin:type_name -> kuma.mesh.v1alpha1.EnvoyAdmin
-	9,  // 5: kuma.mesh.v1alpha1.Dataplane.Networking.listeners:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Listener
-	10, // 6: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.health:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.Health
-	11, // 7: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.serviceProbe:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe
+	4,  // 0: kuma.mesh.v1alpha1.Dataplane.networking:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking
+	5,  // 1: kuma.mesh.v1alpha1.Dataplane.Networking.inbound:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound
+	6,  // 2: kuma.mesh.v1alpha1.Dataplane.Networking.outbound:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Outbound
+	7,  // 3: kuma.mesh.v1alpha1.Dataplane.Networking.transparent_proxying:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying
+	17, // 4: kuma.mesh.v1alpha1.Dataplane.Networking.admin:type_name -> kuma.mesh.v1alpha1.EnvoyAdmin
+	8,  // 5: kuma.mesh.v1alpha1.Dataplane.Networking.listeners:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Listener
+	9,  // 6: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.health:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.Health
+	10, // 7: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.serviceProbe:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe
 	0,  // 8: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.state:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.State
-	13, // 9: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.backendRef:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef
-	1,  // 10: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ip_family_mode:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.IpFamilyMode
-	16, // 11: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.reachable_backends:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends
-	2,  // 12: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.type:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Listener.Type
-	3,  // 13: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.state:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Listener.State
-	19, // 14: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.interval:type_name -> google.protobuf.Duration
-	19, // 15: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.timeout:type_name -> google.protobuf.Duration
-	20, // 16: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.unhealthy_threshold:type_name -> google.protobuf.UInt32Value
-	20, // 17: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.healthy_threshold:type_name -> google.protobuf.UInt32Value
-	12, // 18: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.tcp:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.Tcp
-	14, // 19: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.labels:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.LabelsEntry
-	20, // 20: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.port:type_name -> google.protobuf.UInt32Value
-	17, // 21: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.labels:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.LabelsEntry
-	15, // 22: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends.refs:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	12, // 9: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.backendRef:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef
+	15, // 10: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.reachable_backends:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends
+	1,  // 11: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.type:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Listener.Type
+	2,  // 12: kuma.mesh.v1alpha1.Dataplane.Networking.Listener.state:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Listener.State
+	18, // 13: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.interval:type_name -> google.protobuf.Duration
+	18, // 14: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.timeout:type_name -> google.protobuf.Duration
+	19, // 15: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.unhealthy_threshold:type_name -> google.protobuf.UInt32Value
+	19, // 16: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.healthy_threshold:type_name -> google.protobuf.UInt32Value
+	11, // 17: kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.tcp:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Inbound.ServiceProbe.Tcp
+	13, // 18: kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.labels:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.Outbound.BackendRef.LabelsEntry
+	19, // 19: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.port:type_name -> google.protobuf.UInt32Value
+	16, // 20: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.labels:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef.LabelsEntry
+	14, // 21: kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends.refs:type_name -> kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackendRef
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_api_mesh_v1alpha1_dataplane_proto_init() }
@@ -1337,7 +1240,7 @@ func file_api_mesh_v1alpha1_dataplane_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_mesh_v1alpha1_dataplane_proto_rawDesc), len(file_api_mesh_v1alpha1_dataplane_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      3,
 			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -6,7 +6,6 @@ import "api/mesh/options.proto";
 import "api/mesh/v1alpha1/envoy_admin.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
-import "validate/validate.proto";
 
 option go_package = "github.com/kumahq/kuma/v3/api/mesh/v1alpha1";
 
@@ -168,25 +167,10 @@ message Dataplane {
 
     // TransparentProxying describes configuration for transparent proxying.
     message TransparentProxying {
-      enum IpFamilyMode {
-        // This value is to support backward compatibility and should not be
-        // used in new data plane objects.
-        UnSpecified = 0;
-        // Enables transparent proxying for both IPv4 and IPv6 traffic, This is
-        // the default.
-        DualStack = 1;
-        // Enables transparent proxying for IPv4 traffic only.
-        IPv4 = 2;
-        // Enables transparent proxying for IPv6 traffic only. This mode is to
-        // be supported in the future.
-        IPv6 = 3;
-      }
-
-      // Port on which all inbound traffic is being transparently redirected.
-      uint32 redirect_port_inbound = 1 [(validate.rules).uint32 = {lte: 65535}];
-
-      // Port on which all outbound traffic is being transparently redirected.
-      uint32 redirect_port_outbound = 2 [(validate.rules).uint32 = {lte: 65535}];
+      // `redirect_port_inbound` and `redirect_port_outbound` have been removed.
+      // kuma-dp sends the redirect ports to the control plane in its metadata.
+      reserved 1, 2;
+      reserved "redirect_port_inbound", "redirect_port_outbound";
 
       // List of services that will be accessed directly via IP:PORT
       // Use `*` to indicate direct access to every service in the Mesh.
@@ -203,8 +187,11 @@ message Dataplane {
       reserved 5;
       reserved "reachable_services";
 
-      // The IP family mode to enable for. Can be "IPv4" or "DualStack".
-      IpFamilyMode ip_family_mode = 6;
+      // `ip_family_mode` has been removed. kuma-dp sends the IP family mode to
+      // the control plane in its metadata.
+      reserved 6;
+      reserved "ip_family_mode";
+
       message ReachableBackendRef {
         // Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService
         //  +required

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -314,15 +314,6 @@ components:
                   items:
                     type: string
                   type: array
-                ipFamilyMode:
-                  description: The IP family mode to enable for. Can be "IPv4" or
-                    "DualStack".
-                  enum:
-                  - UnSpecified
-                  - DualStack
-                  - IPv4
-                  - IPv6
-                  type: string
                 reachableBackends:
                   description: |-
                     Reachable backend via transparent proxy when running with
@@ -355,14 +346,6 @@ components:
                         type: object
                       type: array
                   type: object
-                redirectPortInbound:
-                  description: Port on which all inbound traffic is being transparently
-                    redirected.
-                  type: integer
-                redirectPortOutbound:
-                  description: Port on which all outbound traffic is being transparently
-                    redirected.
-                  type: integer
               type: object
           type: object
         type:

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -246,15 +246,6 @@ components:
                       items:
                         type: string
                       type: array
-                    ipFamilyMode:
-                      description: The IP family mode to enable for. Can be "IPv4"
-                        or "DualStack".
-                      enum:
-                      - UnSpecified
-                      - DualStack
-                      - IPv4
-                      - IPv6
-                      type: string
                     reachableBackends:
                       description: |-
                         Reachable backend via transparent proxy when running with
@@ -287,14 +278,6 @@ components:
                             type: object
                           type: array
                       type: object
-                    redirectPortInbound:
-                      description: Port on which all inbound traffic is being transparently
-                        redirected.
-                      type: integer
-                    redirectPortOutbound:
-                      description: Port on which all outbound traffic is being transparently
-                        redirected.
-                      type: integer
                   type: object
               type: object
           type: object

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -84,6 +84,14 @@ func dnsProxyAddresses(tpCfg *tproxy_dp.DataplaneConfig, port string) []string {
 	}
 }
 
+// transparentProxyIPFamilyMode skips IPv6 on hosts without a local IPv6 address, like kumactl install transparent-proxy
+func transparentProxyIPFamilyMode(mode tproxy_config.IPFamilyMode, hasLocalIPv6 bool) tproxy_config.IPFamilyMode {
+	if !hasLocalIPv6 {
+		return tproxy_config.IPFamilyModeIPv4
+	}
+	return mode
+}
+
 // PersistentPreRunE in root command sets the logger and initial config
 // PreRunE loads the Kuma DP config
 // PostRunE actually runs all the components with loaded config
@@ -134,12 +142,10 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 				tpCfg.Redirect.DNS.Port = tproxy_config.Port(cfg.DNS.ProxyPort)
 				tpCfg.Redirect.DNS.Enabled = cfg.DNS.Enabled
 
-				// kumactl install transparent-proxy skips IPv6 rules on the same check
-				if tpCfg.IPFamilyMode != tproxy_config.IPFamilyModeIPv4 {
-					if ok, _ := tproxy_config.HasLocalIPv6(); !ok {
-						runLog.Info("no local IPv6 address found, using IPv4 transparent proxy mode")
-						tpCfg.IPFamilyMode = tproxy_config.IPFamilyModeIPv4
-					}
+				hasLocalIPv6, _ := tproxy_config.HasLocalIPv6()
+				if mode := transparentProxyIPFamilyMode(tpCfg.IPFamilyMode, hasLocalIPv6); mode != tpCfg.IPFamilyMode {
+					runLog.Info("no local IPv6 address found, using IPv4 transparent proxy mode")
+					tpCfg.IPFamilyMode = mode
 				}
 			}
 			cfg.DataplaneRuntime.TransparentProxy = tpCfg

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -57,13 +57,13 @@ var runLog = dataplaneLog.WithName("run")
 // rather than relying on a single :: socket, because nodes with
 // net.ipv6.bindv6only=1 would silently drop IPv4 traffic. Without VNet,
 // we bind to loopback only since OUTPUT chain REDIRECT sends to 127.0.0.1
-// (IPv4) and ::1 (IPv6).
-func dnsProxyAddresses(tpCfg *tproxy_dp.DataplaneConfig, port string) []string {
+// (IPv4) and ::1 (IPv6). With IPv6 disabled, we bind IPv4 addresses only.
+func dnsProxyAddresses(tpCfg *tproxy_dp.DataplaneConfig, ipv6Enabled bool, port string) []string {
 	if tpCfg == nil {
 		return []string{net.JoinHostPort("0.0.0.0", port)}
 	}
 
-	dualStack := tpCfg.IPFamilyMode != tproxy_config.IPFamilyModeIPv4
+	dualStack := tpCfg.IPFamilyMode != tproxy_config.IPFamilyModeIPv4 && ipv6Enabled
 	vnet := tpCfg.HasVNet()
 
 	switch {
@@ -82,14 +82,6 @@ func dnsProxyAddresses(tpCfg *tproxy_dp.DataplaneConfig, port string) []string {
 	default:
 		return []string{net.JoinHostPort("127.0.0.1", port)}
 	}
-}
-
-// transparentProxyIPFamilyMode skips IPv6 on hosts without a local IPv6 address, like kumactl install transparent-proxy
-func transparentProxyIPFamilyMode(mode tproxy_config.IPFamilyMode, hasLocalIPv6 bool) tproxy_config.IPFamilyMode {
-	if !hasLocalIPv6 {
-		return tproxy_config.IPFamilyModeIPv4
-	}
-	return mode
 }
 
 // PersistentPreRunE in root command sets the logger and initial config
@@ -141,12 +133,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 
 				tpCfg.Redirect.DNS.Port = tproxy_config.Port(cfg.DNS.ProxyPort)
 				tpCfg.Redirect.DNS.Enabled = cfg.DNS.Enabled
-
-				hasLocalIPv6, _ := tproxy_config.HasLocalIPv6()
-				if mode := transparentProxyIPFamilyMode(tpCfg.IPFamilyMode, hasLocalIPv6); mode != tpCfg.IPFamilyMode {
-					runLog.Info("no local IPv6 address found, using IPv4 transparent proxy mode")
-					tpCfg.IPFamilyMode = mode
-				}
 			}
 			cfg.DataplaneRuntime.TransparentProxy = tpCfg
 
@@ -318,7 +304,7 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			var dnsConfigReady <-chan struct{}
 			if cfg.DNS.Enabled {
 				portStr := strconv.Itoa(int(cfg.DNS.ProxyPort))
-				addresses := dnsProxyAddresses(cfg.DataplaneRuntime.TransparentProxy, portStr)
+				addresses := dnsProxyAddresses(cfg.DataplaneRuntime.TransparentProxy, cfg.DataplaneRuntime.IPv6Enabled, portStr)
 				runLog.Info("Running with embedded DNS proxy", "port", cfg.DNS.ProxyPort, "addresses", addresses)
 				dnsproxyServer, err := dnsproxy.NewServer(addresses)
 				if err != nil {

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -133,6 +133,14 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 
 				tpCfg.Redirect.DNS.Port = tproxy_config.Port(cfg.DNS.ProxyPort)
 				tpCfg.Redirect.DNS.Enabled = cfg.DNS.Enabled
+
+				// kumactl install transparent-proxy skips IPv6 rules on the same check
+				if tpCfg.IPFamilyMode != tproxy_config.IPFamilyModeIPv4 {
+					if ok, _ := tproxy_config.HasLocalIPv6(); !ok {
+						runLog.Info("no local IPv6 address found, using IPv4 transparent proxy mode")
+						tpCfg.IPFamilyMode = tproxy_config.IPFamilyModeIPv4
+					}
+				}
 			}
 			cfg.DataplaneRuntime.TransparentProxy = tpCfg
 

--- a/app/kuma-dp/cmd/run.go
+++ b/app/kuma-dp/cmd/run.go
@@ -218,10 +218,6 @@ func newRunCmd(opts kuma_cmd.RunCmdOpts, rootCtx *RootContext) *cobra.Command {
 			}
 
 			rootCtx.Features = nil
-			if cfg.DataplaneRuntime.TransparentProxy != nil {
-				rootCtx.Features = append(rootCtx.Features, xds_types.FeatureTransparentProxyInDataplaneMetadata)
-			}
-
 			if cfg.DataplaneRuntime.BindOutbounds {
 				rootCtx.Features = append(rootCtx.Features, xds_types.FeatureBindOutbounds)
 			}

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -71,7 +71,7 @@ var _ = Describe("run", func() {
 
 	Describe("dnsProxyAddresses", func() {
 		It("should fall back to 0.0.0.0 when transparent proxy is nil", func() {
-			Expect(dnsProxyAddresses(nil, "15053")).To(Equal([]string{
+			Expect(dnsProxyAddresses(nil, true, "15053")).To(Equal([]string{
 				net.JoinHostPort("0.0.0.0", "15053"),
 			}))
 		})
@@ -80,7 +80,7 @@ var _ = Describe("run", func() {
 			cfg := &tproxy_dp.DataplaneConfig{
 				IPFamilyMode: tproxy_config.IPFamilyModeIPv4,
 			}
-			Expect(dnsProxyAddresses(cfg, "15053")).To(Equal([]string{
+			Expect(dnsProxyAddresses(cfg, true, "15053")).To(Equal([]string{
 				net.JoinHostPort("127.0.0.1", "15053"),
 			}))
 		})
@@ -89,7 +89,7 @@ var _ = Describe("run", func() {
 			cfg := &tproxy_dp.DataplaneConfig{
 				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
 			}
-			Expect(dnsProxyAddresses(cfg, "15053")).To(Equal([]string{
+			Expect(dnsProxyAddresses(cfg, true, "15053")).To(Equal([]string{
 				net.JoinHostPort("127.0.0.1", "15053"),
 				net.JoinHostPort("::1", "15053"),
 			}))
@@ -104,7 +104,7 @@ var _ = Describe("run", func() {
 					},
 				},
 			}
-			Expect(dnsProxyAddresses(cfg, "15053")).To(Equal([]string{
+			Expect(dnsProxyAddresses(cfg, true, "15053")).To(Equal([]string{
 				net.JoinHostPort("0.0.0.0", "15053"),
 			}))
 		})
@@ -118,22 +118,35 @@ var _ = Describe("run", func() {
 					},
 				},
 			}
-			Expect(dnsProxyAddresses(cfg, "15053")).To(Equal([]string{
+			Expect(dnsProxyAddresses(cfg, true, "15053")).To(Equal([]string{
 				net.JoinHostPort("0.0.0.0", "15053"),
 				net.JoinHostPort("::", "15053"),
 			}))
 		})
-	})
 
-	DescribeTable("transparentProxyIPFamilyMode",
-		func(mode tproxy_config.IPFamilyMode, hasLocalIPv6 bool, expected tproxy_config.IPFamilyMode) {
-			Expect(transparentProxyIPFamilyMode(mode, hasLocalIPv6)).To(Equal(expected))
-		},
-		Entry("keeps dual-stack with local IPv6", tproxy_config.IPFamilyModeDualStack, true, tproxy_config.IPFamilyModeDualStack),
-		Entry("falls back to IPv4 without local IPv6", tproxy_config.IPFamilyModeDualStack, false, tproxy_config.IPFamilyModeIPv4),
-		Entry("keeps IPv4 with local IPv6", tproxy_config.IPFamilyModeIPv4, true, tproxy_config.IPFamilyModeIPv4),
-		Entry("keeps IPv4 without local IPv6", tproxy_config.IPFamilyModeIPv4, false, tproxy_config.IPFamilyModeIPv4),
-	)
+		It("should bind to IPv4 loopback only for dual-stack with IPv6 disabled", func() {
+			cfg := &tproxy_dp.DataplaneConfig{
+				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+			}
+			Expect(dnsProxyAddresses(cfg, false, "15053")).To(Equal([]string{
+				net.JoinHostPort("127.0.0.1", "15053"),
+			}))
+		})
+
+		It("should bind to 0.0.0.0 only for dual-stack VNet with IPv6 disabled", func() {
+			cfg := &tproxy_dp.DataplaneConfig{
+				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+				Redirect: tproxy_dp.DataplaneRedirect{
+					VNet: tproxy_dp.DataplaneVNet{
+						Networks: []string{"docker0:172.17.0.0/16"},
+					},
+				},
+			}
+			Expect(dnsProxyAddresses(cfg, false, "15053")).To(Equal([]string{
+				net.JoinHostPort("0.0.0.0", "15053"),
+			}))
+		})
+	})
 
 	type testCase struct {
 		envVars      map[string]string

--- a/app/kuma-dp/cmd/run_test.go
+++ b/app/kuma-dp/cmd/run_test.go
@@ -125,6 +125,16 @@ var _ = Describe("run", func() {
 		})
 	})
 
+	DescribeTable("transparentProxyIPFamilyMode",
+		func(mode tproxy_config.IPFamilyMode, hasLocalIPv6 bool, expected tproxy_config.IPFamilyMode) {
+			Expect(transparentProxyIPFamilyMode(mode, hasLocalIPv6)).To(Equal(expected))
+		},
+		Entry("keeps dual-stack with local IPv6", tproxy_config.IPFamilyModeDualStack, true, tproxy_config.IPFamilyModeDualStack),
+		Entry("falls back to IPv4 without local IPv6", tproxy_config.IPFamilyModeDualStack, false, tproxy_config.IPFamilyModeIPv4),
+		Entry("keeps IPv4 with local IPv6", tproxy_config.IPFamilyModeIPv4, true, tproxy_config.IPFamilyModeIPv4),
+		Entry("keeps IPv4 without local IPv6", tproxy_config.IPFamilyModeIPv4, false, tproxy_config.IPFamilyModeIPv4),
+	)
+
 	type testCase struct {
 		envVars      map[string]string
 		args         []string

--- a/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
+++ b/app/kuma-dp/pkg/dataplane/envoy/remote_bootstrap_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Remote Bootstrap", func() {
 					},
 				}),
 				expectedBootstrapRequestFile: "bootstrap-request-transparent-proxy.golden.json",
-				features:                     []string{"feature-transparent-proxy-in-dataplane-metadata"},
+				features:                     []string{"feature-spire"},
 			},
 		),
 	)

--- a/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-transparent-proxy.golden.json
+++ b/app/kuma-dp/pkg/dataplane/envoy/testdata/bootstrap-request-transparent-proxy.golden.json
@@ -23,7 +23,7 @@
  "readinessPort": 9902,
  "operatingSystem": "linux",
  "features": [
-  "feature-transparent-proxy-in-dataplane-metadata"
+  "feature-spire"
  ],
  "resources": {
   "maxHeapSizeBytes": 0

--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -64,14 +64,8 @@ networking:
   address: {{ address }}
   inbound:
   - port: {{ port }}
-  transparentProxying:
-    redirectPortInbound: 15006
-    redirectPortOutbound: 15001
 
-The values in 'transparentProxying' section are the defaults set by this command and if needed be changed by supplying 
-'--redirect-inbound-port' and '--redirect-outbound-port' respectively.
-
- 4) the kuma-dp command shall be run with the designated user. 
+ 4) the kuma-dp command shall be run with the designated user and the '--transparent-proxy' flag.
     - if using systemd to run add 'User=kuma-dp' in the '[Service]' section of the service file
     - leverage 'runuser' similar to (assuming aforementioned yaml):
 
@@ -83,7 +77,11 @@ runuser -u kuma-dp -- \
     --dataplane-var name=dp-demo \
     --dataplane-var address=172.19.0.4 \
     --dataplane-var port=80  \
+    --transparent-proxy \
     --binary-path /usr/local/bin/envoy
+
+'--transparent-proxy' uses the redirect ports this command sets by default. If you change them with
+'--redirect-inbound-port' or '--redirect-outbound-port', pass the same ports to kuma-dp with '--transparent-proxy-config'.
 
 `,
 		// Disable automatic flag parsing to ensure that our custom order of precedence
@@ -206,9 +204,9 @@ runuser -u kuma-dp -- \
 	cmd.Flags().BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "dry run")
 	cmd.Flags().BoolVar(&cfg.Verbose, "verbose", cfg.Verbose, "verbose")
 	cmd.Flags().Var(&cfg.IPFamilyMode, "ip-family-mode", "The IP family mode to enable traffic redirection for. Can be 'dualstack' or 'ipv4'")
-	cmd.Flags().Var(&cfg.Redirect.Outbound.Port, "redirect-outbound-port", `outbound port redirected to Envoy, as specified in dataplane's "networking.transparentProxying.redirectPortOutbound"`)
+	cmd.Flags().Var(&cfg.Redirect.Outbound.Port, "redirect-outbound-port", "outbound port redirected to Envoy")
 	cmd.Flags().BoolVar(&cfg.Redirect.Inbound.Enabled, "redirect-inbound", cfg.Redirect.Inbound.Enabled, "redirect the inbound traffic to the Envoy. Should be disabled for Gateway data plane proxies.")
-	cmd.Flags().Var(&cfg.Redirect.Inbound.Port, "redirect-inbound-port", `inbound port redirected to Envoy, as specified in dataplane's "networking.transparentProxying.redirectPortInbound"`)
+	cmd.Flags().Var(&cfg.Redirect.Inbound.Port, "redirect-inbound-port", "inbound port redirected to Envoy")
 	cmd.Flags().Var(&cfg.Redirect.Inbound.ExcludePorts, "exclude-inbound-ports", "a comma separated list of inbound ports to exclude from redirect to Envoy")
 	cmd.Flags().Var(&cfg.Redirect.Outbound.ExcludePorts, "exclude-outbound-ports", "a comma separated list of outbound ports to exclude from redirect to Envoy")
 	cmd.Flags().StringVar(&cfg.KumaDPUser, "kuma-dp-user", cfg.KumaDPUser, fmt.Sprintf("the username or UID of the user that will run kuma-dp. If not provided, the system will search for a user with the default UID ('%s') or the default username ('%s')", consts.OwnerDefaultUID, consts.OwnerDefaultUsername))

--- a/app/kumactl/cmd/install/install_transparent_proxy.go
+++ b/app/kumactl/cmd/install/install_transparent_proxy.go
@@ -80,8 +80,8 @@ runuser -u kuma-dp -- \
     --transparent-proxy \
     --binary-path /usr/local/bin/envoy
 
-'--transparent-proxy' uses the redirect ports this command sets by default. If you change them with
-'--redirect-inbound-port' or '--redirect-outbound-port', pass the same ports to kuma-dp with '--transparent-proxy-config'.
+'--transparent-proxy' assumes this command's defaults. If you change the IP family mode, the redirect ports,
+inbound redirection, or virtual networks, pass the same values to kuma-dp with '--transparent-proxy-config'.
 
 `,
 		// Disable automatic flag parsing to ensure that our custom order of precedence

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -7360,16 +7360,6 @@ components:
                   items:
                     type: string
                   type: array
-                ipFamilyMode:
-                  description: >-
-                    The IP family mode to enable for. Can be "IPv4" or
-                    "DualStack".
-                  enum:
-                    - UnSpecified
-                    - DualStack
-                    - IPv4
-                    - IPv6
-                  type: string
                 reachableBackends:
                   description: >-
                     Reachable backend via transparent proxy when running with
@@ -7407,16 +7397,6 @@ components:
                         type: object
                       type: array
                   type: object
-                redirectPortInbound:
-                  description: >-
-                    Port on which all inbound traffic is being transparently
-                    redirected.
-                  type: integer
-                redirectPortOutbound:
-                  description: >-
-                    Port on which all outbound traffic is being transparently
-                    redirected.
-                  type: integer
               type: object
           type: object
         type:
@@ -15823,16 +15803,6 @@ components:
                       items:
                         type: string
                       type: array
-                    ipFamilyMode:
-                      description: >-
-                        The IP family mode to enable for. Can be "IPv4" or
-                        "DualStack".
-                      enum:
-                        - UnSpecified
-                        - DualStack
-                        - IPv4
-                        - IPv6
-                      type: string
                     reachableBackends:
                       description: >-
                         Reachable backend via transparent proxy when running
@@ -15871,16 +15841,6 @@ components:
                             type: object
                           type: array
                       type: object
-                    redirectPortInbound:
-                      description: >-
-                        Port on which all inbound traffic is being transparently
-                        redirected.
-                      type: integer
-                    redirectPortOutbound:
-                      description: >-
-                        Port on which all outbound traffic is being
-                        transparently redirected.
-                      type: integer
                   type: object
               type: object
           type: object

--- a/docs/generated/raw/protos/Dataplane.json
+++ b/docs/generated/raw/protos/Dataplane.json
@@ -276,41 +276,12 @@
         },
         "kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying": {
             "properties": {
-                "redirect_port_inbound": {
-                    "type": "integer",
-                    "description": "Port on which all inbound traffic is being transparently redirected."
-                },
-                "redirect_port_outbound": {
-                    "type": "integer",
-                    "description": "Port on which all outbound traffic is being transparently redirected."
-                },
                 "direct_access_services": {
                     "items": {
                         "type": "string"
                     },
                     "type": "array",
                     "description": "List of services that will be accessed directly via IP:PORT Use `*` to indicate direct access to every service in the Mesh. Using `*` to directly access every service is a resource-intensive operation, use it only if needed."
-                },
-                "ip_family_mode": {
-                    "enum": [
-                        "UnSpecified",
-                        0,
-                        "DualStack",
-                        1,
-                        "IPv4",
-                        2,
-                        "IPv6",
-                        3
-                    ],
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        }
-                    ],
-                    "title": "Ip Family Mode"
                 },
                 "reachable_backends": {
                     "$ref": "#/definitions/kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends",

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -292,41 +292,12 @@
         },
         "kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying": {
             "properties": {
-                "redirect_port_inbound": {
-                    "type": "integer",
-                    "description": "Port on which all inbound traffic is being transparently redirected."
-                },
-                "redirect_port_outbound": {
-                    "type": "integer",
-                    "description": "Port on which all outbound traffic is being transparently redirected."
-                },
                 "direct_access_services": {
                     "items": {
                         "type": "string"
                     },
                     "type": "array",
                     "description": "List of services that will be accessed directly via IP:PORT Use `*` to indicate direct access to every service in the Mesh. Using `*` to directly access every service is a resource-intensive operation, use it only if needed."
-                },
-                "ip_family_mode": {
-                    "enum": [
-                        "UnSpecified",
-                        0,
-                        "DualStack",
-                        1,
-                        "IPv4",
-                        2,
-                        "IPv6",
-                        3
-                    ],
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        }
-                    ],
-                    "title": "Ip Family Mode"
                 },
                 "reachable_backends": {
                     "$ref": "#/definitions/kuma.mesh.v1alpha1.Dataplane.Networking.TransparentProxying.ReachableBackends",

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/empty_reachable_backend.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/empty_reachable_backend.input.yaml
@@ -23,7 +23,5 @@ networking:
         kuma.io/display-name: foo
         kuma.io/protocol: tcp
   transparentProxying:
-    redirectPortInbound: 15006
-    redirectPortOutbound: 15001
     reachableBackends:
       refs: []

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/missing_reachable_backend.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/missing_reachable_backend.input.yaml
@@ -23,8 +23,6 @@ networking:
         kuma.io/display-name: foo
         kuma.io/protocol: tcp
   transparentProxying:
-    redirectPortInbound: 15006
-    redirectPortOutbound: 15001
     reachableBackends:
       refs:
         - kind: MeshService

--- a/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations_reachable_backend.input.yaml
+++ b/pkg/api-server/testdata/resources/inspect/dataplanes/_layout/multiple_ms_destinations_reachable_backend.input.yaml
@@ -23,8 +23,6 @@ networking:
         kuma.io/display-name: foo
         kuma.io/protocol: tcp
   transparentProxying:
-    redirectPortInbound: 15006
-    redirectPortOutbound: 15001
     reachableBackends:
       refs:
         - kind: MeshService

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -14,8 +14,6 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/kri"
 	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
 	k8s_metadata "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
-	tproxy_config "github.com/kumahq/kuma/v3/pkg/transparentproxy/config"
-	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 )
 
 func (d *DataplaneResource) UsesInterface(address net.IP, port uint32) bool {
@@ -83,24 +81,6 @@ func (d *DataplaneResource) GetAddress() string {
 	}
 
 	return d.Spec.GetNetworking().GetAddress()
-}
-
-func (d *DataplaneResource) GetTransparentProxy() *tproxy_dp.DataplaneConfig {
-	if d == nil {
-		return &tproxy_dp.DataplaneConfig{}
-	}
-
-	if tp := d.Spec.GetNetworking().GetTransparentProxying(); tp != nil {
-		return &tproxy_dp.DataplaneConfig{
-			IPFamilyMode: tproxy_config.IPFamilyModeFromStringer(tp.GetIpFamilyMode()),
-			Redirect: tproxy_dp.DataplaneRedirect{
-				Inbound:  tproxy_dp.DataplaneTrafficFlowFromPortLike(tp.GetRedirectPortInbound()),
-				Outbound: tproxy_dp.DataplaneTrafficFlowFromPortLike(tp.GetRedirectPortOutbound()),
-			},
-		}
-	}
-
-	return &tproxy_dp.DataplaneConfig{}
 }
 
 func (d *DataplaneResource) AdminAddress(defaultAdminPort uint32) string {

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -13,7 +13,6 @@ import (
 	k8s_metadata "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
-	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
 
@@ -424,86 +423,6 @@ var _ = Describe("Dataplane", func() {
 		)
 	})
 
-	Describe("IsUsingTransparentProxy()", func() {
-		type testCase struct {
-			dataplane string
-			expected  bool
-		}
-
-		DescribeTable("should correctly determine if dataplane is using transparent proxy",
-			func(given testCase) {
-				// given
-				var dataplane *DataplaneResource
-				if given.dataplane != "" {
-					dataplane = NewDataplaneResource()
-					Expect(util_proto.FromYAML([]byte(given.dataplane), dataplane.Spec)).To(Succeed())
-				}
-
-				// expect
-				Expect(tproxy_dp.GetDataplaneConfig(dataplane, nil).Enabled()).To(Equal(given.expected))
-			},
-			Entry("`nil` dataplane", testCase{
-				dataplane: ``,
-				expected:  false,
-			}),
-			Entry("dataplane without transparent proxy", testCase{
-				dataplane: `
-                networking: {}
-`,
-				expected: false,
-			}),
-			Entry("dataplane with empty transparent proxy", testCase{
-				dataplane: `
-                networking:
-                  transparent_proxying: {}
-`,
-				expected: false,
-			}),
-			Entry("dataplane with DualStack transparent proxy configured", testCase{
-				dataplane: `
-                networking:
-                  address: fd00::123
-                  transparent_proxying:
-                    ipFamilyMode: DualStack
-                    redirect_port_inbound: 123
-                    redirect_port_outbound: 1234
-`,
-				expected: true,
-			}),
-			Entry("dataplane with IPv4 transparent proxy configured", testCase{
-				dataplane: `
-                networking:
-                  address: 10.244.16.28
-                  transparent_proxying:
-                    ipFamilyMode: IPv4
-                    redirect_port_inbound: 123
-                    redirect_port_outbound: 1234
-`,
-				expected: true,
-			}),
-			Entry("old dataplane with transparent proxy configured and ipv4 address", testCase{
-				dataplane: `
-                networking:
-                  address: 10.244.16.28
-                  transparent_proxying:
-                    redirect_port_inbound: 123
-                    redirect_port_outbound: 1234
-`,
-				expected: true,
-			}),
-			Entry("old dataplane with transparent proxy configured and ipv6 address", testCase{
-				dataplane: `
-                networking:
-                  address: fd00::123
-                  transparent_proxying:
-                    redirect_port_inbound: 123
-                    redirect_port_outbound: 1234
-`,
-				expected: true,
-			}),
-		)
-	})
-
 	_ = Describe("ParseProtocol()", func() {
 		type testCase struct {
 			tag      string
@@ -686,7 +605,6 @@ func BenchmarkDataplaneHash(b *testing.B) {
 		WithAddress("127.0.0.1").
 		WithServices("backend").
 		WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-		WithTransparentProxying(15001, 15006, "").
 		Build()
 
 	b.ReportAllocs()

--- a/pkg/core/resources/apis/mesh/dataplane_validator_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_validator_test.go
@@ -252,16 +252,6 @@ var _ = Describe("Dataplane", func() {
                       kuma.io/display-name: redis
                     port: 8080`,
 		),
-		Entry("no inbound with transparent proxy", `
-            type: Dataplane
-            name: dp-1
-            mesh: default
-            networking:
-              address: 192.168.0.1
-              transparentProxying:
-                redirectPortInbound: 15006
-                redirectPortOutbound: 15001`,
-		),
 		Entry("no inbound outbound-only", `
             type: Dataplane
             name: dp-1

--- a/pkg/core/xds/types/features.go
+++ b/pkg/core/xds/types/features.go
@@ -11,8 +11,6 @@ func (f Features) HasFeature(feature string) bool {
 	return false
 }
 
-const FeatureTransparentProxyInDataplaneMetadata string = "feature-transparent-proxy-in-dataplane-metadata"
-
 // FeatureBindOutbounds indicates that the DP runs with outbound listeners bound to 127.0.0.0/8 range addresses
 const FeatureBindOutbounds string = "feature-bind-outbounds"
 

--- a/pkg/hds/tracker/healthcheck_generator_test.go
+++ b/pkg/hds/tracker/healthcheck_generator_test.go
@@ -20,6 +20,7 @@ import (
 	v3 "github.com/kumahq/kuma/v3/pkg/hds/v3"
 	"github.com/kumahq/kuma/v3/pkg/plugins/resources/memory"
 	"github.com/kumahq/kuma/v3/pkg/test/matchers"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
 
@@ -110,10 +111,12 @@ networking:
       servicePort: 80
       serviceProbe: 
         tcp: {}
-  transparentProxying:
-    redirectPortInbound: 15006
-    redirectPortOutbound: 15001
 `,
+			metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					xds.FieldTransparentProxy: structpb.NewStructValue(util_proto.MustStructToProtoStruct(xds_builders.TransparentProxy("dualstack"))),
+				},
+			},
 			hdsConfig: &dp_server.HdsConfig{
 				Interval: config_types.Duration{Duration: 8 * time.Second},
 				Enabled:  true,
@@ -137,10 +140,12 @@ networking:
       servicePort: 80
       serviceProbe: 
         tcp: {}
-  transparentProxying:
-    redirectPortInbound: 15006
-    redirectPortOutbound: 15001
 `,
+			metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					xds.FieldTransparentProxy: structpb.NewStructValue(util_proto.MustStructToProtoStruct(xds_builders.TransparentProxy("dualstack"))),
+				},
+			},
 			hdsConfig: &dp_server.HdsConfig{
 				Interval: config_types.Duration{Duration: 8 * time.Second},
 				Enabled:  true,

--- a/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
+++ b/pkg/plugins/policies/core/matchers/dataplane_bench_test.go
@@ -71,7 +71,6 @@ func benchDataplane(b *testing.B) *core_mesh.DataplaneResource {
 		WithAddress("127.0.0.1").
 		WithServices("backend").
 		WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-		WithTransparentProxying(15001, 15006, "").
 		Build()
 }
 

--- a/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshpassthrough/plugin/v1alpha1/plugin_test.go
@@ -49,12 +49,12 @@ var _ = Describe("MeshPassthrough", func() {
 				Build()
 			proxy := xds_builders.Proxy().
 				WithApiVersion(envoy_common.APIV3).
+				WithTransparentProxy("ipv4").
 				WithDataplane(
 					builders.Dataplane().
 						WithName("test").
 						WithMesh("default").
 						WithAddress("127.0.0.1").
-						WithTransparentProxying(15006, 15001, "ipv4").
 						AddInbound(
 							builders.Inbound().
 								WithAddress("127.0.0.1").

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/plugin_test.go
@@ -132,7 +132,6 @@ var _ = Describe("MeshTLS", func() {
 						WithName("test").
 						WithMesh("default").
 						WithAddress("127.0.0.1").
-						WithTransparentProxying(15006, 15001, ipFamilyMode).
 						AddOutbound(
 							builders.Outbound().
 								WithAddress("127.0.0.1").
@@ -154,7 +153,7 @@ var _ = Describe("MeshTLS", func() {
 				).
 				WithPolicies(xds_builders.MatchedPolicies().WithFromPolicy(api.MeshTLSType, fromRules))
 
-			proxy := proxyBuilder.Build()
+			proxy := proxyBuilder.WithTransparentProxy(ipFamilyMode).Build()
 			resourceSet.Add(getMeshServiceResources(proxy)...)
 
 			plugin := plugin.NewPlugin().(core_plugins.PolicyPlugin)
@@ -379,12 +378,12 @@ var _ = Describe("MeshTLS on a proxy without inbounds", func() {
 		proxy := xds_builders.Proxy().
 			WithWorkloadIdentity(workloadIdentity()).
 			WithApiVersion(envoy_common.APIV3).
+			WithTransparentProxy("ipv4").
 			WithDataplane(
 				builders.Dataplane().
 					WithName("gateway").
 					WithMesh("default").
 					WithAddress("127.0.0.1").
-					WithTransparentProxying(15006, 15001, "ipv4").
 					AddOutbound(
 						builders.Outbound().
 							WithAddress("127.0.0.1").

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/no-policy.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/no-policy.listeners.golden.yaml
@@ -89,7 +89,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-dualstack-tproxy.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-dualstack-tproxy.listeners.golden.yaml
@@ -141,7 +141,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:
@@ -160,7 +160,7 @@ resources:
     address:
       socketAddress:
         address: '::'
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-external-validator.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-external-validator.listeners.golden.yaml
@@ -141,7 +141,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -149,7 +149,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-mesh-trust.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-mesh-trust.listeners.golden.yaml
@@ -141,7 +141,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-multiple-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-multiple-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -161,7 +161,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-tls-params.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive-with-tls-params.listeners.golden.yaml
@@ -153,7 +153,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/permissive.listeners.golden.yaml
@@ -141,7 +141,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filters:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-dualstack-tproxy.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-dualstack-tproxy.listeners.golden.yaml
@@ -89,7 +89,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:
@@ -118,7 +118,7 @@ resources:
     address:
       socketAddress:
         address: '::'
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-external-validator.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-external-validator.listeners.golden.yaml
@@ -89,7 +89,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -97,7 +97,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-mesh-trust.listeners.golden.yaml
@@ -89,7 +89,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-multiple-mesh-trust-kuma-managed.listeners.golden.yaml
@@ -109,7 +109,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-tls-params.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict-with-tls-params.listeners.golden.yaml
@@ -101,7 +101,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict.listeners.golden.yaml
+++ b/pkg/plugins/policies/meshtls/plugin/v1alpha1/testdata/strict.listeners.golden.yaml
@@ -89,7 +89,7 @@ resources:
     address:
       socketAddress:
         address: 0.0.0.0
-        portValue: 15001
+        portValue: 15006
     enableReusePort: true
     filterChains:
     - filterChainMatch:

--- a/pkg/plugins/runtime/k8s/metadata/annotations.go
+++ b/pkg/plugins/runtime/k8s/metadata/annotations.go
@@ -138,7 +138,6 @@ const (
 )
 
 // these values are defined for users to specify in configuration:
-// values comes from mesh_proto.Dataplane_Networking_TransparentProxying_IpFamilyMode_name
 const (
 	IpFamilyModeDualStack = "dualstack"
 	IpFamilyModeIPv4      = "ipv4"

--- a/pkg/test/resources/builders/dataplane_builder.go
+++ b/pkg/test/resources/builders/dataplane_builder.go
@@ -198,24 +198,6 @@ func (d *DataplaneBuilder) AddOutboundsToServices(services ...string) *Dataplane
 	return d
 }
 
-func (d *DataplaneBuilder) WithTransparentProxying(redirectPortOutbound, redirectPortInbound uint32, ipFamilyMode string) *DataplaneBuilder {
-	d.res.Spec.Networking.TransparentProxying = &mesh_proto.Dataplane_Networking_TransparentProxying{
-		RedirectPortInbound:  redirectPortInbound,
-		RedirectPortOutbound: redirectPortOutbound,
-		IpFamilyMode:         ipFamilyModeEnumValue(ipFamilyMode),
-	}
-	return d
-}
-
-func ipFamilyModeEnumValue(mode string) mesh_proto.Dataplane_Networking_TransparentProxying_IpFamilyMode {
-	switch mode {
-	case "ipv4":
-		return mesh_proto.Dataplane_Networking_TransparentProxying_IPv4
-	default:
-		return mesh_proto.Dataplane_Networking_TransparentProxying_DualStack
-	}
-}
-
 func TagsKVToMap(tagsKV []string) map[string]string {
 	if len(tagsKV)%2 == 1 {
 		panic("tagsKV has to have even number of arguments")

--- a/pkg/test/xds/builders/proxy_builder.go
+++ b/pkg/test/xds/builders/proxy_builder.go
@@ -10,6 +10,8 @@ import (
 	bldrs_core "github.com/kumahq/kuma/v3/pkg/envoy/builders/core"
 	bldrs_tls "github.com/kumahq/kuma/v3/pkg/envoy/builders/tls"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/builders"
+	tproxy_config "github.com/kumahq/kuma/v3/pkg/transparentproxy/config"
+	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
 )
 
@@ -59,6 +61,11 @@ func (p *ProxyBuilder) WithMetadata(metadata *core_xds.DataplaneMetadata) *Proxy
 	return p
 }
 
+func (p *ProxyBuilder) WithTransparentProxy(ipFamilyMode string) *ProxyBuilder {
+	p.res.Metadata.TransparentProxy = TransparentProxy(ipFamilyMode)
+	return p
+}
+
 func (p *ProxyBuilder) WithWorkloadIdentity(workloadIdentity *core_xds.WorkloadIdentity) *ProxyBuilder {
 	p.res.WorkloadIdentity = workloadIdentity
 	return p
@@ -100,4 +107,10 @@ func WorkloadIdentity() *core_xds.WorkloadIdentity {
 			)
 		},
 	}
+}
+
+func TransparentProxy(ipFamilyMode string) *tproxy_dp.DataplaneConfig {
+	cfg := tproxy_dp.DefaultDataplaneConfig()
+	cfg.IPFamilyMode = tproxy_config.IPFamilyMode(ipFamilyMode)
+	return &cfg
 }

--- a/pkg/transparentproxy/config/config.go
+++ b/pkg/transparentproxy/config/config.go
@@ -630,10 +630,6 @@ func (c Config) InitializeKumaDPUser() (string, error) {
 
 type IPFamilyMode string
 
-func IPFamilyModeFromStringer(s fmt.Stringer) IPFamilyMode {
-	return IPFamilyMode(strings.ToLower(s.String()))
-}
-
 func (e *IPFamilyMode) UnmarshalJSON(bs []byte) error {
 	var value string
 

--- a/pkg/transparentproxy/config/dataplane/config_dataplane.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane.go
@@ -5,27 +5,19 @@ import (
 	"golang.org/x/exp/constraints"
 
 	core_config "github.com/kumahq/kuma/v3/pkg/config"
-	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	tproxy_config "github.com/kumahq/kuma/v3/pkg/transparentproxy/config"
-	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 )
 
 type PortLike interface {
 	constraints.Integer | constraints.Float | tproxy_config.Port
 }
 
-type DataplaneConfigGetter interface {
-	GetTransparentProxy() *DataplaneConfig
-}
-
 type DataplaneResourcer interface {
-	DataplaneConfigGetter
 	GetAddress() string
 }
 
 type DataplaneMetadater interface {
-	DataplaneConfigGetter
-	HasFeature(string) bool
+	GetTransparentProxy() *DataplaneConfig
 	GetDNSPort() uint32
 }
 
@@ -109,13 +101,6 @@ func (c *DataplaneConfig) EnabledIPv6() bool {
 	return c.IPFamilyMode != tproxy_config.IPFamilyModeIPv4
 }
 
-func hasFeature(meta DataplaneMetadater, feature string) bool {
-	if meta == nil {
-		return false
-	}
-	return meta.HasFeature(feature)
-}
-
 func getDNSPort(meta DataplaneMetadater) uint32 {
 	if meta == nil {
 		return 0
@@ -130,31 +115,17 @@ func getAddress(dp DataplaneResourcer) string {
 	return dp.GetAddress()
 }
 
-func getConfig(cg DataplaneConfigGetter, fallback DataplaneConfig) *DataplaneConfig {
-	if cg == nil {
-		return pointer.To(fallback)
-	}
-
-	if tp := cg.GetTransparentProxy(); tp != nil {
-		return tp
-	}
-
-	return pointer.To(fallback)
-}
-
 func GetDataplaneConfig(dp DataplaneResourcer, meta DataplaneMetadater) *DataplaneConfig {
-	dnsPort := getDNSPort(meta)
-	address := getAddress(dp)
-
-	if hasFeature(meta, xds_types.FeatureTransparentProxyInDataplaneMetadata) {
-		return getConfig(meta, DefaultDataplaneConfig()).
-			withDNSPort(dnsPort).
-			withAddress(address)
+	cfg := &DataplaneConfig{}
+	if meta != nil {
+		if tp := meta.GetTransparentProxy(); tp != nil {
+			cfg = tp
+		}
 	}
 
-	return getConfig(dp, DataplaneConfig{}).
-		withDNSPort(dnsPort).
-		withAddress(address)
+	return cfg.
+		withDNSPort(getDNSPort(meta)).
+		withAddress(getAddress(dp))
 }
 
 func DefaultDataplaneConfig() DataplaneConfig {

--- a/pkg/transparentproxy/config/dataplane/config_dataplane_test.go
+++ b/pkg/transparentproxy/config/dataplane/config_dataplane_test.go
@@ -4,29 +4,22 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	tproxy_config "github.com/kumahq/kuma/v3/pkg/transparentproxy/config"
 	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 )
 
 type dummyMeta struct {
-	tproxy_dp.DataplaneConfig
-	features map[string]bool
-	dnsPort  uint32
+	transparentProxy *tproxy_dp.DataplaneConfig
+	dnsPort          uint32
 }
 
-func (d *dummyMeta) GetTransparentProxy() *tproxy_dp.DataplaneConfig { return &d.DataplaneConfig }
-
-func (d *dummyMeta) HasFeature(f string) bool { return d.features[f] }
+func (d *dummyMeta) GetTransparentProxy() *tproxy_dp.DataplaneConfig { return d.transparentProxy }
 
 func (d *dummyMeta) GetDNSPort() uint32 { return d.dnsPort }
 
 type dummyDP struct {
-	tproxy_dp.DataplaneConfig
 	address string
 }
-
-func (d *dummyDP) GetTransparentProxy() *tproxy_dp.DataplaneConfig { return &d.DataplaneConfig }
 
 func (d *dummyDP) GetAddress() string { return d.address }
 
@@ -34,17 +27,19 @@ var _ = Describe("DataplaneConfig functions", func() {
 	Describe("Enabled", func() {
 		It("should return true if IPv4 and redirect is enabled", func() {
 			// given
-			dp := &dummyDP{
-				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
-				Redirect: tproxy_dp.DataplaneRedirect{
-					Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
-					Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+			dp := &dummyDP{address: "192.0.2.1"}
+			meta := &dummyMeta{
+				transparentProxy: &tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
 				},
-				address: "192.0.2.1",
 			}
 
 			// when
-			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+			cfg := tproxy_dp.GetDataplaneConfig(dp, meta)
 
 			// then
 			Expect(cfg.Enabled()).To(BeTrue())
@@ -52,17 +47,19 @@ var _ = Describe("DataplaneConfig functions", func() {
 
 		It("should return false if address is not IPv4 and mode is IPv4", func() {
 			// given
-			dp := &dummyDP{
-				IPFamilyMode: tproxy_config.IPFamilyModeIPv4,
-				Redirect: tproxy_dp.DataplaneRedirect{
-					Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
-					Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+			dp := &dummyDP{address: "::1"}
+			meta := &dummyMeta{
+				transparentProxy: &tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeIPv4,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
 				},
-				address: "::1",
 			}
 
 			// when
-			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+			cfg := tproxy_dp.GetDataplaneConfig(dp, meta)
 
 			// then
 			Expect(cfg.Enabled()).To(BeFalse())
@@ -72,12 +69,14 @@ var _ = Describe("DataplaneConfig functions", func() {
 	Describe("EnabledIPv6", func() {
 		It("should return true for mode not IPv4", func() {
 			// given
-			dp := &dummyDP{
-				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+			meta := &dummyMeta{
+				transparentProxy: &tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+				},
 			}
 
 			// when
-			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+			cfg := tproxy_dp.GetDataplaneConfig(nil, meta)
 
 			// then
 			Expect(cfg.EnabledIPv6()).To(BeTrue())
@@ -111,6 +110,7 @@ var _ = Describe("DataplaneConfig functions", func() {
 		It("should return fallback if nil", func() {
 			cfg := tproxy_dp.GetDataplaneConfig(nil, nil)
 			Expect(cfg).ToNot(BeNil())
+			Expect(cfg.Enabled()).To(BeFalse())
 		})
 
 		It("should use meta and dp values", func() {
@@ -118,13 +118,12 @@ var _ = Describe("DataplaneConfig functions", func() {
 			dp := &dummyDP{address: "192.0.2.100"}
 
 			meta := &dummyMeta{
-				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
-				Redirect: tproxy_dp.DataplaneRedirect{
-					Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
-					Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
-				},
-				features: map[string]bool{
-					core_xds.FeatureTransparentProxyInDataplaneMetadata: true,
+				transparentProxy: &tproxy_dp.DataplaneConfig{
+					IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
+					Redirect: tproxy_dp.DataplaneRedirect{
+						Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+						Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
+					},
 				},
 				dnsPort: 12345,
 			}
@@ -137,23 +136,17 @@ var _ = Describe("DataplaneConfig functions", func() {
 			Expect(cfg.Enabled()).To(BeTrue())
 		})
 
-		It("should fallback to dataplane config", func() {
+		It("should return a disabled config when metadata carries no transparent proxy", func() {
 			// given
-			dp := &dummyDP{
-				IPFamilyMode: tproxy_config.IPFamilyModeDualStack,
-				Redirect: tproxy_dp.DataplaneRedirect{
-					Inbound:  tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
-					Outbound: tproxy_dp.DatalpaneTrafficFlow{Enabled: true},
-				},
-				address: "192.0.2.50",
-			}
+			dp := &dummyDP{address: "192.0.2.50"}
+			meta := &dummyMeta{dnsPort: 12345}
 
 			// when
-			cfg := tproxy_dp.GetDataplaneConfig(dp, nil)
+			cfg := tproxy_dp.GetDataplaneConfig(dp, meta)
 
 			// then
-			Expect(cfg.Redirect.DNS.Port.Uint32()).To(Equal(uint32(0)))
-			Expect(cfg.Enabled()).To(BeTrue())
+			Expect(cfg.Redirect.DNS.Port.Uint32()).To(Equal(uint32(12345)))
+			Expect(cfg.Enabled()).To(BeFalse())
 		})
 	})
 })

--- a/pkg/xds/context/destination_index_test.go
+++ b/pkg/xds/context/destination_index_test.go
@@ -34,9 +34,9 @@ var _ = Describe("DestinationIndex", func() {
 				}).
 				WithAddress("127.0.0.1").
 				WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-				WithTransparentProxying(15001, 15006, "").
 				Build()
 
+			dp.Spec.Networking.TransparentProxying = &mesh_proto.Dataplane_Networking_TransparentProxying{}
 			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
 				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
 					{
@@ -68,9 +68,9 @@ var _ = Describe("DestinationIndex", func() {
 				WithName("dp-1").
 				WithAddress("127.0.0.1").
 				WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-				WithTransparentProxying(15001, 15006, "").
 				Build()
 
+			dp.Spec.Networking.TransparentProxying = &mesh_proto.Dataplane_Networking_TransparentProxying{}
 			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
 				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
 					{
@@ -109,9 +109,9 @@ var _ = Describe("DestinationIndex", func() {
 				}).
 				WithAddress("127.0.0.1").
 				WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-				WithTransparentProxying(15001, 15006, "").
 				Build()
 
+			dp.Spec.Networking.TransparentProxying = &mesh_proto.Dataplane_Networking_TransparentProxying{}
 			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
 				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
 					{
@@ -150,9 +150,9 @@ var _ = Describe("DestinationIndex", func() {
 				}).
 				WithAddress("127.0.0.1").
 				WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-				WithTransparentProxying(15001, 15006, "").
 				Build()
 
+			dp.Spec.Networking.TransparentProxying = &mesh_proto.Dataplane_Networking_TransparentProxying{}
 			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
 				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
 					{
@@ -223,9 +223,9 @@ var _ = Describe("DestinationIndex", func() {
 				}).
 				WithAddress("127.0.0.1").
 				WithInboundOfTagsAndProtocol("http", "kuma.io/display-name", "web").
-				WithTransparentProxying(15001, 15006, "").
 				Build()
 
+			dp.Spec.Networking.TransparentProxying = &mesh_proto.Dataplane_Networking_TransparentProxying{}
 			dp.Spec.Networking.TransparentProxying.ReachableBackends = &mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackends{
 				Refs: []*mesh_proto.Dataplane_Networking_TransparentProxying_ReachableBackendRef{
 					{

--- a/pkg/xds/generator/default_proxy_profile_test.go
+++ b/pkg/xds/generator/default_proxy_profile_test.go
@@ -14,7 +14,9 @@ import (
 	. "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
 	test_xds "github.com/kumahq/kuma/v3/pkg/test/xds"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 	"github.com/kumahq/kuma/v3/pkg/tls"
+	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
@@ -23,10 +25,11 @@ import (
 
 var _ = Describe("DefaultProxyProfile", func() {
 	type testCase struct {
-		mesh      string
-		dataplane string
-		expected  string
-		features  xds_types.Features
+		mesh             string
+		dataplane        string
+		expected         string
+		features         xds_types.Features
+		transparentProxy *tproxy_dp.DataplaneConfig
 	}
 
 	DescribeTable("Generate Envoy xDS resources",
@@ -96,9 +99,10 @@ var _ = Describe("DefaultProxyProfile", func() {
 							Version: "1.2.0",
 						},
 					},
-					WorkDir:     "/tmp",
-					Features:    given.features,
-					IPv6Enabled: true,
+					WorkDir:          "/tmp",
+					Features:         given.features,
+					IPv6Enabled:      true,
+					TransparentProxy: given.transparentProxy,
 				},
 				EnvoyAdminMTLSCerts: core_xds.ServerSideMTLSCerts{
 					CaPEM: []byte("caPEM"),
@@ -180,12 +184,9 @@ var _ = Describe("DefaultProxyProfile", func() {
               - port: 59200
                 tags:
                   kuma.io/display-name: elastic
-              transparentProxying:
-                redirectPortOutbound: 15001
-                redirectPortInbound: 15006
-                ipFamilyMode: IPv4
 `,
-			expected: "2-envoy-config.golden.yaml",
+			transparentProxy: xds_builders.TransparentProxy("ipv4"),
+			expected:         "2-envoy-config.golden.yaml",
 		}),
 	)
 })

--- a/pkg/xds/generator/direct_access_proxy_generator_test.go
+++ b/pkg/xds/generator/direct_access_proxy_generator_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/core/xds"
 	. "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	"github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
+	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	util_yaml "github.com/kumahq/kuma/v3/pkg/util/yaml"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
@@ -38,10 +40,11 @@ var _ = Describe("DirectAccessProxyGenerator", func() {
 	generator := generator.DirectAccessProxyGenerator{}
 
 	type testCase struct {
-		dataplaneFile  string
-		dataplanesFile string
-		meshFile       string
-		expected       string
+		dataplaneFile    string
+		dataplanesFile   string
+		meshFile         string
+		transparentProxy *tproxy_dp.DataplaneConfig
+		expected         string
 	}
 
 	DescribeTable("should generate envoy config",
@@ -88,7 +91,7 @@ var _ = Describe("DirectAccessProxyGenerator", func() {
 			proxy := &xds.Proxy{
 				Dataplane:  dataplane,
 				APIVersion: envoy_common.APIV3,
-				Metadata:   &xds.DataplaneMetadata{IPv6Enabled: true},
+				Metadata:   &xds.DataplaneMetadata{IPv6Enabled: true, TransparentProxy: given.transparentProxy},
 			}
 
 			// when
@@ -118,22 +121,25 @@ var _ = Describe("DirectAccessProxyGenerator", func() {
 			expected:       "02.envoy-config.golden.yaml",
 		}),
 		Entry("should generate direct access for all services except taken endpoints by outbound", testCase{
-			dataplaneFile:  "03.dataplane.input.yaml",
-			dataplanesFile: "03.dataplanes.input.yaml",
-			meshFile:       "03.mesh.input.yaml",
-			expected:       "03.envoy-config.golden.yaml",
+			dataplaneFile:    "03.dataplane.input.yaml",
+			dataplanesFile:   "03.dataplanes.input.yaml",
+			meshFile:         "03.mesh.input.yaml",
+			transparentProxy: xds_builders.TransparentProxy("dualstack"),
+			expected:         "03.envoy-config.golden.yaml",
 		}),
 		Entry("should generate direct access for given services", testCase{
-			dataplaneFile:  "04.dataplane.input.yaml",
-			dataplanesFile: "04.dataplanes.input.yaml",
-			meshFile:       "04.mesh.input.yaml",
-			expected:       "04.envoy-config.golden.yaml",
+			dataplaneFile:    "04.dataplane.input.yaml",
+			dataplanesFile:   "04.dataplanes.input.yaml",
+			meshFile:         "04.mesh.input.yaml",
+			transparentProxy: xds_builders.TransparentProxy("dualstack"),
+			expected:         "04.envoy-config.golden.yaml",
 		}),
 		Entry("should not leak inbounds of other services declared by a legacy dataplane", testCase{
-			dataplaneFile:  "05.dataplane.input.yaml",
-			dataplanesFile: "05.dataplanes.input.yaml",
-			meshFile:       "05.mesh.input.yaml",
-			expected:       "05.envoy-config.golden.yaml",
+			dataplaneFile:    "05.dataplane.input.yaml",
+			dataplanesFile:   "05.dataplanes.input.yaml",
+			meshFile:         "05.mesh.input.yaml",
+			transparentProxy: xds_builders.TransparentProxy("dualstack"),
+			expected:         "05.envoy-config.golden.yaml",
 		}),
 	)
 })

--- a/pkg/xds/generator/dns_generator_test.go
+++ b/pkg/xds/generator/dns_generator_test.go
@@ -14,6 +14,8 @@ import (
 	xds_types "github.com/kumahq/kuma/v3/pkg/core/xds/types"
 	. "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
+	tproxy_dp "github.com/kumahq/kuma/v3/pkg/transparentproxy/config/dataplane"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
@@ -22,11 +24,12 @@ import (
 
 var _ = Describe("DNSGenerator", func() {
 	type testCase struct {
-		dataplaneFile string
-		expected      string
-		features      map[string]bool
-		dpLabels      map[string]string
-		dpMesh        string
+		dataplaneFile    string
+		expected         string
+		features         map[string]bool
+		transparentProxy *tproxy_dp.DataplaneConfig
+		dpLabels         map[string]string
+		dpMesh           string
 	}
 
 	DescribeTable("Generate Envoy xDS resources",
@@ -67,9 +70,10 @@ var _ = Describe("DNSGenerator", func() {
 				APIVersion: envoy_common.APIV3,
 				Routing:    model.Routing{},
 				Metadata: &model.DataplaneMetadata{
-					DNSPort:  53001,
-					Version:  &mesh_proto.Version{Envoy: &mesh_proto.EnvoyVersion{Version: "1.20.0"}},
-					Features: given.features,
+					DNSPort:          53001,
+					Version:          &mesh_proto.Version{Envoy: &mesh_proto.EnvoyVersion{Version: "1.20.0"}},
+					Features:         given.features,
+					TransparentProxy: given.transparentProxy,
 				},
 				InternalAddresses: DummyInternalAddresses,
 			}
@@ -97,20 +101,23 @@ var _ = Describe("DNSGenerator", func() {
 			Expect(actual).To(MatchGoldenYAML(filepath.Join("testdata", "dns", given.expected)))
 		},
 		Entry("01. DNS enabled", testCase{
-			dataplaneFile: "1-dataplane.input.yaml",
-			expected:      "1-envoy-config.golden.yaml",
+			dataplaneFile:    "1-dataplane.input.yaml",
+			expected:         "1-envoy-config.golden.yaml",
+			transparentProxy: xds_builders.TransparentProxy("dualstack"),
 		}),
 		Entry("02. DNS disabled", testCase{
 			dataplaneFile: "2-dataplane.input.yaml",
 			expected:      "2-envoy-config.golden.yaml",
 		}),
 		Entry("03. DNS enabled no ipv6", testCase{
-			dataplaneFile: "3-dataplane.input.yaml",
-			expected:      "3-envoy-config.golden.yaml",
+			dataplaneFile:    "3-dataplane.input.yaml",
+			expected:         "3-envoy-config.golden.yaml",
+			transparentProxy: xds_builders.TransparentProxy("ipv4"),
 		}),
 		Entry("04. DNS using proxy map", testCase{
-			dataplaneFile: "4-dataplane.input.yaml",
-			expected:      "4-envoy-config.golden.yaml",
+			dataplaneFile:    "4-dataplane.input.yaml",
+			expected:         "4-envoy-config.golden.yaml",
+			transparentProxy: xds_builders.TransparentProxy("dualstack"),
 			dpLabels: map[string]string{
 				"kuma.io/workload":      "backend",
 				"k8s.kuma.io/namespace": "test-ns",
@@ -119,8 +126,9 @@ var _ = Describe("DNSGenerator", func() {
 			dpMesh: "default",
 		}),
 		Entry("06. DNS enabled with unified naming", testCase{
-			dataplaneFile: "6-dataplane.input.yaml",
-			expected:      "6-envoy-config.golden.yaml",
+			dataplaneFile:    "6-dataplane.input.yaml",
+			expected:         "6-envoy-config.golden.yaml",
+			transparentProxy: xds_builders.TransparentProxy("dualstack"),
 		}),
 	)
 })

--- a/pkg/xds/generator/inbound_proxy_generator_test.go
+++ b/pkg/xds/generator/inbound_proxy_generator_test.go
@@ -13,6 +13,7 @@ import (
 	model "github.com/kumahq/kuma/v3/pkg/core/xds"
 	. "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
@@ -97,10 +98,12 @@ var _ = Describe("InboundProxyGenerator", func() {
 		}),
 		Entry("04. transparent_proxying=true, ip_addresses=2, ports=2", testCase{
 			dataplaneFile: "4-dataplane.input.yaml",
+			dataplaneMeta: &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
 			expected:      "4-envoy-config.golden.yaml",
 		}),
 		Entry("07. transparent_proxying=true, ip_addresses=2, ports=2, loopback inbounds", testCase{
 			dataplaneFile: "7-dataplane.input.yaml",
+			dataplaneMeta: &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
 			expected:      "7-envoy-config.golden.yaml",
 		}),
 		Entry("10. transparent_proxying=false, http protocol", testCase{

--- a/pkg/xds/generator/testdata/direct-access/03.dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/direct-access/03.dataplane.input.yaml
@@ -13,6 +13,4 @@ networking:
       tags:
         kuma.io/display-name: redis
   transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15006
     directAccessServices: ["*"]

--- a/pkg/xds/generator/testdata/direct-access/04.dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/direct-access/04.dataplane.input.yaml
@@ -13,6 +13,4 @@ networking:
       tags:
         kuma.io/display-name: redis
   transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15006
     directAccessServices: ["backend"]

--- a/pkg/xds/generator/testdata/direct-access/05.dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/direct-access/05.dataplane.input.yaml
@@ -8,6 +8,4 @@ networking:
   inbound:
     - port: 1234
   transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15006
     directAccessServices: ["backend"]

--- a/pkg/xds/generator/testdata/dns/1-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/dns/1-dataplane.input.yaml
@@ -12,6 +12,3 @@ networking:
         kind: MeshService
         name: httpbin
         port: 80
-  transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15003

--- a/pkg/xds/generator/testdata/dns/3-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/dns/3-dataplane.input.yaml
@@ -13,7 +13,3 @@ networking:
         kind: MeshService
         name: httpbin
         port: 80
-  transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15003
-    ipFamilyMode: IPv4

--- a/pkg/xds/generator/testdata/dns/4-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/dns/4-dataplane.input.yaml
@@ -12,6 +12,3 @@ networking:
         kind: MeshService
         name: httpbin
         port: 80
-  transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15003

--- a/pkg/xds/generator/testdata/dns/6-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/dns/6-dataplane.input.yaml
@@ -12,6 +12,3 @@ networking:
         kind: MeshService
         name: httpbin
         port: 80
-  transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15003

--- a/pkg/xds/generator/testdata/inbound-proxy/4-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/4-dataplane.input.yaml
@@ -1,7 +1,4 @@
 networking:
-  transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15006
   address: 192.168.0.1
   inbound:
     - port: 80

--- a/pkg/xds/generator/testdata/inbound-proxy/7-dataplane.input.yaml
+++ b/pkg/xds/generator/testdata/inbound-proxy/7-dataplane.input.yaml
@@ -1,7 +1,4 @@
 networking:
-  transparentProxying:
-    redirectPortOutbound: 15001
-    redirectPortInbound: 15006
   address: 192.168.0.1
   inbound:
     - port: 80

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -12,6 +12,7 @@ import (
 	model "github.com/kumahq/kuma/v3/pkg/core/xds"
 	. "github.com/kumahq/kuma/v3/pkg/test/matchers"
 	test_model "github.com/kumahq/kuma/v3/pkg/test/resources/model"
+	xds_builders "github.com/kumahq/kuma/v3/pkg/test/xds/builders"
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 	envoy_common "github.com/kumahq/kuma/v3/pkg/xds/envoy"
@@ -36,17 +37,13 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		}
 
 		return &model.Proxy{
+			Metadata: &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
 			Id: *model.BuildProxyId("", "side-car"),
 			Dataplane: &core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{Version: "v1"},
 				Spec: &mesh_proto.Dataplane{
 					Networking: &mesh_proto.Dataplane_Networking{
 						Inbound: inbounds,
-						TransparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
-							IpFamilyMode:         mesh_proto.Dataplane_Networking_TransparentProxying_DualStack,
-							RedirectPortOutbound: 15001,
-							RedirectPortInbound:  15006,
-						},
 					},
 				},
 			},
@@ -104,15 +101,10 @@ var _ = Describe("TransparentProxyGenerator", func() {
 						Version: "v1",
 					},
 					Spec: &mesh_proto.Dataplane{
-						Networking: &mesh_proto.Dataplane_Networking{
-							TransparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
-								IpFamilyMode:         mesh_proto.Dataplane_Networking_TransparentProxying_DualStack,
-								RedirectPortOutbound: 15001,
-								RedirectPortInbound:  15006,
-							},
-						},
+						Networking: &mesh_proto.Dataplane_Networking{},
 					},
 				},
+				Metadata:          &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
 				APIVersion:        envoy_common.APIV3,
 				InternalAddresses: DummyInternalAddresses,
 			},
@@ -126,15 +118,10 @@ var _ = Describe("TransparentProxyGenerator", func() {
 						Version: "v1",
 					},
 					Spec: &mesh_proto.Dataplane{
-						Networking: &mesh_proto.Dataplane_Networking{
-							TransparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
-								IpFamilyMode:         mesh_proto.Dataplane_Networking_TransparentProxying_DualStack,
-								RedirectPortOutbound: 15001,
-								RedirectPortInbound:  15006,
-							},
-						},
+						Networking: &mesh_proto.Dataplane_Networking{},
 					},
 				},
+				Metadata:   &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
 				APIVersion: envoy_common.APIV3,
 			},
 			expected: "03.envoy.golden.yaml",
@@ -147,15 +134,10 @@ var _ = Describe("TransparentProxyGenerator", func() {
 						Version: "v1",
 					},
 					Spec: &mesh_proto.Dataplane{
-						Networking: &mesh_proto.Dataplane_Networking{
-							TransparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
-								IpFamilyMode:         mesh_proto.Dataplane_Networking_TransparentProxying_IPv4,
-								RedirectPortOutbound: 15001,
-								RedirectPortInbound:  15006,
-							},
-						},
+						Networking: &mesh_proto.Dataplane_Networking{},
 					},
 				},
+				Metadata:   &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("ipv4")},
 				APIVersion: envoy_common.APIV3,
 			},
 			expected: "04.envoy.golden.yaml",
@@ -178,6 +160,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		}),
 		Entry("transparent_proxying=true,inbound_filter,workload identity,gateway", testCase{
 			proxy: &model.Proxy{
+				Metadata: &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
 				Id: *model.BuildProxyId("", "side-car"),
 				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
@@ -185,13 +168,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 						Labels:  map[string]string{mesh_proto.GatewayLabel: mesh_proto.GatewayEnabled},
 					},
 					Spec: &mesh_proto.Dataplane{
-						Networking: &mesh_proto.Dataplane_Networking{
-							TransparentProxying: &mesh_proto.Dataplane_Networking_TransparentProxying{
-								IpFamilyMode:         mesh_proto.Dataplane_Networking_TransparentProxying_DualStack,
-								RedirectPortOutbound: 15001,
-								RedirectPortInbound:  15006,
-							},
-						},
+						Networking: &mesh_proto.Dataplane_Networking{},
 					},
 				},
 				APIVersion:        envoy_common.APIV3,

--- a/pkg/xds/generator/transparent_proxy_generator_test.go
+++ b/pkg/xds/generator/transparent_proxy_generator_test.go
@@ -38,7 +38,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 
 		return &model.Proxy{
 			Metadata: &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
-			Id: *model.BuildProxyId("", "side-car"),
+			Id:       *model.BuildProxyId("", "side-car"),
 			Dataplane: &core_mesh.DataplaneResource{
 				Meta: &test_model.ResourceMeta{Version: "v1"},
 				Spec: &mesh_proto.Dataplane{
@@ -161,7 +161,7 @@ var _ = Describe("TransparentProxyGenerator", func() {
 		Entry("transparent_proxying=true,inbound_filter,workload identity,gateway", testCase{
 			proxy: &model.Proxy{
 				Metadata: &model.DataplaneMetadata{TransparentProxy: xds_builders.TransparentProxy("dualstack")},
-				Id: *model.BuildProxyId("", "side-car"),
+				Id:       *model.BuildProxyId("", "side-car"),
 				Dataplane: &core_mesh.DataplaneResource{
 					Meta: &test_model.ResourceMeta{
 						Version: "v1",

--- a/test/e2e/transparentproxy/transparentproxy_configmap_kubernetes.go
+++ b/test/e2e/transparentproxy/transparentproxy_configmap_kubernetes.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	config_core "github.com/kumahq/kuma/v3/pkg/config/core"
-	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds/types"
+	core_xds "github.com/kumahq/kuma/v3/pkg/core/xds"
 	"github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	. "github.com/kumahq/kuma/v3/test/framework"
@@ -85,7 +85,7 @@ func TransparentProxyConfigMap() {
 		Expect(cluster.DismissCluster()).To(Succeed())
 	})
 
-	It("should contain transparent proxy in configmap feature flag in the xds metadata", func() {
+	It("should carry the transparent proxy configuration in the xds metadata", func() {
 		stdout, err := cluster.
 			GetKumactlOptions().
 			RunKumactlAndGetOutput(
@@ -97,7 +97,7 @@ func TransparentProxyConfigMap() {
 			)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(stdout).To(ContainSubstring(core_xds.FeatureTransparentProxyInDataplaneMetadata))
+		Expect(stdout).To(ContainSubstring(fmt.Sprintf("%q", core_xds.FieldTransparentProxy)))
 	})
 
 	It("should not contain transparentProxying configuration in the Dataplane object", func() {

--- a/test/framework/constants.go
+++ b/test/framework/constants.go
@@ -26,7 +26,4 @@ const (
 	defaultToolKubeConfigPathPattern = "${HOME}/.kube/%s-%s.yaml"
 	legacyKubeConfigPathPattern      = "${HOME}/.kube/%s.yaml"
 	oldKindKubeConfigPathPattern     = "${HOME}/.kube/kind-%s-config"
-
-	redirectPortInbound  = "15006"
-	redirectPortOutbound = "15001"
 )

--- a/test/framework/dataplane_template.go
+++ b/test/framework/dataplane_template.go
@@ -44,8 +44,6 @@ type DataplaneTemplateData struct {
 
 // TransparentProxyConfig represents transparent proxy configuration
 type TransparentProxyConfig struct {
-	RedirectPortInbound  string
-	RedirectPortOutbound string
 	// ReachableBackends is the raw YAML body rendered under
 	// networking.transparentProxying.reachableBackends (e.g. a `refs:` list).
 	ReachableBackends string
@@ -94,14 +92,10 @@ networking:
 {{- if .Protocol }}
     protocol: {{ .Protocol }}
 {{- end }}
-{{- if .TransparentProxy }}
+{{- if and .TransparentProxy .TransparentProxy.ReachableBackends }}
   transparentProxying:
-    redirectPortInbound: {{ .TransparentProxy.RedirectPortInbound }}
-    redirectPortOutbound: {{ .TransparentProxy.RedirectPortOutbound }}
-{{- if .TransparentProxy.ReachableBackends }}
     reachableBackends:
 {{ .TransparentProxy.ReachableBackends }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if .AppendConfig }}

--- a/test/framework/setup.go
+++ b/test/framework/setup.go
@@ -483,9 +483,7 @@ func DemoClientUniversal(name string, mesh string, opt ...AppDeploymentOption) I
 			case transparent:
 				dpp.InboundPort = "3000"
 				dpp.TransparentProxy = &TransparentProxyConfig{
-					RedirectPortInbound:  redirectPortInbound,
-					RedirectPortOutbound: redirectPortOutbound,
-					ReachableBackends:    opts.reachableBackends,
+					ReachableBackends: opts.reachableBackends,
 				}
 			case opts.bindOutbounds:
 				dpp.InboundPort = "13000"
@@ -614,14 +612,7 @@ func TestServerUniversal(name string, mesh string, opt ...AppDeploymentOption) I
 			AppendConfig:       opts.appendDataplaneConfig,
 		}
 
-		// Add transparent proxy configuration
 		transparent := opts.transparent == nil || *opts.transparent // default true
-		if transparent {
-			dpp.TransparentProxy = &TransparentProxyConfig{
-				RedirectPortInbound:  redirectPortInbound,
-				RedirectPortOutbound: redirectPortOutbound,
-			}
-		}
 
 		// Build args
 		args := []string{"test-server"}

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -412,7 +412,14 @@ cp %s/envoy /usr/bin/envoy
 	}
 
 	if transparent {
-		args = append(args, "--transparent-proxy")
+		if dpVersion != "" && !Config.IPV6 {
+			// older kuma-dp binds its DNS proxy to ::1 in dual-stack mode, which fails with IPv6 disabled
+			tpCfgPath := fmt.Sprintf("/kuma/tproxy-%s.yaml", name)
+			_, _ = fmt.Fprintf(cmd, "echo 'ipFamilyMode: ipv4' > %s\n", tpCfgPath)
+			args = append(args, "--transparent-proxy-config="+tpCfgPath)
+		} else {
+			args = append(args, "--transparent-proxy")
+		}
 	}
 
 	if dpyaml != "" {

--- a/test/framework/universal_app.go
+++ b/test/framework/universal_app.go
@@ -411,6 +411,10 @@ cp %s/envoy /usr/bin/envoy
 		"--binary-path", "/usr/local/bin/envoy",
 	}
 
+	if transparent {
+		args = append(args, "--transparent-proxy")
+	}
+
 	if dpyaml != "" {
 		dpPath := fmt.Sprintf("/kuma-dp-%s.yaml", name)
 		_, _ = fmt.Fprintf(cmd, `cat > %s << 'EOF'


### PR DESCRIPTION
## Motivation

`Dataplane.networking.transparentProxying` still carries `redirectPortInbound`, `redirectPortOutbound`, and `ipFamilyMode`, and the control plane falls back to them whenever `kuma-dp` does not advertise `feature-transparent-proxy-in-dataplane-metadata`. #17821 removed the Kubernetes path that wrote those fields, so only Universal data planes that declare redirect ports on the `Dataplane` still depend on the fallback. `kuma-dp` 2.14 already sends the same settings in its metadata when it runs with `--transparent-proxy` or `--transparent-proxy-config`, and 3.0 supports only 2.14+ data planes, so the fields and the feature flag can go.

## Implementation information

- The `Dataplane` proto loses the three fields and the `IpFamilyMode` enum, with their numbers and names reserved, and the Go, OpenAPI, and docs output is regenerated
- The control plane reads transparent proxy settings only from data plane metadata and treats a data plane that sends none as not using transparent proxy
- `FeatureTransparentProxyInDataplaneMetadata` and its advertisement in `kuma-dp` are gone
- The Universal e2e framework starts `kuma-dp` with `--transparent-proxy` instead of rendering redirect ports into the `Dataplane`, and the `kumactl install transparent-proxy` help describes the same flow
- `kuma-dp` binds the embedded DNS proxy only to IPv4 addresses when IPv6 is disabled on the host. With `--transparent-proxy` in the default dual-stack mode it failed to bind `[::1]` and exited, which broke the IPv4 Universal e2e jobs. The compatibility test starts older `kuma-dp` versions, which lack this check, in IPv4 mode on those hosts
- Unit tests set transparent proxy on proxy metadata through a new `xds_builders.TransparentProxy` helper. The MeshTLS goldens now put the inbound passthrough listener on 15006, because the removed builder call had the inbound and outbound ports swapped
- `UPGRADE.md` tells Universal users to switch `kuma-dp` to `--transparent-proxy` before upgrading, since the control plane ignores the removed fields on input
- `make check` is clean and `make test` passes for the affected packages. The e2e changes compile but were not run locally

## Supporting documentation

Closes #18597

Part of #18593
