### PR TITLE
ci(build): restore exec bit before version assert

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -202,6 +202,11 @@ jobs:
         with:
           name: linux_binaries_amd64
           path: ./build/artifacts-linux-amd64
+      # download-artifact does not restore the executable bit, so the binary
+      # lands as 0644 and cannot be executed by the version assert.
+      - name: Restore executable bit on downloaded binaries
+        if: ${{ github.ref_type == 'tag' }}
+        run: chmod -R +x ./build/artifacts-linux-amd64
       - name: Assert built binary reports tag version
         if: ${{ github.ref_type == 'tag' }}
         env:


### PR DESCRIPTION
## Motivation

`publish-binaries` fails on every release tag: `actions/download-artifact` restores files as 0644, so the downloaded `kuma-cp` cannot be executed and `check/binary-version` reads an empty version string. The v2.11.19 build died there, leaving binaries, security assets and provenance unpublished after images and helm charts had already been pushed.

> Changelog: skip

## Implementation information

Mirrors the `chmod -R +x` step #18514 added to `build-images`, applied to the amd64 artifact that `publish-binaries` downloads for the assert. Shipped tarballs were never affected — `mk/distribution.mk` chmods 555 in the job that builds them.

## Supporting documentation

Failing run: https://github.com/kumahq/kuma/actions/runs/34534914302/job/103067239537