### PR TITLE
perf(make): skip network and tool lookups at parse

### DIFF
--- a/mk/api.mk
+++ b/mk/api.mk
@@ -1,4 +1,4 @@
-PROTOC := $(PROTOC_BIN) \
+PROTOC = $(PROTOC_BIN) \
 	--proto_path=$(PROTO_GOOGLE_APIS) \
 	--proto_path=$(PROTO_XDS) \
 	--proto_path=$(PROTO_PGV) \
@@ -7,7 +7,7 @@ PROTOC := $(PROTOC_BIN) \
 	--proto_path=$(KUMA_DIR) \
 	--proto_path=.
 
-PROTOC_GO := $(PROTOC) \
+PROTOC_GO = $(PROTOC) \
 	--plugin=protoc-gen-go=$(PROTOC_GEN_GO) \
 	--plugin=protoc-gen-go-grpc=$(PROTOC_GEN_GO_GRPC) \
 	--go_opt=paths=source_relative \

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -20,7 +20,7 @@ ifneq ($(EXTRA_GOFLAGS),)
 GOFLAGS += $(EXTRA_GOFLAGS)
 endif
 
-TOP := $(shell pwd)
+TOP := $(CURDIR)
 BUILD_DIR ?= $(TOP)/build
 BUILD_ARTIFACTS_DIR ?= $(BUILD_DIR)/artifacts-${GOOS}-${GOARCH}
 BUILD_KUMACTL_DIR := ${BUILD_ARTIFACTS_DIR}/kumactl

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -11,10 +11,10 @@ Q := $(if $(V),,@)
 
 # --- String helpers ---
 
-# _is_digits(x): "yes" iff x is non-empty and contains only digits.
-# Uses $(shell) because recursive $(call) crashes GNU Make (segfault)
-# when evaluated during Makefile parsing in certain versions.
-_is_digits = $(if $(strip $(1)),$(if $(shell echo '$(1)' | grep -qE '^[0-9]+$$' && echo yes),yes))
+# _is_digits(x): "yes" iff x is a single word made only of digits.
+# Nested $(subst) instead of recursive $(call), which crashes GNU Make
+# (segfault) when evaluated during Makefile parsing in certain versions.
+_is_digits = $(if $(filter 1,$(words $(1))),$(if $(subst 0,,$(subst 1,,$(subst 2,,$(subst 3,,$(subst 4,,$(subst 5,,$(subst 6,,$(subst 7,,$(subst 8,,$(subst 9,,$(1))))))))))),,yes))
 
 # --- _retry ---
 

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -13,10 +13,10 @@ KUMA_CHARTS_URL ?= https://kumahq.github.io/charts
 CHART_REPO_NAME ?= kuma
 PROJECT_NAME ?= kuma
 
-ifeq (,$(shell which mise))
+MISE := $(shell which mise)
+ifeq (,$(MISE))
 $(error "mise - https://github.com/jdx/mise - not found. Please install it.")
 endif
-MISE := $(shell which mise)
 
 CI_TOOLS_DIR ?= ${HOME}/.local/share/mise/${PROJECT_NAME}
 ifdef XDG_DATA_HOME
@@ -47,50 +47,61 @@ endef
 # KUBECONFIG_DIR is defined in mk/k8s.mk (included via Makefile).
 # Do not redefine it here.
 
-PROTOS_DEPS_PATH=$(shell $(MISE) where protoc)/include
+# _once(VAR,value): on first expansion replace VAR with the simply-expanded
+# value, so every make invocation does not pay for lookups it never uses.
+_once = $(eval $(1) := $(2))$($(1))
 
-BUF=$(shell $(MISE) which buf)
+PROTOS_DEPS_PATH = $(call _once,PROTOS_DEPS_PATH,$(shell $(MISE) where protoc)/include)
 
-# Proto dependencies via Buf
+BUF = $(call _once,BUF,$(shell $(MISE) which buf))
+
+# Proto dependencies via Buf, exported by dev/protos/deps (network, so not at parse time)
 BUF_CACHE_DIR := $(CI_TOOLS_DIR)/buf/cache
-PROTO_GOOGLE_APIS := $(shell $(BUF) export buf.build/googleapis/googleapis --output $(BUF_CACHE_DIR)/googleapis && echo $(BUF_CACHE_DIR)/googleapis)
-PROTO_PGV := $(shell $(BUF) export buf.build/envoyproxy/protoc-gen-validate --output $(BUF_CACHE_DIR)/pgv && echo $(BUF_CACHE_DIR)/pgv)
+PROTO_GOOGLE_APIS := $(BUF_CACHE_DIR)/googleapis
+PROTO_PGV := $(BUF_CACHE_DIR)/pgv
 # Envoy does not publish a BSR proto snapshot for every patch release, but always does
 # for a minor, so follow ENVOY_VERSION's minor. Override to pick up a later patch's API.
 ENVOY_PROTO_VERSION ?= v$(basename $(ENVOY_VERSION)).0
-PROTO_ENVOY := $(shell $(BUF) export buf.build/envoyproxy/envoy:$(ENVOY_PROTO_VERSION) --output $(BUF_CACHE_DIR)/envoy && echo $(BUF_CACHE_DIR)/envoy)
-PROTO_XDS := $(shell $(BUF) export buf.build/cncf/xds --output $(BUF_CACHE_DIR)/xds && echo $(BUF_CACHE_DIR)/xds)
-YQ=$(shell $(MISE) which yq)
-HELM=$(shell $(MISE) which helm)
+PROTO_ENVOY := $(BUF_CACHE_DIR)/envoy
+PROTO_XDS := $(BUF_CACHE_DIR)/xds
+YQ = $(call _once,YQ,$(shell $(MISE) which yq))
+HELM = $(call _once,HELM,$(shell $(MISE) which helm))
 K3D=$(MISE) exec -- k3d
-KIND=$(shell $(MISE) which kind)
-SETUP_ENVTEST=$(shell $(MISE) which setup-envtest)
-KUBEBUILDER_ASSETS=$(shell $(SETUP_ENVTEST) use $(KUBEBUILDER_ASSETS_VERSION) --bin-dir $(CI_TOOLS_BIN_DIR) -p path)
-CONTROLLER_GEN=$(shell $(MISE) which controller-gen)
-KUBECTL=$(shell $(MISE) which kubectl)
-PROTOC_BIN=$(shell $(MISE) which protoc)
-SHELLCHECK=$(shell $(MISE) which shellcheck)
-ACTIONLINT=$(shell $(MISE) which actionlint)
-CONTAINER_STRUCTURE_TEST=$(shell $(MISE) which container-structure-test)
-PROTOC_GEN_GO=$(shell $(MISE) which protoc-gen-go)
-PROTOC_GEN_GO_GRPC=$(shell $(MISE) which protoc-gen-go-grpc)
+KIND = $(call _once,KIND,$(shell $(MISE) which kind))
+SETUP_ENVTEST = $(call _once,SETUP_ENVTEST,$(shell $(MISE) which setup-envtest))
+KUBEBUILDER_ASSETS = $(call _once,KUBEBUILDER_ASSETS,$(shell $(SETUP_ENVTEST) use $(KUBEBUILDER_ASSETS_VERSION) --bin-dir $(CI_TOOLS_BIN_DIR) -p path))
+CONTROLLER_GEN = $(call _once,CONTROLLER_GEN,$(shell $(MISE) which controller-gen))
+KUBECTL = $(call _once,KUBECTL,$(shell $(MISE) which kubectl))
+PROTOC_BIN = $(call _once,PROTOC_BIN,$(shell $(MISE) which protoc))
+SHELLCHECK = $(call _once,SHELLCHECK,$(shell $(MISE) which shellcheck))
+ACTIONLINT = $(call _once,ACTIONLINT,$(shell $(MISE) which actionlint))
+CONTAINER_STRUCTURE_TEST = $(call _once,CONTAINER_STRUCTURE_TEST,$(shell $(MISE) which container-structure-test))
+PROTOC_GEN_GO = $(call _once,PROTOC_GEN_GO,$(shell $(MISE) which protoc-gen-go))
+PROTOC_GEN_GO_GRPC = $(call _once,PROTOC_GEN_GO_GRPC,$(shell $(MISE) which protoc-gen-go-grpc))
 PROTOC_GEN_VALIDATE=$(MISE) exec -- protoc-gen-validate
 PROTOC_GEN_KUMADOC=$(MISE) exec -- protoc-gen-kumadoc
-PROTOC_GEN_JSONSCHEMA=$(shell $(MISE) which protoc-gen-jsonschema)
-GINKGO=$(shell $(MISE) which ginkgo)
-GOLANGCI_LINT=$(shell $(MISE) which golangci-lint)
-HELM_DOCS=$(shell $(MISE) which helm-docs)
-KUBE_LINTER=$(shell $(MISE) which kube-linter)
-HADOLINT=$(shell $(MISE) which hadolint)
-DASHBOARD_LINTER=$(shell $(MISE) which dashboard-linter)
+PROTOC_GEN_JSONSCHEMA = $(call _once,PROTOC_GEN_JSONSCHEMA,$(shell $(MISE) which protoc-gen-jsonschema))
+GINKGO = $(call _once,GINKGO,$(shell $(MISE) which ginkgo))
+GOLANGCI_LINT = $(call _once,GOLANGCI_LINT,$(shell $(MISE) which golangci-lint))
+HELM_DOCS = $(call _once,HELM_DOCS,$(shell $(MISE) which helm-docs))
+KUBE_LINTER = $(call _once,KUBE_LINTER,$(shell $(MISE) which kube-linter))
+HADOLINT = $(call _once,HADOLINT,$(shell $(MISE) which hadolint))
+DASHBOARD_LINTER = $(call _once,DASHBOARD_LINTER,$(shell $(MISE) which dashboard-linter))
 # oapi-codegen: mise go: backend installs to CI_TOOLS_BIN_DIR, mise which doesn't find it
-OAPI_CODEGEN=$(shell test -f $(CI_TOOLS_BIN_DIR)/oapi-codegen && echo $(CI_TOOLS_BIN_DIR)/oapi-codegen || command -v oapi-codegen)
+OAPI_CODEGEN = $(call _once,OAPI_CODEGEN,$(shell test -f $(CI_TOOLS_BIN_DIR)/oapi-codegen && echo $(CI_TOOLS_BIN_DIR)/oapi-codegen || command -v oapi-codegen))
 
 TOOLS_DEPS_DIRS=$(KUMA_DIR)/mk/dependencies
 TOOLS_DEPS_LOCK_FILE=mk/dependencies/deps.lock
 TOOLS_MAKEFILE=$(KUMA_DIR)/mk/dev.mk
 
-LATEST_RELEASE_BRANCH := $(shell $(YQ) e '.[] | .branch' versions.yml | grep -v dev | sort -V | tail -n 1)
+LATEST_RELEASE_BRANCH = $(call _once,LATEST_RELEASE_BRANCH,$(shell $(YQ) e '.[] | .branch' versions.yml | grep -v dev | sort -V | tail -n 1))
+
+.PHONY: dev/protos/deps
+dev/protos/deps: ## Dev: Export third-party proto dependencies with buf
+	$(BUF) export buf.build/googleapis/googleapis --output $(PROTO_GOOGLE_APIS)
+	$(BUF) export buf.build/envoyproxy/protoc-gen-validate --output $(PROTO_PGV)
+	$(BUF) export buf.build/envoyproxy/envoy:$(ENVOY_PROTO_VERSION) --output $(PROTO_ENVOY)
+	$(BUF) export buf.build/cncf/xds --output $(PROTO_XDS)
 
 .PHONY: cmd/check/%
 cmd/check/%:

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -19,7 +19,7 @@ helm-docs: ## Dev: Runs helm-docs generator
 	$(HELM_DOCS) -s="file" --chart-search-root=./deployments/charts
 
 .PHONY: docs/generated/raw
-docs/generated/raw: docs/generated/raw/rbac.yaml
+docs/generated/raw: docs/generated/raw/rbac.yaml $(if $(strip $(DOCS_PROTOS)),dev/protos/deps)
 	mkdir -p $@
 	command cp $(DOCS_CP_CONFIG) $@/kuma-cp.yaml
 	command cp $(HELM_VALUES_FILE) $@/helm-values.yaml

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -17,7 +17,7 @@ EXTRA_GENERATE_DEPS_TARGETS ?= generate/envoy-imports
 clean/generated: clean/protos clean/builtin-crds clean/legacy-resources clean/resources clean/policies clean/tools
 
 .PHONY: generate/protos
-generate/protos:
+generate/protos: dev/protos/deps
 	find $(PROTO_DIRS) -name '*.proto' -exec $(PROTOC_GO) {} \;
 
 .PHONY: clean/tools


### PR DESCRIPTION
## Motivation

Every `make` invocation spent 7-18s parsing before running anything. That includes `make help` and each of the ~85 recursive `$(MAKE)` calls (`k3d/cluster/start` alone runs 7). Most of that time:

- 4 `buf export` calls at parse time (`mk/dev.mk`), which hit the network (~5s)
- ~25 tool paths defined as `X=$(shell mise which X)`, re-run on every expansion. `container-structure-test` alone was looked up 10 times through the image templates.

## Implementation information

- `buf export` moves into a new `dev/protos/deps` target, a prerequisite of `generate/protos` and of `docs/generated/raw` (only when `DOCS_PROTOS` is set). `PROTO_*` are now plain paths.
- Tool paths, `KUBEBUILDER_ASSETS`, `OAPI_CODEGEN` and `LATEST_RELEASE_BRANCH` are resolved once, on first use, via `_once = $(eval $(1) := $(2))$($(1))`. Checked on GNU make 3.81 (macOS) and 4.x: a variable that is never used never runs its lookup.
- `PROTOC`/`PROTOC_GO` switch from `:=` to `=` so they don't force the lookups at parse time.
- `_is_digits` is now pure make (nested `subst`, no recursion, same results). `TOP` comes from `$(CURDIR)`, and `which mise` runs once.

Result on macOS: `make -n help` drops from 7-18s to ~1.1s, and shells spawned per parse from 42 to 18. `make check` and `make test` pass locally; `CLUSTER=kuma|kuma-2|3` still pass validation and `foo`/`kuma-x` are still rejected.

Variable names and values are unchanged, so the downstream project's overrides keep working.

## Supporting documentation

Part of a series simplifying the Makefiles, after #18689.