### PR TITLE
ci(runners): skip the slug check off maintained branches

### DIFF
--- a/.github/workflows/validate-workflows-and-scripts.yaml
+++ b/.github/workflows/validate-workflows-and-scripts.yaml
@@ -83,7 +83,13 @@ jobs:
           set -e
           # The slug is written by hand at every branch cut, and a missed rename silently
           # falls back to the global variable.
-          expected=$(printf '%s' "${BASE_REF:-$REF_NAME}" | tr '[:lower:]' '[:upper:]' | tr '.-' '__')
+          ref="${BASE_REF:-$REF_NAME}"
+          # A manual run sits on whatever branch the UI offered, which has no variables.
+          case "${ref}" in
+            master|release-*) ;;
+            *) echo "${ref} is not a maintained branch, nothing to check"; exit 0 ;;
+          esac
+          expected=$(printf '%s' "${ref}" | tr '[:lower:]' '[:upper:]' | tr '.-' '__')
           found=$(grep -rhoE 'vars\.RUNNERS_[A-Z0-9_]+_(AMD64|ARM64)' \
             --include='*.yaml' --include='*.yml' .github/workflows \
             | sed -E 's/^vars\.RUNNERS_(.+)_(AMD64|ARM64)$/\1/' | sort -u)


### PR DESCRIPTION
## Motivation

The slug check added in #18642 derives the expected variable name from `github.base_ref` on a pull request and `github.ref_name` otherwise. A manual run sits on whatever branch the workflow-dispatch UI offered, so on a topic branch like `feature/runner-sizing` it expects `RUNNERS_FEATURE/RUNNER_SIZING_<ARCH>`, which is not a legal variable name and matches nothing. The check then fails on the `MASTER` references that are correct for that branch.

## Implementation information

- The check exits early unless the resolved ref is `master` or `release-*`, which are the only branches that carry runner variables. Pull requests are unaffected, since `github.base_ref` already names the branch being merged into.
- `actionlint` is clean on the changed workflow.

## Supporting documentation

Follows #18642, which introduced the check

> Changelog: skip
