### PR TITLE
fix(api-server): normalize a nil overview spec

### DIFF
--- a/api/mesh/v1alpha1/zoneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/zoneoverview/schema.yaml
@@ -2,6 +2,7 @@ components:
   schemas:
     ZoneOverview:
       description: ZoneOverview defines the projected state of a Zone.
+      required: [zone]
       properties:
         zone:
           properties:

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -16893,6 +16893,8 @@ components:
         - $ref: '#/components/schemas/ZoneOverview'
     ZoneOverview:
       description: ZoneOverview defines the projected state of a Zone.
+      required:
+        - zone
       properties:
         zone:
           properties:

--- a/pkg/core/resources/apis/mesh/mesh_resources.go
+++ b/pkg/core/resources/apis/mesh/mesh_resources.go
@@ -306,11 +306,21 @@ func (t *MeshOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return MeshOverviewResourceTypeDescriptor
 }
 
+// newMeshOverviewSpec normalizes a nil spec the way SetSpec does. A nil one would drop
+// the field from the response without any error: the marshaller omits a nil message and
+// then throws the whole spec away once what is left renders as an empty object.
+func newMeshOverviewSpec(spec *mesh_proto.Mesh) *mesh_proto.MeshOverview {
+	if spec == nil {
+		spec = &mesh_proto.Mesh{}
+	}
+	return &mesh_proto.MeshOverview{
+		Mesh: spec,
+	}
+}
+
 func (t *MeshOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &mesh_proto.MeshOverview{
-		Mesh: resource.GetSpec().(*mesh_proto.Mesh),
-	}
+	overview := newMeshOverviewSpec(resource.GetSpec().(*mesh_proto.Mesh))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*mesh_proto.MeshInsight)
 		if !ok {

--- a/pkg/core/resources/apis/mesh/zz_generated.resources.go
+++ b/pkg/core/resources/apis/mesh/zz_generated.resources.go
@@ -308,11 +308,21 @@ func (t *DataplaneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return DataplaneOverviewResourceTypeDescriptor
 }
 
+// newDataplaneOverviewResourceSpec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func newDataplaneOverviewResourceSpec(spec *mesh_proto.Dataplane) *mesh_proto.DataplaneOverview {
+	if spec == nil {
+		spec = &mesh_proto.Dataplane{}
+	}
+	return &mesh_proto.DataplaneOverview{
+		Dataplane: spec,
+	}
+}
+
 func (t *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &mesh_proto.DataplaneOverview{
-		Dataplane: resource.GetSpec().(*mesh_proto.Dataplane),
-	}
+	overview := newDataplaneOverviewResourceSpec(resource.GetSpec().(*mesh_proto.Dataplane))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*mesh_proto.DataplaneInsight)
 		if !ok {

--- a/pkg/core/resources/apis/zone/api/v1alpha1/zoneoverview.go
+++ b/pkg/core/resources/apis/zone/api/v1alpha1/zoneoverview.go
@@ -13,9 +13,20 @@ import (
 // Zone and its insight, never stored and never synced, so it is written by hand rather
 // than generated: the resource generator produces one resource per package, and a
 // generated overview would have to import the Zone package that imports it back.
+//
+// Zone is always populated, see newZoneOverview. A nil one would drop the field from the
+// response without any error: omitempty skips it, and the inlined REST representation
+// throws the whole spec away once it renders as an empty object.
 type ZoneOverview struct {
 	Zone        *Zone                        `json:"zone,omitempty"`
 	ZoneInsight *zoneinsight_api.ZoneInsight `json:"zoneInsight,omitempty"`
+}
+
+func newZoneOverview(zone *Zone) *ZoneOverview {
+	if zone == nil {
+		zone = &Zone{}
+	}
+	return &ZoneOverview{Zone: zone}
 }
 
 const ZoneOverviewType model.ResourceType = "ZoneOverview"
@@ -78,7 +89,7 @@ func (t *ZoneOverviewResource) SetOverviewSpec(resource model.Resource, insight 
 	if !ok {
 		return errors.New("failed to convert to resource type 'Zone'")
 	}
-	overview := &ZoneOverview{Zone: zone}
+	overview := newZoneOverview(zone)
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*zoneinsight_api.ZoneInsight)
 		if !ok {
@@ -155,7 +166,7 @@ func NewZoneOverviews(zones ZoneResourceList, insights zoneinsight_api.ZoneInsig
 	for _, zone := range zones.Items {
 		overview := ZoneOverviewResource{
 			Meta: zone.Meta,
-			Spec: &ZoneOverview{Zone: zone.Spec},
+			Spec: newZoneOverview(zone.Spec),
 		}
 		if insight, exists := insightsByKey[model.MetaToResourceKey(overview.Meta)]; exists {
 			overview.Spec.ZoneInsight = insight.Spec

--- a/pkg/core/resources/apis/zone/api/v1alpha1/zoneoverview_test.go
+++ b/pkg/core/resources/apis/zone/api/v1alpha1/zoneoverview_test.go
@@ -1,0 +1,44 @@
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	zone_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/zone/api/v1alpha1"
+	zoneinsight_api "github.com/kumahq/kuma/v3/pkg/core/resources/apis/zoneinsight/api/v1alpha1"
+	core_model "github.com/kumahq/kuma/v3/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v3/pkg/core/resources/model/rest"
+	"github.com/kumahq/kuma/v3/pkg/test/resources/model"
+)
+
+var _ = Describe("ZoneOverview", func() {
+	overviewJSON := func(overview core_model.Resource) string {
+		GinkgoHelper()
+		bytes, err := rest.From.Resource(overview).(interface{ MarshalJSON() ([]byte, error) }).MarshalJSON()
+		Expect(err).ToNot(HaveOccurred())
+		return string(bytes)
+	}
+
+	DescribeTable("should always render a zone, whatever the Zone spec is",
+		func(spec *zone_api.Zone, expected string) {
+			zone := &zone_api.ZoneResource{
+				Meta: &model.ResourceMeta{Name: "zone-1"},
+				Spec: spec,
+			}
+
+			overview := zone_api.NewZoneOverviewResource()
+			Expect(overview.SetOverviewSpec(zone, nil)).To(Succeed())
+			Expect(overviewJSON(overview)).To(ContainSubstring(expected))
+
+			overviews := zone_api.NewZoneOverviews(
+				zone_api.ZoneResourceList{Items: []*zone_api.ZoneResource{zone}},
+				zoneinsight_api.ZoneInsightResourceList{},
+			)
+			Expect(overviews.Items).To(HaveLen(1))
+			Expect(overviewJSON(overviews.Items[0])).To(ContainSubstring(expected))
+		},
+		Entry("nil spec", nil, `"zone":{}`),
+		Entry("empty spec", &zone_api.Zone{}, `"zone":{}`),
+		Entry("disabled zone", &zone_api.Zone{Enabled: new(bool)}, `"zone":{"enabled":false}`),
+	)
+})

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -292,11 +292,21 @@ func (t *{{.ResourceName}}) Descriptor() model.ResourceTypeDescriptor {
 }
 {{- if and (hasSuffix .ResourceType "Overview") (ne $baseType "Service") }}
 
+// new{{.ResourceName}}Spec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func new{{.ResourceName}}Spec(spec *{{$pkg}}.{{$baseType}}) *{{$pkg}}.{{.ProtoType}} {
+	if spec == nil {
+		spec = &{{$pkg}}.{{$baseType}}{}
+	}
+	return &{{$pkg}}.{{.ProtoType}}{
+		{{$baseType}}: spec,
+	}
+}
+
 func (t *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &{{$pkg}}.{{.ProtoType}}{
-		{{$baseType}}: resource.GetSpec().(*{{$pkg}}.{{$baseType}}),
-	}
+	overview := new{{.ResourceName}}Spec(resource.GetSpec().(*{{$pkg}}.{{$baseType}}))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*{{$pkg}}.{{$baseType}}Insight)
 		if !ok {


### PR DESCRIPTION
## Motivation

The GUI throws `TypeError: Cannot read properties of undefined (reading 'enabled')` because a zone overview item reaches it without its `zone` field.

`zone` disappears whenever `ZoneOverview.Zone` is nil at marshal time, and nothing reports it: `omitempty` skips the nil, and the inlined REST representation then drops the whole spec once what is left renders as `{}`. `SetOverviewSpec` lets a typed-nil through its type assertion, so that payload is one stray nil away. `DataplaneOverview` and `MeshOverview` sit on the same edge.

I could not reproduce a nil spec from any store path - memory, postgres and Kubernetes all normalize it in `SetSpec` - so this closes the hole rather than fixing a reproduced failure. The full write-up is on the issue.

> Changelog: fix(api-server): always render `zone` in a zone overview

## Implementation information

`SetOverviewSpec` now normalizes a nil base spec into an empty one, the same thing `SetSpec` does everywhere else. An empty spec is semantically identical - `Zone.GetEnabled()` already treats nil and empty alike - and keeps the response valid, which beats a 500 on a list endpoint.

The change lives in the resource generator template so `DataplaneOverview` gets it too. `MeshOverview` and `ZoneOverview` are hand-written and are updated in place.

`zone` is now `required` in the ZoneOverview OpenAPI schema, so clients can rely on it instead of defending against it.

A table test pins the rendered payload for a nil, empty and disabled Zone spec; it fails without the fix.

## Supporting documentation

Fix #18338

release-2.14 gets the same fix in a separate PR: the zone family moved to Go structs on master in #18564, so this cannot be cherry-picked.