### PR TITLE
test(e2e): wait for the metallb deployments before its pods

### DIFF
--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -213,6 +213,9 @@ endif
 .PHONY: k3d/configure/metallb
 k3d/configure/metallb:
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply -f $(METALLB_MANIFESTS)
+	@# wait --all pods exits at once with "no matching resources found" when the
+	@# apply above has not produced pods yet, so block on the deployments first.
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) rollout status --timeout=120s -n $(METALLB_NAMESPACE) deployment
 	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) wait --timeout=120s --for=condition=Ready -n $(METALLB_NAMESPACE) --all pods
 	@# Construct a valid address space from the docker network and the template IPAddressPool
 	@# Make sure we only take an IPv4 network


### PR DESCRIPTION
## Motivation

`k3d/configure/metallb` applies the metallb manifests and then waits for every pod in `metallb-system` to be Ready. `kubectl wait --all pods` does not wait for pods to appear: when the apply has not produced any yet, it exits at once with `error: no matching resources found`, and the target fails. A cluster that gets to the wait quickly loses the race, so e2e dies before a single spec runs.

```
deployment.apps/controller created
daemonset.apps/speaker created
error: no matching resources found
make[4]: *** [kuma/mk/k3d.mk:216: k3d/configure/metallb] Error 1
```

## Implementation information

- `kubectl rollout status deployment` on the namespace runs before the pod wait. Unlike `wait`, it blocks while a deployment's pods are still being created, so by the time the pod wait runs there is something to match.
- This is what `release-2.14` and `master` already do in `k3d/cluster/metallb/setup`. Their `mk/k3d.mk` was restructured, so the change is applied by hand rather than cherry-picked.

## Supporting documentation

None.

> Changelog: skip
