### PR TITLE
fix(make): repair broken target definitions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,7 +106,7 @@ make build/kuma-cp        # Build control plane
 make test TEST_PKG_LIST=./pkg/xds/...    # Test specific package
 UPDATE_GOLDEN_FILES=true make test       # Update golden files
 
-make k3d/restart && skaffold dev          # Dev environment
+make k3d/cluster/start && skaffold dev          # Dev environment
 ```
 
 ### Git & PRs

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -183,7 +183,7 @@ You can test development versions by first pushing to `gcr.io`:
 
 ```bash
 gcloud auth configure-docker
-make images/push DOCKER_REGISTRY=gcr.io/proj-123456
+make images docker/push DOCKER_REGISTRY=gcr.io/proj-123456
 ```
 
 then setting up `kubectl` to connect to your cluster and installing Kuma:

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -140,11 +140,11 @@ build/artifacts-$(1)-$(2)/kumactl:
 
 .PHONY: build/artifacts-$(1)-$(2)/kuma-cni
 build/artifacts-$(1)-$(2)/kuma-cni:
-	$(Build_Go_Application) -ldflags="-extldflags=-static" ./app/cni/cmd/kuma-cni
+	$(Build_Go_Application) ./app/cni/cmd/kuma-cni
 
 .PHONY: build/artifacts-$(1)-$(2)/install-cni
 build/artifacts-$(1)-$(2)/install-cni:
-	$(Build_Go_Application) -ldflags="-extldflags=-static" ./app/cni/cmd/install
+	$(Build_Go_Application) ./app/cni/cmd/install
 
 .PHONY: build/artifacts-$(1)-$(2)/envoy
 build/artifacts-$(1)-$(2)/envoy:

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -135,7 +135,7 @@ dev/merge-release:
 
 # Generate a .envrc that prepends e2e test suite configs to whatever
 # KUBECONFIG currently has, and stores CI tooling in .tools.
-.PHONY: dev/enrc
+.PHONY: dev/envrc
 dev/envrc: $(KUBECONFIG_DIR)/kind-kuma-current ## Generate .envrc
 	@echo 'export CI_TOOLS_DIR=$$(expand_path .tools)' > .envrc
 	@for c in \

--- a/mk/distribution.mk
+++ b/mk/distribution.mk
@@ -96,7 +96,7 @@ endif
 build/distributions/out: $(patsubst %,build/distributions/out/$(DISTRIBUTION_TARGET_NAME)-%.tar.gz,$(ENABLED_DIST_NAMES))
 	cd $@; sha256sum *.tar.gz > $(DISTRIBUTION_TARGET_NAME).sha256
 
-.PHONY: build/info/distribution/repo
+.PHONY: build/info/cloudsmith_repository
 build/info/cloudsmith_repository:
 	@echo $(PULP_PACKAGE_TYPE)-binaries-$(PULP_DIST_VERSION)
 

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -103,7 +103,7 @@ docker/save/$(1)/$(2):
 	@mkdir -p build/docker
 	docker save --output build/docker/$(1)-$(2).tar $$(call build_image,$(1),$(2))
 
-.PHONY: docker/$(1)/$(2)
+.PHONY: docker/load/$(1)/$(2)
 docker/load/$(1)/$(2):
 	@docker load --quiet --input build/docker/$(1)-$(2).tar
 

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -111,7 +111,6 @@ docs/generated/openapi/prepare/layout:
 	@mkdir -p $(OAPI_TMP_DIR)
 
 # Create or reset a named subdirectory under $(OAPI_TMP_DIR)
-.PHONY: docs/generated/openapi/prepare/layout/%
 docs/generated/openapi/prepare/layout/%:
 	@rm -rf $(OAPI_TMP_DIR)/$*
 	@mkdir -p $(OAPI_TMP_DIR)/$*

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -123,7 +123,7 @@ test/e2e/debug: $(E2E_DEPS_TARGETS)
 # and doesn't start Kind clusters
 .PHONY: test/e2e/debug-universal
 test/e2e/debug-universal:
-	@echo "Stop using this target use `make test/e2e-universal DEBUG=1`"
+	@echo 'Stop using this target use `make test/e2e-universal DEBUG=1`'
 	$(MAKE) test/e2e-universal DEBUG=1
 
 .PHONY: test/e2e

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -24,7 +24,7 @@ generate/protos:
 clean/tools:
 	rm -rf $(KUMA_DIR)/build/tools-*
 
-.PHONY: clean/proto
+.PHONY: clean/protos
 clean/protos: ## Dev: Remove auto-generated Protobuf files
 	find $(PROTO_DIRS) -name '*.pb.go' -delete
 	find $(PROTO_DIRS) -name '*.pb.validate.go' -delete
@@ -89,6 +89,7 @@ clean/resources: POLICIES_DIR=$(RESOURCES_DIR)
 clean/resources:
 	POLICIES_DIR=$(RESOURCES_DIR) $(MAKE) clean/policies
 
+.PHONY: generate/resources
 generate/resources: POLICIES_DIR=$(RESOURCES_DIR)
 generate/resources:
 	POLICIES_DIR=$(RESOURCES_DIR) $(MAKE) $(addprefix generate/policy/,$(policies))
@@ -96,6 +97,7 @@ generate/resources:
 	POLICIES_DIR=$(RESOURCES_DIR) HELM_VALUES_FILE_POLICY_PATH=".plugins.resources" $(MAKE) generate/policy-helm
 	POLICIES_DIR=$(RESOURCES_DIR) $(MAKE) generate/policy-config
 
+.PHONY: generate/policies
 generate/policies: generate/deep-copy/common $(addprefix generate/policy/,$(policies)) generate/policy-import generate/policy-config generate/policy-defaults generate/policy-helm ## Generate all policies written as plugins
 
 .PHONY: clean/policies
@@ -106,6 +108,7 @@ clean/policy/%:
 	$(shell find $(POLICIES_DIR)/$* \( -name '*.pb.go' -o -name '*.yaml' -o -name 'zz_generated.*'  \) -not -path '*/testdata/*' -type f -delete)
 	@rm -fr $(POLICIES_DIR)/$*/k8s
 
+.PHONY: generate/deep-copy/common
 generate/deep-copy/common:
 	for version in $(foreach dir,$(wildcard $(COMMON_DIR)/*),$(notdir $(dir))); do \
 		$(CONTROLLER_GEN) object paths="./$(COMMON_DIR)/$$version/..."  ; \
@@ -119,6 +122,7 @@ generate/policy/%: $(POLICY_GEN)
 	$(POLICY_GEN) openapi --plugin-dir $(POLICIES_DIR)/$* --yq-bin $(YQ) --openapi-template-path=$(TOOLS_DIR)/openapi/templates/endpoints.yaml --jsonschema-template-path=$(TOOLS_DIR)/openapi/templates/schema.yaml --gomodule $(GO_MODULE)
 	@echo "Policy $* successfully generated"
 
+.PHONY: generate/policy-import generate/policy-config generate/policy-defaults generate/policy-helm
 generate/policy-import:
 	./tools/policy-gen/generate-policy-import.sh $(GO_MODULE) $(POLICIES_DIR) $(policies)
 

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -395,7 +395,6 @@ k3d/cluster/deploy/wait/cp: \
   k3d/cluster/deploy/wait/Ready/pods/$(PROJECT_NAME)-control-plane \
   k3d/cluster/deploy/wait/mesh
 
-.PHONY: k3d/cluster/deploy/wait/%
 k3d/cluster/deploy/wait/%: CONDITION = $(word 1,$(subst /, ,$*))
 k3d/cluster/deploy/wait/%: KIND      = $(word 2,$(subst /, ,$*))
 k3d/cluster/deploy/wait/%: APP       = $(word 3,$(subst /, ,$*))

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -111,7 +111,7 @@ kind/cluster/deploy/kuma: build/kumactl kind/cluster/load
 
 .PHONY: kind/cluster/deploy/helm
 kind/cluster/deploy/helm: kind/cluster/load
-	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) delete namespace $(KUMA_NAMESPACE) | true
+	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) delete namespace $(KUMA_NAMESPACE) || true
 	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) create namespace $(KUMA_NAMESPACE)
 	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) helm install --namespace $(KUMA_NAMESPACE) \
                 --set global.image.registry="$(DOCKER_REGISTRY)" \


### PR DESCRIPTION
## Motivation

An audit of `mk/*.mk` turned up a few real bugs:

- `test/e2e/debug-universal` ran the universal e2e suite twice. The backticks inside a double-quoted `echo` are command substitution, so the whole suite runs inside the echo, then again on the next line.
- `kuma-cni` and `install-cni` shipped without version stamps and without `-s -w`. The recipe passed a second `-ldflags`, and Go only uses the last one.
- `kind/cluster/deploy/helm` piped into `true` instead of `|| true`.

## Implementation information

- Quote the `echo` with single quotes.
- Drop the extra `-ldflags="-extldflags=-static"` on the CNI binaries. `CGO_ENABLED=0` already links statically, so it had no effect. Checked with `go version -m` / `strings` on a linux/amd64 build: the version is embedded again.
- Fix four `.PHONY` names that did not match their targets (`dev/envrc`, `clean/protos`, `docker/load/*`, `build/info/cloudsmith_repository`). Drop `.PHONY` on pattern rules, where it does nothing. Add the missing `.PHONY` in `generate.mk`.
- Fix doc refs to removed targets (`images/push`, `k3d/restart`).

## Supporting documentation

First of a series simplifying the Makefiles (parse-time cost, dead code, duplication come next).