### PR TITLE
fix(api-server): check kuma.io/origin on federated zones for every resource type

### DIFF
--- a/pkg/api-server/resource_validation.go
+++ b/pkg/api-server/resource_validation.go
@@ -48,7 +48,7 @@ func (r *resourceCrudHandler) validateOriginForWrite(meta core_model.ResourceMet
 		}
 	}
 
-	if r.federatedZone && r.descriptor.IsPluginOriginated {
+	if r.federatedZone {
 		if ok && origin != mesh_proto.ZoneResourceOrigin {
 			err.AddViolationAt(validators.Root().Key(mesh_proto.ResourceOriginLabel), fmt.Sprintf("the origin label must be set to '%s'", mesh_proto.ZoneResourceOrigin))
 		}

--- a/pkg/api-server/testdata/resources/crud/zone/create_dataplane_origin_global_foreign_zone.golden.json
+++ b/pkg/api-server/testdata/resources/crud/zone/create_dataplane_origin_global_foreign_zone.golden.json
@@ -5,12 +5,20 @@
  "detail": "Resource is not valid",
  "invalid_parameters": [
   {
+   "field": "labels[\"kuma.io/origin\"]",
+   "reason": "the origin label must be set to 'zone'"
+  },
+  {
    "field": "labels[\"kuma.io/zone\"]",
    "reason": "kuma.io/zone label should have zone-1 value"
   }
  ],
  "details": "Resource is not valid",
  "causes": [
+  {
+   "field": "labels[\"kuma.io/origin\"]",
+   "message": "the origin label must be set to 'zone'"
+  },
   {
    "field": "labels[\"kuma.io/zone\"]",
    "message": "kuma.io/zone label should have zone-1 value"

--- a/pkg/api-server/testdata/resources/crud/zone/delete_global_origin_secret.golden.json
+++ b/pkg/api-server/testdata/resources/crud/zone/delete_global_origin_secret.golden.json
@@ -1,0 +1,19 @@
+{
+ "type": "/std-errors",
+ "status": 400,
+ "title": "Could not delete a resource",
+ "detail": "Resource is not valid",
+ "invalid_parameters": [
+  {
+   "field": "[\"kuma.io/origin\"]",
+   "reason": "the origin label must be set to 'zone'"
+  }
+ ],
+ "details": "Resource is not valid",
+ "causes": [
+  {
+   "field": "[\"kuma.io/origin\"]",
+   "message": "the origin label must be set to 'zone'"
+  }
+ ]
+}

--- a/pkg/api-server/testdata/resources/crud/zone/delete_global_origin_secret.input.yaml
+++ b/pkg/api-server/testdata/resources/crud/zone/delete_global_origin_secret.input.yaml
@@ -1,0 +1,10 @@
+#/meshes/default/secrets/secret-global 400 method=DELETE
+type: Mesh
+name: default
+---
+type: Secret
+mesh: default
+name: secret-global
+labels:
+  kuma.io/origin: global
+data: dGVzdA==


### PR DESCRIPTION
## Motivation

Follow-up to #18412. On a federated zone the origin check in `validateOriginForWrite` was gated on `IsPluginOriginated`, so it never ran for Secret, GlobalSecret and Config. `deleteResource` reuses that function, which left a hole: a zone user could `DELETE` a Global-synced secret such as `dataplane-token-signing-key-default-1` or the `zone-token-signing-public-key-1` GlobalSecret via the REST API, while updating the same resource was already rejected by origin immutability. KDS does not restore the deleted resource until the stream reconnects, so DP token and zone token verification on that zone breaks silently.

Reproduced manually on a Universal Global + federated Universal zone: `DELETE /meshes/default/secrets/dataplane-token-signing-key-default-1` on the zone returned 200 and the secret stayed gone for 20+ seconds.

## Implementation information

Drop the `IsPluginOriginated` gate so the federated-zone origin check applies to every type. The gate dates from #8873, where it only served to limit the new create-time `kuma.io/origin: zone` requirement to plugin policies; it was never meant as an ownership exemption.

Consequences on federated zones only (Global and non-federated zones are untouched):

- Delete of a Global-synced Secret, GlobalSecret or Config is rejected. All such resources are Global-owned (mesh CAs, signing keys, `kuma-cluster-id`), so nothing legitimate breaks.
- A `PUT` that carries `kuma.io/origin: global` on a Dataplane, Secret, GlobalSecret or Config is rejected instead of silently rewritten to `zone`, matching what policies already do. The `create_dataplane_origin_global_foreign_zone` golden gains that violation.
- kuma-dp registration and KDS sync do not go through this validation and are unaffected.

The k8s webhook keeps the same exemption in `isResourceAllowed`; `kubectl delete secret` on a k8s zone is a separate, RBAC-governed path and is out of scope here.

## Supporting documentation

Follow-up to #18412.
