### PR TITLE
fix(k8s): drop reserved pod labels before computing Dataplane labels

### DIFF
--- a/pkg/plugins/runtime/k8s/controllers/pod_converter.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter.go
@@ -245,6 +245,13 @@ func mergeLabels(existingLabels map[string]string, labelSets ...map[string]strin
 	for _, labels := range labelSets {
 		maps.Copy(mergedLabels, labels)
 	}
+	// Reserved keys are owned by the control plane: drop whatever the Pod or a
+	// stale Dataplane carried so Compute rebuilds them from scratch.
+	for k := range mergedLabels {
+		if mesh_proto.IsReservedLabelKey(k) {
+			delete(mergedLabels, k)
+		}
+	}
 	return mergedLabels
 }
 

--- a/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
+++ b/pkg/plugins/runtime/k8s/controllers/pod_converter_test.go
@@ -277,6 +277,12 @@ var _ = Describe("PodToDataplane(..)", func() {
 			existingDataplane: "update-dataplane.existing-dataplane.yaml",
 			dataplane:         "update-dataplane.dataplane.yaml",
 		}),
+		Entry("Reserved pod labels and stale Dataplane labels are dropped", testCase{
+			pod:               "reserved-pod-labels.pod.yaml",
+			servicesForPod:    "reserved-pod-labels.services-for-pod.yaml",
+			existingDataplane: "reserved-pod-labels.existing-dataplane.yaml",
+			dataplane:         "reserved-pod-labels.dataplane.yaml",
+		}),
 		Entry("Multiple services selecting a single port deduplicates overlapping inbounds", testCase{
 			pod:            "duplicated-inbounds.pod.yaml",
 			servicesForPod: "duplicated-inbounds.services-for-pod.yaml",

--- a/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/01.dataplane.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     version: "0.1"
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/23.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/23.dataplane.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     version: "0.1"
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/31.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/31.dataplane.yaml
@@ -6,7 +6,6 @@ metadata:
     k8s.kuma.io/service-account: redis-sa
     kuma.io/display-name: redis-example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     kuma.io/workload: redis
     version: "6.0"
   name: redis-example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/32.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/32.dataplane.yaml
@@ -6,7 +6,6 @@ metadata:
     k8s.kuma.io/service-account: mysql-service-account
     kuma.io/display-name: mysql-example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     kuma.io/workload: mysql-service-account
     version: "5.7"
   name: mysql-example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/33.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/33.dataplane.yaml
@@ -6,7 +6,6 @@ metadata:
     k8s.kuma.io/service-account: postgres-account
     kuma.io/display-name: postgres-example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     kuma.io/workload: postgres-account
     tier: database
   name: postgres-example

--- a/pkg/plugins/runtime/k8s/controllers/testdata/47.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/47.dataplane.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     rollouts-pod-template-hash: green
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/48.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/48.dataplane.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     rollouts-pod-template-hash: green
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/duplicated-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/duplicated-inbounds.dataplane.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     version: "0.1"
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/overlapping-inbounds.dataplane.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/sidecar-injection: enabled
     rollouts-pod-template-hash: active-hash
   name: example
 spec:

--- a/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.dataplane.yaml
@@ -1,3 +1,5 @@
+apiVersion: kuma.io/v1alpha1
+kind: Dataplane
 mesh: default
 metadata:
   labels:
@@ -5,8 +7,8 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    version: "0.1"
   name: example
+  namespace: demo
 spec:
   networking:
     address: 192.168.0.1
@@ -14,4 +16,4 @@ spec:
     - health:
         ready: true
       port: 8080
-      protocol: http
+      protocol: tcp

--- a/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.existing-dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.existing-dataplane.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuma.io/v1alpha1
+kind: Dataplane
+mesh: default
+metadata:
+  name: example
+  namespace: demo
+  labels:
+    app: example
+    kuma.io/kds-sync: disabled
+spec:
+  networking:
+    address: 192.168.0.1
+    inbound:
+      - port: 8080

--- a/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.pod.yaml
@@ -1,0 +1,14 @@
+metadata:
+  namespace: demo
+  name: example
+  labels:
+    app: example
+    kuma.io/zone: zone-uni
+    kuma.io/env: universal
+    kuma.io/kds-sync: disabled
+spec:
+  containers:
+    - ports:
+        - containerPort: 8080
+status:
+  podIP: 192.168.0.1

--- a/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.services-for-pod.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/reserved-pod-labels.services-for-pod.yaml
@@ -1,0 +1,8 @@
+metadata:
+  namespace: demo
+  name: example
+spec:
+  clusterIP: 192.168.0.1
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.dataplane.yaml
+++ b/pkg/plugins/runtime/k8s/controllers/testdata/update-dataplane.dataplane.yaml
@@ -7,7 +7,6 @@ metadata:
     k8s.kuma.io/namespace: demo
     kuma.io/display-name: example
     kuma.io/mesh: default
-    kuma.io/zone: default
     version: "0.1"
   name: example
   namespace: playground


### PR DESCRIPTION
## Motivation

Reapplies #18411, which was reverted in #18566. The revert wasn't due to a bug in the change: re-stamping `kuma.io/zone` on Dataplanes exposed a pre-existing issue in the federation e2e test, where the zone CP started as `default` and got renamed on federation, leaving pre-federation MeshTrafficPermissions with a stale zone label. #18620 fixed that by pinning the zone name before federating.

## Implementation information

Revert of `3e48420eed`, plus regenerating goldens `47`/`48` which #18571 had adjusted after the revert.

## Supporting documentation

Fix #18418
