### PR TITLE
ci(runners): select runners by size from JSON vars

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,90 @@
+# Choosing runners
+
+Almost every job picks its runner through repository variables, so a fork or a downstream repository can move CI onto its own runners without editing any workflow. Three of them apply to one architecture: a pull-request tier, a per-branch one and a global one, each set independently. Nothing here is required: with all three unset, every job keeps the runner it had, which is a GitHub-hosted label for most of them and the shared `ubuntu-latest-kong` pool for the e2e legs.
+
+## The variables
+
+| name | scope | wins over |
+| --- | --- | --- |
+| `RUNNERS_PR_<ARCH>` | `pull_request` runs only | everything below |
+| `RUNNERS_<BRANCH_SLUG>_<ARCH>` | one branch, one architecture | the global variable |
+| `RUNNERS_<ARCH>` | one architecture, every branch | the built-in default |
+
+`RUNNERS_PR_<ARCH>` exists so pull requests can run somewhere other than pushes to the same branch, on a smaller or cheaper pool, without giving up the per-branch override for pushes. Leave it unset and pull requests follow the branch.
+
+`<ARCH>` is `AMD64` or `ARM64`. `<BRANCH_SLUG>` is the branch name uppercased with `-` and `.` replaced by `_`, so `master` is `MASTER` and `release-2.14` is `RELEASE_2_14`.
+
+The value is a JSON object mapping a size to the labels a runner must carry:
+
+```json
+{
+  "sm": ["self-hosted", "linux", "x64", "size-sm"],
+  "md": ["self-hosted", "linux", "x64", "size-md"],
+  "lg": ["self-hosted", "linux", "x64", "size-lg"]
+}
+```
+
+A job runs only on a runner that has **all** the labels listed for its size. A repository without a pool for one of the sizes points that key at a pool it does have; nothing requires three distinct pools.
+
+## Sizes
+
+Jobs declare the size they need, not a pool. The rule:
+
+- **sm** for a job with no checkout, or a checkout plus only `gh`, `jq`, `git` or `curl`. Gates, dispatchers, matrix generators, comment posters, and the pollers that spend hours waiting on another workflow.
+- **md** for a job that needs the mise toolchain and does network, artifact or git work, but compiles no Go, builds no container image and starts no cluster. Publishing, SBOM generation, backports, doc generation.
+- **lg** for a job that compiles Go, runs `go test -race` or golangci-lint, builds images with buildx, starts a k3d or kind cluster, or builds a CodeQL database.
+
+When a job's steps change, revisit its size. Overshooting wastes a large slot. Undershooting gets the job OOM-killed on a small one.
+
+## The expression
+
+```yaml
+runs-on: >-
+  ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+  || vars.RUNNERS_RELEASE_2_7_AMD64
+  || vars.RUNNERS_AMD64
+  || '{}').lg
+  || 'ubuntu-24.04' }}
+```
+
+`>-` folds the newlines into single spaces, so the expression GitHub evaluates is the same one-line string. Every continuation line has to sit at the same indentation, or YAML keeps the newline instead of folding it.
+
+Reading it: on a pull request take the PR variable, otherwise the per-branch one, otherwise the global one, otherwise an empty object. Then look up the size. If any step yields nothing, fall back to the GitHub-hosted label. Only one possibly-missing property is ever dereferenced, because `'{}'` guarantees the object exists.
+
+Workflows that a `pull_request` event can reach, directly or as a reusable workflow called from one, add a fork guard in front, so code from a fork never runs on a self-hosted runner:
+
+```yaml
+runs-on: >-
+  ${{ (github.event_name == 'pull_request'
+  && github.event.pull_request.head.repo.full_name != github.repository)
+  && 'ubuntu-24.04'
+  || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+  || vars.RUNNERS_RELEASE_2_7_AMD64
+  || vars.RUNNERS_AMD64
+  || '{}').lg
+  || 'ubuntu-24.04' }}
+```
+
+The `env` context is not available in `runs-on`, which is why the default label is written inline at every site rather than defined once.
+
+### The e2e jobs
+
+`_test.yaml` runs the same job across architectures, so it cannot read `vars` per leg. `build-test-distribute.yaml` resolves the tiers for both architectures into one `RUNNERS_BY_ARCH` map, and each leg indexes the result by `matrix.arch` and then by size. That path additionally sends `master` to GitHub-hosted runners; the per-job sites above do not.
+
+## Adding an architecture
+
+Set `RUNNERS_ARM64` (or the `PR` or per-branch form) to the same size-to-labels object, with labels that name an arm64 pool. Nothing else changes: `build-test-distribute.yaml` resolves both architectures into one `RUNNERS_BY_ARCH` map, hands it to every reusable workflow it calls, and the jobs with an architecture matrix index it by `matrix.arch`. An architecture nobody has set resolves to an empty object, so those jobs keep falling back to the runner they use now.
+
+Today that means the arm64 e2e legs in `_test.yaml` and the `linux/arm64` leg of `build-binaries`, which cross-compiles on an amd64 host while `RUNNERS_ARM64` is unset and builds natively once it is. Binaries are unaffected either way, since `CGO_ENABLED=0` makes the two byte-identical. A `darwin` leg cross-compiles wherever it lands, so it always asks for amd64.
+
+`build-images` still builds every architecture on one host through qemu, so an arm64 pool does not speed it up without splitting that job per architecture first.
+
+## Exceptions
+
+- `scorecard.yml` must keep a literal label, because `scorecard-action` rejects an expression-based `runs-on` during workflow verification.
+- `pr-comments.yaml` must stay GitHub-hosted. It checks out the head of the PR a maintainer commented on, which is a fork on most pull requests, and runs `make` against it. `runs-on` cannot read the step that resolves `isCrossRepository`, so the runner is chosen before the workflow knows whose code it is about to run.
+- `_provenance.yaml` and `lifecycle.yml` have no `runs-on`. They call reusable workflows that choose their own runner.
+
+## Cutting a release branch
+
+Variable names cannot contain `-` or `.`, and an inline expression cannot sanitize `github.ref_name`, so the branch slug is written into the workflows by hand. After cutting `release-X.Y`, replace `RUNNERS_RELEASE_2_7_` with `RUNNERS_RELEASE_X_Y_` across `.github/workflows/` on the new branch, comments included, and set the matching variables. A missed rename would silently fall back to the global variable, and this branch carries no workflow that checks for it. `PR` is exempt, since it names a tier rather than a branch.

--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
     inputs:
+      RUNNERS_BY_ARCH:
+        required: true
+        type: string
       FULL_MATRIX:
         required: true
         type: string
@@ -33,7 +36,7 @@ on:
 permissions:
   contents: read
 env:
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   FULL_MATRIX: ${{ inputs.FULL_MATRIX }}
   ALLOW_PUSH: ${{ inputs.ALLOW_PUSH }}
   GH_OWNER: ${{ github.repository_owner }}
@@ -52,7 +55,14 @@ jobs:
   # repository cache budget is shared with every branch.
   build-binaries:
     timeout-minutes: 40
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    # A darwin leg cross-compiles wherever it lands, so it stays on amd64. An arch with no
+    # pool set falls back, which is every arm64 leg today.
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.os == 'linux' && matrix.arch || 'amd64'].lg
+      || 'ubuntu-24.04' }}
     permissions:
       contents: read
     strategy:
@@ -146,7 +156,15 @@ jobs:
   publish-binaries:
     needs: [build-binaries]
     timeout-minutes: 30
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -222,8 +240,15 @@ jobs:
           make publish/pulp
   build-images:
     needs: [build-binaries] # consumes the linux_binaries artifact
-    # pining to this version since we use older base image for kuma-init and we don't want to change it since it can break users environment
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-22.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     permissions:
       id-token: write # Required for image signing
       contents: write # needed to upload SBOM assets to GitHub releases
@@ -387,7 +412,15 @@ jobs:
           registry_password: ${{ secrets.DOCKER_API_KEY }}
   digest-images:
     needs: [build-images]
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     if: ${{ fromJSON(inputs.ALLOW_PUSH) }}
     outputs:
       DIGESTS: ${{ steps.compute-digests.outputs.digests }}
@@ -406,7 +439,15 @@ jobs:
   publish-helm:
     needs: [build-images]
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -11,6 +11,9 @@ permissions:
   contents: read
 env:
   CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
+  # The universal test images carry only the C locale. Anything else here
+  # reaches their bash over ssh and it warns onto the stdout tests parse.
+  LC_ALL: C.UTF-8
   E2E_PARAM_K8S_VERSION: ${{ fromJSON(inputs.matrix).k8sVersion }}
   E2E_PARAM_CNI_NETWORK_PLUGIN: ${{ fromJSON(inputs.matrix).cniNetworkPlugin }}
   E2E_PARAM_ARCH: ${{ fromJSON(inputs.matrix).arch }}

--- a/.github/workflows/_e2e.yaml
+++ b/.github/workflows/_e2e.yaml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
 env:
-  CI_TOOLS_DIR: /home/runner/work/kuma/kuma/.ci_tools
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   E2E_PARAM_K8S_VERSION: ${{ fromJSON(inputs.matrix).k8sVersion }}
   E2E_PARAM_CNI_NETWORK_PLUGIN: ${{ fromJSON(inputs.matrix).cniNetworkPlugin }}
   E2E_PARAM_ARCH: ${{ fromJSON(inputs.matrix).arch }}
@@ -20,7 +20,7 @@ env:
 jobs:
   e2e:
     timeout-minutes: 60
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner) }}
     if: ${{ inputs.runner != '' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -58,6 +58,24 @@ jobs:
           restore-keys: |
             go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-test-race-${{ runner.os }}-
+      # /proc/meminfo reports the host, not the cgroup a containerised runner gets,
+      # so without this the GC never pushes back and `go test -race` swaps instead.
+      - name: Set GOMEMLIMIT dynamically based on available memory
+        run: |
+          set -e
+          available=$(($(grep MemTotal /proc/meminfo | awk '{print $2}') * 1024))
+          for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+            [ -r "$f" ] || continue
+            limit=$(cat "$f")
+            case "$limit" in ''|*[!0-9]*) continue ;; esac
+            if [ "$limit" -lt "$available" ]; then
+              available=$limit
+            fi
+            break
+          done
+          gomemlimit=$((available * 8 / 10))
+          echo "GOMEMLIMIT=${gomemlimit}" >> "$GITHUB_ENV"
+          echo "Setting GOMEMLIMIT to $(numfmt --to=iec "$gomemlimit")"
       - run: |
           make test
       - name: Save Go build cache

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -13,7 +13,7 @@ on:
 permissions:
   contents: read
 env:
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   # This is automatically managed by CI
   K8S_MIN_VERSION: v1.25.16-k3s4
   K8S_MAX_VERSION: v1.31.1-k3s1
@@ -21,7 +21,15 @@ jobs:
   test_unit:
     timeout-minutes: 30
     if: ${{ !(contains(github.event.pull_request.labels.*.name, 'ci/skip-test') || inputs.IS_RELEASE_TAG) }}
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
@@ -60,7 +68,15 @@ jobs:
           key: go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
   gen_e2e_matrix:
     timeout-minutes: 2
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -129,7 +145,9 @@ jobs:
     uses: ./.github/workflows/_e2e.yaml
     with:
       matrix: ${{ toJSON(matrix) }}
-      runner: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
+      runner: >-
+        ${{ toJSON(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg
+        || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong')) }}
     secrets: inherit
   test_e2e_env:
     needs: ["gen_e2e_matrix"]
@@ -141,5 +159,7 @@ jobs:
     uses: ./.github/workflows/_e2e.yaml
     with:
       matrix: ${{ toJSON(matrix) }}
-      runner: ${{ fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch] }}
+      runner: >-
+        ${{ toJSON(fromJSON(inputs.RUNNERS_BY_ARCH)[matrix.arch].lg
+        || (matrix.arch == 'arm64' && 'ubuntu-latest-arm64-kong' || 'ubuntu-latest-kong')) }}
     secrets: inherit

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -13,7 +13,15 @@ permissions:
 jobs:
   approve-and-auto-merge:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     if: contains(github.event.pull_request.labels.*.name, 'ci/auto-merge')
     permissions:
       pull-requests: write

--- a/.github/workflows/blackbox-tests.yaml
+++ b/.github/workflows/blackbox-tests.yaml
@@ -8,7 +8,12 @@ permissions:
 jobs:
   blackbox-tests:
     timeout-minutes: 30
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-20.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: "Set up Go"

--- a/.github/workflows/bom.yaml
+++ b/.github/workflows/bom.yaml
@@ -7,7 +7,12 @@ permissions: read-all
 jobs:
   sbom:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -13,11 +13,20 @@ permissions:
   contents: read
 env:
   KUMA_DIR: "."
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  # Parent of the checkout, to keep CI tools out of the SBOM.
+  CI_TOOLS_DIR: ${{ github.workspace }}/../.ci_tools
 jobs:
   release_sha_gate:
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: read
@@ -107,7 +116,15 @@ jobs:
       contents: write # needed to upload SBOM assets to GitHub releases
       checks: write # needed for golangci/golangci-lint-action to add code annotations in PRs
     timeout-minutes: 25
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     env:
       FULL_MATRIX: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci/run-full-matrix') }}
       ALLOW_PUSH: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci/force-publish') }}
@@ -115,6 +132,29 @@ jobs:
       FORCE_PUBLISH_FROM_FORK: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci/force-publish') && github.event.pull_request.head.repo.full_name != github.repository }}
     outputs:
       FULL_MATRIX: ${{ env.FULL_MATRIX }}
+      # Per-arch lookup, each side independent. See .github/workflows/README.md.
+      #   1. fork PR                           -> free GitHub-hosted runners (security)
+      #   2. master (push, or PR targeting it) -> free GitHub-hosted runners
+      #   3. vars.RUNNERS_PR_<ARCH>            -> pull_request runs, per-arch
+      #   4. vars.RUNNERS_RELEASE_2_7_<ARCH>   -> per-branch + per-arch override
+      #   5. vars.RUNNERS_<ARCH>               -> global per-arch override
+      #   6. default                           -> the standard self-hosted Kong pool
+      # Each variable is a JSON object of size to label array, spliced in raw, so a caller
+      # gets {"<arch>":{"<size>":[labels]}}. An unset arch resolves to {} and the consumer
+      # falls back, so adding an arch is setting a variable.
+      # `github.base_ref` is empty outside pull_request, where `github.ref_name` is
+      # '<number>/merge'. The slug is hardcoded: var names take no '-' or '.', and an
+      # inline expression cannot sanitize `github.ref_name`.
+      RUNNERS_BY_ARCH: >-
+        ${{ ((github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository)
+        || (github.base_ref || github.ref_name) == 'master')
+        && '{"amd64":{"lg":["ubuntu-24.04"]},"arm64":{"lg":["ubuntu-24.04-arm"]}}'
+        || format('{{"amd64":{0},"arm64":{1}}}',
+        (github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+        || vars.RUNNERS_RELEASE_2_7_AMD64 || vars.RUNNERS_AMD64 || '{}',
+        (github.event_name == 'pull_request' && vars.RUNNERS_PR_ARM64)
+        || vars.RUNNERS_RELEASE_2_7_ARM64 || vars.RUNNERS_ARM64 || '{}') }}
       ALLOW_PUSH: ${{ env.ALLOW_PUSH }}
       BUILD: ${{ env.BUILD }}
       IMAGES: ${{ steps.metadata.outputs.images }}
@@ -183,14 +223,7 @@ jobs:
     with:
       FULL_MATRIX: ${{ needs.check.outputs.FULL_MATRIX }}
       IS_RELEASE_TAG: ${{ github.ref_type == 'tag' }}
-      # Per-arch lookup (each side independent):
-      #   1. fork PR                         -> free GitHub-hosted runners (security)
-      #   2. vars.RUNS_ON_RELEASE_2_7_<ARCH> -> per-branch + per-arch override
-      #   3. vars.RUNS_ON_<ARCH>             -> global per-arch override
-      #   4. default                         -> the standard self-hosted Kong pool
-      # Branch slug is hardcoded because GitHub var names can't contain '-' or '.',
-      # and inline expressions can't sanitize `github.ref_name`.
-      RUNNERS_BY_ARCH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04-arm"}' || format('{{"amd64":"{0}","arm64":"{1}"}}', vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-latest-kong', vars.RUNS_ON_RELEASE_2_7_ARM64 || vars.RUNS_ON_ARM64 || 'ubuntu-latest-arm64-kong') }}
+      RUNNERS_BY_ARCH: ${{ needs.check.outputs.RUNNERS_BY_ARCH }}
     secrets: inherit
   build_publish:
     permissions:
@@ -208,6 +241,7 @@ jobs:
       REGISTRY: ${{ needs.check.outputs.REGISTRY }}
       NOTARY_REPOSITORY: ${{ needs.check.outputs.NOTARY_REPOSITORY }}
       VERSION_NAME: ${{ needs.check.outputs.VERSION_NAME }}
+      RUNNERS_BY_ARCH: ${{ needs.check.outputs.RUNNERS_BY_ARCH }}
     secrets: inherit
   provenance:
     needs: ["check", "build_publish"]
@@ -231,7 +265,15 @@ jobs:
       id-token: write
     timeout-minutes: 10
     if: ${{ always() }}
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name != github.repository)
+      && 'ubuntu-24.04'
+      || fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     env:
       SECURITY_ASSETS_DOWNLOAD_PATH: "${{ github.workspace }}/security-assets"
       SECURITY_ASSETS_PACKAGE_NAME: "security-assets" # Cloudsmith package for hosting security assets

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -177,14 +177,23 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           fetch-depth: 0
-      - name: Cache Go build
+      # Module contents are a pure function of go.sum, so one immutable entry
+      # is shared with every other job and branch.
+      - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          path: ~/go/pkg/mod
+          key: go-mod-dist-${{ hashFiles('**/go.sum') }}
+      # Pull requests restore by prefix from the newest push-event entry instead
+      # of writing their own short-lived merge-ref entries. A save took 13 minutes
+      # when seven runners shared one host's disk.
+      - name: Restore Go build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-build-${{ runner.os }}-
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
@@ -205,6 +214,12 @@ jobs:
       - if: ${{ github.ref_type != 'tag' }}
         run: |
           make check
+      - name: Save Go build cache
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
       - id: sca-project
         uses: Kong/public-shared-actions/security-actions/sca@0aaaa49782e9028086feb943ec04e03e35e3f813 # v2.7.2
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,12 @@ permissions:
 jobs:
   commit-lint:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Check PR title

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,7 +9,12 @@ jobs:
   analyze:
     timeout-minutes: 30
     name: Analyze
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     permissions:
       actions: read
       security-events: write

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -23,7 +23,12 @@ env:
 jobs:
   package:
     name: Package
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     outputs:
       filename: ${{ steps.package.outputs.filename }}
     steps:

--- a/.github/workflows/pr-comments.yaml
+++ b/.github/workflows/pr-comments.yaml
@@ -12,7 +12,9 @@ jobs:
   pr_comments:
     timeout-minutes: 120
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/golden_files') || contains(github.event.comment.body, '/golden_files_e2e') || contains(github.event.comment.body, '/tproxy_golden_files'))
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    # Checks out the PR head, a fork on most PRs, and runs make against it. runs-on cannot
+    # read the step that resolves isCrossRepository, so this stays GitHub-hosted.
+    runs-on: ubuntu-24.04
     steps:
       # Commands are additive: one comment can request multiple actions, and all
       # matching steps below will run in order.

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -12,7 +12,12 @@ jobs:
   notify-about-merged-pr:
     timeout-minutes: 10
     name: "Notify about merged PR"
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     steps:
       - name: "Send repository dispatch event"
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,12 @@ permissions:
 jobs:
   release:
     timeout-minutes: 30
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,7 +14,10 @@ jobs:
   analysis:
     timeout-minutes: 10
     name: Scorecard analysis
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    # Must be a literal Ubuntu label; the scorecard-action publish step
+    # rejects expression-based runs-on values during workflow verification.
+    # See https://github.com/ossf/scorecard-action#workflow-restrictions
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/transparentproxy-tests.yaml
+++ b/.github/workflows/transparentproxy-tests.yaml
@@ -4,14 +4,19 @@ on:
   schedule:
     - cron: 0 2 * * *
 env:
-  CI_TOOLS_DIR: "/home/runner/work/kuma/kuma/.ci_tools"
+  CI_TOOLS_DIR: ${{ github.workspace }}/.ci_tools
   IPV6: "true"
 permissions:
   contents: read
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/trigger-release-tasks.yaml
+++ b/.github/workflows/trigger-release-tasks.yaml
@@ -52,7 +52,12 @@ jobs:
         !startsWith(github.event.workflow_run.head_branch, 'release-')
       )
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       contents: read # to confirm the ref is really a tag, via the git refs API
     outputs:
@@ -122,7 +127,12 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_smoke)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: "Trigger downstream smoke test"
@@ -165,7 +175,12 @@ jobs:
       needs.guard.outputs.should_dispatch == 'true' &&
       (github.event_name != 'workflow_dispatch' || inputs.run_verify)
     timeout-minutes: 5
-    runs-on: ${{ vars.RUNS_ON_MASTER_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     permissions:
       # same-repo dispatch needs no cross-org token, unlike smoke; the default
       # GITHUB_TOKEN only gains workflow_dispatch rights with actions:write.

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -20,7 +20,12 @@ permissions:
 jobs:
   generate-docs:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').md
+      || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/.github/workflows/update-insecure-dependencies.yaml
+++ b/.github/workflows/update-insecure-dependencies.yaml
@@ -8,7 +8,12 @@ permissions:
 jobs:
   build-matrix:
     timeout-minutes: 10
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').sm
+      || 'ubuntu-24.04' }}
     outputs:
       branches: ${{ steps.generate-matrix.outputs.branches }}
     steps:
@@ -29,7 +34,12 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.build-matrix.outputs.branches) }}
-    runs-on: ${{ vars.RUNS_ON_RELEASE_2_7_AMD64 || vars.RUNS_ON_AMD64 || 'ubuntu-24.04' }}
+    runs-on: >-
+      ${{ fromJSON((github.event_name == 'pull_request' && vars.RUNNERS_PR_AMD64)
+      || vars.RUNNERS_RELEASE_2_7_AMD64
+      || vars.RUNNERS_AMD64
+      || '{}').lg
+      || 'ubuntu-24.04' }}
     steps:
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -31,9 +31,12 @@ golangci-lint-fmt:
 		--enable gofumpt
 
 .PHONY: fmt/ci
+# `yq -i` reserializes the document and drops the folded runs-on scalars, so `check` fails
+# on its own diff. No `sed -i`: GNU and BSD disagree on its argument.
 fmt/ci:
-	$(YQ) -i '.env.K8S_MIN_VERSION = "$(K8S_MIN_VERSION)" | .env.K8S_MAX_VERSION = "$(K8S_MAX_VERSION)"' .github/workflows/"$(ACTION_PREFIX)"_test.yaml
-	grep -r "golangci/golangci-lint-action" .github/workflows --include \*ml | cut -d ':' -f 1 | xargs -n 1 $(YQ) -i '(.jobs.* | select(. | has("steps")) | .steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version) |= "$(GOLANGCI_LINT_VERSION)"'
+	@f=.github/workflows/"$(ACTION_PREFIX)"_test.yaml; t=$$(mktemp); \
+	sed -E -e 's|^(  K8S_MIN_VERSION: ).*|\1$(K8S_MIN_VERSION)|' \
+	       -e 's|^(  K8S_MAX_VERSION: ).*|\1$(K8S_MAX_VERSION)|' "$$f" > "$$t" && mv "$$t" "$$f"
 
 .PHONY: helm-lint
 helm-lint:

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -177,6 +177,9 @@ endif
 .PHONY: k3d/configure/metallb
 k3d/configure/metallb:
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f $(METALLB_MANIFESTS)
+	@# wait --all pods exits at once with "no matching resources found" when the
+	@# apply above has not produced pods yet, so block on the deployments first.
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) rollout status --timeout=120s -n $(METALLB_NAMESPACE) deployment
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait --timeout=120s --for=condition=Ready -n $(METALLB_NAMESPACE) --all pods
 	@# Construct a valid address space from the docker network and the template IPAddressPool
 	@IFS=. read -ra NETWORK_ADDR_SPACE <<< "$$(docker network inspect kind --format '{{ (index .IPAM.Config 0).Subnet }}')"; \

--- a/test/framework/ssh/ssh.go
+++ b/test/framework/ssh/ssh.go
@@ -41,6 +41,9 @@ func NewApp(appName string, logsPath string, verbose bool, port string, envMap m
 		"-q", "-tt",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
+		// -tt merges the remote stderr into stdout, so a locale the container
+		// does not have makes bash warn there and callers parse the warning.
+		"-o", "SetEnv=LC_ALL=C.UTF-8",
 		"root@localhost", "-p", port,
 	}
 	for k, v := range envMap {


### PR DESCRIPTION
## Motivation

Runner selection on this branch resolves to a single label, so a job can name only one of a pool's labels and every job takes the same slot whatever it does. #18642 replaced that on master with a size-aware scheme; this branch needs the same before it can run on the pools the variables point at.

## Implementation information

- Jobs read `RUNNERS_PR_<ARCH>`, `vars.RUNNERS_RELEASE_2_7_<ARCH>` or `RUNNERS_<ARCH>`, a JSON object of size to label array, and ask for `sm`, `md` or `lg` by what their steps do. The sizes come from the same job-by-job reading as master, so a job that exists on both branches asks for the same size.
- The per-arch map moves out of the `test` caller into an output of the job that already publishes `FULL_MATRIX`, and every reusable workflow it calls reads it from there. An architecture nobody has set resolves to an empty object, so those legs keep the runner they use now.
- `CI_TOOLS_DIR` comes from `github.workspace`, and `GOMEMLIMIT` from the cgroup cap when one is set rather than `/proc/meminfo`, which reports the host inside a container.
- The fork-PR carve-out covers every site a `pull_request` reaches, so code from a fork cannot run on a self-hosted runner.
- `_e2e.yaml` takes its runner as a string, so `_test.yaml` passes the label array as JSON and `_e2e.yaml` parses it back. Its `CI_TOOLS_DIR` moves to `github.workspace` for the same reason as the rest.
- Ported by hand rather than cherry-picked, since the workflows here differ from master beyond the runner lines. `actionlint` reports nothing this change did not already report on the branch, and none of the variables is set in this repository, so every site resolves to the label it used before.

This branch has no workflow-validation workflow, so the slug check that master gained is not part of this backport, and the README says so.

- A second commit carries kumahq/kuma#18659 back to this branch: the `check` job restores the Go build cache by prefix and saves it only on a push, instead of writing a multi-gigabyte entry per pull request that only that merge ref can read, and `test_unit` reads its memory limit from the cgroup rather than `/proc/meminfo`.

- A third commit pins `LC_ALL=C` for the ssh the universal tests run, and sets the same value in the `_e2e.yaml` env. The universal image carries only the C locale, so any other value reaches its bash through ssh env forwarding, and `-tt` puts the resulting warning on the stdout `ExtractSecretDataFromResponse` parses. Every control plane token fetch then fails with `invalid character 'b' looking for beginning of value`. Branches from 2.11 on use `golang.org/x/crypto/ssh` with a separate stderr and no pty, so they never had this.

## Supporting documentation

`.github/workflows/README.md` documents the variable names, the JSON shape, the size rule and the branch-slug rename. Backport of #18642.

> Changelog: skip

