### PR TITLE
ci(runners): stop pull requests saving the Go build cache

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -63,6 +63,24 @@ jobs:
           restore-keys: |
             go-test-race-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-test-race-${{ runner.os }}-
+      # /proc/meminfo reports the host, not the cgroup a containerised runner gets,
+      # so without this the GC never pushes back and `go test -race` swaps instead.
+      - name: Set GOMEMLIMIT dynamically based on available memory
+        run: |
+          set -e
+          available=$(($(grep MemTotal /proc/meminfo | awk '{print $2}') * 1024))
+          for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+            [ -r "$f" ] || continue
+            limit=$(cat "$f")
+            case "$limit" in ''|*[!0-9]*) continue ;; esac
+            if [ "$limit" -lt "$available" ]; then
+              available=$limit
+            fi
+            break
+          done
+          gomemlimit=$((available * 8 / 10))
+          echo "GOMEMLIMIT=${gomemlimit}" >> "$GITHUB_ENV"
+          echo "Setting GOMEMLIMIT to $(numfmt --to=iec "$gomemlimit")"
       - run: |
           make test
       - name: Save Go build cache

--- a/.github/workflows/build-test-distribute.yaml
+++ b/.github/workflows/build-test-distribute.yaml
@@ -175,16 +175,31 @@ jobs:
           version: 2026.8.14
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - name: Cache Go build
+      # Module contents are a pure function of go.sum, so one immutable entry
+      # is shared with every other job and branch.
+      - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          path: ~/go/pkg/mod
+          key: go-mod-dist-${{ hashFiles('**/go.sum') }}
+      # Pull requests restore by prefix from the newest push-event entry instead
+      # of writing their own short-lived merge-ref entries. A save took 13 minutes
+      # when seven runners shared one host's disk.
+      - name: Restore Go build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-build-${{ runner.os }}-
       - run: go build ./...
+      - name: Save Go build cache
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
   check:
     needs: ["release_sha_gate"]
     permissions:
@@ -271,14 +286,23 @@ jobs:
           gomemlimit=$((available * 8 / 10))
           echo "GOMEMLIMIT=${gomemlimit}" >> "$GITHUB_ENV"
           echo "Setting GOMEMLIMIT to $(numfmt --to=iec "$gomemlimit")"
-      - name: Cache Go build
+      # Module contents are a pure function of go.sum, so one immutable entry
+      # is shared with every other job and branch.
+      - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          path: ~/go/pkg/mod
+          key: go-mod-dist-${{ hashFiles('**/go.sum') }}
+      # Pull requests restore by prefix from the newest push-event entry instead
+      # of writing their own short-lived merge-ref entries. A save took 13 minutes
+      # when seven runners shared one host's disk.
+      - name: Restore Go build cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
           restore-keys: |
+            go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-build-${{ runner.os }}-
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
@@ -304,6 +328,12 @@ jobs:
       - if: ${{ github.ref_type != 'tag' }}
         run: |
           make check
+      - name: Save Go build cache
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
       - name: "Set metadata for downstream jobs"
         id: metadata
         run: |


### PR DESCRIPTION
## Motivation

Twelve downstream pull requests opened at once put a self-hosted pool under real load, and jobs started dying at their `timeout-minutes`. GitHub reports a job killed that way as `cancelled`, so it read like someone pressed the button. Two of them, by step:

```
check       11 min of real work, then 805s (13.4 min) in "Post Cache Go build"  -> killed
test_unit                            1706s (28.4 min) in "Run make test"        -> killed
```

`check` and `build_check` still used the full `actions/cache`, so its post step wrote a multi-gigabyte entry on every run. A pull request's write is scoped to its own merge ref, so nothing else can ever read it, and the entry expires with the branch. `_test.yaml` and `_build_publish.yaml` already restore by prefix and save only on a push, with a comment saying why. These two jobs were the ones left behind.

`test_unit` sets no `GOMEMLIMIT`. `/proc/meminfo` reports the host, not the cgroup a containerised runner gets, so the GC sees far more memory than the job can have, never pushes back, and `go test -race` swaps instead of collecting. `check` already reads the cgroup cap; `test_unit` did not.

## Implementation information

- `check` and `build_check` split the one cache step into a module cache, a `cache/restore` and a `cache/save` gated on `github.event_name == 'push'`. The module cache keeps its own immutable key, since its contents are a pure function of `go.sum` and one entry serves every job and branch.
- The build cache key gains `github.sha` and keeps the two shorter prefixes as `restore-keys`, so existing entries still hit and a pull request restores from the newest push on its base.
- `test_unit` gets the same `GOMEMLIMIT` step `check` has, reading `/sys/fs/cgroup/memory.max` and falling back to `/proc/meminfo` where no cap is set.
- `actionlint` is clean and `make fmt/ci` leaves the workflows unchanged.

## Supporting documentation

The runner-side half of this is a separate change: the pool's root volume served 3000 IOPS and 125 MB/s to seven slots that share it with seven Docker data roots, every checkout and Go cache, and a 56GiB swapfile. That is being provisioned properly, but writing gigabytes per pull request for a cache nobody reads is worth stopping either way.

> Changelog: skip
