### PR TITLE
chore(generate): refresh the zone CRDs for controller-gen 0.22

### DIFF
--- a/pkg/core/resources/apis/zone/k8s/crd/kuma.io_zones.yaml
+++ b/pkg/core/resources/apis/zone/k8s/crd/kuma.io_zones.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: zones.kuma.io
 spec:
   group: kuma.io

--- a/pkg/core/resources/apis/zone/k8s/schema/kuma.io_zones.yaml
+++ b/pkg/core/resources/apis/zone/k8s/schema/kuma.io_zones.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: zones.kuma.io
 spec:
   group: kuma.io

--- a/pkg/core/resources/apis/zoneinsight/k8s/crd/kuma.io_zoneinsights.yaml
+++ b/pkg/core/resources/apis/zoneinsight/k8s/crd/kuma.io_zoneinsights.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: zoneinsights.kuma.io
 spec:
   group: kuma.io

--- a/pkg/core/resources/apis/zoneinsight/k8s/schema/kuma.io_zoneinsights.yaml
+++ b/pkg/core/resources/apis/zoneinsight/k8s/schema/kuma.io_zoneinsights.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.22.0
   name: zoneinsights.kuma.io
 spec:
   group: kuma.io


### PR DESCRIPTION
## Motivation

`make check` fails on master. #18471 bumped `controller-gen` from 0.21.0 to 0.22.0 and regenerated 96 files, but the zone and zoneinsight CRDs and schemas were left stamped `controller-gen.kubebuilder.io/version: v0.21.0`. `check` regenerates and diffs, so every branch cut from master since that bump fails on four files nobody touched.

## Implementation information

- `POLICIES_DIR=pkg/core/resources/apis make generate/policy/zone generate/policy/zoneinsight` with `controller-gen` 0.22.0.
- The whole diff is the version annotation, four lines across four files. No schema field changed.
- `pkg/core/resources/apis/zoneinsight/upgrade/testdata/zoneinsights.2.14.crd.yaml` still names 0.21.0 and stays that way: it is a fixture of what 2.14 shipped, not generated output.

> Changelog: skip
