### PR TITLE
fix(tools): pass error schema to resource-gen

### DIFF
--- a/api/mesh/v1alpha1/dataplane/rest.yaml
+++ b/api/mesh/v1alpha1/dataplane/rest.yaml
@@ -478,7 +478,7 @@ paths:
         "200":
           $ref: '#/components/responses/DataplaneDeleteSuccessResponse'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Deletes Dataplane entity
       tags:
       - Dataplane
@@ -501,7 +501,7 @@ paths:
         "200":
           $ref: '#/components/responses/DataplaneItem'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Returns Dataplane entity
       tags:
       - Dataplane

--- a/api/mesh/v1alpha1/dataplaneinsight/rest.yaml
+++ b/api/mesh/v1alpha1/dataplaneinsight/rest.yaml
@@ -448,7 +448,7 @@ paths:
         "200":
           $ref: '#/components/responses/DataplaneInsightItem'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Returns DataplaneInsight entity
       tags:
       - DataplaneInsight

--- a/api/mesh/v1alpha1/mesh/rest.yaml
+++ b/api/mesh/v1alpha1/mesh/rest.yaml
@@ -149,7 +149,7 @@ paths:
         "200":
           $ref: '#/components/responses/MeshDeleteSuccessResponse'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Deletes Mesh entity
       tags:
       - Mesh
@@ -166,7 +166,7 @@ paths:
         "200":
           $ref: '#/components/responses/MeshItem'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Returns Mesh entity
       tags:
       - Mesh

--- a/api/system/v1alpha1/secret/rest.yaml
+++ b/api/system/v1alpha1/secret/rest.yaml
@@ -158,7 +158,7 @@ paths:
         "200":
           $ref: '#/components/responses/SecretDeleteSuccessResponse'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Deletes Secret entity
       tags:
       - Secret
@@ -181,7 +181,7 @@ paths:
         "200":
           $ref: '#/components/responses/SecretItem'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Returns Secret entity
       tags:
       - Secret

--- a/api/system/v1alpha1/zone/rest.yaml
+++ b/api/system/v1alpha1/zone/rest.yaml
@@ -146,7 +146,7 @@ paths:
         "200":
           $ref: '#/components/responses/ZoneDeleteSuccessResponse'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Deletes Zone entity
       tags:
       - Zone
@@ -163,7 +163,7 @@ paths:
         "200":
           $ref: '#/components/responses/ZoneItem'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Returns Zone entity
       tags:
       - Zone

--- a/api/system/v1alpha1/zoneinsight/rest.yaml
+++ b/api/system/v1alpha1/zoneinsight/rest.yaml
@@ -321,7 +321,7 @@ paths:
         "200":
           $ref: '#/components/responses/ZoneInsightItem'
         "404":
-          $ref: ../../<no value>#/components/responses/NotFound
+          $ref: ../../base/specs/common/error_schema.yaml#/components/responses/NotFound
       summary: Returns ZoneInsight entity
       tags:
       - ZoneInsight

--- a/docs/generated/openapi.yaml
+++ b/docs/generated/openapi.yaml
@@ -3374,6 +3374,275 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/MeshTrafficPermissionList'
+  /dataplanes:
+    get:
+      operationId: getDataplaneListAllMeshes
+      parameters:
+        - description: offset in the list of entities
+          in: query
+          name: offset
+          required: false
+          schema:
+            example: 0
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneList'
+      summary: Returns a list of Dataplane across all meshes.
+      tags:
+        - Dataplane
+  /meshes/{mesh}/dataplanes:
+    get:
+      operationId: getDataplaneList
+      parameters:
+        - description: offset in the list of entities
+          example: 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneList'
+      summary: Returns a list of Dataplane in the mesh.
+      tags:
+        - Dataplane
+  /meshes/{mesh}/dataplanes/{name}:
+    delete:
+      operationId: deleteDataplane
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the Dataplane
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneDeleteSuccessResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Deletes Dataplane entity
+      tags:
+        - Dataplane
+    get:
+      operationId: getDataplane
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the Dataplane
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneItem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Returns Dataplane entity
+      tags:
+        - Dataplane
+    put:
+      operationId: putDataplane
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the Dataplane
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataplaneItem'
+        description: Put request
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneCreateOrUpdateSuccessResponse'
+        '201':
+          $ref: '#/components/responses/DataplaneCreateOrUpdateSuccessResponse'
+      summary: Creates or Updates Dataplane entity
+      tags:
+        - Dataplane
+  /dataplane-insights:
+    get:
+      operationId: getDataplaneInsightListAllMeshes
+      parameters:
+        - description: offset in the list of entities
+          in: query
+          name: offset
+          required: false
+          schema:
+            example: 0
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneInsightList'
+      summary: Returns a list of DataplaneInsight across all meshes.
+      tags:
+        - DataplaneInsight
+  /meshes/{mesh}/dataplane-insights:
+    get:
+      operationId: getDataplaneInsightList
+      parameters:
+        - description: offset in the list of entities
+          example: 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneInsightList'
+      summary: Returns a list of DataplaneInsight in the mesh.
+      tags:
+        - DataplaneInsight
+  /meshes/{mesh}/dataplane-insights/{name}:
+    get:
+      operationId: getDataplaneInsight
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the DataplaneInsight
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/DataplaneInsightItem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Returns DataplaneInsight entity
+      tags:
+        - DataplaneInsight
   /meshes/{mesh}/dataplanes/{name}/_overview:
     get:
       operationId: getDataplaneOverview
@@ -3584,6 +3853,104 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/GlobalSecretList'
+  /meshes:
+    get:
+      operationId: getMeshList
+      parameters:
+        - description: offset in the list of entities
+          example: 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+      responses:
+        '200':
+          $ref: '#/components/responses/MeshList'
+      summary: Returns a list of Mesh.
+      tags:
+        - Mesh
+  /meshes/{name}:
+    delete:
+      operationId: deleteMesh
+      parameters:
+        - description: name of the Mesh
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/MeshDeleteSuccessResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Deletes Mesh entity
+      tags:
+        - Mesh
+    get:
+      operationId: getMesh
+      parameters:
+        - description: name of the Mesh
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/MeshItem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Returns Mesh entity
+      tags:
+        - Mesh
+    put:
+      operationId: putMesh
+      parameters:
+        - description: name of the Mesh
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeshItem'
+        description: Put request
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
+        '201':
+          $ref: '#/components/responses/MeshCreateOrUpdateSuccessResponse'
+      summary: Creates or Updates Mesh entity
+      tags:
+        - Mesh
   /mesh-insights/{name}:
     get:
       operationId: getMeshInsight
@@ -3661,6 +4028,322 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/Internal'
+  /meshes/{mesh}/secrets:
+    get:
+      operationId: getSecretList
+      parameters:
+        - description: offset in the list of entities
+          example: 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SecretList'
+      summary: Returns a list of Secret in the mesh.
+      tags:
+        - Secret
+  /meshes/{mesh}/secrets/{name}:
+    delete:
+      operationId: deleteSecret
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the Secret
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SecretDeleteSuccessResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Deletes Secret entity
+      tags:
+        - Secret
+    get:
+      operationId: getSecret
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the Secret
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SecretItem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Returns Secret entity
+      tags:
+        - Secret
+    put:
+      operationId: putSecret
+      parameters:
+        - description: name of the mesh
+          in: path
+          name: mesh
+          required: true
+          schema:
+            type: string
+        - description: name of the Secret
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretItem'
+        description: Put request
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/SecretCreateOrUpdateSuccessResponse'
+        '201':
+          $ref: '#/components/responses/SecretCreateOrUpdateSuccessResponse'
+      summary: Creates or Updates Secret entity
+      tags:
+        - Secret
+  /secrets:
+    get:
+      operationId: getSecretListAllMeshes
+      parameters:
+        - description: offset in the list of entities
+          in: query
+          name: offset
+          required: false
+          schema:
+            example: 0
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+      responses:
+        '200':
+          $ref: '#/components/responses/SecretList'
+      summary: Returns a list of Secret across all meshes.
+      tags:
+        - Secret
+  /zones:
+    get:
+      operationId: getZoneList
+      parameters:
+        - description: offset in the list of entities
+          example: 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+      responses:
+        '200':
+          $ref: '#/components/responses/ZoneList'
+      summary: Returns a list of Zone.
+      tags:
+        - Zone
+  /zones/{name}:
+    delete:
+      operationId: deleteZone
+      parameters:
+        - description: name of the Zone
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/ZoneDeleteSuccessResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Deletes Zone entity
+      tags:
+        - Zone
+    get:
+      operationId: getZone
+      parameters:
+        - description: name of the Zone
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/ZoneItem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Returns Zone entity
+      tags:
+        - Zone
+    put:
+      operationId: putZone
+      parameters:
+        - description: name of the Zone
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZoneItem'
+        description: Put request
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/ZoneCreateOrUpdateSuccessResponse'
+        '201':
+          $ref: '#/components/responses/ZoneCreateOrUpdateSuccessResponse'
+      summary: Creates or Updates Zone entity
+      tags:
+        - Zone
+  /zone-insights:
+    get:
+      operationId: getZoneInsightList
+      parameters:
+        - description: offset in the list of entities
+          example: 0
+          in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+        - description: the number of items per page
+          in: query
+          name: size
+          required: false
+          schema:
+            default: 100
+            maximum: 1000
+            minimum: 1
+            type: integer
+        - description: filter by labels when multiple filters are present, they are ANDed
+          example:
+            label.k8s.kuma.io/namespace: my-ns
+          in: query
+          name: filter
+          required: false
+          schema:
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            type: object
+      responses:
+        '200':
+          $ref: '#/components/responses/ZoneInsightList'
+      summary: Returns a list of ZoneInsight.
+      tags:
+        - ZoneInsight
+  /zone-insights/{name}:
+    get:
+      operationId: getZoneInsight
+      parameters:
+        - description: name of the ZoneInsight
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/ZoneInsightItem'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      summary: Returns ZoneInsight entity
+      tags:
+        - ZoneInsight
   /zones/{name}/_overview:
     get:
       operationId: getZoneOverview
@@ -15606,6 +16289,297 @@ components:
       allOf:
         - $ref: '#/components/schemas/Meta'
         - $ref: '#/components/schemas/MeshOverview'
+    DataplaneInsightItem:
+      properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        mTLS:
+          description: Insights about mTLS for Dataplane.
+          properties:
+            certificateExpirationTime:
+              description: |-
+                Expiration time of the last certificate that was generated for a
+                Dataplane.
+              format: date-time
+              type: string
+            certificateRegenerations:
+              description: Number of certificate regenerations for a Dataplane.
+              type: integer
+            issuedBackend:
+              description: Backend that was used to generate current certificate
+              type: string
+            lastCertificateRegeneration:
+              description: Time on which the last certificate was generated.
+              format: date-time
+              type: string
+            supportedBackends:
+              description: Supported backends (CA).
+              items:
+                type: string
+              type: array
+          type: object
+        mesh:
+          maxLength: 253
+          pattern: ^[0-9a-z-_.]*$
+          type: string
+        metadata:
+          properties: {}
+          type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
+        name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+        openTelemetry:
+          description: Insights about OTel runtime resolution for this Dataplane.
+          properties:
+            backends:
+              items:
+                properties:
+                  logs:
+                    properties:
+                      blockedReasons:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
+                      envAllowed:
+                        type: boolean
+                      envInputPresent:
+                        type: boolean
+                      missingFields:
+                        items:
+                          type: string
+                        type: array
+                      overrideKinds:
+                        items:
+                          type: string
+                        type: array
+                      state:
+                        type: string
+                    type: object
+                  metrics:
+                    properties:
+                      blockedReasons:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
+                      envAllowed:
+                        type: boolean
+                      envInputPresent:
+                        type: boolean
+                      missingFields:
+                        items:
+                          type: string
+                        type: array
+                      overrideKinds:
+                        items:
+                          type: string
+                        type: array
+                      state:
+                        type: string
+                    type: object
+                  name:
+                    type: string
+                  traces:
+                    properties:
+                      blockedReasons:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
+                      envAllowed:
+                        type: boolean
+                      envInputPresent:
+                        type: boolean
+                      missingFields:
+                        items:
+                          type: string
+                        type: array
+                      overrideKinds:
+                        items:
+                          type: string
+                        type: array
+                      state:
+                        type: string
+                    type: object
+                type: object
+              type: array
+          type: object
+        subscriptions:
+          description: List of ADS subscriptions created by a given Dataplane.
+          items:
+            description: >-
+              DiscoverySubscription describes a single ADS subscription created
+              by a Dataplane to the Control Plane.
+            properties:
+              connectTime:
+                description: Time when a given Dataplane connected to the Control Plane.
+                format: date-time
+                type: string
+              controlPlaneInstanceId:
+                description: Control Plane instance that handled given subscription.
+                type: string
+              disconnectTime:
+                description: >-
+                  Time when a given Dataplane disconnected from the Control
+                  Plane.
+                format: date-time
+                type: string
+              generation:
+                description: >-
+                  Generation is an integer number which is periodically
+                  increased by the
+
+                  status sink
+                type: integer
+              id:
+                description: Unique id per ADS subscription.
+                type: string
+              status:
+                description: Status of the ADS subscription.
+                properties:
+                  cds:
+                    description: CDS defines all CDS stats.
+                    properties:
+                      responsesAcknowledged:
+                        description: Number of xDS responses ACKed by the Dataplane.
+                        type: integer
+                      responsesRejected:
+                        description: Number of xDS responses NACKed by the Dataplane.
+                        type: integer
+                      responsesSent:
+                        description: Number of xDS responses sent to the Dataplane.
+                        type: integer
+                    type: object
+                  eds:
+                    description: EDS defines all EDS stats.
+                    properties:
+                      responsesAcknowledged:
+                        description: Number of xDS responses ACKed by the Dataplane.
+                        type: integer
+                      responsesRejected:
+                        description: Number of xDS responses NACKed by the Dataplane.
+                        type: integer
+                      responsesSent:
+                        description: Number of xDS responses sent to the Dataplane.
+                        type: integer
+                    type: object
+                  lastUpdateTime:
+                    description: >-
+                      Time when status of a given ADS subscription was most
+                      recently updated.
+                    format: date-time
+                    type: string
+                  lds:
+                    description: LDS defines all LDS stats.
+                    properties:
+                      responsesAcknowledged:
+                        description: Number of xDS responses ACKed by the Dataplane.
+                        type: integer
+                      responsesRejected:
+                        description: Number of xDS responses NACKed by the Dataplane.
+                        type: integer
+                      responsesSent:
+                        description: Number of xDS responses sent to the Dataplane.
+                        type: integer
+                    type: object
+                  rds:
+                    description: RDS defines all RDS stats.
+                    properties:
+                      responsesAcknowledged:
+                        description: Number of xDS responses ACKed by the Dataplane.
+                        type: integer
+                      responsesRejected:
+                        description: Number of xDS responses NACKed by the Dataplane.
+                        type: integer
+                      responsesSent:
+                        description: Number of xDS responses sent to the Dataplane.
+                        type: integer
+                    type: object
+                  total:
+                    description: Total defines an aggregate over individual xDS stats.
+                    properties:
+                      responsesAcknowledged:
+                        description: Number of xDS responses ACKed by the Dataplane.
+                        type: integer
+                      responsesRejected:
+                        description: Number of xDS responses NACKed by the Dataplane.
+                        type: integer
+                      responsesSent:
+                        description: Number of xDS responses sent to the Dataplane.
+                        type: integer
+                    type: object
+                type: object
+              version:
+                description: Version of Envoy and Kuma dataplane
+                properties:
+                  dependencies:
+                    additionalProperties:
+                      type: string
+                    description: Versions of other dependencies
+                    type: object
+                  envoy:
+                    description: Version of Envoy
+                    properties:
+                      build:
+                        description: Full build tag of Envoy version
+                        type: string
+                      kumaDpCompatible:
+                        description: >-
+                          True iff Envoy version is compatible with Kuma DP
+                          version
+                        type: boolean
+                      version:
+                        description: Version number of Envoy
+                        type: string
+                    type: object
+                  kumaDp:
+                    description: Version of Kuma Dataplane
+                    properties:
+                      buildDate:
+                        description: Build date of Kuma Dataplane version
+                        type: string
+                      gitCommit:
+                        description: Git commit of Kuma Dataplane version
+                        type: string
+                      gitTag:
+                        description: Git tag of Kuma Dataplane version
+                        type: string
+                      kumaCpCompatible:
+                        description: >-
+                          True iff Kuma DP version is compatible with Kuma CP
+                          version
+                        type: boolean
+                      version:
+                        description: Version number of Kuma Dataplane
+                        type: string
+                    type: object
+                type: object
+            type: object
+          type: array
+        type:
+          type: string
+      required:
+        - type
+        - name
+        - mesh
+      type: object
     GlobalSecretItem:
       type: object
       required:
@@ -15764,6 +16738,299 @@ components:
                 type: integer
             type: object
           type: object
+      type: object
+    SecretItem:
+      properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        data:
+          description: Value of the secret
+          format: byte
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        mesh:
+          maxLength: 253
+          pattern: ^[0-9a-z-_.]*$
+          type: string
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
+        name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+        type:
+          type: string
+      required:
+        - type
+        - name
+        - mesh
+      type: object
+    ZoneItem:
+      properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        enabled:
+          description: >-
+            enable allows to turn the zone on/off and exclude the whole zone
+            from
+
+            balancing traffic on it
+          type: boolean
+        kri:
+          description: Kuma Resource Identifier (KRI) of the given resource
+          readOnly: true
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
+        name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+        type:
+          type: string
+      required:
+        - type
+        - name
+      type: object
+    ZoneInsightItem:
+      properties:
+        creationTime:
+          description: Time at which the resource was created
+          format: date-time
+          readOnly: true
+          type: string
+        envoyAdminStreams:
+          description: |-
+            Statistics about Envoy Admin Streams
+            Deprecated: use kds_streams instead.
+          properties:
+            clustersGlobalInstanceId:
+              description: Global instance ID that handles Clusters streams.
+              type: string
+            configDumpGlobalInstanceId:
+              description: Global instance ID that handles XDS Config Dump streams.
+              type: string
+            statsGlobalInstanceId:
+              description: Global instance ID that handles Stats streams.
+              type: string
+          type: object
+        healthCheck:
+          properties:
+            time:
+              description: Time last health check received
+              format: date-time
+              type: string
+          type: object
+        kdsStreams:
+          description: >-
+            Information about kds streams that are estabilished between global
+            and zone
+          properties:
+            clusters:
+              description: Details of stream that handles Clusters stream.
+              properties:
+                connectTime:
+                  description: Time when the stream was open.
+                  format: date-time
+                  type: string
+                globalInstanceId:
+                  description: Global instance ID that handles the stream.
+                  type: string
+              type: object
+            configDump:
+              description: Details of stream that handles XDS Config Dump stream.
+              properties:
+                connectTime:
+                  description: Time when the stream was open.
+                  format: date-time
+                  type: string
+                globalInstanceId:
+                  description: Global instance ID that handles the stream.
+                  type: string
+              type: object
+            globalToZone:
+              description: >-
+                Details of stream that handles global to zone resource sync
+                stream.
+              properties:
+                connectTime:
+                  description: Time when the stream was open.
+                  format: date-time
+                  type: string
+                globalInstanceId:
+                  description: Global instance ID that handles the stream.
+                  type: string
+              type: object
+            stats:
+              description: Details of stream that handles Stats stream.
+              properties:
+                connectTime:
+                  description: Time when the stream was open.
+                  format: date-time
+                  type: string
+                globalInstanceId:
+                  description: Global instance ID that handles the stream.
+                  type: string
+              type: object
+            zoneToGlobal:
+              description: >-
+                Details of stream that handles zone to global resource sync
+                stream.
+              properties:
+                connectTime:
+                  description: Time when the stream was open.
+                  format: date-time
+                  type: string
+                globalInstanceId:
+                  description: Global instance ID that handles the stream.
+                  type: string
+              type: object
+          type: object
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        modificationTime:
+          description: Time at which the resource was updated
+          format: date-time
+          readOnly: true
+          type: string
+        name:
+          maxLength: 253
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+        subscriptions:
+          description: List of KDS subscriptions created by a given Zone Kuma CP.
+          items:
+            description: >-
+              KDSSubscription describes a single KDS subscription created by a
+              Zone to the Global.
+            properties:
+              authTokenProvided:
+                description: Indicates if subscription provided auth token
+                type: boolean
+              config:
+                description: Config of Zone Kuma CP
+                type: string
+              connectTime:
+                description: Time when a given Zone connected to the Global.
+                format: date-time
+                type: string
+              disconnectTime:
+                description: Time when a given Zone disconnected from the Global.
+                format: date-time
+                type: string
+              generation:
+                description: >-
+                  Generation is an integer number which is periodically
+                  increased by the
+
+                  status sink
+                type: integer
+              globalInstanceId:
+                description: Global CP instance that handled given subscription.
+                type: string
+              id:
+                description: Unique id per KDS subscription.
+                type: string
+              status:
+                description: Status of the KDS subscription.
+                properties:
+                  lastUpdateTime:
+                    description: >-
+                      Time when status of a given KDS subscription was most
+                      recently updated.
+                    format: date-time
+                    type: string
+                  stat:
+                    additionalProperties:
+                      description: >-
+                        DiscoveryServiceStats defines all stats over a single
+                        xDS service.
+                      properties:
+                        responsesAcknowledged:
+                          description: Number of xDS responses ACKed by the Dataplane.
+                          type: integer
+                        responsesRejected:
+                          description: Number of xDS responses NACKed by the Dataplane.
+                          type: integer
+                        responsesSent:
+                          description: Number of xDS responses sent to the Dataplane.
+                          type: integer
+                      type: object
+                    type: object
+                  total:
+                    description: Total defines an aggregate over individual KDS stats.
+                    properties:
+                      responsesAcknowledged:
+                        description: Number of xDS responses ACKed by the Dataplane.
+                        type: integer
+                      responsesRejected:
+                        description: Number of xDS responses NACKed by the Dataplane.
+                        type: integer
+                      responsesSent:
+                        description: Number of xDS responses sent to the Dataplane.
+                        type: integer
+                    type: object
+                type: object
+              version:
+                description: Version of Zone Kuma CP.
+                properties:
+                  kumaCp:
+                    description: Version of Zone Kuma CP
+                    properties:
+                      buildDate:
+                        description: Build date of Kuma ControlPlane version
+                        type: string
+                      gitCommit:
+                        description: Git commit of Kuma ControlPlane version
+                        type: string
+                      gitTag:
+                        description: Git tag of Kuma ControlPlane version
+                        type: string
+                      kumaCpGlobalCompatible:
+                        description: >-
+                          True iff this Zone CP version is compatible with
+                          Global CP
+                        type: boolean
+                      version:
+                        description: Version number of Kuma ControlPlane
+                        type: string
+                    type: object
+                type: object
+              zoneInstanceId:
+                description: >-
+                  Zone CP instance that handled the given subscription (This is
+                  the leader at
+
+                  time of connection).
+                type: string
+            type: object
+          type: array
+        type:
+          type: string
+      required:
+        - type
+        - name
       type: object
     ZoneOverviewWithMeta:
       allOf:
@@ -18999,6 +20266,112 @@ components:
         application/json:
           schema:
             type: object
+    DataplaneCreateOrUpdateSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              warnings:
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+                readOnly: true
+                type: array
+            type: object
+      description: Successful response
+    DataplaneDeleteSuccessResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+      description: Successful response
+    DataplaneItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DataplaneItem'
+      description: Successful response
+    DataplaneList:
+      content:
+        application/json:
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/components/schemas/DataplaneItem'
+                type: array
+              next:
+                description: URL to the next page, or null when this is the last page
+                type:
+                  - string
+                  - 'null'
+              total:
+                description: The total number of entities
+                type: number
+            required:
+              - total
+              - items
+              - next
+            type: object
+      description: List
+    DataplaneInsightCreateOrUpdateSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              warnings:
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+                readOnly: true
+                type: array
+            type: object
+      description: Successful response
+    DataplaneInsightDeleteSuccessResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+      description: Successful response
+    DataplaneInsightItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DataplaneInsightItem'
+      description: Successful response
+    DataplaneInsightList:
+      content:
+        application/json:
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/components/schemas/DataplaneInsightItem'
+                type: array
+              next:
+                description: URL to the next page, or null when this is the last page
+                type:
+                  - string
+                  - 'null'
+              total:
+                description: The total number of entities
+                type: number
+            required:
+              - total
+              - items
+              - next
+            type: object
+      description: List
     GetDataplaneOverviewResponse:
       description: A response containing the overview of a dataplane.
       content:
@@ -19081,6 +20454,59 @@ components:
         application/json:
           schema:
             type: object
+    MeshCreateOrUpdateSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              warnings:
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+                readOnly: true
+                type: array
+            type: object
+      description: Successful response
+    MeshDeleteSuccessResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+      description: Successful response
+    MeshItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshItem'
+      description: Successful response
+    MeshList:
+      content:
+        application/json:
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/components/schemas/MeshItem'
+                type: array
+              next:
+                description: URL to the next page, or null when this is the last page
+                type:
+                  - string
+                  - 'null'
+              total:
+                description: The total number of entities
+                type: number
+            required:
+              - total
+              - items
+              - next
+            type: object
+      description: List
     GetMeshInsightResponse:
       description: A response containing the insight of a mesh.
       content:
@@ -19139,6 +20565,165 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/MeshOverviewWithMeta'
+    SecretCreateOrUpdateSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              warnings:
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+                readOnly: true
+                type: array
+            type: object
+      description: Successful response
+    SecretDeleteSuccessResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+      description: Successful response
+    SecretItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SecretItem'
+      description: Successful response
+    SecretList:
+      content:
+        application/json:
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/components/schemas/SecretItem'
+                type: array
+              next:
+                description: URL to the next page, or null when this is the last page
+                type:
+                  - string
+                  - 'null'
+              total:
+                description: The total number of entities
+                type: number
+            required:
+              - total
+              - items
+              - next
+            type: object
+      description: List
+    ZoneCreateOrUpdateSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              warnings:
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+                readOnly: true
+                type: array
+            type: object
+      description: Successful response
+    ZoneDeleteSuccessResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+      description: Successful response
+    ZoneItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ZoneItem'
+      description: Successful response
+    ZoneList:
+      content:
+        application/json:
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/components/schemas/ZoneItem'
+                type: array
+              next:
+                description: URL to the next page, or null when this is the last page
+                type:
+                  - string
+                  - 'null'
+              total:
+                description: The total number of entities
+                type: number
+            required:
+              - total
+              - items
+              - next
+            type: object
+      description: List
+    ZoneInsightCreateOrUpdateSuccessResponse:
+      content:
+        application/json:
+          schema:
+            properties:
+              warnings:
+                description: >
+                  warnings is a list of warning messages to return to the
+                  requesting Kuma API clients.
+
+                  Warning messages describe a problem the client making the API
+                  request should correct or be aware of.
+                items:
+                  type: string
+                readOnly: true
+                type: array
+            type: object
+      description: Successful response
+    ZoneInsightDeleteSuccessResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+      description: Successful response
+    ZoneInsightItem:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ZoneInsightItem'
+      description: Successful response
+    ZoneInsightList:
+      content:
+        application/json:
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/components/schemas/ZoneInsightItem'
+                type: array
+              next:
+                description: URL to the next page, or null when this is the last page
+                type:
+                  - string
+                  - 'null'
+              total:
+                description: The total number of entities
+                type: number
+            required:
+              - total
+              - items
+              - next
+            type: object
+      description: List
     GetZoneOverviewResponse:
       description: A response containing the overview of a zone.
       content:

--- a/mk/generate.mk
+++ b/mk/generate.mk
@@ -204,8 +204,8 @@ $(foreach s,$(OAS_SPECS),$(eval $(call OAS_RULE,$(s))))
 
 .PHONY: generate/oas
 generate/oas: $(GENERATE_OAS_PREREQUISITES) $(RESOURCE_GEN) $(OAPI_GEN) $(OAS_TYPES)
-	@$(RESOURCE_GEN) -package mesh   -generator openapi -readDir $(KUMA_DIR) -writeDir .
-	@$(RESOURCE_GEN) -package system -generator openapi -readDir $(KUMA_DIR) -writeDir .
+	@$(RESOURCE_GEN) -package mesh   -generator openapi -readDir $(KUMA_DIR) -writeDir . -error-schema=$(OAS_ERROR_SCHEMA)
+	@$(RESOURCE_GEN) -package system -generator openapi -readDir $(KUMA_DIR) -writeDir . -error-schema=$(OAS_ERROR_SCHEMA)
 	@$(OAPI_GEN) kri --error-schema=$(OAS_ERROR_SCHEMA)
 
 .PHONY: validate/openapi-generated-docs

--- a/tools/resource-gen/pkg/generator/main.go
+++ b/tools/resource-gen/pkg/generator/main.go
@@ -409,8 +409,9 @@ func init() {
 `))
 
 var (
-	readDir  = "."
-	writeDir = "."
+	readDir     = "."
+	writeDir    = "."
+	errorSchema = commontemplate.DefaultOpenAPIErrorSchema
 )
 
 func Run() {
@@ -421,6 +422,7 @@ func Run() {
 	flag.StringVar(&pkg, "package", "", "the name of the package to generate: (mesh, system)")
 	flag.StringVar(&readDir, "readDir", "", "where to read files from, default: .")
 	flag.StringVar(&writeDir, "writeDir", "", "where to write files to, default: .")
+	flag.StringVar(&errorSchema, "error-schema", commontemplate.DefaultOpenAPIErrorSchema, "OpenAPI document with the shared error responses, relative to the specs root")
 
 	flag.Parse()
 
@@ -571,12 +573,13 @@ func openApiGenerator(pkg string, resources []ResourceInfo) error {
 			path.Join(readDir, "tools", "openapi", "templates", "endpoints.yaml"),
 			tmpRestPath,
 			map[string]any{
-				"Package":   "v1alpha1",
-				"Name":      r.ResourceType,
-				"ShortName": r.ShortName,
-				"Scope":     scope,
-				"Path":      r.WsPath,
-				"ReadOnly":  r.WsReadOnly,
+				"Package":     "v1alpha1",
+				"Name":        r.ResourceType,
+				"ShortName":   r.ShortName,
+				"Scope":       scope,
+				"Path":        r.WsPath,
+				"ReadOnly":    r.WsReadOnly,
+				"ErrorSchema": errorSchema,
 			},
 		); err != nil {
 			return err


### PR DESCRIPTION
## Motivation

kumahq/kuma#18693 (the protobuf spec revert) restored resource-gen's openapi generator from before kumahq/kuma#18688. It renders `tools/openapi/templates/endpoints.yaml` without `ErrorSchema`, so every generated `rest.yaml` (Dataplane, DataplaneInsight, Mesh, Secret, Zone, ZoneInsight) got `$ref: ../../<no value>#/components/responses/NotFound`. The bundler cannot resolve that and silently drops those resources from `docs/generated/openapi.yaml`.

Downstream (Kong Mesh) hits the same bug for its own proto resources and needs `OAS_ERROR_SCHEMA` to reach resource-gen, like it already reaches policy-gen and `oapi-gen kri`.

## Implementation information

- resource-gen: add `-error-schema` (default `commontemplate.DefaultOpenAPIErrorSchema`) and pass it as `ErrorSchema` to `endpoints.yaml`
- `mk/generate.mk`: pass `-error-schema=$(OAS_ERROR_SCHEMA)` to both `resource-gen -generator openapi` calls
- regenerate the six `rest.yaml` files and `docs/generated/openapi.yaml`, which gets the dropped resources back

Labelled `ci/skip-test`: generator and generated-spec change only; `make check` still runs.

## Supporting documentation

- kumahq/kuma#18688, kumahq/kuma#18693
- downstream: Kong/kong-mesh#10634, Kong/kong-mesh#10815

> Changelog: skip