### PR TITLE
fix(oas): always serve dataplane outbound address

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -100,6 +100,23 @@ Do this before you upgrade the control plane. `kuma-dp` 2.14 already supports bo
 
 On Kubernetes, if your 2.14 control plane runs with `transparentProxy.configMap.enabled` set to `false`, set it to `true` and restart your workloads before you upgrade the control plane.
 
+### `Dataplane` outbounds always carry an address
+
+`Dataplane.networking.outbound[].address` used to be left empty when it was not
+set, and every reader applied `127.0.0.1` on its own. The control plane now
+writes `127.0.0.1` into an outbound that comes in without an address, and the
+OpenAPI schema marks the field as required, so a `Dataplane` read back from the
+API always has one. Data plane behavior is unchanged: an outbound without an
+address was already bound to `127.0.0.1`.
+
+**Action required**
+
+None. Writing an outbound without an address keeps working. A `Dataplane`
+stored before the upgrade keeps its empty address until it is applied again,
+and a global control plane serves whatever a zone sent it, so a client that
+reads from a global control plane federated with zones on an older version
+should still fall back to `127.0.0.1`.
+
 ### KDS full resync is periodic again, not every second
 
 Removing the polling KDS watchdog carried the poll loop's `refreshInterval` of

--- a/api/mesh/v1alpha1/dataplane.pb.go
+++ b/api/mesh/v1alpha1/dataplane.pb.go
@@ -488,7 +488,10 @@ type Dataplane_Networking_Outbound struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// IP on which the consumed service will be available to this data plane
 	// proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
-	// Headless Service. Defaults to 127.0.0.1
+	// Headless Service. When left out, the control plane sets it to
+	// 127.0.0.1, so a Dataplane read back from the API always carries one.
+	//
+	//	+required
 	Address string `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
 	// Port on which the consumed service will be available to this data plane
 	// proxy. When transparent proxying is not used, Envoy will bind to this

--- a/api/mesh/v1alpha1/dataplane.proto
+++ b/api/mesh/v1alpha1/dataplane.proto
@@ -137,7 +137,9 @@ message Dataplane {
     message Outbound {
       // IP on which the consumed service will be available to this data plane
       // proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
-      // Headless Service. Defaults to 127.0.0.1
+      // Headless Service. When left out, the control plane sets it to
+      // 127.0.0.1, so a Dataplane read back from the API always carries one.
+      //  +required
       string address = 3;
 
       // Port on which the consumed service will be available to this data plane

--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -267,7 +267,8 @@ components:
                     description: |-
                       IP on which the consumed service will be available to this data plane
                       proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
-                      Headless Service. Defaults to 127.0.0.1
+                      Headless Service. When left out, the control plane sets it to
+                      127.0.0.1, so a Dataplane read back from the API always carries one.
                     type: string
                   backendRef:
                     description: BackendRef is a way to target MeshService.
@@ -298,6 +299,8 @@ components:
                       proxy. When transparent proxying is not used, Envoy will bind to this
                       port.
                     type: integer
+                required:
+                - address
                 type: object
               type: array
             transparentProxying:
@@ -325,24 +328,26 @@ components:
                       items:
                         properties:
                           kind:
-                            description: "Type of the backend: MeshService, MeshExternalService
-                              or MeshMultiZoneService\n\n\t+required"
+                            description: 'Type of the backend: MeshService, MeshExternalService
+                              or MeshMultiZoneService'
                             type: string
                           labels:
                             additionalProperties:
                               type: string
-                            description: "Labels used to select backends\n\n\t+optional"
+                            description: Labels used to select backends
                             type: object
                           name:
-                            description: "Name of the backend.\n\n\t+optional"
+                            description: Name of the backend.
                             type: string
                           namespace:
-                            description: "Namespace of the backend. Might be empty\n\n\t+optional"
+                            description: Namespace of the backend. Might be empty
                             type: string
                           port:
-                            description: "Port of the backend.\n\n\t+optional"
+                            description: Port of the backend.
                             format: uint32
                             type: integer
+                        required:
+                        - kind
                         type: object
                       type: array
                   type: object

--- a/api/mesh/v1alpha1/dataplane_helpers.go
+++ b/api/mesh/v1alpha1/dataplane_helpers.go
@@ -17,6 +17,10 @@ const (
 	K8sKumaIOPrefix = "k8s.kuma.io/"
 )
 
+// DefaultOutboundAddress is the address an outbound listener is bound to when
+// the Dataplane does not set one explicitly.
+const DefaultOutboundAddress = "127.0.0.1"
+
 const (
 	KubeNamespaceTag = "k8s.kuma.io/namespace"
 	// KDSSyncLabel a label that controls properties of the KDS sync.
@@ -241,7 +245,7 @@ func (n *Dataplane_Networking) ToOutboundInterface(outbound *Dataplane_Networkin
 	if outbound.Address != "" {
 		oface.DataplaneIP = outbound.Address
 	} else {
-		oface.DataplaneIP = "127.0.0.1"
+		oface.DataplaneIP = DefaultOutboundAddress
 	}
 	return oface
 }

--- a/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
+++ b/api/mesh/v1alpha1/dataplaneoverview/schema.yaml
@@ -199,7 +199,8 @@ components:
                         description: |-
                           IP on which the consumed service will be available to this data plane
                           proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a
-                          Headless Service. Defaults to 127.0.0.1
+                          Headless Service. When left out, the control plane sets it to
+                          127.0.0.1, so a Dataplane read back from the API always carries one.
                         type: string
                       backendRef:
                         description: BackendRef is a way to target MeshService.
@@ -230,6 +231,8 @@ components:
                           proxy. When transparent proxying is not used, Envoy will bind to this
                           port.
                         type: integer
+                    required:
+                    - address
                     type: object
                   type: array
                 transparentProxying:
@@ -257,24 +260,26 @@ components:
                           items:
                             properties:
                               kind:
-                                description: "Type of the backend: MeshService, MeshExternalService
-                                  or MeshMultiZoneService\n\n\t+required"
+                                description: 'Type of the backend: MeshService, MeshExternalService
+                                  or MeshMultiZoneService'
                                 type: string
                               labels:
                                 additionalProperties:
                                   type: string
-                                description: "Labels used to select backends\n\n\t+optional"
+                                description: Labels used to select backends
                                 type: object
                               name:
-                                description: "Name of the backend.\n\n\t+optional"
+                                description: Name of the backend.
                                 type: string
                               namespace:
-                                description: "Namespace of the backend. Might be empty\n\n\t+optional"
+                                description: Namespace of the backend. Might be empty
                                 type: string
                               port:
-                                description: "Port of the backend.\n\n\t+optional"
+                                description: Port of the backend.
                                 format: uint32
                                 type: integer
+                            required:
+                            - kind
                             type: object
                           type: array
                       type: object

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -7297,7 +7297,11 @@ components:
                       proxy. On Kubernetes, it's usually ClusterIP of a Service
                       or PodIP of a
 
-                      Headless Service. Defaults to 127.0.0.1
+                      Headless Service. When left out, the control plane sets it
+                      to
+
+                      127.0.0.1, so a Dataplane read back from the API always
+                      carries one.
                     type: string
                   backendRef:
                     description: BackendRef is a way to target MeshService.
@@ -7337,6 +7341,8 @@ components:
 
                       port.
                     type: integer
+                required:
+                  - address
                 type: object
               type: array
             transparentProxying:
@@ -7377,23 +7383,27 @@ components:
                       items:
                         properties:
                           kind:
-                            description: "Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService\n\n\t+required"
+                            description: >-
+                              Type of the backend: MeshService,
+                              MeshExternalService or MeshMultiZoneService
                             type: string
                           labels:
                             additionalProperties:
                               type: string
-                            description: "Labels used to select backends\n\n\t+optional"
+                            description: Labels used to select backends
                             type: object
                           name:
-                            description: "Name of the backend.\n\n\t+optional"
+                            description: Name of the backend.
                             type: string
                           namespace:
-                            description: "Namespace of the backend. Might be empty\n\n\t+optional"
+                            description: Namespace of the backend. Might be empty
                             type: string
                           port:
-                            description: "Port of the backend.\n\n\t+optional"
+                            description: Port of the backend.
                             format: uint32
                             type: integer
+                        required:
+                          - kind
                         type: object
                       type: array
                   type: object
@@ -15738,7 +15748,11 @@ components:
                           proxy. On Kubernetes, it's usually ClusterIP of a
                           Service or PodIP of a
 
-                          Headless Service. Defaults to 127.0.0.1
+                          Headless Service. When left out, the control plane
+                          sets it to
+
+                          127.0.0.1, so a Dataplane read back from the API
+                          always carries one.
                         type: string
                       backendRef:
                         description: BackendRef is a way to target MeshService.
@@ -15779,6 +15793,8 @@ components:
 
                           port.
                         type: integer
+                    required:
+                      - address
                     type: object
                   type: array
                 transparentProxying:
@@ -15821,23 +15837,27 @@ components:
                           items:
                             properties:
                               kind:
-                                description: "Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService\n\n\t+required"
+                                description: >-
+                                  Type of the backend: MeshService,
+                                  MeshExternalService or MeshMultiZoneService
                                 type: string
                               labels:
                                 additionalProperties:
                                   type: string
-                                description: "Labels used to select backends\n\n\t+optional"
+                                description: Labels used to select backends
                                 type: object
                               name:
-                                description: "Name of the backend.\n\n\t+optional"
+                                description: Name of the backend.
                                 type: string
                               namespace:
-                                description: "Namespace of the backend. Might be empty\n\n\t+optional"
+                                description: Namespace of the backend. Might be empty
                                 type: string
                               port:
-                                description: "Port of the backend.\n\n\t+optional"
+                                description: Port of the backend.
                                 format: uint32
                                 type: integer
+                            required:
+                              - kind
                             type: object
                           type: array
                       type: object

--- a/docs/generated/raw/protos/Dataplane.json
+++ b/docs/generated/raw/protos/Dataplane.json
@@ -231,7 +231,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "IP on which the consumed service will be available to this data plane proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a Headless Service. Defaults to 127.0.0.1"
+                    "description": "IP on which the consumed service will be available to this data plane proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a Headless Service. When left out, the control plane sets it to 127.0.0.1, so a Dataplane read back from the API always carries one."
                 },
                 "port": {
                     "type": "integer",
@@ -298,27 +298,27 @@
             "properties": {
                 "kind": {
                     "type": "string",
-                    "description": "Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService  +required"
+                    "description": "Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService"
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name of the backend.  +optional"
+                    "description": "Name of the backend."
                 },
                 "namespace": {
                     "type": "string",
-                    "description": "Namespace of the backend. Might be empty  +optional"
+                    "description": "Namespace of the backend. Might be empty"
                 },
                 "port": {
                     "additionalProperties": true,
                     "type": "integer",
-                    "description": "Port of the backend.  +optional"
+                    "description": "Port of the backend."
                 },
                 "labels": {
                     "additionalProperties": {
                         "type": "string"
                     },
                     "type": "object",
-                    "description": "Labels used to select backends  +optional"
+                    "description": "Labels used to select backends"
                 }
             },
             "additionalProperties": true,

--- a/docs/generated/raw/protos/DataplaneOverview.json
+++ b/docs/generated/raw/protos/DataplaneOverview.json
@@ -247,7 +247,7 @@
             "properties": {
                 "address": {
                     "type": "string",
-                    "description": "IP on which the consumed service will be available to this data plane proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a Headless Service. Defaults to 127.0.0.1"
+                    "description": "IP on which the consumed service will be available to this data plane proxy. On Kubernetes, it's usually ClusterIP of a Service or PodIP of a Headless Service. When left out, the control plane sets it to 127.0.0.1, so a Dataplane read back from the API always carries one."
                 },
                 "port": {
                     "type": "integer",
@@ -314,27 +314,27 @@
             "properties": {
                 "kind": {
                     "type": "string",
-                    "description": "Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService  +required"
+                    "description": "Type of the backend: MeshService, MeshExternalService or MeshMultiZoneService"
                 },
                 "name": {
                     "type": "string",
-                    "description": "Name of the backend.  +optional"
+                    "description": "Name of the backend."
                 },
                 "namespace": {
                     "type": "string",
-                    "description": "Namespace of the backend. Might be empty  +optional"
+                    "description": "Namespace of the backend. Might be empty"
                 },
                 "port": {
                     "additionalProperties": true,
                     "type": "integer",
-                    "description": "Port of the backend.  +optional"
+                    "description": "Port of the backend."
                 },
                 "labels": {
                     "additionalProperties": {
                         "type": "string"
                     },
                     "type": "object",
-                    "description": "Labels used to select backends  +optional"
+                    "description": "Labels used to select backends"
                 }
             },
             "additionalProperties": true,

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -33,6 +33,12 @@ ifneq ($(strip $(DOCS_PROTOS)),)
 		--jsonschema_out=$@/protos \
 		--plugin=protoc-gen-jsonschema=$(PROTOC_GEN_JSONSCHEMA) \
 		$(DOCS_PROTOS)
+# `+required` and `+optional` drive schema generation, they are not prose, so
+# they are dropped from the published reference. No `sed -i`: GNU and BSD
+# disagree on its argument.
+	for f in $@/protos/*.json; do \
+		t=$$(mktemp) && sed -E 's/[[:space:]]*\+(required|optional)"/"/g' "$$f" > "$$t" && mv "$$t" "$$f"; \
+	done
 endif
 
 # Built beside the target and moved on success, so a failing generator cannot

--- a/pkg/core/managers/apis/dataplane/dataplane_manager.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager.go
@@ -57,6 +57,9 @@ func (m *dataplaneManager) Create(ctx context.Context, resource core_model.Resou
 	}
 
 	m.setHealth(dp)
+	if err := dp.Default(); err != nil {
+		return err
+	}
 	labels, err := resource_labels.Compute(
 		resource.Descriptor(),
 		resource.GetSpec(),
@@ -99,6 +102,10 @@ func (m *dataplaneManager) Update(ctx context.Context, resource core_model.Resou
 	owner := core_mesh.NewMeshResource()
 	if err := m.store.Get(ctx, owner, core_store.GetByKey(resource.GetMeta().GetMesh(), core_model.NoMesh)); err != nil {
 		return core_manager.MeshNotFound(resource.GetMeta().GetMesh())
+	}
+
+	if err := dp.Default(); err != nil {
+		return err
 	}
 
 	opts := core_store.NewUpdateOptions(fs...)

--- a/pkg/core/managers/apis/dataplane/dataplane_manager_test.go
+++ b/pkg/core/managers/apis/dataplane/dataplane_manager_test.go
@@ -135,4 +135,88 @@ var _ = Describe("Dataplane Manager", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(actual.Spec.Networking.Inbound[0].State).To(Equal(mesh_proto.Dataplane_Networking_Inbound_NotReady))
 	})
+	It("should default the outbound address on create and keep an explicit one", func() {
+		// setup
+		s := memory.NewStore()
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		// given an outbound without an address and one that picks its own
+		input := core_mesh.DataplaneResource{
+			Spec: &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "10.0.0.1",
+					Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+						{
+							Port: 10001,
+							BackendRef: &mesh_proto.Dataplane_Networking_Outbound_BackendRef{
+								Kind: "MeshService",
+								Name: "backend",
+								Port: 80,
+							},
+						},
+						{
+							Port:    10002,
+							Address: "240.0.0.1",
+							BackendRef: &mesh_proto.Dataplane_Networking_Outbound_BackendRef{
+								Kind: "MeshService",
+								Name: "redis",
+								Port: 6379,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// when
+		err = manager.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		actual := core_mesh.NewDataplaneResource()
+		Expect(s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))).To(Succeed())
+		Expect(actual.Spec.Networking.Outbound[0].Address).To(Equal("127.0.0.1"))
+		Expect(actual.Spec.Networking.Outbound[1].Address).To(Equal("240.0.0.1"))
+	})
+
+	It("should default the outbound address on update", func() {
+		// setup
+		s := memory.NewStore()
+		manager := dataplane.NewDataplaneManager(s, "zone-1", config_core.Zone, false, "", dataplane.NewMembershipValidator())
+		err := s.Create(context.Background(), core_mesh.NewMeshResource(), store.CreateByKey(model.DefaultMesh, model.NoMesh))
+		Expect(err).ToNot(HaveOccurred())
+
+		input := core_mesh.DataplaneResource{
+			Spec: &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "10.0.0.1",
+				},
+			},
+		}
+		Expect(manager.Create(context.Background(), &input, store.CreateByKey("dp1", "default"))).To(Succeed())
+
+		// given an outbound added without an address
+		actual := core_mesh.NewDataplaneResource()
+		Expect(s.Get(context.Background(), actual, store.GetByKey("dp1", "default"))).To(Succeed())
+		actual.Spec.Networking.Outbound = []*mesh_proto.Dataplane_Networking_Outbound{
+			{
+				Port: 10001,
+				BackendRef: &mesh_proto.Dataplane_Networking_Outbound_BackendRef{
+					Kind: "MeshService",
+					Name: "backend",
+					Port: 80,
+				},
+			},
+		}
+
+		// when
+		Expect(manager.Update(context.Background(), actual)).To(Succeed())
+
+		// then
+		updated := core_mesh.NewDataplaneResource()
+		Expect(s.Get(context.Background(), updated, store.GetByKey("dp1", "default"))).To(Succeed())
+		Expect(updated.Spec.Networking.Outbound[0].Address).To(Equal("127.0.0.1"))
+	})
 })

--- a/pkg/core/resources/apis/mesh/dataplane_helpers.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers.go
@@ -16,6 +16,18 @@ import (
 	k8s_metadata "github.com/kumahq/kuma/v3/pkg/plugins/runtime/k8s/metadata"
 )
 
+// Default fills in the outbound address so that every Dataplane the API serves
+// carries one, which is what the OpenAPI schema promises. It is called by the
+// Kubernetes defaulting webhook and by the Dataplane resource manager.
+func (d *DataplaneResource) Default() error {
+	for _, outbound := range d.Spec.GetNetworking().GetOutbound() {
+		if outbound.GetAddress() == "" {
+			outbound.Address = mesh_proto.DefaultOutboundAddress
+		}
+	}
+	return nil
+}
+
 func (d *DataplaneResource) UsesInterface(address net.IP, port uint32) bool {
 	return d.UsesInboundInterface(address, port) || d.UsesOutboundInterface(address, port)
 }

--- a/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
+++ b/pkg/core/resources/apis/mesh/dataplane_helpers_test.go
@@ -16,6 +16,38 @@ import (
 	util_proto "github.com/kumahq/kuma/v3/pkg/util/proto"
 )
 
+var _ = Describe("Default", func() {
+	It("should fill in the outbound address and keep an explicit one", func() {
+		// given
+		dp := &DataplaneResource{
+			Spec: &mesh_proto.Dataplane{
+				Networking: &mesh_proto.Dataplane_Networking{
+					Address: "10.0.0.1",
+					Outbound: []*mesh_proto.Dataplane_Networking_Outbound{
+						{Port: 10001},
+						{Port: 10002, Address: "240.0.0.1"},
+					},
+				},
+			},
+		}
+
+		// when
+		Expect(dp.Default()).To(Succeed())
+
+		// then
+		Expect(dp.Spec.Networking.Outbound[0].Address).To(Equal("127.0.0.1"))
+		Expect(dp.Spec.Networking.Outbound[1].Address).To(Equal("240.0.0.1"))
+	})
+
+	It("should not fail on a dataplane without networking", func() {
+		// given
+		dp := &DataplaneResource{Spec: &mesh_proto.Dataplane{}}
+
+		// when and then
+		Expect(dp.Default()).To(Succeed())
+	})
+})
+
 var _ = Describe("InboundIdentifyingName", func() {
 	type testCase struct {
 		meta     test_model.ResourceMeta

--- a/tools/resource-gen/pkg/generator/generator_suite_test.go
+++ b/tools/resource-gen/pkg/generator/generator_suite_test.go
@@ -1,0 +1,11 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/kumahq/kuma/v3/pkg/test"
+)
+
+func TestGenerator(t *testing.T) {
+	test.RunSpecs(t, "Resource Generator Suite")
+}

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"text/template"
@@ -526,6 +527,11 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 		if !r.Global {
 			schema.Required = append(schema.Required, "mesh")
 		}
+		for _, required := range s.Required {
+			if !slices.Contains(schema.Required, required) {
+				schema.Required = append(schema.Required, required)
+			}
+		}
 
 		outDir := path.Join(writeDir, "api", pkg, "v1alpha1", strings.ToLower(r.ResourceType))
 
@@ -743,13 +749,61 @@ func (r *reflector) reflectFromType(t reflect.Type) (*jsonschema.Schema, error) 
 	}
 
 	s := rflctr.ReflectFromType(t)
+	applyFieldMarkers(s)
 	return &jsonschema.Schema{
 		Type:        "object",
 		Properties:  s.Properties,
+		Required:    s.Required,
 		OneOf:       s.OneOf,
 		Extras:      s.Extras,
 		Description: s.Description,
 	}, nil
+}
+
+// Field markers carried over from the proto comments. Protobuf makes every
+// field optional on the wire, so `+required` is the only way to tell the
+// generator that a field is always part of the served resource.
+const (
+	requiredMarker = "+required"
+	optionalMarker = "+optional"
+)
+
+// applyFieldMarkers promotes `+required` field markers to JSON Schema `required`
+// entries and drops every marker from the rendered descriptions.
+func applyFieldMarkers(s *jsonschema.Schema) {
+	if s == nil {
+		return
+	}
+	if s.Properties != nil {
+		for pair := s.Properties.Oldest(); pair != nil; pair = pair.Next() {
+			description, required := stripFieldMarkers(pair.Value.Description)
+			pair.Value.Description = description
+			if required && !slices.Contains(s.Required, pair.Key) {
+				s.Required = append(s.Required, pair.Key)
+			}
+			applyFieldMarkers(pair.Value)
+		}
+	}
+	applyFieldMarkers(s.Items)
+	applyFieldMarkers(s.AdditionalProperties)
+	for _, sub := range slices.Concat(s.OneOf, s.AnyOf, s.AllOf) {
+		applyFieldMarkers(sub)
+	}
+}
+
+func stripFieldMarkers(description string) (string, bool) {
+	var required bool
+	var kept []string
+	for line := range strings.SplitSeq(description, "\n") {
+		switch strings.TrimSpace(line) {
+		case requiredMarker:
+			required = true
+		case optionalMarker:
+		default:
+			kept = append(kept, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n")), required
 }
 
 func lowerFirst(s string) string {

--- a/tools/resource-gen/pkg/generator/markers_test.go
+++ b/tools/resource-gen/pkg/generator/markers_test.go
@@ -1,0 +1,88 @@
+package generator
+
+import (
+	"github.com/invopop/jsonschema"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("applyFieldMarkers", func() {
+	It("should promote +required to the parent schema and strip every marker", func() {
+		// given
+		properties := jsonschema.NewProperties()
+		properties.Set("kind", &jsonschema.Schema{
+			Type:        "string",
+			Description: "Type of the backend\n\n\t+required",
+		})
+		properties.Set("name", &jsonschema.Schema{
+			Type:        "string",
+			Description: "Name of the backend.\n\n\t+optional",
+		})
+		schema := &jsonschema.Schema{Type: "object", Properties: properties}
+
+		// when
+		applyFieldMarkers(schema)
+
+		// then
+		Expect(schema.Required).To(Equal([]string{"kind"}))
+		Expect(properties.Value("kind").Description).To(Equal("Type of the backend"))
+		Expect(properties.Value("name").Description).To(Equal("Name of the backend."))
+	})
+
+	It("should descend into nested objects and arrays", func() {
+		// given
+		itemProperties := jsonschema.NewProperties()
+		itemProperties.Set("address", &jsonschema.Schema{
+			Type:        "string",
+			Description: "IP of the outbound\n\n\t+required",
+		})
+		outboundProperties := jsonschema.NewProperties()
+		outboundProperties.Set("outbound", &jsonschema.Schema{
+			Type:  "array",
+			Items: &jsonschema.Schema{Type: "object", Properties: itemProperties},
+		})
+		schema := &jsonschema.Schema{Type: "object", Properties: outboundProperties}
+
+		// when
+		applyFieldMarkers(schema)
+
+		// then
+		Expect(schema.Required).To(BeEmpty())
+		Expect(outboundProperties.Value("outbound").Items.Required).To(Equal([]string{"address"}))
+		Expect(itemProperties.Value("address").Description).To(Equal("IP of the outbound"))
+	})
+
+	It("should be idempotent", func() {
+		// given
+		properties := jsonschema.NewProperties()
+		properties.Set("kind", &jsonschema.Schema{
+			Type:        "string",
+			Description: "Type of the backend\n\n\t+required",
+		})
+		schema := &jsonschema.Schema{Type: "object", Properties: properties}
+
+		// when
+		applyFieldMarkers(schema)
+		applyFieldMarkers(schema)
+
+		// then
+		Expect(schema.Required).To(Equal([]string{"kind"}))
+		Expect(properties.Value("kind").Description).To(Equal("Type of the backend"))
+	})
+
+	It("should not repeat a field the reflector already made required", func() {
+		// given
+		properties := jsonschema.NewProperties()
+		properties.Set("kind", &jsonschema.Schema{
+			Type:        "string",
+			Description: "Type of the backend\n\n\t+required",
+		})
+		schema := &jsonschema.Schema{Type: "object", Properties: properties, Required: []string{"kind"}}
+
+		// when
+		applyFieldMarkers(schema)
+
+		// then
+		Expect(schema.Required).To(Equal([]string{"kind"}))
+	})
+})


### PR DESCRIPTION
## Motivation

The OpenAPI spec described `dataplane.networking.outbound[].address` as
"Defaults to 127.0.0.1", which left a consumer unable to tell whether the field
is always served or whether an absent value means "assume 127.0.0.1". It was the
second one: the address is only ever authored by a user on Universal, an empty
value was accepted, and every reader applied `127.0.0.1` on its own
(`ToOutboundInterface`, `GetAddressWithFallback`). So the field could not simply
be marked non-optional; the control plane had to start serving it.

> Changelog: fix(oas): always serve dataplane outbound address

## Implementation information

- `DataplaneResource.Default()` fills in `127.0.0.1` for an outbound that comes
  in without an address. That is the existing `core_model.Defaulter` extension
  point, so the Kubernetes defaulting webhook picks it up as well. The Dataplane
  resource manager calls it explicitly on Create and Update because it bypasses
  the base manager and writes to the store directly.
- The proto to OpenAPI generator now understands the `+required` and `+optional`
  field markers instead of rendering them into the descriptions. Protobuf makes
  every field optional on the wire, so a marker is the only way to tell the
  generator that a field is always part of the served resource. This also fixes
  the markers that leak today on `transparentProxying.reachableBackends.refs`,
  both in the OAS and in the generated proto reference under `docs/generated`.
- `address` carries `+required`, so the Dataplane and DataplaneOverview schemas
  now list it under the outbound item's `required`.

Envoy configuration is unchanged: an outbound without an address was already
bound to `127.0.0.1`, and the proxy builder clears the legacy outbound list
before generation anyway.

Verified against a running control plane: an addressless outbound comes back as
`127.0.0.1` on the resource, list, overview and `_kri` endpoints and through
`kumactl get`, an explicit address is preserved, an invalid one is still
rejected, and a Dataplane synced zone to global carries the address too.

### Trade-offs worth a reviewer's attention

- A global control plane replays KDS-synced resources byte for byte, so a zone
  that has not been upgraded yet can still put an addressless outbound on
  global. Defaulting in the syncer is not an option: it compares specs to decide
  on an update, so mutating on write would re-Update on every sync tick. Same
  for a Dataplane stored before the upgrade and never applied again. Both are
  called out in `UPGRADE.md`.
- The schema is shared between the PUT request body and the GET response, so a
  client that validates request bodies against it would now reject a write the
  control plane still accepts. The alternative, describing the field with
  `default: 127.0.0.1` and leaving it optional, keeps the request side honest
  but gives the consumer no guarantee that the field is there, which is what was
  asked for.

Closes #13578