### PR TITLE
perf(mads): reuse MeshMetric matches per mesh

### DIFF
--- a/pkg/mads/v1/reconcile/snapshot_generator.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator.go
@@ -2,6 +2,8 @@ package reconcile
 
 import (
 	"context"
+	"maps"
+	"sync"
 
 	envoy_cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/pkg/errors"
@@ -17,18 +19,30 @@ import (
 	"github.com/kumahq/kuma/v3/pkg/util/pointer"
 	util_xds_v3 "github.com/kumahq/kuma/v3/pkg/util/xds/v3"
 	"github.com/kumahq/kuma/v3/pkg/xds/cache/mesh"
+	xds_context "github.com/kumahq/kuma/v3/pkg/xds/context"
 )
 
 func NewSnapshotGenerator(resourceManager core_manager.ReadOnlyResourceManager, meshCache *mesh.Cache) *SnapshotGenerator {
 	return &SnapshotGenerator{
 		resourceManager: resourceManager,
 		meshCache:       meshCache,
+		matchesByMesh:   map[string]meshMetricMatches{},
 	}
 }
 
 type SnapshotGenerator struct {
 	resourceManager core_manager.ReadOnlyResourceManager
 	meshCache       *mesh.Cache
+
+	matchesMutex  sync.Mutex
+	matchesByMesh map[string]meshMetricMatches
+}
+
+// meshMetricMatches are the MeshMetric confs matched to the dataplanes of a mesh. Matching
+// depends only on what the mesh context hash covers, so they are reused until it changes.
+type meshMetricMatches struct {
+	meshHash         string
+	confToDataplanes map[*v1alpha1.Conf]*core_mesh.DataplaneResource
 }
 
 func (s *SnapshotGenerator) GenerateSnapshot(ctx context.Context) (map[string]envoy_cache.ResourceSnapshot, error) {
@@ -92,19 +106,36 @@ func (s *SnapshotGenerator) getMatchingDataplanes(ctx context.Context, meshesWit
 			return nil, errors.Wrap(err, "could not get mesh context")
 		}
 
-		for _, dp := range meshContext.DataplanesByName {
-			matchedPolicies, err := matchers.MatchedPolicies(v1alpha1.MeshMetricType, dp, meshContext.Resources)
-			if err != nil {
-				return nil, errors.Wrap(err, "error on matching dpp")
-			}
-			if matchedPolicies.ProxyConf != nil {
-				conf := matchedPolicies.ProxyConf.Conf.(v1alpha1.Conf)
-				meshMetricConfToDataplanes[&conf] = dp
-			}
+		matches, err := s.matchesFor(meshName, meshContext)
+		if err != nil {
+			return nil, err
 		}
+		maps.Copy(meshMetricConfToDataplanes, matches)
 	}
 
 	return meshMetricConfToDataplanes, nil
+}
+
+func (s *SnapshotGenerator) matchesFor(meshName string, meshContext xds_context.MeshContext) (map[*v1alpha1.Conf]*core_mesh.DataplaneResource, error) {
+	s.matchesMutex.Lock()
+	defer s.matchesMutex.Unlock()
+	if cached, ok := s.matchesByMesh[meshName]; ok && cached.meshHash == meshContext.Hash {
+		return cached.confToDataplanes, nil
+	}
+
+	matches := map[*v1alpha1.Conf]*core_mesh.DataplaneResource{}
+	for _, dp := range meshContext.DataplanesByName {
+		matchedPolicies, err := matchers.MatchedPolicies(v1alpha1.MeshMetricType, dp, meshContext.Resources)
+		if err != nil {
+			return nil, errors.Wrap(err, "error on matching dpp")
+		}
+		if matchedPolicies.ProxyConf != nil {
+			conf := matchedPolicies.ProxyConf.Conf.(v1alpha1.Conf)
+			matches[&conf] = dp
+		}
+	}
+	s.matchesByMesh[meshName] = meshMetricMatches{meshHash: meshContext.Hash, confToDataplanes: matches}
+	return matches, nil
 }
 
 func createSnapshot(resources []*core_xds.Resource) envoy_cache.ResourceSnapshot {

--- a/pkg/mads/v1/reconcile/snapshot_generator_test.go
+++ b/pkg/mads/v1/reconcile/snapshot_generator_test.go
@@ -629,5 +629,59 @@ var _ = Describe("snapshotGenerator", func() {
 				},
 			}),
 		)
+
+		It("matches dataplanes again once the mesh changes", func() {
+			meshContextBuilder := xds_context.NewMeshContextBuilder(resourceManager, server.MeshResourceTypes(), net.LookupIP, "")
+			newMetrics, err := metrics.NewMetrics("")
+			Expect(err).ToNot(HaveOccurred())
+			cache, err := mesh.NewCache(time.Millisecond, meshContextBuilder, newMetrics)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx := context.Background()
+			createDataplane := func(name, address string) {
+				dp := samples.DataplaneBackendBuilder().
+					WithName(name).
+					WithAddress(address).
+					WithInboundOfTags("kuma.io/display-name", name).
+					Build()
+				Expect(resourceManager.Create(ctx, dp,
+					core_store.CreateBy(core_model.MetaToResourceKey(dp.GetMeta())),
+					core_store.CreateWithLabels(dp.GetMeta().GetLabels()))).To(Succeed())
+			}
+			Expect(resourceManager.Create(ctx, core_mesh.NewMeshResource(), core_store.CreateByKey("default", core_model.NoMesh))).To(Succeed())
+			createDataplane("backend-01", "192.168.0.1")
+			meshMetric := &v1alpha1.MeshMetricResource{
+				Meta: &test_model.ResourceMeta{Name: "default", Mesh: "default"},
+				Spec: &v1alpha1.MeshMetric{
+					TargetRef: &common_api.TopLevelTargetRef{Kind: common_api.TopLevelTargetRefKindMesh},
+					Default: v1alpha1.Conf{
+						Backends: &[]v1alpha1.Backend{{
+							Type: v1alpha1.PrometheusBackendType,
+							Prometheus: &v1alpha1.PrometheusBackend{
+								Port: 1234,
+								Path: "/custom",
+								Tls:  &v1alpha1.PrometheusTls{Mode: v1alpha1.Disabled},
+							},
+						}},
+					},
+				},
+			}
+			Expect(resourceManager.Create(ctx, meshMetric, core_store.CreateBy(core_model.MetaToResourceKey(meshMetric.GetMeta())))).To(Succeed())
+			snapshotter := NewSnapshotGenerator(resourceManager, cache)
+
+			snapshotPerClient, err := snapshotter.GenerateSnapshot(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshotPerClient[meshmetrics_generator.DefaultKumaClientId].GetResources(mads_v1.MonitoringAssignmentType)).
+				To(HaveKey("/meshes/default/dataplanes/backend-01"))
+
+			createDataplane("backend-02", "192.168.0.2")
+
+			Eventually(func(g Gomega) {
+				snapshotPerClient, err := snapshotter.GenerateSnapshot(ctx)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(snapshotPerClient[meshmetrics_generator.DefaultKumaClientId].GetResources(mads_v1.MonitoringAssignmentType)).
+					To(HaveKey("/meshes/default/dataplanes/backend-02"))
+			}).Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
## Motivation

On every 1s tick, MADS matched MeshMetric policies against every dataplane of every mesh with a MeshMetric. It did this without any cache and whether or not anything had changed.

## Implementation information

- Keep the MeshMetric matches per mesh together with the mesh context hash they were computed for, and reuse them while the hash is unchanged. Matching depends only on dataplanes and policies, and both are covered by that hash.
- A mesh listed once per MeshMetric backend is now matched once per tick instead of once per listing.
- New test: adding a dataplane shows up in the next snapshot once the mesh context changes.

## Supporting documentation

- MADR 106: #18682
