### PR TITLE
fix(make): fail recipes on broken pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-SHELL := /usr/bin/env bash
+# pipefail in SHELL, not .SHELLFLAGS: macOS ships make 3.81, which ignores .SHELLFLAGS.
+SHELL := /usr/bin/env bash -o pipefail
+.DELETE_ON_ERROR:
 
 .PHONY: help
 help: ## Display this help screen

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -113,8 +113,8 @@ check: format lint check/rbac ## Dev: Run code checks (go fmt, go vet, ...)
 check/rbac:
 	@BASE=$$(git merge-base HEAD origin/master); \
 	RBAC_CHANGED=$$(for f in $$(git --no-pager diff $$BASE --name-only -- deployments/); do \
-		{ cat "$$f" 2>/dev/null; git --no-pager show "$$BASE:$$f" 2>/dev/null; } \
-			| grep -qE 'kind: (Role|RoleBinding|ClusterRole|ClusterRoleBinding)' && echo true && break; \
+		grep -qE 'kind: (Role|RoleBinding|ClusterRole|ClusterRoleBinding)' \
+			<({ cat "$$f" 2>/dev/null; git --no-pager show "$$BASE:$$f" 2>/dev/null; }) && echo true && break; \
 	done); \
 	UPGRADE_CHANGED=$$(git --no-pager diff $$BASE --quiet UPGRADE.md; [ $$? -ne 0 ] && echo true || echo ""); \
 	if [ -n "$$RBAC_CHANGED" ] && [ -z "$$UPGRADE_CHANGED" ]; then \

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -42,12 +42,12 @@ ifneq ($(strip $(DOCS_PROTOS)),)
 endif
 
 # Built beside the target and moved on success, so a failing generator cannot
-# leave the committed file truncated. pipefail because the redirect would
-# otherwise report sed's status and hide a helm or yq failure entirely.
+# leave the committed file truncated. SHELL sets pipefail, so a helm or yq
+# failure is not hidden behind sed's status.
 .PHONY: docs/generated/raw/rbac.yaml
 docs/generated/raw/rbac.yaml:
 	@mkdir -p docs/generated/raw
-	@set -o pipefail; $(HELM) template --namespace $(PROJECT_NAME)-system $(PROJECT_NAME) deployments/charts/$(PROJECT_NAME) | \
+	@$(HELM) template --namespace $(PROJECT_NAME)-system $(PROJECT_NAME) deployments/charts/$(PROJECT_NAME) | \
 	$(YQ) eval-all 'select((.kind == "ClusterRole" or .kind == "ClusterRoleBinding" or .kind == "Role" or .kind == "RoleBinding") and (.metadata.annotations["helm.sh/hook"] == null)) | del(.metadata.labels)' - | \
 	grep -Ev '^\s*#' | \
 	sed 's/[[:space:]]*#.*$$//' > $@.tmp || { rm -f $@.tmp; exit 1; }

--- a/mk/e2e.new.mk
+++ b/mk/e2e.new.mk
@@ -133,7 +133,7 @@ test/e2e: $(E2E_DEPS_TARGETS) $(E2E_K8S_BIN_DEPS) ## Run slower e2e tests (slowe
 	@# skipinboundtags on job-0) would fail even though that's expected.
 	@# Instead, validate the package list so we don't accidentally run the
 	@# wrong packages (like KUBE_E2E_PKG_LIST) for another year.
-	@echo '$(E2E_PKG_LIST)' | grep -q '\./test/e2e/' || \
+	@grep -q '\./test/e2e/' <<< '$(E2E_PKG_LIST)' || \
 		{ echo "ERROR: E2E_PKG_LIST does not contain ./test/e2e/ packages: $(E2E_PKG_LIST)"; exit 1; }
 	$(MAKE) docker/tag
 	$(MAKE) test/e2e/k8s/start

--- a/mk/k3d.mk
+++ b/mk/k3d.mk
@@ -431,7 +431,7 @@ endif
 k3d/cluster/deploy/kumactl/install:
 	$(Q)$(KUMACTL) install --mode $(KUMA_MODE) control-plane $(KUMACTL_INSTALL_CONTROL_PLANE_IMAGES) \
 	  | $(KUBECTL) apply --filename - \
-	  | grep --invert-match 'unchanged'
+	  | { grep --invert-match 'unchanged' || true; }
 	$(Q)printf '\n'
 
 .PHONY: k3d/cluster/deploy/kumactl/clean

--- a/mk/kind.mk
+++ b/mk/kind.mk
@@ -111,7 +111,7 @@ kind/cluster/deploy/kuma: build/kumactl kind/cluster/load
 
 .PHONY: kind/cluster/deploy/helm
 kind/cluster/deploy/helm: kind/cluster/load
-	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) delete namespace $(KUMA_NAMESPACE) | true
+	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) delete namespace $(KUMA_NAMESPACE) || true
 	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) $(KUBECTL) create namespace $(KUMA_NAMESPACE)
 	KUBECONFIG=$(KIND_CLUSTER_KUBECONFIG) helm install --namespace $(KUMA_NAMESPACE) \
                 --set global.image.registry="$(DOCKER_REGISTRY)" \


### PR DESCRIPTION
## Motivation

`SHELL` was plain bash, so a pipeline reported only its last command's status. Recipes like `kumactl install | kubectl apply`, `helm template | yq` and `curl | sed` succeeded even when the command feeding the pipe failed.

## Implementation information

- `SHELL := /usr/bin/env bash -o pipefail`. The flag goes in `SHELL`, not `.SHELLFLAGS`, because macOS ships GNU make 3.81, which ignores `.SHELLFLAGS`. Checked on 3.81: it applies to recipes and `$(shell)`, and a pipeline that ends a recipe line now fails it. There is no global `-e`: several multi-command recipe lines rely on it being off.
- `.DELETE_ON_ERROR:` so a failed recipe doesn't leave a half-written target behind.
- `check/rbac`: `{ ... } | grep -q` becomes a false negative under pipefail. `grep -q` exits on the first match, and the command feeding the pipe then fails on the closed pipe (SIGPIPE). This reproduced 3 out of 3 times, so it now reads through process substitution. Checked both ways: a probe edit to an RBAC manifest fails the check, and a clean tree passes.
- k3d `kumactl/install`: `grep --invert-match unchanged` exited 1 when every resource was unchanged, which already failed redeploys.
- kind `deploy/helm`: `| true` → `|| true`. Under pipefail the old form would fail when the namespace is absent. The same line is fixed in #18689; the identical change merges cleanly.
- `e2e` package guard uses a here-string instead of `echo | grep -q`.
- The redundant `set -o pipefail` in `docs/generated/raw/rbac.yaml` is gone.

`make check` passes locally. The downstream project doesn't include the top-level `Makefile`, so its recipes are unaffected until it opts in.

## Supporting documentation

Part of a series simplifying the Makefiles, after #18689 and #18690.