### PR TITLE
fix(api-server): normalize a nil overview spec

### DIFF
--- a/pkg/core/resources/apis/mesh/zz_generated.resources.go
+++ b/pkg/core/resources/apis/mesh/zz_generated.resources.go
@@ -432,11 +432,21 @@ func (t *DataplaneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return DataplaneOverviewResourceTypeDescriptor
 }
 
+// newDataplaneOverviewResourceSpec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func newDataplaneOverviewResourceSpec(spec *mesh_proto.Dataplane) *mesh_proto.DataplaneOverview {
+	if spec == nil {
+		spec = &mesh_proto.Dataplane{}
+	}
+	return &mesh_proto.DataplaneOverview{
+		Dataplane: spec,
+	}
+}
+
 func (t *DataplaneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &mesh_proto.DataplaneOverview{
-		Dataplane: resource.GetSpec().(*mesh_proto.Dataplane),
-	}
+	overview := newDataplaneOverviewResourceSpec(resource.GetSpec().(*mesh_proto.Dataplane))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*mesh_proto.DataplaneInsight)
 		if !ok {
@@ -3005,11 +3015,21 @@ func (t *ZoneEgressOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneEgressOverviewResourceTypeDescriptor
 }
 
+// newZoneEgressOverviewResourceSpec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func newZoneEgressOverviewResourceSpec(spec *mesh_proto.ZoneEgress) *mesh_proto.ZoneEgressOverview {
+	if spec == nil {
+		spec = &mesh_proto.ZoneEgress{}
+	}
+	return &mesh_proto.ZoneEgressOverview{
+		ZoneEgress: spec,
+	}
+}
+
 func (t *ZoneEgressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &mesh_proto.ZoneEgressOverview{
-		ZoneEgress: resource.GetSpec().(*mesh_proto.ZoneEgress),
-	}
+	overview := newZoneEgressOverviewResourceSpec(resource.GetSpec().(*mesh_proto.ZoneEgress))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*mesh_proto.ZoneEgressInsight)
 		if !ok {
@@ -3375,11 +3395,21 @@ func (t *ZoneIngressOverviewResource) Descriptor() model.ResourceTypeDescriptor 
 	return ZoneIngressOverviewResourceTypeDescriptor
 }
 
+// newZoneIngressOverviewResourceSpec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func newZoneIngressOverviewResourceSpec(spec *mesh_proto.ZoneIngress) *mesh_proto.ZoneIngressOverview {
+	if spec == nil {
+		spec = &mesh_proto.ZoneIngress{}
+	}
+	return &mesh_proto.ZoneIngressOverview{
+		ZoneIngress: spec,
+	}
+}
+
 func (t *ZoneIngressOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &mesh_proto.ZoneIngressOverview{
-		ZoneIngress: resource.GetSpec().(*mesh_proto.ZoneIngress),
-	}
+	overview := newZoneIngressOverviewResourceSpec(resource.GetSpec().(*mesh_proto.ZoneIngress))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*mesh_proto.ZoneIngressInsight)
 		if !ok {

--- a/pkg/core/resources/apis/system/system_suite_test.go
+++ b/pkg/core/resources/apis/system/system_suite_test.go
@@ -1,0 +1,11 @@
+package system_test
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v2/pkg/test"
+)
+
+func TestSystem(t *testing.T) {
+	test.RunSpecs(t, "System Resources Suite")
+}

--- a/pkg/core/resources/apis/system/zone_overview.go
+++ b/pkg/core/resources/apis/system/zone_overview.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	system_proto "github.com/kumahq/kuma/v2/api/system/v1alpha1"
 	"github.com/kumahq/kuma/v2/pkg/core/resources/model"
 )
 
@@ -15,10 +14,7 @@ func NewZoneOverviews(zones ZoneResourceList, insights ZoneInsightResourceList) 
 	for _, zone := range zones.Items {
 		overview := ZoneOverviewResource{
 			Meta: zone.Meta,
-			Spec: &system_proto.ZoneOverview{
-				Zone:        zone.Spec,
-				ZoneInsight: nil,
-			},
+			Spec: newZoneOverviewResourceSpec(zone.Spec),
 		}
 		insight, exists := insightsByKey[model.MetaToResourceKey(overview.Meta)]
 		if exists {

--- a/pkg/core/resources/apis/system/zone_overview_test.go
+++ b/pkg/core/resources/apis/system/zone_overview_test.go
@@ -1,0 +1,45 @@
+package system_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	system_proto "github.com/kumahq/kuma/v2/api/system/v1alpha1"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/apis/system"
+	core_model "github.com/kumahq/kuma/v2/pkg/core/resources/model"
+	"github.com/kumahq/kuma/v2/pkg/core/resources/model/rest"
+	"github.com/kumahq/kuma/v2/pkg/test/resources/model"
+	util_proto "github.com/kumahq/kuma/v2/pkg/util/proto"
+)
+
+var _ = Describe("ZoneOverview", func() {
+	overviewJSON := func(overview core_model.Resource) string {
+		GinkgoHelper()
+		bytes, err := rest.From.Resource(overview).(interface{ MarshalJSON() ([]byte, error) }).MarshalJSON()
+		Expect(err).ToNot(HaveOccurred())
+		return string(bytes)
+	}
+
+	DescribeTable("should always render a zone, whatever the Zone spec is",
+		func(spec *system_proto.Zone, expected string) {
+			zone := &system.ZoneResource{
+				Meta: &model.ResourceMeta{Name: "zone-1"},
+				Spec: spec,
+			}
+
+			overview := system.NewZoneOverviewResource()
+			Expect(overview.SetOverviewSpec(zone, nil)).To(Succeed())
+			Expect(overviewJSON(overview)).To(ContainSubstring(expected))
+
+			overviews := system.NewZoneOverviews(
+				system.ZoneResourceList{Items: []*system.ZoneResource{zone}},
+				system.ZoneInsightResourceList{},
+			)
+			Expect(overviews.Items).To(HaveLen(1))
+			Expect(overviewJSON(overviews.Items[0])).To(ContainSubstring(expected))
+		},
+		Entry("nil spec", nil, `"zone":{}`),
+		Entry("empty spec", &system_proto.Zone{}, `"zone":{}`),
+		Entry("disabled zone", &system_proto.Zone{Enabled: util_proto.Bool(false)}, `"zone":{"enabled":false}`),
+	)
+})

--- a/pkg/core/resources/apis/system/zz_generated.resources.go
+++ b/pkg/core/resources/apis/system/zz_generated.resources.go
@@ -544,11 +544,21 @@ func (t *ZoneOverviewResource) Descriptor() model.ResourceTypeDescriptor {
 	return ZoneOverviewResourceTypeDescriptor
 }
 
+// newZoneOverviewResourceSpec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func newZoneOverviewResourceSpec(spec *system_proto.Zone) *system_proto.ZoneOverview {
+	if spec == nil {
+		spec = &system_proto.Zone{}
+	}
+	return &system_proto.ZoneOverview{
+		Zone: spec,
+	}
+}
+
 func (t *ZoneOverviewResource) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &system_proto.ZoneOverview{
-		Zone: resource.GetSpec().(*system_proto.Zone),
-	}
+	overview := newZoneOverviewResourceSpec(resource.GetSpec().(*system_proto.Zone))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*system_proto.ZoneInsight)
 		if !ok {

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -292,11 +292,21 @@ func (t *{{.ResourceName}}) Descriptor() model.ResourceTypeDescriptor {
 }
 {{- if and (hasSuffix .ResourceType "Overview") (ne $baseType "Service") }}
 
+// new{{.ResourceName}}Spec normalizes a nil spec the way SetSpec does. A nil one would
+// drop the field from the response without any error: the marshaller omits a nil message
+// and then throws the whole spec away once what is left renders as an empty object.
+func new{{.ResourceName}}Spec(spec *{{$pkg}}.{{$baseType}}) *{{$pkg}}.{{.ProtoType}} {
+	if spec == nil {
+		spec = &{{$pkg}}.{{$baseType}}{}
+	}
+	return &{{$pkg}}.{{.ProtoType}}{
+		{{$baseType}}: spec,
+	}
+}
+
 func (t *{{.ResourceName}}) SetOverviewSpec(resource model.Resource, insight model.Resource) error {
 	t.SetMeta(resource.GetMeta())
-	overview := &{{$pkg}}.{{.ProtoType}}{
-		{{$baseType}}: resource.GetSpec().(*{{$pkg}}.{{$baseType}}),
-	}
+	overview := new{{.ResourceName}}Spec(resource.GetSpec().(*{{$pkg}}.{{$baseType}}))
 	if insight != nil {
 		ins, ok := insight.GetSpec().(*{{$pkg}}.{{$baseType}}Insight)
 		if !ok {


### PR DESCRIPTION
## Motivation

The GUI throws `TypeError: Cannot read properties of undefined (reading 'enabled')` because a zone overview item reaches it without its `zone` field.

`zone` disappears whenever `ZoneOverview.Zone` is nil at marshal time, and nothing reports it: jsonpb omits the nil message, and the inlined REST representation then drops the whole spec once what is left renders as `{}`. `SetOverviewSpec` lets a typed-nil through its type assertion, so that payload is one stray nil away. `DataplaneOverview`, `ZoneIngressOverview` and `ZoneEgressOverview` sit on the same edge.

I could not reproduce a nil spec from any store path - memory, postgres and Kubernetes all normalize it in `SetSpec` - so this closes the hole rather than fixing a reproduced failure. The full write-up is on the issue.

> Changelog: fix(api-server): always render `zone` in a zone overview

## Implementation information

`SetOverviewSpec` now normalizes a nil base spec into an empty one, the same thing `SetSpec` does everywhere else. An empty spec is semantically identical - `Zone.GetEnabled()` already treats nil and empty alike - and keeps the response valid, which beats a 500 on a list endpoint. `NewZoneOverviews` gets the same treatment.

The change lives in the resource generator template, so all four overview types are covered.

A table test pins the rendered payload for a nil, empty and disabled Zone spec; it fails without the fix. The package had no test suite, so this adds one.

## Supporting documentation

Same fix as #18663 on master, raised separately rather than backported: the zone family moved to Go structs on master in #18564, so the master change does not cherry-pick.

Fix #18338