### PR TITLE
fix(k8s): default sidecar concurrency to 2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,21 +8,6 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
-### Sidecar Envoy concurrency defaults to 2 without a CPU limit
-
-Removing the default sidecar CPU limit in 2.14 also removed the `--concurrency`
-flag from injected sidecars, because concurrency was derived only from that
-limit. Envoy then sized its worker threads to every core on the node, which
-raised sidecar memory and upstream connection counts on large nodes. The
-injector now emits `--concurrency=2` when no CPU limit is set, matching the
-behaviour before 2.14. With a CPU limit the value is still derived from it,
-floored at 2.
-
-**Action required**
-
-None. To pick a different value, set the `kuma.io/sidecar-proxy-concurrency`
-annotation on the Pod; `"0"` lets Envoy size workers to all visible CPUs.
-
 ### `MeshIdentity.spec.spiffeID` is immutable and its trust domain no longer follows the zone
 
 A trust domain is an identity namespace, so moving one is a migration rather

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,21 @@ does not have any particular instructions.
 
 ## Upgrade to `3.0.0`
 
+### Sidecar Envoy concurrency defaults to 2 without a CPU limit
+
+Removing the default sidecar CPU limit in 2.14 also removed the `--concurrency`
+flag from injected sidecars, because concurrency was derived only from that
+limit. Envoy then sized its worker threads to every core on the node, which
+raised sidecar memory and upstream connection counts on large nodes. The
+injector now emits `--concurrency=2` when no CPU limit is set, matching the
+behaviour before 2.14. With a CPU limit the value is still derived from it,
+floored at 2.
+
+**Action required**
+
+None. To pick a different value, set the `kuma.io/sidecar-proxy-concurrency`
+annotation on the Pod; `"0"` lets Envoy size workers to all visible CPUs.
+
 ### `MeshIdentity.spec.spiffeID` is immutable and its trust domain no longer follows the zone
 
 A trust domain is an identity namespace, so moving one is a migration rather

--- a/pkg/plugins/runtime/k8s/containers/factory.go
+++ b/pkg/plugins/runtime/k8s/containers/factory.go
@@ -83,12 +83,10 @@ func (i *DataplaneProxyFactory) proxyConcurrencyFor(annotations map[string]strin
 		return int64(count), err
 	}
 
+	// Only autotune down to 2 to mitigate the latency risk if a worker
+	// thread blocks. This also covers the no-limit case, where Envoy
+	// would otherwise size workers to every core on the node.
 	cpuLimit := kube_api.MustParse(i.ContainerConfig.Resources.Limits.CPU)
-	if cpuLimit.IsZero() {
-		return 0, nil
-	}
-	// Only autotune to down to 2 to mitigate the latency
-	// risk if a worker thread blocks.
 	return max(cpuLimit.MilliValue()/1000, 2), nil
 }
 

--- a/pkg/plugins/runtime/k8s/containers/factory_test.go
+++ b/pkg/plugins/runtime/k8s/containers/factory_test.go
@@ -71,4 +71,24 @@ var _ = Describe("DataplaneProxyFactory", func() {
 			Expect(ok).To(BeFalse())
 		})
 	})
+
+	DescribeTable("proxyConcurrencyFor",
+		func(cpuLimit string, annotations map[string]string, expected int64) {
+			factory := &DataplaneProxyFactory{
+				ContainerConfig: runtime_k8s.DataplaneContainer{
+					Resources: runtime_k8s.SidecarResources{
+						Limits: runtime_k8s.SidecarResourceLimits{CPU: cpuLimit},
+					},
+				},
+			}
+			concurrency, err := factory.proxyConcurrencyFor(annotations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(concurrency).To(Equal(expected))
+		},
+		Entry("defaults to 2 without a CPU limit", "0", nil, int64(2)),
+		Entry("floors at 2 with a small CPU limit", "500m", nil, int64(2)),
+		Entry("follows a larger CPU limit", "3000m", nil, int64(3)),
+		Entry("annotation overrides the CPU limit", "3000m", map[string]string{metadata.KumaSidecarConcurrencyAnnotation: "8"}, int64(8)),
+		Entry("annotation 0 keeps Envoy's own sizing", "0", map[string]string{metadata.KumaSidecarConcurrencyAnnotation: "0"}, int64(0)),
+	)
 })

--- a/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/injector_test.go
@@ -841,6 +841,22 @@ spec:
                     kuma.io/sidecar-injection: enabled`,
 			cfgFile: "inject.spire.config.yaml",
 		}),
+		Entry("44. sidecar without CPU limit", testCase{
+			num: "44",
+			mesh: `
+              apiVersion: kuma.io/v1alpha1
+              kind: Mesh
+              metadata:
+                name: default`,
+			namespace: `
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: default
+                labels:
+                  kuma.io/sidecar-injection: enabled`,
+			cfgFile: "inject.no-cpu-limit.config.yaml",
+		}),
 	)
 
 	It("falls back to init-container sidecar injection when native sidecars are unavailable", func() {

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.44.golden.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.44.golden.yaml
@@ -1,0 +1,222 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/default-container: busybox
+    kuma.io/application-probe-proxy-port: "9000"
+    kuma.io/envoy-admin-port: "9901"
+    kuma.io/sidecar-injected: "true"
+    traffic.kuma.io/transparent-proxy-config: |
+      ipFamilyMode: dualstack
+      kumaDPUser: "5678"
+      redirect:
+        dns:
+          captureAll: false
+          enabled: false
+          port: 0
+          resolvConfigPath: /etc/resolv.conf
+          skipConntrackZoneSplit: false
+        inbound:
+          enabled: true
+          excludePorts:
+          - 9000
+          - 9902
+          port: 15006
+        outbound:
+          enabled: true
+          port: 15001
+      retry:
+        maxRetries: 4
+        sleepBetweenRetries: 2s
+      wait: 5
+      waitInterval: 0
+  labels:
+    kuma.io/mesh: default
+    run: busybox
+  name: busybox
+spec:
+  containers:
+  - image: busybox
+    name: busybox
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  initContainers:
+  - args:
+    - --config=/tmp/transparent-proxy/base/config.yaml
+    command:
+    - /usr/bin/kumactl
+    - install
+    - transparent-proxy
+    env:
+    - name: XTABLES_LOCKFILE
+      value: /tmp/xtables.lock
+    image: kuma/kuma-init:latest
+    imagePullPolicy: IfNotPresent
+    name: kuma-init
+    resources:
+      limits:
+        memory: 50M
+      requests:
+        cpu: 20m
+        memory: 20M
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 0
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /tmp
+      name: kuma-init-tmp
+    - mountPath: /tmp/transparent-proxy/base
+      name: transparent-proxy-base
+      readOnly: true
+  - args:
+    - run
+    - --log-level=info
+    - --concurrency=2
+    - --transparent-proxy-config=/tmp/transparent-proxy/base/config.yaml
+    env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: KUMA_APPLICATION_PROBE_PROXY_PORT
+      value: "9000"
+    - name: KUMA_CONTROL_PLANE_CA_CERT
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIDMzCCAhugAwIBAgIQDhlInfsXYHamKN+29qnQvzANBgkqhkiG9w0BAQsFADAP
+        MQ0wCwYDVQQDEwRrdW1hMB4XDTIxMDQwMjEwMjIyNloXDTMxMDMzMTEwMjIyNlow
+        DzENMAsGA1UEAxMEa3VtYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+        AL4GGg+e2O7eA12F0F6v2rr8j2iVSFKepnZtL15lrCds6lqK50sXWOw8PKZp2ihA
+        XJVTSZzKasyLDTAR9VYQjTpE526EzvtdthSagf32QWW+wY6LMpEdexKOOCx2se55
+        Rd97L33yYPfgX15OYliHPD056jjhotHLdN2lpy7+STDvQyRnXAu73YkY37Ed4hI4
+        t/V6soHyEGNcDhm9p5fBGqz0njBbQkp2lTY5/kj42qB7Q6rCM2tbPsEMooeAAw5m
+        hyY4xj0tP9ucqlUz8gc+6o8HDNst8NeJXZktWn+COytjr/NzGgS22kvSDphisJot
+        o0FyoIOdAtxC1qxXXR+XuUUCAwEAAaOBijCBhzAOBgNVHQ8BAf8EBAMCAqQwHQYD
+        VR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wHQYD
+        VR0OBBYEFKRLkgIzX/OjKw9idepuQ/RMtT+AMCYGA1UdEQQfMB2CCWxvY2FsaG9z
+        dIcQ/QChIwAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAQEAPs5yJZhoYlGW
+        CpA8dSISivM8/8iBNQ3fVwP63ft0EJLMVGu2RFZ4/UAJ/rUPSGN8xhXSk5+1d56a
+        /kaH9rX0HaRIHHlxA7iPUKxAj44x9LKmqPHToL3XlWY1AXzvicW9d+GM2FaQee+I
+        leaqLbz0AZvlnu271Z1CeaACuU9GljujvyiTTE9naHUEqvHgSpPtilJalyJ5/zIl
+        Z9F0+UWt3TOYMs5g+SCt0MwHTNbisbmewpcFFJzjt2kvtrc9t9dkF81xhcS19w7q
+        h1AeP3RRlLl7bv9EAVXEmIavih/29PA3ZSy+pbYNW7jNJHjMQ4hQ0E+xcCazU/O4
+        ypWGaanvPg==
+        -----END CERTIFICATE-----
+    - name: KUMA_CONTROL_PLANE_URL
+      value: http://kuma-control-plane.kuma-system:5681
+    - name: KUMA_DATAPLANE_DRAIN_TIME
+      value: 31s
+    - name: KUMA_DATAPLANE_MESH
+      value: default
+    - name: KUMA_DATAPLANE_RUNTIME_TOKEN_PATH
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - name: KUMA_DNS_ENABLED
+      value: "false"
+    - name: KUMA_READINESS_PORT
+      value: "9902"
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    image: kuma/kuma-sidecar:latest
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - killall
+          - -USR2
+          - kuma-dp
+    livenessProbe:
+      failureThreshold: 212
+      httpGet:
+        path: /ready
+        port: 9902
+      initialDelaySeconds: 260
+      periodSeconds: 25
+      successThreshold: 1
+      timeoutSeconds: 23
+    name: kuma-sidecar
+    readinessProbe:
+      failureThreshold: 112
+      httpGet:
+        path: /ready
+        port: 9902
+      initialDelaySeconds: 11
+      periodSeconds: 15
+      successThreshold: 11
+      timeoutSeconds: 13
+    resources:
+      limits:
+        ephemeral-storage: 1G
+        memory: 1512Mi
+      requests:
+        cpu: 150m
+        ephemeral-storage: 50M
+        memory: 164Mi
+    restartPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 5678
+      runAsUser: 5678
+    startupProbe:
+      failureThreshold: 213
+      httpGet:
+        path: /ready
+        port: 9902
+      initialDelaySeconds: 261
+      periodSeconds: 26
+      successThreshold: 1
+      timeoutSeconds: 24
+    volumeMounts:
+    - mountPath: /tmp
+      name: kuma-sidecar-tmp
+    - mountPath: /tmp/transparent-proxy/base
+      name: transparent-proxy-base
+      readOnly: true
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-w7dxf
+      readOnly: true
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  - emptyDir:
+      sizeLimit: 10M
+    name: kuma-init-tmp
+  - emptyDir:
+      sizeLimit: 10M
+    name: kuma-sidecar-tmp
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations['traffic.kuma.io/transparent-proxy-config']
+        path: config.yaml
+    name: transparent-proxy-base
+status: {}

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.44.input.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.44.input.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  labels:
+    run: busybox
+spec:
+  volumes:
+  - name: default-token-w7dxf
+    secret:
+      secretName: default-token-w7dxf
+  containers:
+  - name: busybox
+    image: busybox
+    resources: {}
+    volumeMounts:
+    - name: default-token-w7dxf
+      readOnly: true
+      mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.no-cpu-limit.config.yaml
+++ b/pkg/plugins/runtime/k8s/webhooks/injector/testdata/inject.no-cpu-limit.config.yaml
@@ -1,0 +1,56 @@
+controlPlane:
+  apiServer:
+    url: http://kuma-control-plane.kuma-system:5681
+sidecarContainer:
+  image: kuma/kuma-sidecar:latest
+  ipFamilyMode: dualstack
+  redirectPortOutbound: 15001
+  redirectPortInbound: 15006
+  uid: 5678
+  gid: 5678
+  drainTime: 31s
+
+  readinessProbe:
+    initialDelaySeconds: 11
+    timeoutSeconds:      13
+    periodSeconds:       15
+    successThreshold:    11
+    failureThreshold:    112
+  livenessProbe:
+    initialDelaySeconds: 260
+    timeoutSeconds:      23
+    periodSeconds:       25
+    failureThreshold:    212
+  startupProbe:
+    initialDelaySeconds: 261
+    timeoutSeconds:      24
+    periodSeconds:       26
+    failureThreshold:    213
+  resources:
+    requests:
+      cpu: 150m
+      memory: 164Mi
+    limits:
+      cpu: "0"
+      memory: 1512Mi
+initContainer:
+  image: kuma/kuma-init:latest
+  resources:
+    requests:
+      cpu: 20m
+      memory: 20M
+    limits:
+      cpu: 0
+      memory: 50M
+validationContainer:
+  resources:
+    requests:
+      cpu: 20m
+      memory: 20M
+    limits:
+      cpu: "0"
+      memory: 50M
+applicationProbeProxyPort: 9000
+exceptions:
+  labels:
+    "openshift.io/deployer-pod-for.name": "*"


### PR DESCRIPTION
## Motivation

Since 2.14 the injected sidecar has no `--concurrency` flag. Removing the default sidecar CPU limit (#16207) also removed the only input the injector used to derive concurrency, so `proxyConcurrencyFor` returns 0 and the flag is skipped. Envoy then sizes workers to every core on the node: a sidecar that ran 2 workers on 2.13 runs 30+ on a 32-core node, with the matching increase in memory and upstream connection counts. Neither the code, the changelog, nor the upgrade note mentioned this.

## Implementation information

`proxyConcurrencyFor` now falls back to 2 when the CPU limit is zero, which is exactly what 2.13 emitted with its 1000m default limit and what Consul ships as its fixed default. The limit-derived path and the `kuma.io/sidecar-proxy-concurrency` annotation are unchanged, so `"0"` on the annotation still hands sizing to Envoy. The regression slipped through because every injector fixture pins an 1100m sidecar limit, so no golden ever exercised the shipped default. Added a fixture with the zero limit, a golden for it, a table test on `proxyConcurrencyFor`, and an `UPGRADE.md` note.

## Supporting documentation

Istio derives concurrency from `ISTIO_CPU_LIMIT` (downward API `limits.cpu`, node allocatable when unset) but ships a 2000m default limit, so its default is 2. Linkerd runs 1 worker by default. Consul injects `-envoy-concurrency=2` by default. No mesh treats "no limit" as "use every core" for sidecars.

- https://github.com/istio/istio/blob/master/pilot/cmd/pilot-agent/config/config.go
- https://linkerd.io/2/tasks/configuring-proxy-concurrency/
- https://developer.hashicorp.com/consul/docs/reference/dataplane/cli
- https://www.envoyproxy.io/docs/envoy/latest/operations/cli